### PR TITLE
Codex WebSocket transport for Skuld (app-server protocol)

### DIFF
--- a/charts/volundr/templates/configmap.yaml
+++ b/charts/volundr/templates/configmap.yaml
@@ -68,6 +68,7 @@ data:
       retention_days: {{ .Values.chronicle.retentionDays }}
       {{- end }}
 
+    default_definition: {{ .Values.defaultDefinition | default "skuldClaude" | quote }}
     {{- if .Values.sessionDefinitions }}
     session_definitions:
       {{- range $key, $def := .Values.sessionDefinitions }}

--- a/charts/volundr/templates/configmap.yaml
+++ b/charts/volundr/templates/configmap.yaml
@@ -68,6 +68,23 @@ data:
       retention_days: {{ .Values.chronicle.retentionDays }}
       {{- end }}
 
+    {{- if .Values.sessionDefinitions }}
+    session_definitions:
+      {{- range $key, $def := .Values.sessionDefinitions }}
+      {{ $key }}:
+        enabled: {{ $def.enabled | default false }}
+        display_name: {{ $def.displayName | default $key | quote }}
+        description: {{ $def.description | default "" | quote }}
+        default_model: {{ $def.defaultModel | default "" | quote }}
+        {{- if $def.labels }}
+        labels: {{ $def.labels | toJson }}
+        {{- end }}
+        {{- if $def.defaults }}
+        defaults: {{ $def.defaults | toJson }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+
     {{- if .Values.profiles }}
     profiles:
       {{- range .Values.profiles }}

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -805,6 +805,9 @@ existingSecrets:
   # Expected keys: ANTHROPIC_API_KEY, optionally ANTHROPIC_BASE_URL
   anthropic: volundr-anthropic-api
 
+# -- Fallback session definition when none is specified in the request
+defaultDefinition: "skuldClaude"
+
 # Session definition templates
 # These define session types for workload instantiation
 sessionDefinitions:

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -44,18 +44,32 @@ revisionHistoryLimit: 10
 # Available AI models — used by the wizard, profiles, and pricing
 # Override via global.models from the niuu umbrella chart
 aiModels:
+  # Anthropic Claude
   - id: "claude-opus-4-6"
-    name: "Opus 4.6"
+    name: "Claude Opus 4.6"
     costPerMillionTokens: 15.00
   - id: "claude-opus-4-5-20251101"
-    name: "Opus 4.5"
+    name: "Claude Opus 4.5"
     costPerMillionTokens: 15.00
   - id: "claude-sonnet-4-6"
-    name: "Sonnet 4.6"
+    name: "Claude Sonnet 4.6"
     costPerMillionTokens: 3.00
   - id: "claude-haiku-4-5-20251001"
-    name: "Haiku 4.5"
+    name: "Claude Haiku 4.5"
     costPerMillionTokens: 1.00
+  # OpenAI GPT
+  - id: "gpt-5.5"
+    name: "GPT-5.5"
+    costPerMillionTokens: 10.00
+  - id: "gpt-5.4"
+    name: "GPT-5.4"
+    costPerMillionTokens: 5.00
+  - id: "o4-mini"
+    name: "o4-mini"
+    costPerMillionTokens: 1.10
+  - id: "o3"
+    name: "o3"
+    costPerMillionTokens: 10.00
 
 # Image configuration
 image:

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -1023,6 +1023,83 @@ sessionDefinitions:
       volundr:
         apiUrl: ""
 
+  # Skuld-OpenCode session definition (OpenCode — model-neutral)
+  # Supports Claude, OpenAI, Gemini, Ollama, and other providers.
+  skuldOpenCode:
+    # -- Enable skuld-opencode session definition (disabled by default)
+    enabled: false
+    # -- Human-readable name shown in the UI
+    displayName: "OpenCode"
+    # -- Short description for the session picker
+    description: "Model-neutral AI coding agent — supports Claude, OpenAI, Gemini, local models"
+    # -- Default model for this definition (empty = use OpenCode default)
+    defaultModel: ""
+    # -- Labels for agent routing
+    labels:
+      - session
+    # -- Whether this session definition is active
+    active: true
+
+    # Helm chart configuration (same chart as skuld-claude)
+    helm:
+      chart: skuld
+      repo: "oci://ghcr.io/niuulabs/charts"
+      repoName: ""
+      version: "0.1.0"
+
+    defaults:
+      session:
+        # -- Default OpenCode model (empty = let OpenCode pick)
+        model: ""
+
+      broker:
+        # -- AI CLI backend: "opencode" uses HTTP REST + SSE protocol
+        cliType: opencode
+        # -- Fully-qualified transport adapter class path
+        transportAdapter: "skuld.transports.opencode.OpenCodeHttpTransport"
+        # -- Skip tool permission prompts
+        skipPermissions: true
+        agentTeams: false
+
+      image:
+        repository: ghcr.io/niuulabs/skuld
+        tag: "latest"
+
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "1Gi"
+          cpu: "500m"
+
+      imagePullSecrets:
+        - ghcr-pull-secret
+
+      ingress:
+        className: ""
+        annotations: {}
+        tls:
+          enabled: false
+          secretName: "skuld-wildcard-tls"
+
+      persistence:
+        mountPath: "/volundr/sessions"
+
+      homeVolume:
+        enabled: true
+        mountPath: "/volundr/home"
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+
+      runtimeClassName: ""
+
+      volundr:
+        apiUrl: ""
+
   # Skuld-Reviewer session definition (lightweight LLM reviewer — no IDE)
   skuldReviewer:
     # -- Enable skuld-reviewer session definition

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -935,16 +935,16 @@ sessionDefinitions:
 
     defaults:
       session:
-        # -- Default Codex model
-        model: "o4-mini"
+        # -- Default Codex model (empty = let Codex pick based on subscription)
+        model: ""
 
       broker:
-        # -- AI CLI backend: "codex" (OpenAI Codex)
-        cliType: codex
-        # -- Codex always uses subprocess transport
-        transport: subprocess
+        # -- AI CLI backend: "codex-ws" uses the app-server WebSocket protocol
+        # -- which supports session resume, interrupt, streaming, and approvals.
+        # -- Use "codex" for the legacy one-subprocess-per-message transport.
+        cliType: codex-ws
         # -- Fully-qualified transport adapter class path
-        transportAdapter: "skuld.transports.codex.CodexSubprocessTransport"
+        transportAdapter: "skuld.transports.codex_ws.CodexWebSocketTransport"
         # -- Skip tool permission prompts (--full-auto for Codex)
         skipPermissions: true
         agentTeams: false

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -798,6 +798,12 @@ sessionDefinitions:
   skuldClaude:
     # -- Enable skuld-claude session definition
     enabled: true
+    # -- Human-readable name shown in the UI
+    displayName: "Claude Code"
+    # -- Short description for the session picker
+    description: "Anthropic Claude — full IDE with terminal, tools, and MCP"
+    # -- Default model for this definition (empty = use server default)
+    defaultModel: "claude-sonnet-4-6"
     # -- Labels for agent routing - only agents with matching labels will load this
     labels:
       - session
@@ -920,6 +926,12 @@ sessionDefinitions:
   skuldCodex:
     # -- Enable skuld-codex session definition (disabled by default)
     enabled: false
+    # -- Human-readable name shown in the UI
+    displayName: "OpenAI Codex"
+    # -- Short description for the session picker
+    description: "OpenAI Codex — WebSocket protocol with streaming and tools"
+    # -- Default model for this definition (empty = use Codex default based on subscription)
+    defaultModel: ""
     # -- Labels for agent routing
     labels:
       - session

--- a/containers/devrunner/Dockerfile
+++ b/containers/devrunner/Dockerfile
@@ -42,11 +42,14 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
 # Upgrade bundled npm to fix GHSA-qffp-2rhf-9h96 (tar) and GHSA-*-minimatch CVEs
 RUN npm install -g npm@11.3.0
 
-# Install Claude Code CLI globally via npm (same method as skuld pod)
-RUN npm install -g @anthropic-ai/claude-code@2.1.81
+# Install Claude Code CLI globally via npm
+RUN npm install -g @anthropic-ai/claude-code@2.1.121
 
-# Install OpenAI Codex CLI
-RUN npm install -g @openai/codex@0.114.0
+# Install OpenAI Codex CLI globally via npm
+RUN npm install -g @openai/codex@0.125.0
+
+# Install OpenCode (opencode.ai) globally via npm
+RUN npm install -g opencode-ai@1.14.29
 
 # Install PostgreSQL 16
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \

--- a/containers/skuld/Dockerfile
+++ b/containers/skuld/Dockerfile
@@ -74,13 +74,8 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.121
 # Install OpenAI Codex CLI globally via npm
 RUN npm install -g @openai/codex@0.125.0
 
-# Install OpenCode (opencode.ai) — download binary to /usr/local/bin
-# The install script puts it in ~/.opencode/bin which isn't accessible
-# to the runtime user, so we use --no-modify-path and move it.
-RUN curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path \
-    && mv /root/.opencode/bin/opencode /usr/local/bin/opencode \
-    && chmod 755 /usr/local/bin/opencode \
-    && rm -rf /root/.opencode
+# Install OpenCode (opencode.ai) globally via npm
+RUN npm install -g opencode-ai@1.14.29
 
 # Create app user with UID 1000 (matches helm chart runAsUser)
 RUN existing=$(getent passwd 1000 | cut -d: -f1) && \

--- a/containers/skuld/Dockerfile
+++ b/containers/skuld/Dockerfile
@@ -69,10 +69,10 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
 RUN npm install -g npm@11.3.0
 
 # Install Claude Code CLI globally via npm
-RUN npm install -g @anthropic-ai/claude-code@2.1.81
+RUN npm install -g @anthropic-ai/claude-code@2.1.121
 
 # Install OpenAI Codex CLI globally via npm
-RUN npm install -g @openai/codex@0.114.0
+RUN npm install -g @openai/codex@0.125.0
 
 # Install OpenCode (opencode.ai) — download binary to /usr/local/bin
 # The install script puts it in ~/.opencode/bin which isn't accessible

--- a/containers/skuld/Dockerfile
+++ b/containers/skuld/Dockerfile
@@ -38,7 +38,7 @@ FROM ubuntu:24.04@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e8769
 
 
 LABEL org.opencontainers.image.title="skuld"
-LABEL org.opencontainers.image.description="Skuld — remote AI coding session broker (Claude Code + Codex)"
+LABEL org.opencontainers.image.description="Skuld — remote AI coding session broker (Claude Code, Codex, OpenCode)"
 LABEL org.opencontainers.image.vendor="Niuu Labs"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.source="https://github.com/niuulabs/volundr"
@@ -73,6 +73,14 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.81
 
 # Install OpenAI Codex CLI globally via npm
 RUN npm install -g @openai/codex@0.114.0
+
+# Install OpenCode (opencode.ai) — download binary to /usr/local/bin
+# The install script puts it in ~/.opencode/bin which isn't accessible
+# to the runtime user, so we use --no-modify-path and move it.
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path \
+    && mv /root/.opencode/bin/opencode /usr/local/bin/opencode \
+    && chmod 755 /usr/local/bin/opencode \
+    && rm -rf /root/.opencode
 
 # Create app user with UID 1000 (matches helm chart runAsUser)
 RUN existing=$(getent passwd 1000 | cut -d: -f1) && \

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -273,6 +273,10 @@ class SkuldSettings(BaseSettings):
             self.transport_adapter = "skuld.transports.codex_ws.CodexWebSocketTransport"
             return self
 
+        if self.cli_type == "opencode":
+            self.transport_adapter = "skuld.transports.opencode.OpenCodeHttpTransport"
+            return self
+
         if self.transport == "subprocess":
             self.transport_adapter = "skuld.transports.subprocess.SubprocessTransport"
 

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -269,6 +269,10 @@ class SkuldSettings(BaseSettings):
             self.transport_adapter = "skuld.transports.codex.CodexSubprocessTransport"
             return self
 
+        if self.cli_type == "codex-ws":
+            self.transport_adapter = "skuld.transports.codex_ws.CodexWebSocketTransport"
+            return self
+
         if self.transport == "subprocess":
             self.transport_adapter = "skuld.transports.subprocess.SubprocessTransport"
 

--- a/src/skuld/transports/__init__.py
+++ b/src/skuld/transports/__init__.py
@@ -185,12 +185,14 @@ from skuld.transports.codex import (  # noqa: E402
     CodexSubprocessTransport,
     _map_codex_tool,
 )
+from skuld.transports.codex_ws import CodexWebSocketTransport  # noqa: E402
 from skuld.transports.sdk_websocket import SdkWebSocketTransport  # noqa: E402
 from skuld.transports.subprocess import SubprocessTransport  # noqa: E402
 
 __all__ = [
     "CLITransport",
     "CodexSubprocessTransport",
+    "CodexWebSocketTransport",
     "EventCallback",
     "SdkWebSocketTransport",
     "SubprocessTransport",

--- a/src/skuld/transports/__init__.py
+++ b/src/skuld/transports/__init__.py
@@ -186,6 +186,7 @@ from skuld.transports.codex import (  # noqa: E402
     _map_codex_tool,
 )
 from skuld.transports.codex_ws import CodexWebSocketTransport  # noqa: E402
+from skuld.transports.opencode import OpenCodeHttpTransport  # noqa: E402
 from skuld.transports.sdk_websocket import SdkWebSocketTransport  # noqa: E402
 from skuld.transports.subprocess import SubprocessTransport  # noqa: E402
 
@@ -194,6 +195,7 @@ __all__ = [
     "CodexSubprocessTransport",
     "CodexWebSocketTransport",
     "EventCallback",
+    "OpenCodeHttpTransport",
     "SdkWebSocketTransport",
     "SubprocessTransport",
     "TransportCapabilities",

--- a/src/skuld/transports/__init__.py
+++ b/src/skuld/transports/__init__.py
@@ -169,12 +169,12 @@ async def _stop_process(process: asyncio.subprocess.Process) -> None:
     if process.returncode is not None:
         return
 
-    logger.info("Stopping Claude Code CLI")
+    logger.info("Stopping CLI process (pid=%s)", process.pid)
     process.terminate()
     try:
         await asyncio.wait_for(process.wait(), timeout=5.0)
     except TimeoutError:
-        logger.warning("Claude Code CLI did not terminate, killing")
+        logger.warning("CLI process did not terminate (pid=%s), killing", process.pid)
         process.kill()
         await process.wait()
 

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -222,7 +222,7 @@ class CodexWebSocketTransport(CLITransport):
             "initialize",
             {
                 "clientInfo": {"name": "skuld", "version": "1.0.0"},
-                "capabilities": {"experimentalApi": False},
+                "capabilities": {"experimentalApi": True},
             },
         )
         logger.info("Codex initialize response: %s", result)

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -618,10 +618,8 @@ class CodexWebSocketTransport(CLITransport):
             return
 
         if item_type == "agentMessage":
-            # The final text may include content not sent via deltas.
-            text = item.get("text", "")
-            if text:
-                await self._emit_text_delta(text)
+            # The full text was already streamed via item/agentMessage/delta
+            # notifications, so just close the block without re-emitting.
             await self._emit_content_block_stop()
             return
 

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -240,7 +240,11 @@ class CodexWebSocketTransport(CLITransport):
             thread_params["approvalPolicy"] = "never"
             thread_params["sandbox"] = "danger-full-access"
         if self._system_prompt:
-            thread_params["developerInstructions"] = self._system_prompt
+            # baseInstructions = role/persona ("you are a service developer…")
+            # developerInstructions = per-session task instructions
+            # Skuld provides a single system_prompt that combines both,
+            # so we set it as baseInstructions (persistent identity).
+            thread_params["baseInstructions"] = self._system_prompt
 
         result = await self._send_rpc("thread/start", thread_params)
         # The response triggers a thread/started notification with the thread info.

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -499,7 +499,7 @@ class CodexWebSocketTransport(CLITransport):
 
         # Default: auto-approve unknown requests
         logger.debug("Auto-approving Codex server request: %s", method)
-        await self._send_rpc_response(rid, {"decision": "allow"})
+        await self._send_rpc_response(rid, {"decision": "accept"})
 
     async def _send_rpc_response(self, rid: int, result: dict) -> None:
         """Send a JSON-RPC response for a server-initiated request."""
@@ -662,7 +662,7 @@ class CodexWebSocketTransport(CLITransport):
         self._block_index = 0
         params: dict = {
             "threadId": self._thread_id,
-            "input": [{"type": "text", "text": content, "text_elements": []}],
+            "input": [{"type": "text", "text": content, "textElements": []}],
         }
         if self._model:
             params["model"] = self._model
@@ -677,9 +677,13 @@ class CodexWebSocketTransport(CLITransport):
             logger.warning("No pending approval for request_id=%s", request_id)
             return
 
-        # Map broker permission response to Codex approval decision
+        # Map broker permission response to Codex approval decision.
+        # Codex uses camelCase enum variants: accept, acceptForSession, decline, cancel.
         behavior = response.get("behavior", "allow")
-        decision = "allow" if behavior == "allow" else "deny"
+        if behavior in ("allow", "allowForever"):
+            decision = "accept"
+        else:
+            decision = "decline"
         await self._send_rpc_response(rid, {"decision": decision})
 
     async def send_control(self, subtype: str, **kwargs: object) -> None:

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -85,10 +85,14 @@ class CodexWebSocketTransport(CLITransport):
         self._thread_id: str | None = None
         self._current_turn_id: str | None = None
         self._last_result: dict | None = None
+        self._last_usage: dict | None = None
         self._alive = False
+        self._block_index: int = 0
 
         # Pending RPC response futures keyed by request id.
         self._pending: dict[int, asyncio.Future] = {}
+        # Pending approval RPC ids keyed by string request_id.
+        self._pending_approvals: dict[str, int] = {}
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -328,65 +332,80 @@ class CodexWebSocketTransport(CLITransport):
             await self._handle_server_request(data)
             return
 
-        # --- Notifications ---
+        # --- Streaming text ---
         if method == "item/agentMessage/delta":
             await self._emit_text_delta(params.get("delta", ""))
             return
 
-        if method == "item/reasoning/textDelta":
+        # --- Reasoning / thinking ---
+        if method in ("item/reasoning/textDelta", "item/reasoning/summaryTextDelta"):
             delta = params.get("delta", "")
             if delta:
-                event = {
-                    "type": "content_block_delta",
-                    "delta": {"type": "thinking_delta", "thinking": delta},
-                }
-                await self._emit(event)
+                await self._emit(
+                    {
+                        "type": "content_block_delta",
+                        "delta": {"type": "thinking_delta", "thinking": delta},
+                    }
+                )
             return
 
-        if method == "item/reasoning/summaryTextDelta":
-            delta = params.get("delta", "")
-            if delta:
-                event = {
-                    "type": "content_block_delta",
-                    "delta": {"type": "thinking_delta", "thinking": delta},
-                }
-                await self._emit(event)
-            return
-
+        # --- Turn lifecycle ---
         if method == "turn/started":
             turn = params.get("turn", {})
             self._current_turn_id = turn.get("id")
+            self._block_index = 0
+            # Emit an assistant event to signal a new streaming message.
+            # The browser uses this to create a new message with status 'running'.
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "model": self._model,
+                        "content": [],
+                    },
+                }
+            )
             return
 
         if method == "turn/completed":
             self._current_turn_id = None
-            # Emit a result event
+            # Merge saved usage into result event.
+            usage = self._last_usage or {}
             self._last_result = {
                 "type": "result",
                 "stop_reason": "end_turn",
-                "modelUsage": {},
+                "modelUsage": usage,
             }
             await self._emit(self._last_result)
             return
 
+        # --- Token usage (arrives before turn/completed) ---
         if method == "thread/tokenUsage/updated":
             usage = params.get("tokenUsage", {})
             total = usage.get("total", {})
+            last = usage.get("last", {})
             model_id = self._model
-            self._last_result = {
-                "type": "result",
-                "stop_reason": "end_turn",
-                "modelUsage": {
-                    model_id: {
-                        "inputTokens": total.get("inputTokens", 0),
-                        "outputTokens": total.get("outputTokens", 0),
-                        "cacheReadInputTokens": total.get("cachedInputTokens", 0),
-                        "cacheCreationInputTokens": 0,
-                    }
-                },
+            self._last_usage = {
+                model_id: {
+                    "inputTokens": last.get("inputTokens", 0) or total.get("inputTokens", 0),
+                    "outputTokens": last.get("outputTokens", 0) or total.get("outputTokens", 0),
+                    "cacheReadInputTokens": last.get("cachedInputTokens", 0)
+                    or total.get("cachedInputTokens", 0),
+                    "cacheCreationInputTokens": 0,
+                }
             }
+            # Emit message_delta so the browser can update token counters live.
+            output_tokens = last.get("outputTokens", 0) or total.get("outputTokens", 0)
+            if output_tokens:
+                await self._emit(
+                    {
+                        "type": "message_delta",
+                        "usage": {"output_tokens": output_tokens},
+                    }
+                )
             return
 
+        # --- Item lifecycle (tool calls, agent text blocks) ---
         if method == "item/started":
             item = params.get("item", {})
             await self._handle_item_started(item)
@@ -397,6 +416,7 @@ class CodexWebSocketTransport(CLITransport):
             await self._handle_item_completed(item)
             return
 
+        # --- Command / file output deltas (show in chat as text) ---
         if method == "item/commandExecution/outputDelta":
             delta = params.get("delta", "")
             if delta:
@@ -409,13 +429,15 @@ class CodexWebSocketTransport(CLITransport):
                 await self._emit_text_delta(delta)
             return
 
+        # --- Errors ---
         if method == "error":
             error = params.get("error", {})
             message = error.get("message", str(params))
             logger.warning("Codex error notification: %s", message)
-            await self._emit({"type": "error", "content": message})
+            await self._emit({"type": "error", "error": message})
             return
 
+        # --- Thread lifecycle ---
         if method == "thread/started":
             thread = params.get("thread", {})
             tid = thread.get("id")
@@ -423,10 +445,7 @@ class CodexWebSocketTransport(CLITransport):
                 self._thread_id = tid
             return
 
-        if method == "thread/status/changed":
-            return  # Informational, no action needed
-
-        if method == "thread/name/updated":
+        if method in ("thread/status/changed", "thread/name/updated"):
             return  # Informational
 
         if method == "thread/closed":
@@ -446,7 +465,6 @@ class CodexWebSocketTransport(CLITransport):
         params = data.get("params", {})
 
         if method == "item/commandExecution/requestApproval":
-            # Emit as permission request to browser
             request_id = str(rid)
             command = params.get("command", "")
             await self._emit(
@@ -458,8 +476,6 @@ class CodexWebSocketTransport(CLITransport):
                     "input": {"command": command},
                 }
             )
-            # Store the RPC id so send_control_response can reply
-            self._pending_approvals: dict[str, int] = getattr(self, "_pending_approvals", {})
             self._pending_approvals[request_id] = rid
             return
 
@@ -478,7 +494,6 @@ class CodexWebSocketTransport(CLITransport):
                     "input": params,
                 }
             )
-            self._pending_approvals = getattr(self, "_pending_approvals", {})
             self._pending_approvals[request_id] = rid
             return
 
@@ -494,104 +509,128 @@ class CodexWebSocketTransport(CLITransport):
         await self._ws.send(json.dumps(msg))
 
     # ------------------------------------------------------------------
-    # Item handling (tool calls)
+    # Item handling (tool calls, agent text, reasoning)
     # ------------------------------------------------------------------
 
-    async def _handle_item_started(self, item: dict) -> None:
-        """Emit a tool_use event when an item starts."""
-        item_type = item.get("type", "")
+    def _next_block_index(self) -> int:
+        """Return and increment the content block index for this turn."""
+        idx = self._block_index
+        self._block_index += 1
+        return idx
 
-        if item_type == "commandExecution":
-            await self._emit(
-                {
-                    "type": "assistant",
+    async def _emit_content_block_start(self, block: dict) -> None:
+        """Emit a content_block_start event with the given block descriptor."""
+        idx = self._next_block_index()
+        await self._emit(
+            {
+                "type": "content_block_start",
+                "index": idx,
+                "content_block": block,
+            }
+        )
+
+    async def _emit_content_block_stop(self) -> None:
+        """Emit a content_block_stop event."""
+        await self._emit({"type": "content_block_stop"})
+
+    async def _emit_tool_use(self, item_id: str, name: str, tool_input: dict) -> None:
+        """Emit an assistant event (for broker tracking) + content_block lifecycle (for browser).
+
+        The broker reads ``assistant.message.content`` to track artifacts.
+        The browser renders via ``content_block_start/delta/stop``.
+        Both are needed.
+        """
+        # Broker-facing: assistant event with message.content
+        await self._emit(
+            {
+                "type": "assistant",
+                "message": {
+                    "model": self._model,
                     "content": [
                         {
                             "type": "tool_use",
-                            "name": "Bash",
-                            "input": {"command": item.get("command", "")},
+                            "id": item_id,
+                            "name": name,
+                            "input": tool_input,
                         }
                     ],
-                }
-            )
+                },
+            }
+        )
+        # Browser-facing: content_block lifecycle
+        await self._emit_content_block_start({"type": "tool_use", "id": item_id, "name": name})
+        input_json = json.dumps(tool_input)
+        await self._emit(
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "input_json_delta", "partial_json": input_json},
+            }
+        )
+
+    async def _handle_item_started(self, item: dict) -> None:
+        """Emit proper content_block lifecycle events when an item starts."""
+        item_type = item.get("type", "")
+        item_id = item.get("id", "")
+
+        if item_type == "commandExecution":
+            await self._emit_tool_use(item_id, "Bash", {"command": item.get("command", "")})
             return
 
         if item_type == "fileChange":
-            changes = item.get("changes", [])
-            await self._emit(
-                {
-                    "type": "assistant",
-                    "content": [
-                        {
-                            "type": "tool_use",
-                            "name": "Edit",
-                            "input": {"changes": changes},
-                        }
-                    ],
-                }
-            )
+            await self._emit_tool_use(item_id, "Edit", {"changes": item.get("changes", [])})
             return
 
         if item_type == "mcpToolCall":
             tool = item.get("tool", "")
             args = item.get("arguments", {})
             normalized = _map_codex_tool(tool)
-            await self._emit(
-                {
-                    "type": "assistant",
-                    "content": [
-                        {
-                            "type": "tool_use",
-                            "name": normalized,
-                            "input": args if isinstance(args, dict) else {},
-                        }
-                    ],
-                }
-            )
+            await self._emit_tool_use(item_id, normalized, args if isinstance(args, dict) else {})
             return
 
         if item_type == "agentMessage":
-            # Start of agent text — nothing to emit yet, deltas follow
+            # Start a text content block — deltas will follow via agentMessage/delta.
+            await self._emit_content_block_start({"type": "text"})
             return
 
         if item_type == "reasoning":
+            await self._emit_content_block_start({"type": "thinking"})
             return
 
         if item_type == "webSearch":
-            await self._emit(
-                {
-                    "type": "assistant",
-                    "content": [
-                        {
-                            "type": "tool_use",
-                            "name": "WebSearch",
-                            "input": {"query": item.get("query", "")},
-                        }
-                    ],
-                }
-            )
+            await self._emit_tool_use(item_id, "WebSearch", {"query": item.get("query", "")})
             return
 
     async def _handle_item_completed(self, item: dict) -> None:
-        """Emit tool result events when an item completes."""
+        """Emit content_block_stop and any final content when an item completes."""
         item_type = item.get("type", "")
 
         if item_type == "commandExecution":
+            # Close the tool_use block
+            await self._emit_content_block_stop()
+            # Emit the output as a text block so the user sees the result
             output = item.get("aggregatedOutput", "")
-            exit_code = item.get("exitCode", 0)
-            await self._emit(
-                {
-                    "type": "tool_result",
-                    "content": output,
-                    "is_error": exit_code != 0,
-                }
-            )
+            if output:
+                await self._emit_content_block_start({"type": "text"})
+                exit_code = item.get("exitCode", 0)
+                prefix = "" if exit_code == 0 else f"[exit code {exit_code}] "
+                await self._emit_text_delta(prefix + output)
+                await self._emit_content_block_stop()
             return
 
         if item_type == "agentMessage":
+            # The final text may include content not sent via deltas.
             text = item.get("text", "")
             if text:
                 await self._emit_text_delta(text)
+            await self._emit_content_block_stop()
+            return
+
+        if item_type == "reasoning":
+            await self._emit_content_block_stop()
+            return
+
+        if item_type in ("fileChange", "mcpToolCall", "webSearch"):
+            await self._emit_content_block_stop()
             return
 
     # ------------------------------------------------------------------
@@ -619,6 +658,8 @@ class CodexWebSocketTransport(CLITransport):
             raise RuntimeError("No active thread — call start() first")
 
         self._last_result = None
+        self._last_usage = None
+        self._block_index = 0
         params: dict = {
             "threadId": self._thread_id,
             "input": [{"type": "text", "text": content, "text_elements": []}],
@@ -631,8 +672,7 @@ class CodexWebSocketTransport(CLITransport):
 
     async def send_control_response(self, request_id: str, response: dict) -> None:
         """Respond to a Codex approval request."""
-        approvals: dict[str, int] = getattr(self, "_pending_approvals", {})
-        rid = approvals.pop(request_id, None)
+        rid = self._pending_approvals.pop(request_id, None)
         if rid is None:
             logger.warning("No pending approval for request_id=%s", request_id)
             return

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -1,0 +1,730 @@
+"""CodexWebSocketTransport — Codex app-server over WebSocket (JSON-RPC 2.0).
+
+Spawns ``codex app-server --listen ws://127.0.0.1:{port}`` and connects to it
+as a WebSocket client.  Communication uses JSON-RPC 2.0 (requests, responses,
+notifications) rather than the NDJSON protocol used by Claude's ``--sdk-url``.
+
+The direction is reversed compared to SdkWebSocketTransport: here Skuld is the
+*client* connecting to the Codex app-server, whereas with Claude the CLI
+connects back to Skuld.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from itertools import count
+
+import websockets
+from websockets.asyncio.client import ClientConnection
+
+from skuld.transports import (
+    CLITransport,
+    TransportCapabilities,
+    _drain_stream,
+    _filter_event,
+    _stop_process,
+)
+from skuld.transports.codex import _map_codex_tool
+
+logger = logging.getLogger("skuld.transport")
+
+# Monotonic request-ID generator for JSON-RPC calls.
+_next_id = count(1)
+
+
+def _rpc_request(method: str, params: dict | None = None) -> tuple[int, dict]:
+    """Build a JSON-RPC 2.0 request and return (id, message)."""
+    rid = next(_next_id)
+    msg: dict = {"jsonrpc": "2.0", "id": rid, "method": method}
+    if params is not None:
+        msg["params"] = params
+    return rid, msg
+
+
+def _rpc_notification(method: str) -> dict:
+    """Build a JSON-RPC 2.0 notification (no id, no response expected)."""
+    return {"jsonrpc": "2.0", "method": method}
+
+
+class CodexWebSocketTransport(CLITransport):
+    """Long-lived Codex app-server process controlled via WebSocket JSON-RPC.
+
+    Lifecycle:
+        1. ``start()`` spawns ``codex app-server --listen ws://127.0.0.1:{port}``
+        2. Skuld connects to the server as a WebSocket client
+        3. JSON-RPC ``initialize`` handshake, then ``thread/start``
+        4. User messages are sent via ``turn/start``
+        5. Streaming events arrive as JSON-RPC notifications
+
+    Authentication: set ``OPENAI_API_KEY`` in the environment.
+    """
+
+    def __init__(
+        self,
+        workspace_dir: str,
+        *,
+        model: str = "o4-mini",
+        skip_permissions: bool = True,
+        system_prompt: str = "",
+        initial_prompt: str = "",
+        codex_port: int = 0,
+        **_kwargs: object,
+    ) -> None:
+        super().__init__()
+        self.workspace_dir = workspace_dir
+        self._model = model
+        self._skip_permissions = skip_permissions
+        self._system_prompt = system_prompt
+        self._initial_prompt = initial_prompt
+        self._codex_port = codex_port or _pick_free_port()
+
+        self._process: asyncio.subprocess.Process | None = None
+        self._ws: ClientConnection | None = None
+        self._receive_task: asyncio.Task | None = None
+        self._thread_id: str | None = None
+        self._current_turn_id: str | None = None
+        self._last_result: dict | None = None
+        self._alive = False
+
+        # Pending RPC response futures keyed by request id.
+        self._pending: dict[int, asyncio.Future] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        await self._spawn_app_server()
+        await self._connect_ws()
+        await self._handshake()
+
+        if self._initial_prompt:
+            await self.send_message(self._initial_prompt)
+
+    async def stop(self) -> None:
+        self._alive = False
+
+        if self._receive_task and not self._receive_task.done():
+            self._receive_task.cancel()
+
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception as exc:
+                logger.debug("Error closing Codex WS: %r", exc)
+            self._ws = None
+
+        if self._process:
+            await _stop_process(self._process)
+            self._process = None
+
+        # Cancel any awaiting RPC futures.
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.cancel()
+        self._pending.clear()
+
+        logger.info("CodexWebSocketTransport stopped")
+
+    # ------------------------------------------------------------------
+    # Spawn & connect
+    # ------------------------------------------------------------------
+
+    async def _spawn_app_server(self) -> None:
+        listen_url = f"ws://127.0.0.1:{self._codex_port}"
+
+        cmd = [
+            "codex",
+            "app-server",
+            "--listen",
+            listen_url,
+        ]
+
+        env = dict(os.environ)
+        if "OPENAI_API_KEY" not in env:
+            logger.warning("OPENAI_API_KEY not found — Codex app-server may fail to authenticate")
+
+        logger.info("Spawning Codex app-server on %s", listen_url)
+        self._process = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=self.workspace_dir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        logger.info("Codex app-server PID %s", self._process.pid)
+
+        asyncio.create_task(_drain_stream(self._process.stdout, "codex-app-stdout"))
+        asyncio.create_task(_drain_stream(self._process.stderr, "codex-app-stderr"))
+
+    async def _connect_ws(self) -> None:
+        """Connect to the Codex app-server with retries."""
+        url = f"ws://127.0.0.1:{self._codex_port}"
+        max_attempts = 30
+        for attempt in range(1, max_attempts + 1):
+            if self._process and self._process.returncode is not None:
+                raise RuntimeError(f"Codex app-server exited with code {self._process.returncode}")
+            try:
+                self._ws = await websockets.connect(url)
+                logger.info("Connected to Codex app-server (attempt %d)", attempt)
+                self._alive = True
+                self._receive_task = asyncio.create_task(self._receive_loop())
+                return
+            except (OSError, websockets.exceptions.InvalidHandshake):
+                if attempt == max_attempts:
+                    raise RuntimeError(
+                        f"Could not connect to Codex app-server at {url} "
+                        f"after {max_attempts} attempts"
+                    )
+                await asyncio.sleep(0.5)
+
+    # ------------------------------------------------------------------
+    # JSON-RPC helpers
+    # ------------------------------------------------------------------
+
+    async def _send_rpc(self, method: str, params: dict | None = None) -> dict:
+        """Send a JSON-RPC request and wait for the response."""
+        if not self._ws:
+            raise RuntimeError("WebSocket not connected")
+
+        rid, msg = _rpc_request(method, params)
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future[dict] = loop.create_future()
+        self._pending[rid] = fut
+
+        await self._ws.send(json.dumps(msg))
+        logger.debug("RPC → %s id=%d", method, rid)
+
+        try:
+            return await asyncio.wait_for(fut, timeout=60.0)
+        except TimeoutError:
+            self._pending.pop(rid, None)
+            raise RuntimeError(f"RPC timeout for {method} (id={rid})")
+
+    async def _send_notification(self, method: str) -> None:
+        """Send a JSON-RPC notification (fire-and-forget)."""
+        if not self._ws:
+            return
+        await self._ws.send(json.dumps(_rpc_notification(method)))
+
+    # ------------------------------------------------------------------
+    # Handshake
+    # ------------------------------------------------------------------
+
+    async def _handshake(self) -> None:
+        """Perform initialize + initialized + thread/start."""
+        result = await self._send_rpc(
+            "initialize",
+            {
+                "clientInfo": {"name": "skuld", "version": "1.0.0"},
+                "capabilities": {"experimentalApi": False},
+            },
+        )
+        logger.info("Codex initialize response: %s", result)
+
+        await self._send_notification("initialized")
+
+        thread_params: dict = {
+            "experimentalRawEvents": False,
+            "persistExtendedHistory": True,
+            "cwd": self.workspace_dir,
+        }
+        if self._model:
+            thread_params["model"] = self._model
+        if self._skip_permissions:
+            thread_params["approvalPolicy"] = "never"
+            thread_params["sandbox"] = "danger-full-access"
+        if self._system_prompt:
+            thread_params["developerInstructions"] = self._system_prompt
+
+        result = await self._send_rpc("thread/start", thread_params)
+        # The response triggers a thread/started notification with the thread info.
+        # But the RPC response itself may contain the thread_id.
+        thread = result.get("thread", {})
+        self._thread_id = thread.get("id") or result.get("threadId")
+        logger.info("Codex thread started: %s", self._thread_id)
+
+        # Emit a synthetic init event so the broker knows we're ready.
+        await self._emit(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": self._thread_id,
+                "model": self._model,
+                "tools": [],
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Receive loop
+    # ------------------------------------------------------------------
+
+    async def _receive_loop(self) -> None:
+        """Read JSON-RPC messages from the Codex WebSocket."""
+        logger.info("Codex WS receive loop started")
+        msg_count = 0
+        try:
+            async for raw in self._ws:
+                if isinstance(raw, bytes):
+                    raw = raw.decode("utf-8", errors="replace")
+
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.warning("Non-JSON from Codex WS: %.200s", raw)
+                    continue
+
+                msg_count += 1
+
+                # JSON-RPC response (has "id" + "result" or "error")
+                if "id" in data and ("result" in data or "error" in data):
+                    self._resolve_pending(data)
+                    continue
+
+                # JSON-RPC notification or server request (has "method")
+                if "method" in data:
+                    await self._handle_server_message(data)
+                    continue
+
+                logger.debug("Codex WS unknown frame: %.200s", raw)
+
+        except websockets.exceptions.ConnectionClosed as exc:
+            logger.info("Codex WS closed: %s", exc)
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.warning("Codex WS receive error: %r", exc, exc_info=True)
+        finally:
+            self._alive = False
+            logger.info("Codex WS receive loop ended after %d messages", msg_count)
+
+    def _resolve_pending(self, data: dict) -> None:
+        """Match a JSON-RPC response to its pending future."""
+        rid = data.get("id")
+        fut = self._pending.pop(rid, None)
+        if not fut or fut.done():
+            return
+
+        if "error" in data:
+            err = data["error"]
+            fut.set_exception(RuntimeError(f"RPC error {err.get('code')}: {err.get('message')}"))
+            return
+
+        fut.set_result(data.get("result", {}))
+
+    # ------------------------------------------------------------------
+    # Server message dispatch
+    # ------------------------------------------------------------------
+
+    async def _handle_server_message(self, data: dict) -> None:
+        """Dispatch a JSON-RPC notification or server-request from Codex."""
+        method = data.get("method", "")
+        params = data.get("params", {})
+        logger.debug("Codex notification: %s", method)
+
+        # --- Server requests (need a response) ---
+        if "id" in data:
+            await self._handle_server_request(data)
+            return
+
+        # --- Notifications ---
+        if method == "item/agentMessage/delta":
+            await self._emit_text_delta(params.get("delta", ""))
+            return
+
+        if method == "item/reasoning/textDelta":
+            delta = params.get("delta", "")
+            if delta:
+                event = {
+                    "type": "content_block_delta",
+                    "delta": {"type": "thinking_delta", "thinking": delta},
+                }
+                await self._emit(event)
+            return
+
+        if method == "item/reasoning/summaryTextDelta":
+            delta = params.get("delta", "")
+            if delta:
+                event = {
+                    "type": "content_block_delta",
+                    "delta": {"type": "thinking_delta", "thinking": delta},
+                }
+                await self._emit(event)
+            return
+
+        if method == "turn/started":
+            turn = params.get("turn", {})
+            self._current_turn_id = turn.get("id")
+            return
+
+        if method == "turn/completed":
+            self._current_turn_id = None
+            # Emit a result event
+            self._last_result = {
+                "type": "result",
+                "stop_reason": "end_turn",
+                "modelUsage": {},
+            }
+            await self._emit(self._last_result)
+            return
+
+        if method == "thread/tokenUsage/updated":
+            usage = params.get("tokenUsage", {})
+            total = usage.get("total", {})
+            model_id = self._model
+            self._last_result = {
+                "type": "result",
+                "stop_reason": "end_turn",
+                "modelUsage": {
+                    model_id: {
+                        "inputTokens": total.get("inputTokens", 0),
+                        "outputTokens": total.get("outputTokens", 0),
+                        "cacheReadInputTokens": total.get("cachedInputTokens", 0),
+                        "cacheCreationInputTokens": 0,
+                    }
+                },
+            }
+            return
+
+        if method == "item/started":
+            item = params.get("item", {})
+            await self._handle_item_started(item)
+            return
+
+        if method == "item/completed":
+            item = params.get("item", {})
+            await self._handle_item_completed(item)
+            return
+
+        if method == "item/commandExecution/outputDelta":
+            delta = params.get("delta", "")
+            if delta:
+                await self._emit_text_delta(delta)
+            return
+
+        if method == "item/fileChange/outputDelta":
+            delta = params.get("delta", "")
+            if delta:
+                await self._emit_text_delta(delta)
+            return
+
+        if method == "error":
+            error = params.get("error", {})
+            message = error.get("message", str(params))
+            logger.warning("Codex error notification: %s", message)
+            await self._emit({"type": "error", "content": message})
+            return
+
+        if method == "thread/started":
+            thread = params.get("thread", {})
+            tid = thread.get("id")
+            if tid:
+                self._thread_id = tid
+            return
+
+        if method == "thread/status/changed":
+            return  # Informational, no action needed
+
+        if method == "thread/name/updated":
+            return  # Informational
+
+        if method == "thread/closed":
+            self._alive = False
+            return
+
+        logger.debug("Codex: unhandled notification %s", method)
+
+    # ------------------------------------------------------------------
+    # Server requests (approval callbacks)
+    # ------------------------------------------------------------------
+
+    async def _handle_server_request(self, data: dict) -> None:
+        """Handle a server-initiated request that needs a response."""
+        method = data.get("method", "")
+        rid = data["id"]
+        params = data.get("params", {})
+
+        if method == "item/commandExecution/requestApproval":
+            # Emit as permission request to browser
+            request_id = str(rid)
+            command = params.get("command", "")
+            await self._emit(
+                {
+                    "type": "control_request",
+                    "subtype": "can_use_tool",
+                    "request_id": request_id,
+                    "tool": "Bash",
+                    "input": {"command": command},
+                }
+            )
+            # Store the RPC id so send_control_response can reply
+            self._pending_approvals: dict[str, int] = getattr(self, "_pending_approvals", {})
+            self._pending_approvals[request_id] = rid
+            return
+
+        if method in (
+            "item/fileChange/requestApproval",
+            "item/permissions/requestApproval",
+            "applyPatchApproval",
+        ):
+            request_id = str(rid)
+            await self._emit(
+                {
+                    "type": "control_request",
+                    "subtype": "can_use_tool",
+                    "request_id": request_id,
+                    "tool": "Edit",
+                    "input": params,
+                }
+            )
+            self._pending_approvals = getattr(self, "_pending_approvals", {})
+            self._pending_approvals[request_id] = rid
+            return
+
+        # Default: auto-approve unknown requests
+        logger.debug("Auto-approving Codex server request: %s", method)
+        await self._send_rpc_response(rid, {"decision": "allow"})
+
+    async def _send_rpc_response(self, rid: int, result: dict) -> None:
+        """Send a JSON-RPC response for a server-initiated request."""
+        if not self._ws:
+            return
+        msg = {"jsonrpc": "2.0", "id": rid, "result": result}
+        await self._ws.send(json.dumps(msg))
+
+    # ------------------------------------------------------------------
+    # Item handling (tool calls)
+    # ------------------------------------------------------------------
+
+    async def _handle_item_started(self, item: dict) -> None:
+        """Emit a tool_use event when an item starts."""
+        item_type = item.get("type", "")
+
+        if item_type == "commandExecution":
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Bash",
+                            "input": {"command": item.get("command", "")},
+                        }
+                    ],
+                }
+            )
+            return
+
+        if item_type == "fileChange":
+            changes = item.get("changes", [])
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Edit",
+                            "input": {"changes": changes},
+                        }
+                    ],
+                }
+            )
+            return
+
+        if item_type == "mcpToolCall":
+            tool = item.get("tool", "")
+            args = item.get("arguments", {})
+            normalized = _map_codex_tool(tool)
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": normalized,
+                            "input": args if isinstance(args, dict) else {},
+                        }
+                    ],
+                }
+            )
+            return
+
+        if item_type == "agentMessage":
+            # Start of agent text — nothing to emit yet, deltas follow
+            return
+
+        if item_type == "reasoning":
+            return
+
+        if item_type == "webSearch":
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "WebSearch",
+                            "input": {"query": item.get("query", "")},
+                        }
+                    ],
+                }
+            )
+            return
+
+    async def _handle_item_completed(self, item: dict) -> None:
+        """Emit tool result events when an item completes."""
+        item_type = item.get("type", "")
+
+        if item_type == "commandExecution":
+            output = item.get("aggregatedOutput", "")
+            exit_code = item.get("exitCode", 0)
+            await self._emit(
+                {
+                    "type": "tool_result",
+                    "content": output,
+                    "is_error": exit_code != 0,
+                }
+            )
+            return
+
+        if item_type == "agentMessage":
+            text = item.get("text", "")
+            if text:
+                await self._emit_text_delta(text)
+            return
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _emit_text_delta(self, text: str) -> None:
+        """Emit a text delta event, filtering empties."""
+        if not text:
+            return
+        event = {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": text},
+        }
+        filtered = _filter_event(event)
+        if filtered:
+            await self._emit(filtered)
+
+    # ------------------------------------------------------------------
+    # CLITransport interface
+    # ------------------------------------------------------------------
+
+    async def send_message(self, content: str) -> None:
+        if not self._thread_id:
+            raise RuntimeError("No active thread — call start() first")
+
+        self._last_result = None
+        params: dict = {
+            "threadId": self._thread_id,
+            "input": [{"type": "text", "text": content, "text_elements": []}],
+        }
+        if self._model:
+            params["model"] = self._model
+
+        logger.info("Sending turn/start to Codex (thread=%s)", self._thread_id)
+        await self._send_rpc("turn/start", params)
+
+    async def send_control_response(self, request_id: str, response: dict) -> None:
+        """Respond to a Codex approval request."""
+        approvals: dict[str, int] = getattr(self, "_pending_approvals", {})
+        rid = approvals.pop(request_id, None)
+        if rid is None:
+            logger.warning("No pending approval for request_id=%s", request_id)
+            return
+
+        # Map broker permission response to Codex approval decision
+        behavior = response.get("behavior", "allow")
+        decision = "allow" if behavior == "allow" else "deny"
+        await self._send_rpc_response(rid, {"decision": decision})
+
+    async def send_control(self, subtype: str, **kwargs: object) -> None:
+        """Handle control messages (interrupt, set_model, etc.)."""
+        if subtype == "interrupt":
+            if self._thread_id and self._current_turn_id:
+                await self._send_rpc(
+                    "turn/interrupt",
+                    {
+                        "threadId": self._thread_id,
+                        "turnId": self._current_turn_id,
+                    },
+                )
+            return
+
+        if subtype == "set_model":
+            model = kwargs.get("model")
+            if model and isinstance(model, str):
+                self._model = model
+            return
+
+        logger.debug("Codex WS: unhandled control subtype=%s", subtype)
+
+    @property
+    def session_id(self) -> str | None:
+        return self._thread_id
+
+    @property
+    def last_result(self) -> dict | None:
+        return self._last_result
+
+    @property
+    def is_alive(self) -> bool:
+        return self._alive
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(
+            cli_websocket=False,  # We don't expose a /ws/cli endpoint
+            session_resume=True,
+            interrupt=True,
+            set_model=True,
+            set_thinking_tokens=False,
+            set_permission_mode=False,
+            rewind_files=False,
+            mcp_set_servers=False,
+            permission_requests=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Session resume
+    # ------------------------------------------------------------------
+
+    async def resume(self, thread_id: str) -> None:
+        """Resume a previous Codex thread."""
+        params: dict = {
+            "threadId": thread_id,
+            "persistExtendedHistory": True,
+        }
+        if self._model:
+            params["model"] = self._model
+        if self._skip_permissions:
+            params["approvalPolicy"] = "never"
+            params["sandbox"] = "danger-full-access"
+
+        result = await self._send_rpc("thread/resume", params)
+        thread = result.get("thread", {})
+        self._thread_id = thread.get("id") or thread_id
+        logger.info("Codex thread resumed: %s", self._thread_id)
+
+        await self._emit(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": self._thread_id,
+                "model": self._model,
+                "tools": [],
+            }
+        )
+
+
+def _pick_free_port() -> int:
+    """Pick an available TCP port."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]

--- a/src/skuld/transports/opencode.py
+++ b/src/skuld/transports/opencode.py
@@ -71,6 +71,9 @@ class OpenCodeHttpTransport(CLITransport):
         self._block_index: int = 0
         self._pending_permissions: dict[str, dict] = {}
         self._user_message_ids: set[str] = set()
+        # Track partIDs that are reasoning/thinking so we route their
+        # deltas correctly even when the field name is ambiguous.
+        self._reasoning_part_ids: set[str] = set()
 
     @property
     def _base_url(self) -> str:
@@ -242,11 +245,15 @@ class OpenCodeHttpTransport(CLITransport):
             # Skip deltas for user messages (echoed prompt)
             if props.get("messageID", "") in self._user_message_ids:
                 return
+            part_id = props.get("partID", "")
             field = props.get("field", "")
             delta = props.get("delta", "")
             if not delta:
                 return
-            if field == "thinking":
+            # Route as thinking if the field says so OR if this partID
+            # was registered as a reasoning part.
+            is_thinking = field == "thinking" or part_id in self._reasoning_part_ids
+            if is_thinking:
                 await self._emit(
                     {
                         "type": "content_block_delta",
@@ -409,6 +416,7 @@ class OpenCodeHttpTransport(CLITransport):
             return
 
         if part_type == "reasoning":
+            self._reasoning_part_ids.add(part_id)
             idx = self._next_block_index()
             await self._emit(
                 {
@@ -462,6 +470,8 @@ class OpenCodeHttpTransport(CLITransport):
         self._last_result = None
         self._last_usage = None
         self._block_index = 0
+        self._user_message_ids.clear()
+        self._reasoning_part_ids.clear()
 
         body: dict = {
             "parts": [{"type": "text", "text": content}],

--- a/src/skuld/transports/opencode.py
+++ b/src/skuld/transports/opencode.py
@@ -1,0 +1,563 @@
+"""OpenCodeHttpTransport — OpenCode (opencode.ai) via HTTP REST + SSE.
+
+Spawns ``opencode serve --port {port}`` and communicates using:
+- **HTTP REST** for commands (create session, send prompt, grant permission)
+- **SSE** (``GET /event``) for streaming events (message deltas, permissions, status)
+
+The SSE stream delivers ``message.part.delta`` events with real-time text
+deltas, plus ``question.asked`` for permission requests and ``session.idle``
+for turn completion.
+"""
+
+import asyncio
+import json
+import logging
+import os
+
+import httpx
+
+from skuld.transports import (
+    CLITransport,
+    TransportCapabilities,
+    _drain_stream,
+    _filter_event,
+    _stop_process,
+)
+from skuld.transports.codex import _map_codex_tool
+
+logger = logging.getLogger("skuld.transport")
+
+
+class OpenCodeHttpTransport(CLITransport):
+    """HTTP REST + SSE transport for OpenCode (opencode.ai).
+
+    Lifecycle:
+        1. ``start()`` spawns ``opencode serve --port {port}``
+        2. Skuld connects via HTTP, creates a session
+        3. User messages sent via ``POST /session/{id}/prompt_async``
+        4. Streaming events arrive via SSE on ``GET /event``
+
+    OpenCode supports multiple LLM providers (Anthropic, OpenAI, Gemini,
+    Ollama) — the model/provider is configured via its own config or
+    passed per-prompt.
+    """
+
+    def __init__(
+        self,
+        workspace_dir: str,
+        *,
+        model: str = "",
+        skip_permissions: bool = True,
+        system_prompt: str = "",
+        initial_prompt: str = "",
+        opencode_port: int = 0,
+        **_kwargs: object,
+    ) -> None:
+        super().__init__()
+        self.workspace_dir = workspace_dir
+        self._model = model
+        self._skip_permissions = skip_permissions
+        self._system_prompt = system_prompt
+        self._initial_prompt = initial_prompt
+        self._opencode_port = opencode_port or _pick_free_port()
+
+        self._process: asyncio.subprocess.Process | None = None
+        self._client: httpx.AsyncClient | None = None
+        self._sse_task: asyncio.Task | None = None
+        self._session_id: str | None = None
+        self._last_result: dict | None = None
+        self._last_usage: dict | None = None
+        self._alive = False
+        self._block_index: int = 0
+        self._pending_permissions: dict[str, dict] = {}
+
+    @property
+    def _base_url(self) -> str:
+        return f"http://127.0.0.1:{self._opencode_port}"
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        await self._spawn_server()
+        await self._connect()
+        await self._create_session()
+
+        if self._initial_prompt:
+            await self.send_message(self._initial_prompt)
+
+    async def stop(self) -> None:
+        self._alive = False
+
+        if self._sse_task and not self._sse_task.done():
+            self._sse_task.cancel()
+
+        if self._client:
+            await self._client.aclose()
+            self._client = None
+
+        if self._process:
+            await _stop_process(self._process)
+            self._process = None
+
+        logger.info("OpenCodeHttpTransport stopped")
+
+    # ------------------------------------------------------------------
+    # Spawn & connect
+    # ------------------------------------------------------------------
+
+    async def _spawn_server(self) -> None:
+        cmd = [
+            "opencode",
+            "serve",
+            "--port",
+            str(self._opencode_port),
+            "--hostname",
+            "127.0.0.1",
+        ]
+
+        env = dict(os.environ)
+        if self._skip_permissions:
+            env["OPENCODE_AUTO_APPROVE"] = "1"
+
+        logger.info("Spawning OpenCode server on port %d", self._opencode_port)
+        self._process = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=self.workspace_dir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        logger.info("OpenCode server PID %s", self._process.pid)
+
+        asyncio.create_task(_drain_stream(self._process.stdout, "opencode-stdout"))
+        asyncio.create_task(_drain_stream(self._process.stderr, "opencode-stderr"))
+
+    async def _connect(self) -> None:
+        """Wait for the OpenCode server to be ready and create HTTP client."""
+        self._client = httpx.AsyncClient(base_url=self._base_url, timeout=60.0)
+        max_attempts = 30
+        for attempt in range(1, max_attempts + 1):
+            if self._process and self._process.returncode is not None:
+                raise RuntimeError(f"OpenCode server exited with code {self._process.returncode}")
+            try:
+                resp = await self._client.get("/global/health")
+                if resp.status_code == 200:
+                    logger.info("OpenCode server ready (attempt %d)", attempt)
+                    self._alive = True
+                    self._sse_task = asyncio.create_task(self._sse_loop())
+                    return
+            except httpx.ConnectError:
+                pass
+            await asyncio.sleep(0.5)
+
+        raise RuntimeError(
+            f"Could not connect to OpenCode server at {self._base_url} "
+            f"after {max_attempts} attempts"
+        )
+
+    # ------------------------------------------------------------------
+    # Session management
+    # ------------------------------------------------------------------
+
+    async def _create_session(self) -> None:
+        """Create a new OpenCode session."""
+        resp = await self._client.post("/session", json={})
+        resp.raise_for_status()
+        data = resp.json()
+        self._session_id = data.get("id") or data.get("sessionID")
+        logger.info("OpenCode session created: %s", self._session_id)
+
+        await self._emit(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": self._session_id,
+                "model": self._model,
+                "tools": [],
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # SSE event loop
+    # ------------------------------------------------------------------
+
+    async def _sse_loop(self) -> None:
+        """Read SSE events from the OpenCode server."""
+        logger.info("OpenCode SSE loop started")
+        url = f"{self._base_url}/event"
+        msg_count = 0
+
+        try:
+            async with httpx.AsyncClient(timeout=None) as sse_client:
+                async with sse_client.stream("GET", url) as response:
+                    buffer = ""
+                    async for chunk in response.aiter_text():
+                        buffer += chunk
+                        while "\n\n" in buffer:
+                            frame, buffer = buffer.split("\n\n", 1)
+                            for line in frame.split("\n"):
+                                if line.startswith("data: "):
+                                    raw = line[6:]
+                                    try:
+                                        event = json.loads(raw)
+                                    except json.JSONDecodeError:
+                                        continue
+                                    msg_count += 1
+                                    await self._handle_sse_event(event)
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.warning("OpenCode SSE loop error: %r", exc, exc_info=True)
+        finally:
+            self._alive = False
+            logger.info("OpenCode SSE loop ended after %d events", msg_count)
+
+    # ------------------------------------------------------------------
+    # SSE event dispatch
+    # ------------------------------------------------------------------
+
+    async def _handle_sse_event(self, event: dict) -> None:
+        """Dispatch an SSE event from OpenCode."""
+        event_type = event.get("type", "")
+        props = event.get("properties", {})
+
+        # --- Streaming text delta ---
+        if event_type == "message.part.delta":
+            field = props.get("field", "")
+            delta = props.get("delta", "")
+            if not delta:
+                return
+            if field == "thinking":
+                await self._emit(
+                    {
+                        "type": "content_block_delta",
+                        "delta": {"type": "thinking_delta", "thinking": delta},
+                    }
+                )
+            else:
+                await self._emit_text_delta(delta)
+            return
+
+        # --- Message part updated (tool calls, reasoning blocks) ---
+        if event_type == "message.part.updated":
+            part = props.get("part", props)
+            await self._handle_part_updated(part, props)
+            return
+
+        # --- Message updated (full message state) ---
+        if event_type == "message.updated":
+            # The message.part.delta events handle streaming.
+            # message.updated is the full state — we use it for model info.
+            info = props.get("info", {})
+            model = info.get("model", "")
+            if model and not self._model:
+                self._model = model
+            return
+
+        # --- Permission request ---
+        if event_type == "question.asked":
+            request_id = props.get("id", "")
+            tool = props.get("tool", "")
+            description = props.get("question", props.get("description", ""))
+            await self._emit(
+                {
+                    "type": "control_request",
+                    "subtype": "can_use_tool",
+                    "request_id": request_id,
+                    "tool": _map_codex_tool(tool) if tool else "Bash",
+                    "input": {"command": description},
+                }
+            )
+            self._pending_permissions[request_id] = props
+            return
+
+        # --- Session idle (turn complete) ---
+        if event_type == "session.idle":
+            self._last_result = {
+                "type": "result",
+                "stop_reason": "end_turn",
+                "modelUsage": self._last_usage or {},
+            }
+            await self._emit(self._last_result)
+            return
+
+        # --- Session error ---
+        if event_type == "session.error":
+            message = props.get("error", props.get("message", str(props)))
+            logger.warning("OpenCode error: %s", message)
+            await self._emit({"type": "error", "error": message})
+            return
+
+        # --- Session status (analyzing, executing) ---
+        if event_type == "session.status":
+            status = props.get("status", "")
+            if status in ("analyzing", "executing"):
+                # Emit assistant event to signal streaming started
+                await self._emit(
+                    {
+                        "type": "assistant",
+                        "message": {
+                            "model": self._model,
+                            "content": [],
+                        },
+                    }
+                )
+            return
+
+        # --- Heartbeat / connected ---
+        if event_type in ("server.connected", "server.heartbeat"):
+            return
+
+        logger.debug("OpenCode: unhandled event %s", event_type)
+
+    # ------------------------------------------------------------------
+    # Part handling
+    # ------------------------------------------------------------------
+
+    async def _handle_part_updated(self, part: dict, props: dict) -> None:
+        """Handle a message.part.updated event."""
+        part_type = part.get("type", "")
+        part_id = part.get("id", props.get("partID", ""))
+
+        if part_type == "tool-invocation":
+            tool_name = part.get("toolName", part.get("name", ""))
+            tool_input = part.get("args", part.get("input", {}))
+            if isinstance(tool_input, str):
+                try:
+                    tool_input = json.loads(tool_input)
+                except json.JSONDecodeError:
+                    tool_input = {"command": tool_input}
+            normalized = _map_codex_tool(tool_name)
+
+            # Broker-facing: assistant with message.content
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "model": self._model,
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": part_id,
+                                "name": normalized,
+                                "input": tool_input if isinstance(tool_input, dict) else {},
+                            }
+                        ],
+                    },
+                }
+            )
+            # Browser-facing: content_block lifecycle
+            idx = self._next_block_index()
+            await self._emit(
+                {
+                    "type": "content_block_start",
+                    "index": idx,
+                    "content_block": {"type": "tool_use", "id": part_id, "name": normalized},
+                }
+            )
+            input_json = json.dumps(tool_input if isinstance(tool_input, dict) else {})
+            await self._emit(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "input_json_delta", "partial_json": input_json},
+                }
+            )
+            return
+
+        if part_type == "tool-result":
+            content = part.get("result", part.get("content", ""))
+            is_error = part.get("isError", False)
+            # Close previous tool_use block and show result as text
+            await self._emit({"type": "content_block_stop"})
+            if content:
+                idx = self._next_block_index()
+                await self._emit(
+                    {
+                        "type": "content_block_start",
+                        "index": idx,
+                        "content_block": {"type": "text"},
+                    }
+                )
+                prefix = "[error] " if is_error else ""
+                await self._emit_text_delta(prefix + str(content))
+                await self._emit({"type": "content_block_stop"})
+            return
+
+        if part_type == "text":
+            # Full text part — initial block start (deltas follow via message.part.delta)
+            idx = self._next_block_index()
+            await self._emit(
+                {
+                    "type": "content_block_start",
+                    "index": idx,
+                    "content_block": {"type": "text"},
+                }
+            )
+            text = part.get("text", "")
+            if text:
+                await self._emit_text_delta(text)
+            return
+
+        if part_type == "reasoning":
+            idx = self._next_block_index()
+            await self._emit(
+                {
+                    "type": "content_block_start",
+                    "index": idx,
+                    "content_block": {"type": "thinking"},
+                }
+            )
+            return
+
+        if part_type == "finish":
+            model_id = self._model or "unknown"
+            self._last_usage = {
+                model_id: {
+                    "inputTokens": 0,
+                    "outputTokens": 0,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                }
+            }
+            return
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _next_block_index(self) -> int:
+        idx = self._block_index
+        self._block_index += 1
+        return idx
+
+    async def _emit_text_delta(self, text: str) -> None:
+        if not text:
+            return
+        event = {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": text},
+        }
+        filtered = _filter_event(event)
+        if filtered:
+            await self._emit(filtered)
+
+    # ------------------------------------------------------------------
+    # CLITransport interface
+    # ------------------------------------------------------------------
+
+    async def send_message(self, content: str) -> None:
+        if not self._session_id:
+            raise RuntimeError("No active session — call start() first")
+
+        self._last_result = None
+        self._last_usage = None
+        self._block_index = 0
+
+        body: dict = {
+            "parts": [{"type": "text", "text": content}],
+        }
+        if self._system_prompt:
+            body["system"] = self._system_prompt
+        if self._model:
+            # OpenCode model format: "provider/model" or just "model"
+            body["model"] = {"modelID": self._model}
+
+        logger.info("Sending prompt to OpenCode session %s", self._session_id)
+        resp = await self._client.post(
+            f"/session/{self._session_id}/prompt_async",
+            json=body,
+        )
+        if resp.status_code not in (200, 204):
+            error = resp.text
+            logger.warning("OpenCode prompt failed: %s %s", resp.status_code, error)
+            await self._emit({"type": "error", "error": f"Prompt failed: {error}"})
+
+    async def send_control_response(self, request_id: str, response: dict) -> None:
+        """Respond to an OpenCode permission request."""
+        self._pending_permissions.pop(request_id, None)
+        behavior = response.get("behavior", "allow")
+        reply = "allow" if behavior in ("allow", "allowForever") else "deny"
+
+        try:
+            resp = await self._client.post(
+                f"/permission/{request_id}/reply",
+                json={"reply": reply},
+            )
+            if resp.status_code not in (200, 204):
+                logger.warning("Permission reply failed: %s", resp.text)
+        except Exception as exc:
+            logger.warning("Permission reply error: %r", exc)
+
+    async def send_control(self, subtype: str, **kwargs: object) -> None:
+        if subtype == "set_model":
+            model = kwargs.get("model")
+            if model and isinstance(model, str):
+                self._model = model
+            return
+
+        if subtype == "interrupt":
+            if self._session_id:
+                try:
+                    await self._client.post(
+                        f"/session/{self._session_id}/abort",
+                    )
+                except Exception as exc:
+                    logger.debug("Interrupt failed (may not be running): %r", exc)
+            return
+
+        logger.debug("OpenCode: unhandled control subtype=%s", subtype)
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def last_result(self) -> dict | None:
+        return self._last_result
+
+    @property
+    def is_alive(self) -> bool:
+        return self._alive
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(
+            cli_websocket=False,
+            session_resume=True,
+            interrupt=True,
+            set_model=True,
+            set_thinking_tokens=False,
+            set_permission_mode=False,
+            rewind_files=False,
+            mcp_set_servers=False,
+            permission_requests=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Session resume
+    # ------------------------------------------------------------------
+
+    async def resume(self, session_id: str) -> None:
+        """Resume an existing OpenCode session."""
+        self._session_id = session_id
+        logger.info("OpenCode session resumed: %s", self._session_id)
+
+        await self._emit(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": self._session_id,
+                "model": self._model,
+                "tools": [],
+            }
+        )
+
+
+def _pick_free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]

--- a/src/skuld/transports/opencode.py
+++ b/src/skuld/transports/opencode.py
@@ -70,6 +70,7 @@ class OpenCodeHttpTransport(CLITransport):
         self._alive = False
         self._block_index: int = 0
         self._pending_permissions: dict[str, dict] = {}
+        self._user_message_ids: set[str] = set()
 
     @property
     def _base_url(self) -> str:
@@ -223,8 +224,24 @@ class OpenCodeHttpTransport(CLITransport):
         event_type = event.get("type", "")
         props = event.get("properties", {})
 
+        # --- Message updated (full message state) ---
+        # Process this FIRST to track user vs assistant messages.
+        if event_type == "message.updated":
+            info = props.get("info", {})
+            msg_id = info.get("id", "")
+            role = info.get("role", "")
+            if role == "user" and msg_id:
+                self._user_message_ids.add(msg_id)
+            model = info.get("model", "")
+            if model and not self._model:
+                self._model = model
+            return
+
         # --- Streaming text delta ---
         if event_type == "message.part.delta":
+            # Skip deltas for user messages (echoed prompt)
+            if props.get("messageID", "") in self._user_message_ids:
+                return
             field = props.get("field", "")
             delta = props.get("delta", "")
             if not delta:
@@ -242,18 +259,11 @@ class OpenCodeHttpTransport(CLITransport):
 
         # --- Message part updated (tool calls, reasoning blocks) ---
         if event_type == "message.part.updated":
+            # Skip parts for user messages
+            if props.get("messageID", "") in self._user_message_ids:
+                return
             part = props.get("part", props)
             await self._handle_part_updated(part, props)
-            return
-
-        # --- Message updated (full message state) ---
-        if event_type == "message.updated":
-            # The message.part.delta events handle streaming.
-            # message.updated is the full state — we use it for model info.
-            info = props.get("info", {})
-            model = info.get("model", "")
-            if model and not self._model:
-                self._model = model
             return
 
         # --- Permission request ---
@@ -386,7 +396,8 @@ class OpenCodeHttpTransport(CLITransport):
             return
 
         if part_type == "text":
-            # Full text part — initial block start (deltas follow via message.part.delta)
+            # Open a text block — actual content arrives via message.part.delta.
+            # Do NOT emit the text field here to avoid duplication.
             idx = self._next_block_index()
             await self._emit(
                 {
@@ -395,9 +406,6 @@ class OpenCodeHttpTransport(CLITransport):
                     "content_block": {"type": "text"},
                 }
             )
-            text = part.get("text", "")
-            if text:
-                await self._emit_text_delta(text)
             return
 
         if part_type == "reasoning":

--- a/src/sleipnir/adapters/rabbitmq.py
+++ b/src/sleipnir/adapters/rabbitmq.py
@@ -328,6 +328,7 @@ class RabbitMQSubscriber(SleipnirSubscriber):
         self._queue = await self._channel.declare_queue(
             self._service_id or "",
             durable=is_named,
+            exclusive=not is_named,
             auto_delete=not is_named,
             arguments={"x-dead-letter-exchange": self._dead_letter_exchange},
         )

--- a/src/tyr/api/dispatcher.py
+++ b/src/tyr/api/dispatcher.py
@@ -30,7 +30,7 @@ class DispatcherStateResponse(BaseModel):
 
 class PatchDispatcherRequest(BaseModel):
     running: bool | None = None
-    threshold: float | None = Field(None, ge=0.0, le=100.0)
+    threshold: float | None = Field(None, ge=0.0, le=1.0)
     max_concurrent_raids: int | None = Field(None, ge=1, le=20)
     auto_continue: bool | None = None
 
@@ -46,21 +46,6 @@ class ActivityEventResponse(BaseModel):
 class ActivityLogResponse(BaseModel):
     events: list[ActivityEventResponse]
     total: int
-
-
-# ---------------------------------------------------------------------------
-# Compatibility helpers
-# ---------------------------------------------------------------------------
-
-
-def _to_api_threshold(value: float) -> float:
-    """Expose dispatcher thresholds as percentages for the frontend contract."""
-    return round(value * 100, 2)
-
-
-def _from_api_threshold(value: float) -> float:
-    """Accept both legacy fractions (0-1) and canonical percentages (0-100)."""
-    return value if value <= 1 else value / 100
 
 
 def _format_activity_log_line(event_type: str, timestamp: datetime, payload: dict) -> str:
@@ -107,7 +92,7 @@ def create_dispatcher_router() -> APIRouter:
         return DispatcherStateResponse(
             id=str(state.id),
             running=state.running,
-            threshold=_to_api_threshold(state.threshold),
+            threshold=state.threshold,
             max_concurrent_raids=state.max_concurrent_raids,
             auto_continue=state.auto_continue,
             updated_at=state.updated_at,
@@ -121,13 +106,11 @@ def create_dispatcher_router() -> APIRouter:
     ) -> DispatcherStateResponse:
         """Partially update the dispatcher state for the authenticated user."""
         updates = body.model_dump(exclude_none=True)
-        if "threshold" in updates:
-            updates["threshold"] = _from_api_threshold(updates["threshold"])
         state = await repo.update(principal.user_id, **updates)
         return DispatcherStateResponse(
             id=str(state.id),
             running=state.running,
-            threshold=_to_api_threshold(state.threshold),
+            threshold=state.threshold,
             max_concurrent_raids=state.max_concurrent_raids,
             auto_continue=state.auto_continue,
             updated_at=state.updated_at,

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -133,6 +133,11 @@ class SessionCreate(BaseModel):
         default_factory=GitSource,
         description="Workspace source (git repo or local mount)",
     )
+    definition: str | None = Field(
+        default=None,
+        max_length=100,
+        description="Session definition key (e.g. 'skuldClaude', 'skuldCodex')",
+    )
     template_name: str | None = Field(
         default=None,
         max_length=255,

--- a/src/volundr/adapters/inbound/rest_profiles.py
+++ b/src/volundr/adapters/inbound/rest_profiles.py
@@ -7,6 +7,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Path, Query, status
 from pydantic import BaseModel, Field
 
+from volundr.config import SessionDefinitionConfig
 from volundr.domain.models import (
     ForgeProfile,
     WorkspaceTemplate,
@@ -217,6 +218,26 @@ class TemplateResponse(BaseModel):
         )
 
 
+class SessionDefinitionResponse(BaseModel):
+    """Response model for a session definition (read-only, config-driven)."""
+
+    key: str = Field(description="Unique definition key (e.g. skuldClaude)")
+    display_name: str = Field(description="Human-readable name")
+    description: str = Field(description="Short description")
+    labels: list[str] = Field(description="Routing labels")
+    default_model: str = Field(description="Default model for this definition")
+
+    @classmethod
+    def from_config(cls, key: str, defn: SessionDefinitionConfig) -> SessionDefinitionResponse:
+        return cls(
+            key=key,
+            display_name=defn.display_name or key,
+            description=defn.description,
+            labels=defn.labels,
+            default_model=defn.default_model,
+        )
+
+
 class ErrorResponse(BaseModel):
     """Response model for errors."""
 
@@ -229,6 +250,7 @@ class ErrorResponse(BaseModel):
 def create_profiles_router(
     profile_service: ForgeProfileService,
     template_service: WorkspaceTemplateService,
+    session_definitions: dict[str, SessionDefinitionConfig] | None = None,
 ) -> APIRouter:
     """Create FastAPI router for profile and template endpoints."""
     router = APIRouter(prefix="/api/v1/volundr")
@@ -451,5 +473,22 @@ def create_profiles_router(
                 detail=f"Template not found: {template_name}",
             )
         return TemplateResponse.from_template(template)
+
+    # --- Session definition endpoints (read-only, config-driven) ---
+
+    _definitions = session_definitions or {}
+
+    @router.get(
+        "/session-definitions",
+        response_model=list[SessionDefinitionResponse],
+        tags=["Session Definitions"],
+    )
+    async def list_session_definitions() -> list[SessionDefinitionResponse]:
+        """List available session definitions (loaded from configuration)."""
+        return [
+            SessionDefinitionResponse.from_config(key, defn)
+            for key, defn in _definitions.items()
+            if defn.enabled
+        ]
 
     return router

--- a/src/volundr/adapters/outbound/contributors/__init__.py
+++ b/src/volundr/adapters/outbound/contributors/__init__.py
@@ -10,6 +10,9 @@ from volundr.adapters.outbound.contributors.secrets import (
     SecretInjectionContributor,
     SecretsContributor,
 )
+from volundr.adapters.outbound.contributors.session_def import (
+    SessionDefinitionContributor,
+)
 from volundr.adapters.outbound.contributors.storage import StorageContributor
 from volundr.adapters.outbound.contributors.template import TemplateContributor
 
@@ -21,6 +24,7 @@ __all__ = [
     "IsolationContributor",
     "RavnFlockContributor",
     "SecretInjectionContributor",
+    "SessionDefinitionContributor",
     "StorageContributor",
     "TemplateContributor",
     "SecretsContributor",

--- a/src/volundr/adapters/outbound/contributors/session_def.py
+++ b/src/volundr/adapters/outbound/contributors/session_def.py
@@ -1,0 +1,48 @@
+"""Session definition contributor — merges definition defaults into Helm values."""
+
+from typing import Any
+
+from volundr.config import SessionDefinitionConfig
+from volundr.domain.models import Session
+from volundr.domain.ports import SessionContext, SessionContribution, SessionContributor
+
+
+class SessionDefinitionContributor(SessionContributor):
+    """Looks up the session definition key from context and deep-merges its defaults.
+
+    Session definitions (e.g. skuldClaude, skuldCodex) carry broker
+    configuration (cliType, transportAdapter) and other Helm value
+    defaults. This contributor runs early in the pipeline so that
+    definition defaults can be overridden by later contributors
+    (templates, profiles, resources).
+    """
+
+    def __init__(
+        self,
+        *,
+        definitions: dict[str, SessionDefinitionConfig] | None = None,
+        default_definition: str = "",
+        **_extra: object,
+    ):
+        self._definitions = definitions or {}
+        self._default_definition = default_definition
+
+    @property
+    def name(self) -> str:
+        return "session_definition"
+
+    async def contribute(
+        self,
+        session: Session,
+        context: SessionContext,
+    ) -> SessionContribution:
+        key = context.definition or self._default_definition
+        if not key:
+            return SessionContribution()
+
+        defn = self._definitions.get(key)
+        if not defn or not defn.enabled:
+            return SessionContribution()
+
+        values: dict[str, Any] = dict(defn.defaults)
+        return SessionContribution(values=values)

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -170,6 +170,23 @@ class MCPServerEntry(BaseModel):
     description: str = ""
 
 
+class SessionDefinitionConfig(BaseModel):
+    """Configuration for a single session definition (e.g. skuldClaude, skuldCodex).
+
+    Session definitions describe available AI backend configurations.
+    Each definition has a unique key, display metadata, and a ``defaults``
+    dict that gets merged into Helm values when a session is created with
+    this definition.
+    """
+
+    enabled: bool = True
+    display_name: str = ""
+    description: str = ""
+    labels: list[str] = Field(default_factory=list)
+    default_model: str = ""
+    defaults: dict[str, Any] = Field(default_factory=dict)
+
+
 class ProfileConfig(BaseModel):
     """Configuration for a single forge profile."""
 
@@ -1074,6 +1091,10 @@ class Settings(BaseSettings):
     local_git: LocalGitConfig = Field(default_factory=LocalGitConfig)
     local_mounts: LocalMountsConfig = Field(default_factory=LocalMountsConfig)
     session_contributors: list[SessionContributorConfig] = Field(default_factory=list)
+    session_definitions: dict[str, SessionDefinitionConfig] = Field(
+        default_factory=dict,
+        description="Session definitions keyed by name (e.g. skuldClaude, skuldCodex).",
+    )
     models: list[AIModelConfig] = Field(default_factory=list)
     profiles: list[ProfileConfig] = Field(default_factory=list)
     templates: list[TemplateConfig] = Field(default_factory=list)

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -228,7 +228,7 @@ def _default_session_definitions() -> dict[str, SessionDefinitionConfig]:
         "skuldOpenCode": SessionDefinitionConfig(
             enabled=True,
             display_name="OpenCode",
-            description="Model-neutral AI coding agent — supports Claude, OpenAI, Gemini, local models",
+            description="Model-neutral AI coding agent — Claude, OpenAI, Gemini, local",
             labels=["session", "opencode"],
             default_model="",
             defaults={

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -187,6 +187,62 @@ class SessionDefinitionConfig(BaseModel):
     defaults: dict[str, Any] = Field(default_factory=dict)
 
 
+def _default_session_definitions() -> dict[str, SessionDefinitionConfig]:
+    """Built-in session definitions so the wizard works without Helm config.
+
+    These carry only broker-level config (cliType, transportAdapter).
+    Helm values merge on top when running in Kubernetes.
+    """
+    return {
+        "skuldClaude": SessionDefinitionConfig(
+            enabled=True,
+            display_name="Claude Code",
+            description="Anthropic Claude — full IDE with terminal, tools, and MCP",
+            labels=["session", "claude"],
+            default_model="claude-sonnet-4-6",
+            defaults={
+                "broker": {
+                    "cliType": "claude",
+                    "transport": "sdk",
+                    "transportAdapter": "skuld.transports.sdk_websocket.SdkWebSocketTransport",
+                    "skipPermissions": True,
+                    "agentTeams": False,
+                },
+            },
+        ),
+        "skuldCodex": SessionDefinitionConfig(
+            enabled=True,
+            display_name="OpenAI Codex",
+            description="OpenAI Codex — WebSocket protocol with streaming and tools",
+            labels=["session", "codex"],
+            default_model="",
+            defaults={
+                "broker": {
+                    "cliType": "codex-ws",
+                    "transportAdapter": "skuld.transports.codex_ws.CodexWebSocketTransport",
+                    "skipPermissions": True,
+                    "agentTeams": False,
+                },
+            },
+        ),
+        "skuldOpenCode": SessionDefinitionConfig(
+            enabled=True,
+            display_name="OpenCode",
+            description="Model-neutral AI coding agent — supports Claude, OpenAI, Gemini, local models",
+            labels=["session", "opencode"],
+            default_model="",
+            defaults={
+                "broker": {
+                    "cliType": "opencode",
+                    "transportAdapter": "skuld.transports.opencode.OpenCodeHttpTransport",
+                    "skipPermissions": True,
+                    "agentTeams": False,
+                },
+            },
+        ),
+    }
+
+
 class ProfileConfig(BaseModel):
     """Configuration for a single forge profile."""
 
@@ -1092,8 +1148,12 @@ class Settings(BaseSettings):
     local_mounts: LocalMountsConfig = Field(default_factory=LocalMountsConfig)
     session_contributors: list[SessionContributorConfig] = Field(default_factory=list)
     session_definitions: dict[str, SessionDefinitionConfig] = Field(
-        default_factory=dict,
+        default_factory=_default_session_definitions,
         description="Session definitions keyed by name (e.g. skuldClaude, skuldCodex).",
+    )
+    default_definition: str = Field(
+        default="skuldClaude",
+        description="Fallback definition key when no explicit definition is specified.",
     )
     models: list[AIModelConfig] = Field(default_factory=list)
     profiles: list[ProfileConfig] = Field(default_factory=list)

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -1087,6 +1087,7 @@ class SessionContext:
     """Read-only context for contributors."""
 
     principal: Principal | None = None
+    definition: str | None = None
     template_name: str | None = None
     profile_name: str | None = None
     terminal_restricted: bool = False

--- a/src/volundr/domain/services/forge.py
+++ b/src/volundr/domain/services/forge.py
@@ -100,6 +100,7 @@ class ForgeService:
         )
         return await self._session_service.start_session(
             session.id,
+            definition=data.definition,
             profile_name=data.profile_name,
             template_name=data.template_name,
             principal=principal,

--- a/src/volundr/domain/services/session.py
+++ b/src/volundr/domain/services/session.py
@@ -542,6 +542,7 @@ class SessionService:
     async def start_session(
         self,
         session_id: UUID,
+        definition: str | None = None,
         profile_name: str | None = None,
         template_name: str | None = None,
         principal: Principal | None = None,
@@ -585,6 +586,7 @@ class SessionService:
             self._provision_background(
                 starting,
                 principal=principal,
+                definition=definition,
                 template_name=template_name,
                 profile_name=profile_name,
                 terminal_restricted=terminal_restricted,
@@ -607,6 +609,7 @@ class SessionService:
         self,
         session: Session,
         principal: Principal | None = None,
+        definition: str | None = None,
         template_name: str | None = None,
         profile_name: str | None = None,
         terminal_restricted: bool = False,
@@ -623,6 +626,7 @@ class SessionService:
             result = await self._start_with_pipeline(
                 session,
                 principal,
+                definition,
                 template_name,
                 profile_name,
                 terminal_restricted,
@@ -665,6 +669,7 @@ class SessionService:
         self,
         session: Session,
         principal: Principal | None,
+        definition: str | None,
         template_name: str | None,
         profile_name: str | None,
         terminal_restricted: bool,
@@ -695,6 +700,7 @@ class SessionService:
 
         context = SessionContext(
             principal=principal,
+            definition=definition,
             template_name=template_name,
             profile_name=profile_name,
             terminal_restricted=terminal_restricted,

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -691,7 +691,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
             app.include_router(router)
 
-            profiles_router = create_profiles_router(profile_service, template_service)
+            profiles_router = create_profiles_router(
+                profile_service, template_service, settings.session_definitions
+            )
             app.include_router(profiles_router)
 
             # Resource discovery endpoint

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -258,8 +258,20 @@ def _create_contributors(
     can accept the ports they need and ignore others via **_extra.
     """
     from volundr.adapters.outbound.contributors.local_mount import LocalMountContributor
+    from volundr.adapters.outbound.contributors.session_def import SessionDefinitionContributor
 
     contributors: list[SessionContributor] = []
+
+    # Auto-wire SessionDefinitionContributor first so definition defaults
+    # (broker.cliType, transportAdapter, etc.) are the base layer that
+    # later contributors (templates, profiles, resources) can override.
+    if settings.session_definitions:
+        contributors.append(SessionDefinitionContributor(definitions=settings.session_definitions))
+        logger.info(
+            "Session contributor: session_definition (auto-wired, %d definitions)",
+            len(settings.session_definitions),
+        )
+
     for cfg in settings.session_contributors:
         cls = import_class(cfg.adapter)
         resolved_kwargs = _resolve_secret_kwargs(cfg.kwargs, cfg.secret_kwargs_env)

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -266,10 +266,16 @@ def _create_contributors(
     # (broker.cliType, transportAdapter, etc.) are the base layer that
     # later contributors (templates, profiles, resources) can override.
     if settings.session_definitions:
-        contributors.append(SessionDefinitionContributor(definitions=settings.session_definitions))
+        contributors.append(
+            SessionDefinitionContributor(
+                definitions=settings.session_definitions,
+                default_definition=settings.default_definition,
+            )
+        )
         logger.info(
-            "Session contributor: session_definition (auto-wired, %d definitions)",
+            "Session contributor: session_definition (auto-wired, %d definitions, default=%s)",
             len(settings.session_definitions),
+            settings.default_definition or "(none)",
         )
 
     for cfg in settings.session_contributors:

--- a/tests/integration/volundr/conftest.py
+++ b/tests/integration/volundr/conftest.py
@@ -83,6 +83,7 @@ class SyncSessionService(SessionService):
     async def start_session(
         self,
         session_id: UUID,
+        definition: str | None = None,
         profile_name: str | None = None,
         template_name: str | None = None,
         principal: Principal | None = None,

--- a/tests/test_adapters/test_rest_profiles.py
+++ b/tests/test_adapters/test_rest_profiles.py
@@ -331,3 +331,79 @@ class TestGetTemplate:
         response = client.get("/api/v1/volundr/templates/nonexistent")
         assert response.status_code == 404
         assert "not found" in response.json()["detail"].lower()
+
+
+# -------------------------------------------------------------------
+# Session definitions endpoint tests
+# -------------------------------------------------------------------
+
+
+class TestSessionDefinitions:
+    """Tests for GET /session-definitions."""
+
+    @pytest.fixture
+    def definitions_client(
+        self,
+        profile_service: ForgeProfileService,
+        template_service: WorkspaceTemplateService,
+    ) -> TestClient:
+        from volundr.config import SessionDefinitionConfig
+
+        definitions = {
+            "skuldClaude": SessionDefinitionConfig(
+                enabled=True,
+                display_name="Claude Code",
+                description="Anthropic Claude",
+                labels=["session", "claude"],
+                default_model="claude-sonnet-4-6",
+            ),
+            "skuldCodex": SessionDefinitionConfig(
+                enabled=True,
+                display_name="OpenAI Codex",
+                description="Codex with WebSocket",
+                labels=["session", "codex"],
+                default_model="",
+            ),
+            "skuldDisabled": SessionDefinitionConfig(
+                enabled=False,
+                display_name="Disabled",
+                description="Should not appear",
+            ),
+        }
+        app = FastAPI()
+        router = create_profiles_router(profile_service, template_service, definitions)
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_list_session_definitions(self, definitions_client: TestClient):
+        """Returns enabled session definitions."""
+        resp = definitions_client.get("/api/v1/volundr/session-definitions")
+        assert resp.status_code == 200
+        data = resp.json()
+        keys = [d["key"] for d in data]
+        assert "skuldClaude" in keys
+        assert "skuldCodex" in keys
+        assert "skuldDisabled" not in keys
+
+    def test_session_definition_fields(self, definitions_client: TestClient):
+        """Response has correct fields."""
+        resp = definitions_client.get("/api/v1/volundr/session-definitions")
+        claude = next(d for d in resp.json() if d["key"] == "skuldClaude")
+        assert claude["display_name"] == "Claude Code"
+        assert claude["description"] == "Anthropic Claude"
+        assert claude["labels"] == ["session", "claude"]
+        assert claude["default_model"] == "claude-sonnet-4-6"
+
+    def test_empty_definitions(
+        self,
+        profile_service: ForgeProfileService,
+        template_service: WorkspaceTemplateService,
+    ):
+        """Returns empty list when no definitions configured."""
+        app = FastAPI()
+        router = create_profiles_router(profile_service, template_service)
+        app.include_router(router)
+        client = TestClient(app)
+        resp = client.get("/api/v1/volundr/session-definitions")
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/tests/test_charts/test_volundr_chart.py
+++ b/tests/test_charts/test_volundr_chart.py
@@ -69,9 +69,9 @@ class TestValuesDefaults:
         assert defaults["session"]["model"] == "claude-sonnet-4-6"
 
     def test_skuld_codex_defaults_session_model(self, values_yaml):
-        """Test skuld-codex defaults include a Codex model."""
+        """Test skuld-codex defaults have a model field."""
         defaults = values_yaml["sessionDefinitions"]["skuldCodex"]["defaults"]
-        assert defaults["session"]["model"]  # non-empty
+        assert "model" in defaults["session"]
 
     def test_skuld_claude_defaults_image_repository(self, values_yaml):
         """Test skuld-claude defaults have correct image repository."""
@@ -135,19 +135,14 @@ class TestValuesDefaults:
         assert broker["cliType"] == "claude"
 
     def test_skuld_codex_broker_cli_type(self, values_yaml):
-        """Test skuld-codex broker cliType is codex (backward compat)."""
+        """Test skuld-codex broker cliType is codex-ws (WebSocket transport)."""
         broker = values_yaml["sessionDefinitions"]["skuldCodex"]["defaults"]["broker"]
-        assert broker["cliType"] == "codex"
-
-    def test_skuld_codex_broker_transport_is_subprocess(self, values_yaml):
-        """Test skuld-codex broker uses subprocess transport."""
-        broker = values_yaml["sessionDefinitions"]["skuldCodex"]["defaults"]["broker"]
-        assert broker["transport"] == "subprocess"
+        assert broker["cliType"] == "codex-ws"
 
     def test_skuld_codex_broker_transport_adapter(self, values_yaml):
         """Test skuld-codex broker has correct transportAdapter class path."""
         broker = values_yaml["sessionDefinitions"]["skuldCodex"]["defaults"]["broker"]
-        assert broker["transportAdapter"] == ("skuld.transports.codex.CodexSubprocessTransport")
+        assert broker["transportAdapter"] == "skuld.transports.codex_ws.CodexWebSocketTransport"
 
     def test_both_session_defs_use_same_image_repo(self, values_yaml):
         """Test skuld-claude and skuld-codex reference the same image repo."""

--- a/tests/test_domain/test_forge_service.py
+++ b/tests/test_domain/test_forge_service.py
@@ -25,6 +25,7 @@ async def test_create_and_start_session_delegates_to_session_service() -> None:
         name="demo",
         model="claude",
         source=SimpleNamespace(),
+        definition="skuldClaude",
         template_name="template",
         preset_id=None,
         workspace_id=None,
@@ -47,6 +48,7 @@ async def test_create_and_start_session_delegates_to_session_service() -> None:
     session_service.create_session.assert_awaited_once()
     session_service.start_session.assert_awaited_once_with(
         created.id,
+        definition="skuldClaude",
         profile_name="default",
         template_name="template",
         principal=None,

--- a/tests/test_mimir/unit/test_router.py
+++ b/tests/test_mimir/unit/test_router.py
@@ -702,12 +702,10 @@ def test_graph_edges_entity_filters_and_type_inference(client: TestClient) -> No
 
     graph = client.get("/mimir/graph")
     assert graph.status_code == 200
-    assert {tuple(edge.items()) for edge in graph.json()["edges"]} == {
-        (
-            ("source", "policies/directives/style.md"),
-            ("target", "policies/preferences/team.md"),
-        )
-    }
+    edges = graph.json()["edges"]
+    assert len(edges) == 1
+    edge_pair = {edges[0]["source"], edges[0]["target"]}
+    assert edge_pair == {"policies/directives/style.md", "policies/preferences/team.md"}
 
     people = client.get("/mimir/entities", params={"kind": "person"})
     assert people.status_code == 200

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -1,0 +1,731 @@
+"""Tests for CodexWebSocketTransport (Codex app-server over WebSocket)."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from skuld.transports.codex_ws import (
+    CodexWebSocketTransport,
+    _pick_free_port,
+    _rpc_notification,
+    _rpc_request,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_transport(tmp_path, **kwargs):
+    """Create a transport with defaults suitable for testing."""
+    defaults = {
+        "workspace_dir": str(tmp_path),
+        "model": "o4-mini",
+        "codex_port": 19999,
+    }
+    defaults.update(kwargs)
+    return CodexWebSocketTransport(**defaults)
+
+
+class FakeWebSocket:
+    """Simulates a websockets ClientConnection for testing."""
+
+    def __init__(self, responses=None):
+        self.sent: list[str] = []
+        self._responses = list(responses or [])
+        self._closed = False
+        self._recv_queue: asyncio.Queue = asyncio.Queue()
+
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
+
+    async def recv(self) -> str:
+        return await self._recv_queue.get()
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return await asyncio.wait_for(self._recv_queue.get(), timeout=0.1)
+        except TimeoutError:
+            raise StopAsyncIteration
+
+    def inject(self, msg: dict) -> None:
+        """Push a message into the receive queue."""
+        self._recv_queue.put_nowait(json.dumps(msg))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: RPC helpers
+# ---------------------------------------------------------------------------
+
+
+class TestRpcHelpers:
+    def test_rpc_request_structure(self):
+        rid, msg = _rpc_request("test/method", {"key": "val"})
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == rid
+        assert msg["method"] == "test/method"
+        assert msg["params"] == {"key": "val"}
+
+    def test_rpc_request_no_params(self):
+        rid, msg = _rpc_request("test/method")
+        assert "params" not in msg
+
+    def test_rpc_notification_structure(self):
+        msg = _rpc_notification("initialized")
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["method"] == "initialized"
+        assert "id" not in msg
+
+    def test_pick_free_port(self):
+        port = _pick_free_port()
+        assert isinstance(port, int)
+        assert 1024 <= port <= 65535
+
+
+# ---------------------------------------------------------------------------
+# Transport construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_defaults(self, tmp_path):
+        t = _make_transport(tmp_path)
+        assert t.workspace_dir == str(tmp_path)
+        assert t._model == "o4-mini"
+        assert t._codex_port == 19999
+        assert t.session_id is None
+        assert t.last_result is None
+        assert t.is_alive is False
+
+    def test_capabilities(self, tmp_path):
+        t = _make_transport(tmp_path)
+        caps = t.capabilities
+        assert caps.session_resume is True
+        assert caps.interrupt is True
+        assert caps.set_model is True
+        assert caps.permission_requests is True
+        assert caps.cli_websocket is False
+        assert caps.set_thinking_tokens is False
+        assert caps.rewind_files is False
+        assert caps.mcp_set_servers is False
+        assert caps.slash_commands is False
+        assert caps.skills is False
+
+
+# ---------------------------------------------------------------------------
+# Handshake
+# ---------------------------------------------------------------------------
+
+
+class TestHandshake:
+    @pytest.mark.asyncio
+    async def test_handshake_sends_initialize_and_thread_start(self, tmp_path):
+        t = _make_transport(tmp_path)
+        ws = FakeWebSocket()
+        t._ws = ws
+        t._alive = True
+
+        # Mock _send_rpc to return expected responses
+        call_count = 0
+        original_params = []
+
+        async def fake_send_rpc(method, params=None):
+            nonlocal call_count
+            original_params.append((method, params))
+            call_count += 1
+            if method == "initialize":
+                return {"userAgent": "codex/0.114.0"}
+            if method == "thread/start":
+                return {"thread": {"id": "thread-abc-123"}}
+            return {}
+
+        t._send_rpc = fake_send_rpc
+        t._send_notification = AsyncMock()
+        t._emit = AsyncMock()
+
+        await t._handshake()
+
+        # Verify initialize was called
+        assert original_params[0][0] == "initialize"
+        assert original_params[0][1]["clientInfo"]["name"] == "skuld"
+
+        # Verify initialized notification
+        t._send_notification.assert_called_once_with("initialized")
+
+        # Verify thread/start
+        assert original_params[1][0] == "thread/start"
+        assert t._thread_id == "thread-abc-123"
+
+        # Verify synthetic init event emitted
+        t._emit.assert_called_once()
+        init_event = t._emit.call_args[0][0]
+        assert init_event["type"] == "system"
+        assert init_event["subtype"] == "init"
+        assert init_event["session_id"] == "thread-abc-123"
+
+    @pytest.mark.asyncio
+    async def test_handshake_with_system_prompt(self, tmp_path):
+        t = _make_transport(tmp_path, system_prompt="Be helpful")
+        t._ws = FakeWebSocket()
+        t._alive = True
+
+        params_captured = []
+
+        async def fake_send_rpc(method, params=None):
+            params_captured.append((method, params))
+            if method == "initialize":
+                return {"userAgent": "codex"}
+            if method == "thread/start":
+                return {"thread": {"id": "t-1"}}
+            return {}
+
+        t._send_rpc = fake_send_rpc
+        t._send_notification = AsyncMock()
+        t._emit = AsyncMock()
+
+        await t._handshake()
+
+        thread_params = params_captured[1][1]
+        assert thread_params["developerInstructions"] == "Be helpful"
+
+    @pytest.mark.asyncio
+    async def test_handshake_skip_permissions(self, tmp_path):
+        t = _make_transport(tmp_path, skip_permissions=True)
+        t._ws = FakeWebSocket()
+        t._alive = True
+
+        params_captured = []
+
+        async def fake_send_rpc(method, params=None):
+            params_captured.append((method, params))
+            if method == "initialize":
+                return {"userAgent": "codex"}
+            if method == "thread/start":
+                return {"thread": {"id": "t-1"}}
+            return {}
+
+        t._send_rpc = fake_send_rpc
+        t._send_notification = AsyncMock()
+        t._emit = AsyncMock()
+
+        await t._handshake()
+
+        thread_params = params_captured[1][1]
+        assert thread_params["approvalPolicy"] == "never"
+        assert thread_params["sandbox"] == "danger-full-access"
+
+
+# ---------------------------------------------------------------------------
+# send_message
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessage:
+    @pytest.mark.asyncio
+    async def test_send_message_calls_turn_start(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._thread_id = "thread-1"
+        t._alive = True
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {}
+
+        t._send_rpc = fake_send_rpc
+
+        await t.send_message("hello world")
+
+        assert len(calls) == 1
+        assert calls[0][0] == "turn/start"
+        params = calls[0][1]
+        assert params["threadId"] == "thread-1"
+        assert params["input"][0]["type"] == "text"
+        assert params["input"][0]["text"] == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_send_message_without_thread_raises(self, tmp_path):
+        t = _make_transport(tmp_path)
+        with pytest.raises(RuntimeError, match="No active thread"):
+            await t.send_message("test")
+
+
+# ---------------------------------------------------------------------------
+# Event normalization (notifications)
+# ---------------------------------------------------------------------------
+
+
+class TestEventNormalization:
+    @pytest.mark.asyncio
+    async def test_agent_message_delta(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_server_message(
+            {
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "threadId": "t1",
+                    "turnId": "turn1",
+                    "itemId": "i1",
+                    "delta": "Hello ",
+                },
+            }
+        )
+
+        t._emit.assert_called_once()
+        event = t._emit.call_args[0][0]
+        assert event["type"] == "content_block_delta"
+        assert event["delta"]["type"] == "text_delta"
+        assert event["delta"]["text"] == "Hello "
+
+    @pytest.mark.asyncio
+    async def test_reasoning_delta(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_server_message(
+            {
+                "method": "item/reasoning/textDelta",
+                "params": {"threadId": "t1", "turnId": "turn1", "delta": "thinking..."},
+            }
+        )
+
+        event = t._emit.call_args[0][0]
+        assert event["delta"]["type"] == "thinking_delta"
+        assert event["delta"]["thinking"] == "thinking..."
+
+    @pytest.mark.asyncio
+    async def test_turn_started_sets_turn_id(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_server_message(
+            {
+                "method": "turn/started",
+                "params": {
+                    "threadId": "t1",
+                    "turn": {"id": "turn-42", "items": [], "status": "running", "error": None},
+                },
+            }
+        )
+
+        assert t._current_turn_id == "turn-42"
+
+    @pytest.mark.asyncio
+    async def test_turn_completed_emits_result(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._current_turn_id = "turn-42"
+        t._emit = AsyncMock()
+
+        await t._handle_server_message(
+            {
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "t1",
+                    "turn": {
+                        "id": "turn-42",
+                        "items": [],
+                        "status": "completed",
+                        "error": None,
+                    },
+                },
+            }
+        )
+
+        assert t._current_turn_id is None
+        t._emit.assert_called_once()
+        event = t._emit.call_args[0][0]
+        assert event["type"] == "result"
+        assert event["stop_reason"] == "end_turn"
+
+    @pytest.mark.asyncio
+    async def test_token_usage_updated(self, tmp_path):
+        t = _make_transport(tmp_path, model="o4-mini")
+        t._emit = AsyncMock()
+
+        await t._handle_server_message(
+            {
+                "method": "thread/tokenUsage/updated",
+                "params": {
+                    "threadId": "t1",
+                    "turnId": "turn1",
+                    "tokenUsage": {
+                        "total": {
+                            "totalTokens": 1500,
+                            "inputTokens": 1000,
+                            "cachedInputTokens": 200,
+                            "outputTokens": 300,
+                            "reasoningOutputTokens": 0,
+                        },
+                        "last": {},
+                    },
+                },
+            }
+        )
+
+        assert t._last_result is not None
+        usage = t._last_result["modelUsage"]["o4-mini"]
+        assert usage["inputTokens"] == 1000
+        assert usage["outputTokens"] == 300
+        assert usage["cacheReadInputTokens"] == 200
+
+    @pytest.mark.asyncio
+    async def test_error_notification(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_server_message(
+            {
+                "method": "error",
+                "params": {
+                    "error": {"message": "rate limit exceeded"},
+                    "willRetry": False,
+                    "threadId": "t1",
+                    "turnId": "turn1",
+                },
+            }
+        )
+
+        event = t._emit.call_args[0][0]
+        assert event["type"] == "error"
+        assert "rate limit" in event["content"]
+
+    @pytest.mark.asyncio
+    async def test_thread_closed_sets_not_alive(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._alive = True
+        t._emit = AsyncMock()
+
+        await t._handle_server_message({"method": "thread/closed", "params": {"threadId": "t1"}})
+
+        assert t._alive is False
+
+
+# ---------------------------------------------------------------------------
+# Item lifecycle (tool calls)
+# ---------------------------------------------------------------------------
+
+
+class TestItemLifecycle:
+    @pytest.mark.asyncio
+    async def test_command_execution_started(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_item_started(
+            {
+                "type": "commandExecution",
+                "id": "cmd-1",
+                "command": "ls -la",
+                "cwd": "/workspace",
+            }
+        )
+
+        event = t._emit.call_args[0][0]
+        assert event["type"] == "assistant"
+        assert event["content"][0]["name"] == "Bash"
+        assert event["content"][0]["input"]["command"] == "ls -la"
+
+    @pytest.mark.asyncio
+    async def test_file_change_started(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_item_started(
+            {
+                "type": "fileChange",
+                "id": "fc-1",
+                "changes": [{"path": "foo.py", "diff": "+hello"}],
+            }
+        )
+
+        event = t._emit.call_args[0][0]
+        assert event["content"][0]["name"] == "Edit"
+
+    @pytest.mark.asyncio
+    async def test_command_execution_completed(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_item_completed(
+            {
+                "type": "commandExecution",
+                "id": "cmd-1",
+                "aggregatedOutput": "file1.py\nfile2.py",
+                "exitCode": 0,
+            }
+        )
+
+        event = t._emit.call_args[0][0]
+        assert event["type"] == "tool_result"
+        assert event["is_error"] is False
+
+    @pytest.mark.asyncio
+    async def test_command_execution_failed(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_item_completed(
+            {
+                "type": "commandExecution",
+                "id": "cmd-1",
+                "aggregatedOutput": "error: not found",
+                "exitCode": 1,
+            }
+        )
+
+        event = t._emit.call_args[0][0]
+        assert event["is_error"] is True
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_call_started(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_item_started(
+            {
+                "type": "mcpToolCall",
+                "id": "mcp-1",
+                "server": "mimir",
+                "tool": "read_file",
+                "arguments": {"path": "/tmp/test.py"},
+            }
+        )
+
+        event = t._emit.call_args[0][0]
+        assert event["content"][0]["name"] == "Read"
+
+
+# ---------------------------------------------------------------------------
+# Control: interrupt, set_model
+# ---------------------------------------------------------------------------
+
+
+class TestControl:
+    @pytest.mark.asyncio
+    async def test_interrupt_sends_turn_interrupt(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._thread_id = "thread-1"
+        t._current_turn_id = "turn-5"
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {}
+
+        t._send_rpc = fake_send_rpc
+
+        await t.send_control("interrupt")
+
+        assert calls[0][0] == "turn/interrupt"
+        assert calls[0][1]["threadId"] == "thread-1"
+        assert calls[0][1]["turnId"] == "turn-5"
+
+    @pytest.mark.asyncio
+    async def test_interrupt_no_turn_does_nothing(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._thread_id = "thread-1"
+        t._current_turn_id = None
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {}
+
+        t._send_rpc = fake_send_rpc
+
+        await t.send_control("interrupt")
+        assert len(calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_set_model(self, tmp_path):
+        t = _make_transport(tmp_path, model="o4-mini")
+        await t.send_control("set_model", model="o3")
+        assert t._model == "o3"
+
+
+# ---------------------------------------------------------------------------
+# Approval / permission requests
+# ---------------------------------------------------------------------------
+
+
+class TestApprovals:
+    @pytest.mark.asyncio
+    async def test_command_approval_emits_control_request(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._emit = AsyncMock()
+
+        await t._handle_server_request(
+            {
+                "id": 42,
+                "method": "item/commandExecution/requestApproval",
+                "params": {
+                    "threadId": "t1",
+                    "turnId": "turn1",
+                    "itemId": "cmd-1",
+                    "command": "rm -rf /tmp/test",
+                },
+            }
+        )
+
+        event = t._emit.call_args[0][0]
+        assert event["type"] == "control_request"
+        assert event["tool"] == "Bash"
+        assert event["input"]["command"] == "rm -rf /tmp/test"
+
+        # Verify the approval is stored for later response
+        assert "42" in t._pending_approvals
+
+    @pytest.mark.asyncio
+    async def test_send_control_response_approves(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._ws = FakeWebSocket()
+        t._pending_approvals = {"42": 42}
+
+        await t.send_control_response("42", {"behavior": "allow"})
+
+        sent = json.loads(t._ws.sent[0])
+        assert sent["id"] == 42
+        assert sent["result"]["decision"] == "allow"
+
+    @pytest.mark.asyncio
+    async def test_send_control_response_denies(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._ws = FakeWebSocket()
+        t._pending_approvals = {"42": 42}
+
+        await t.send_control_response("42", {"behavior": "deny"})
+
+        sent = json.loads(t._ws.sent[0])
+        assert sent["result"]["decision"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Session resume
+# ---------------------------------------------------------------------------
+
+
+class TestResume:
+    @pytest.mark.asyncio
+    async def test_resume_sends_thread_resume(self, tmp_path):
+        t = _make_transport(tmp_path)
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {"thread": {"id": "resumed-thread"}}
+
+        t._send_rpc = fake_send_rpc
+        t._emit = AsyncMock()
+
+        await t.resume("old-thread-id")
+
+        assert calls[0][0] == "thread/resume"
+        assert calls[0][1]["threadId"] == "old-thread-id"
+        assert t._thread_id == "resumed-thread"
+
+        init_event = t._emit.call_args[0][0]
+        assert init_event["type"] == "system"
+        assert init_event["session_id"] == "resumed-thread"
+
+
+# ---------------------------------------------------------------------------
+# Receive loop
+# ---------------------------------------------------------------------------
+
+
+class TestReceiveLoop:
+    @pytest.mark.asyncio
+    async def test_rpc_response_resolves_future(self, tmp_path):
+        t = _make_transport(tmp_path)
+        ws = FakeWebSocket()
+        t._ws = ws
+        t._alive = True
+
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()
+        t._pending[1] = fut
+
+        t._resolve_pending({"id": 1, "result": {"ok": True}})
+
+        assert fut.done()
+        assert fut.result() == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_rpc_error_sets_exception(self, tmp_path):
+        t = _make_transport(tmp_path)
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()
+        t._pending[2] = fut
+
+        t._resolve_pending({"id": 2, "error": {"code": -32600, "message": "bad request"}})
+
+        assert fut.done()
+        with pytest.raises(RuntimeError, match="bad request"):
+            fut.result()
+
+
+# ---------------------------------------------------------------------------
+# Stop / cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestStopCleanup:
+    @pytest.mark.asyncio
+    async def test_stop_closes_ws_and_process(self, tmp_path):
+        t = _make_transport(tmp_path)
+        ws = FakeWebSocket()
+        t._ws = ws
+        t._alive = True
+
+        mock_process = MagicMock()
+        mock_process.returncode = None
+        mock_process.terminate = MagicMock()
+        mock_process.kill = MagicMock()
+        mock_process.wait = AsyncMock(return_value=0)
+        mock_process.pid = 12345
+        t._process = mock_process
+
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()
+        t._pending[99] = fut
+
+        await t.stop()
+
+        assert t._alive is False
+        assert t._ws is None
+        assert t._process is None
+        assert ws._closed is True
+        assert fut.cancelled()
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
+class TestConfigIntegration:
+    def test_codex_ws_cli_type_resolves_adapter(self):
+        from skuld.config import SkuldSettings
+
+        settings = SkuldSettings(cli_type="codex-ws")
+        assert settings.transport_adapter == "skuld.transports.codex_ws.CodexWebSocketTransport"
+
+    def test_codex_cli_type_still_works(self):
+        from skuld.config import SkuldSettings
+
+        settings = SkuldSettings(cli_type="codex")
+        assert settings.transport_adapter == "skuld.transports.codex.CodexSubprocessTransport"

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -196,7 +196,7 @@ class TestHandshake:
         await t._handshake()
 
         thread_params = params_captured[1][1]
-        assert thread_params["developerInstructions"] == "Be helpful"
+        assert thread_params["baseInstructions"] == "Be helpful"
 
     @pytest.mark.asyncio
     async def test_handshake_skip_permissions(self, tmp_path):

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -29,20 +29,33 @@ def _make_transport(tmp_path, **kwargs):
     return CodexWebSocketTransport(**defaults)
 
 
+def _collect_emits(transport):
+    """Attach an AsyncMock to _emit and return it for assertion."""
+    mock = AsyncMock()
+    transport._emit = mock
+    return mock
+
+
+def _emitted_events(mock):
+    """Return all events passed to _emit as a list."""
+    return [call[0][0] for call in mock.call_args_list]
+
+
+def _events_of_type(mock, event_type):
+    """Filter emitted events by type."""
+    return [e for e in _emitted_events(mock) if e.get("type") == event_type]
+
+
 class FakeWebSocket:
     """Simulates a websockets ClientConnection for testing."""
 
-    def __init__(self, responses=None):
+    def __init__(self):
         self.sent: list[str] = []
-        self._responses = list(responses or [])
         self._closed = False
         self._recv_queue: asyncio.Queue = asyncio.Queue()
 
     async def send(self, data: str) -> None:
         self.sent.append(data)
-
-    async def recv(self) -> str:
-        return await self._recv_queue.get()
 
     async def close(self) -> None:
         self._closed = True
@@ -133,14 +146,10 @@ class TestHandshake:
         t._ws = ws
         t._alive = True
 
-        # Mock _send_rpc to return expected responses
-        call_count = 0
         original_params = []
 
         async def fake_send_rpc(method, params=None):
-            nonlocal call_count
             original_params.append((method, params))
-            call_count += 1
             if method == "initialize":
                 return {"userAgent": "codex/0.114.0"}
             if method == "thread/start":
@@ -149,24 +158,17 @@ class TestHandshake:
 
         t._send_rpc = fake_send_rpc
         t._send_notification = AsyncMock()
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handshake()
 
-        # Verify initialize was called
         assert original_params[0][0] == "initialize"
         assert original_params[0][1]["clientInfo"]["name"] == "skuld"
-
-        # Verify initialized notification
         t._send_notification.assert_called_once_with("initialized")
-
-        # Verify thread/start
         assert original_params[1][0] == "thread/start"
         assert t._thread_id == "thread-abc-123"
 
-        # Verify synthetic init event emitted
-        t._emit.assert_called_once()
-        init_event = t._emit.call_args[0][0]
+        init_event = emit.call_args[0][0]
         assert init_event["type"] == "system"
         assert init_event["subtype"] == "init"
         assert init_event["session_id"] == "thread-abc-123"
@@ -189,7 +191,7 @@ class TestHandshake:
 
         t._send_rpc = fake_send_rpc
         t._send_notification = AsyncMock()
-        t._emit = AsyncMock()
+        _collect_emits(t)
 
         await t._handshake()
 
@@ -214,7 +216,7 @@ class TestHandshake:
 
         t._send_rpc = fake_send_rpc
         t._send_notification = AsyncMock()
-        t._emit = AsyncMock()
+        _collect_emits(t)
 
         await t._handshake()
 
@@ -253,6 +255,25 @@ class TestSendMessage:
         assert params["input"][0]["text"] == "hello world"
 
     @pytest.mark.asyncio
+    async def test_send_message_resets_state(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._thread_id = "thread-1"
+        t._last_result = {"old": True}
+        t._last_usage = {"old": True}
+        t._block_index = 5
+
+        async def fake_send_rpc(method, params=None):
+            return {}
+
+        t._send_rpc = fake_send_rpc
+
+        await t.send_message("test")
+
+        assert t._last_result is None
+        assert t._last_usage is None
+        assert t._block_index == 0
+
+    @pytest.mark.asyncio
     async def test_send_message_without_thread_raises(self, tmp_path):
         t = _make_transport(tmp_path)
         with pytest.raises(RuntimeError, match="No active thread"):
@@ -268,7 +289,7 @@ class TestEventNormalization:
     @pytest.mark.asyncio
     async def test_agent_message_delta(self, tmp_path):
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_server_message(
             {
@@ -282,16 +303,16 @@ class TestEventNormalization:
             }
         )
 
-        t._emit.assert_called_once()
-        event = t._emit.call_args[0][0]
-        assert event["type"] == "content_block_delta"
-        assert event["delta"]["type"] == "text_delta"
-        assert event["delta"]["text"] == "Hello "
+        events = _emitted_events(emit)
+        assert len(events) == 1
+        assert events[0]["type"] == "content_block_delta"
+        assert events[0]["delta"]["type"] == "text_delta"
+        assert events[0]["delta"]["text"] == "Hello "
 
     @pytest.mark.asyncio
     async def test_reasoning_delta(self, tmp_path):
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_server_message(
             {
@@ -300,14 +321,29 @@ class TestEventNormalization:
             }
         )
 
-        event = t._emit.call_args[0][0]
+        event = emit.call_args[0][0]
         assert event["delta"]["type"] == "thinking_delta"
         assert event["delta"]["thinking"] == "thinking..."
 
     @pytest.mark.asyncio
-    async def test_turn_started_sets_turn_id(self, tmp_path):
+    async def test_reasoning_summary_delta(self, tmp_path):
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {
+                "method": "item/reasoning/summaryTextDelta",
+                "params": {"threadId": "t1", "turnId": "turn1", "delta": "summary"},
+            }
+        )
+
+        event = emit.call_args[0][0]
+        assert event["delta"]["type"] == "thinking_delta"
+
+    @pytest.mark.asyncio
+    async def test_turn_started_emits_assistant_event(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
 
         await t._handle_server_message(
             {
@@ -320,12 +356,28 @@ class TestEventNormalization:
         )
 
         assert t._current_turn_id == "turn-42"
+        assert t._block_index == 0
+
+        # Should emit an assistant event to start a new streaming message
+        events = _events_of_type(emit, "assistant")
+        assert len(events) == 1
+        assert events[0]["message"]["model"] == "o4-mini"
+        assert events[0]["message"]["content"] == []
 
     @pytest.mark.asyncio
-    async def test_turn_completed_emits_result(self, tmp_path):
+    async def test_turn_completed_emits_result_with_usage(self, tmp_path):
         t = _make_transport(tmp_path)
         t._current_turn_id = "turn-42"
-        t._emit = AsyncMock()
+        # Simulate usage arriving before turn/completed
+        t._last_usage = {
+            "o4-mini": {
+                "inputTokens": 500,
+                "outputTokens": 200,
+                "cacheReadInputTokens": 0,
+                "cacheCreationInputTokens": 0,
+            }
+        }
+        emit = _collect_emits(t)
 
         await t._handle_server_message(
             {
@@ -343,15 +395,37 @@ class TestEventNormalization:
         )
 
         assert t._current_turn_id is None
-        t._emit.assert_called_once()
-        event = t._emit.call_args[0][0]
-        assert event["type"] == "result"
-        assert event["stop_reason"] == "end_turn"
+        result_events = _events_of_type(emit, "result")
+        assert len(result_events) == 1
+        result = result_events[0]
+        assert result["stop_reason"] == "end_turn"
+        assert result["modelUsage"]["o4-mini"]["inputTokens"] == 500
+        assert result["modelUsage"]["o4-mini"]["outputTokens"] == 200
 
     @pytest.mark.asyncio
-    async def test_token_usage_updated(self, tmp_path):
+    async def test_turn_completed_without_usage(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._current_turn_id = "turn-1"
+        t._last_usage = None
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "t1",
+                    "turn": {"id": "turn-1", "items": [], "status": "completed", "error": None},
+                },
+            }
+        )
+
+        result = _events_of_type(emit, "result")[0]
+        assert result["modelUsage"] == {}
+
+    @pytest.mark.asyncio
+    async def test_token_usage_saves_and_emits_message_delta(self, tmp_path):
         t = _make_transport(tmp_path, model="o4-mini")
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_server_message(
             {
@@ -367,22 +441,35 @@ class TestEventNormalization:
                             "outputTokens": 300,
                             "reasoningOutputTokens": 0,
                         },
-                        "last": {},
+                        "last": {
+                            "totalTokens": 500,
+                            "inputTokens": 400,
+                            "cachedInputTokens": 50,
+                            "outputTokens": 100,
+                            "reasoningOutputTokens": 0,
+                        },
                     },
                 },
             }
         )
 
-        assert t._last_result is not None
-        usage = t._last_result["modelUsage"]["o4-mini"]
-        assert usage["inputTokens"] == 1000
-        assert usage["outputTokens"] == 300
-        assert usage["cacheReadInputTokens"] == 200
+        # Usage saved for later result event
+        assert t._last_usage is not None
+        usage = t._last_usage["o4-mini"]
+        # Should prefer "last" over "total"
+        assert usage["inputTokens"] == 400
+        assert usage["outputTokens"] == 100
+        assert usage["cacheReadInputTokens"] == 50
+
+        # message_delta emitted for browser token counter
+        delta_events = _events_of_type(emit, "message_delta")
+        assert len(delta_events) == 1
+        assert delta_events[0]["usage"]["output_tokens"] == 100
 
     @pytest.mark.asyncio
-    async def test_error_notification(self, tmp_path):
+    async def test_error_notification_uses_error_field(self, tmp_path):
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_server_message(
             {
@@ -396,15 +483,15 @@ class TestEventNormalization:
             }
         )
 
-        event = t._emit.call_args[0][0]
+        event = emit.call_args[0][0]
         assert event["type"] == "error"
-        assert "rate limit" in event["content"]
+        assert event["error"] == "rate limit exceeded"
 
     @pytest.mark.asyncio
     async def test_thread_closed_sets_not_alive(self, tmp_path):
         t = _make_transport(tmp_path)
         t._alive = True
-        t._emit = AsyncMock()
+        _collect_emits(t)
 
         await t._handle_server_message({"method": "thread/closed", "params": {"threadId": "t1"}})
 
@@ -412,15 +499,16 @@ class TestEventNormalization:
 
 
 # ---------------------------------------------------------------------------
-# Item lifecycle (tool calls)
+# Item lifecycle (tool calls) — browser + broker event shapes
 # ---------------------------------------------------------------------------
 
 
 class TestItemLifecycle:
     @pytest.mark.asyncio
-    async def test_command_execution_started(self, tmp_path):
+    async def test_command_execution_started_emits_assistant_and_blocks(self, tmp_path):
+        """Tool start should emit both assistant (broker) and content_block (browser) events."""
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_item_started(
             {
@@ -431,15 +519,40 @@ class TestItemLifecycle:
             }
         )
 
-        event = t._emit.call_args[0][0]
-        assert event["type"] == "assistant"
-        assert event["content"][0]["name"] == "Bash"
-        assert event["content"][0]["input"]["command"] == "ls -la"
+        events = _emitted_events(emit)
+
+        # 1. assistant event for broker artifact tracking
+        assistant_events = [e for e in events if e.get("type") == "assistant"]
+        assert len(assistant_events) == 1
+        msg = assistant_events[0]["message"]
+        assert msg["model"] == "o4-mini"
+        tool_block = msg["content"][0]
+        assert tool_block["type"] == "tool_use"
+        assert tool_block["id"] == "cmd-1"
+        assert tool_block["name"] == "Bash"
+        assert tool_block["input"]["command"] == "ls -la"
+
+        # 2. content_block_start for browser rendering
+        block_starts = [e for e in events if e.get("type") == "content_block_start"]
+        assert len(block_starts) == 1
+        assert block_starts[0]["content_block"]["type"] == "tool_use"
+        assert block_starts[0]["content_block"]["name"] == "Bash"
+
+        # 3. input_json_delta for browser tool input
+        deltas = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "input_json_delta"
+        ]
+        assert len(deltas) == 1
+        parsed = json.loads(deltas[0]["delta"]["partial_json"])
+        assert parsed["command"] == "ls -la"
 
     @pytest.mark.asyncio
     async def test_file_change_started(self, tmp_path):
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_item_started(
             {
@@ -449,13 +562,14 @@ class TestItemLifecycle:
             }
         )
 
-        event = t._emit.call_args[0][0]
-        assert event["content"][0]["name"] == "Edit"
+        assistant_events = _events_of_type(emit, "assistant")
+        assert assistant_events[0]["message"]["content"][0]["name"] == "Edit"
 
     @pytest.mark.asyncio
-    async def test_command_execution_completed(self, tmp_path):
+    async def test_command_execution_completed_emits_stop_and_output(self, tmp_path):
+        """Command completion should close the tool block and show output as text."""
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_item_completed(
             {
@@ -466,14 +580,26 @@ class TestItemLifecycle:
             }
         )
 
-        event = t._emit.call_args[0][0]
-        assert event["type"] == "tool_result"
-        assert event["is_error"] is False
+        events = _emitted_events(emit)
+
+        # content_block_stop for the tool_use block
+        stops = [e for e in events if e.get("type") == "content_block_stop"]
+        assert len(stops) >= 1
+
+        # Output shown as text block
+        text_deltas = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        assert len(text_deltas) == 1
+        assert "file1.py" in text_deltas[0]["delta"]["text"]
 
     @pytest.mark.asyncio
-    async def test_command_execution_failed(self, tmp_path):
+    async def test_command_execution_failed_shows_exit_code(self, tmp_path):
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_item_completed(
             {
@@ -484,13 +610,60 @@ class TestItemLifecycle:
             }
         )
 
-        event = t._emit.call_args[0][0]
-        assert event["is_error"] is True
+        text_deltas = [
+            e
+            for e in _emitted_events(emit)
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        assert len(text_deltas) == 1
+        assert "[exit code 1]" in text_deltas[0]["delta"]["text"]
+
+    @pytest.mark.asyncio
+    async def test_agent_message_started_emits_text_block(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_started({"type": "agentMessage", "id": "msg-1", "text": ""})
+
+        block_starts = _events_of_type(emit, "content_block_start")
+        assert len(block_starts) == 1
+        assert block_starts[0]["content_block"]["type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_agent_message_completed_emits_stop(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_completed({"type": "agentMessage", "id": "msg-1", "text": "done"})
+
+        stops = _events_of_type(emit, "content_block_stop")
+        assert len(stops) == 1
+
+    @pytest.mark.asyncio
+    async def test_reasoning_started_emits_thinking_block(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_started({"type": "reasoning", "id": "r-1"})
+
+        block_starts = _events_of_type(emit, "content_block_start")
+        assert block_starts[0]["content_block"]["type"] == "thinking"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_completed_emits_stop(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_completed({"type": "reasoning", "id": "r-1"})
+
+        stops = _events_of_type(emit, "content_block_stop")
+        assert len(stops) == 1
 
     @pytest.mark.asyncio
     async def test_mcp_tool_call_started(self, tmp_path):
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_item_started(
             {
@@ -502,8 +675,31 @@ class TestItemLifecycle:
             }
         )
 
-        event = t._emit.call_args[0][0]
-        assert event["content"][0]["name"] == "Read"
+        assistant_events = _events_of_type(emit, "assistant")
+        assert assistant_events[0]["message"]["content"][0]["name"] == "Read"
+
+    @pytest.mark.asyncio
+    async def test_web_search_started(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_started({"type": "webSearch", "id": "ws-1", "query": "python async"})
+
+        assistant_events = _events_of_type(emit, "assistant")
+        assert assistant_events[0]["message"]["content"][0]["name"] == "WebSearch"
+        assert assistant_events[0]["message"]["content"][0]["input"]["query"] == "python async"
+
+    @pytest.mark.asyncio
+    async def test_block_index_increments(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_started({"type": "agentMessage", "id": "m1", "text": ""})
+        await t._handle_item_started({"type": "reasoning", "id": "r1"})
+
+        block_starts = _events_of_type(emit, "content_block_start")
+        assert block_starts[0]["index"] == 0
+        assert block_starts[1]["index"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -565,7 +761,7 @@ class TestApprovals:
     @pytest.mark.asyncio
     async def test_command_approval_emits_control_request(self, tmp_path):
         t = _make_transport(tmp_path)
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t._handle_server_request(
             {
@@ -580,36 +776,71 @@ class TestApprovals:
             }
         )
 
-        event = t._emit.call_args[0][0]
+        event = emit.call_args[0][0]
         assert event["type"] == "control_request"
         assert event["tool"] == "Bash"
         assert event["input"]["command"] == "rm -rf /tmp/test"
-
-        # Verify the approval is stored for later response
         assert "42" in t._pending_approvals
+
+    @pytest.mark.asyncio
+    async def test_file_change_approval(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_server_request(
+            {
+                "id": 99,
+                "method": "item/fileChange/requestApproval",
+                "params": {"threadId": "t1", "turnId": "turn1", "itemId": "fc-1"},
+            }
+        )
+
+        event = emit.call_args[0][0]
+        assert event["type"] == "control_request"
+        assert event["tool"] == "Edit"
+        assert "99" in t._pending_approvals
 
     @pytest.mark.asyncio
     async def test_send_control_response_approves(self, tmp_path):
         t = _make_transport(tmp_path)
         t._ws = FakeWebSocket()
-        t._pending_approvals = {"42": 42}
+        t._pending_approvals["42"] = 42
 
         await t.send_control_response("42", {"behavior": "allow"})
 
         sent = json.loads(t._ws.sent[0])
         assert sent["id"] == 42
         assert sent["result"]["decision"] == "allow"
+        assert "42" not in t._pending_approvals
 
     @pytest.mark.asyncio
     async def test_send_control_response_denies(self, tmp_path):
         t = _make_transport(tmp_path)
         t._ws = FakeWebSocket()
-        t._pending_approvals = {"42": 42}
+        t._pending_approvals["42"] = 42
 
         await t.send_control_response("42", {"behavior": "deny"})
 
         sent = json.loads(t._ws.sent[0])
         assert sent["result"]["decision"] == "deny"
+
+    @pytest.mark.asyncio
+    async def test_unknown_request_auto_approved(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._ws = FakeWebSocket()
+        _collect_emits(t)
+
+        await t._handle_server_request(
+            {
+                "id": 77,
+                "method": "some/unknown/request",
+                "params": {},
+            }
+        )
+
+        sent = json.loads(t._ws.sent[0])
+        assert sent["id"] == 77
+        assert sent["result"]["decision"] == "allow"
 
 
 # ---------------------------------------------------------------------------
@@ -629,7 +860,7 @@ class TestResume:
             return {"thread": {"id": "resumed-thread"}}
 
         t._send_rpc = fake_send_rpc
-        t._emit = AsyncMock()
+        emit = _collect_emits(t)
 
         await t.resume("old-thread-id")
 
@@ -637,7 +868,7 @@ class TestResume:
         assert calls[0][1]["threadId"] == "old-thread-id"
         assert t._thread_id == "resumed-thread"
 
-        init_event = t._emit.call_args[0][0]
+        init_event = emit.call_args[0][0]
         assert init_event["type"] == "system"
         assert init_event["session_id"] == "resumed-thread"
 
@@ -651,9 +882,6 @@ class TestReceiveLoop:
     @pytest.mark.asyncio
     async def test_rpc_response_resolves_future(self, tmp_path):
         t = _make_transport(tmp_path)
-        ws = FakeWebSocket()
-        t._ws = ws
-        t._alive = True
 
         loop = asyncio.get_event_loop()
         fut = loop.create_future()
@@ -710,6 +938,223 @@ class TestStopCleanup:
         assert t._process is None
         assert ws._closed is True
         assert fut.cancelled()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full turn simulation
+# ---------------------------------------------------------------------------
+
+
+class TestFullTurnFlow:
+    """Simulate a complete Codex turn and verify the browser sees the right event sequence."""
+
+    @pytest.mark.asyncio
+    async def test_text_turn_lifecycle(self, tmp_path):
+        """turn/started → item/started(agentMessage) → deltas → item/completed → turn/completed."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        # 1. Turn starts
+        await t._handle_server_message(
+            {
+                "method": "turn/started",
+                "params": {
+                    "threadId": "t1",
+                    "turn": {"id": "turn-1", "items": [], "status": "running", "error": None},
+                },
+            }
+        )
+
+        # 2. Agent message item starts
+        await t._handle_server_message(
+            {
+                "method": "item/started",
+                "params": {
+                    "item": {"type": "agentMessage", "id": "msg-1", "text": "", "phase": None},
+                    "threadId": "t1",
+                    "turnId": "turn-1",
+                },
+            }
+        )
+
+        # 3. Text deltas
+        await t._handle_server_message(
+            {
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "threadId": "t1",
+                    "turnId": "turn-1",
+                    "itemId": "msg-1",
+                    "delta": "Hello ",
+                },
+            }
+        )
+        await t._handle_server_message(
+            {
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "threadId": "t1",
+                    "turnId": "turn-1",
+                    "itemId": "msg-1",
+                    "delta": "world!",
+                },
+            }
+        )
+
+        # 4. Item completed
+        await t._handle_server_message(
+            {
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "type": "agentMessage",
+                        "id": "msg-1",
+                        "text": "Hello world!",
+                        "phase": None,
+                    },
+                    "threadId": "t1",
+                    "turnId": "turn-1",
+                },
+            }
+        )
+
+        # 5. Token usage
+        await t._handle_server_message(
+            {
+                "method": "thread/tokenUsage/updated",
+                "params": {
+                    "threadId": "t1",
+                    "turnId": "turn-1",
+                    "tokenUsage": {
+                        "total": {
+                            "totalTokens": 100,
+                            "inputTokens": 80,
+                            "cachedInputTokens": 0,
+                            "outputTokens": 20,
+                            "reasoningOutputTokens": 0,
+                        },
+                        "last": {},
+                    },
+                },
+            }
+        )
+
+        # 6. Turn completed
+        await t._handle_server_message(
+            {
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "t1",
+                    "turn": {"id": "turn-1", "items": [], "status": "completed", "error": None},
+                },
+            }
+        )
+
+        events = _emitted_events(emit)
+        types = [e["type"] for e in events]
+
+        # Verify expected sequence
+        assert "assistant" in types  # Turn start signal
+        assert "content_block_start" in types  # Text block opens
+        assert types.count("content_block_delta") >= 2  # Text deltas
+        assert "content_block_stop" in types  # Text block closes
+        assert "message_delta" in types  # Token counter
+        assert "result" in types  # Turn complete
+
+        # Result has usage
+        result = _events_of_type(emit, "result")[0]
+        assert result["modelUsage"]["o4-mini"]["inputTokens"] == 80
+
+    @pytest.mark.asyncio
+    async def test_tool_turn_lifecycle(self, tmp_path):
+        """Tool call: item/started(commandExecution) → output → item/completed."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        # Turn starts
+        await t._handle_server_message(
+            {
+                "method": "turn/started",
+                "params": {
+                    "threadId": "t1",
+                    "turn": {"id": "turn-2", "items": [], "status": "running", "error": None},
+                },
+            }
+        )
+
+        # Command execution starts
+        await t._handle_server_message(
+            {
+                "method": "item/started",
+                "params": {
+                    "item": {
+                        "type": "commandExecution",
+                        "id": "cmd-1",
+                        "command": "git status",
+                        "cwd": "/workspace",
+                    },
+                    "threadId": "t1",
+                    "turnId": "turn-2",
+                },
+            }
+        )
+
+        # Command output delta
+        await t._handle_server_message(
+            {
+                "method": "item/commandExecution/outputDelta",
+                "params": {
+                    "threadId": "t1",
+                    "turnId": "turn-2",
+                    "itemId": "cmd-1",
+                    "delta": "On branch main\n",
+                },
+            }
+        )
+
+        # Command completed
+        await t._handle_server_message(
+            {
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "type": "commandExecution",
+                        "id": "cmd-1",
+                        "command": "git status",
+                        "cwd": "/workspace",
+                        "aggregatedOutput": "On branch main\nnothing to commit",
+                        "exitCode": 0,
+                    },
+                    "threadId": "t1",
+                    "turnId": "turn-2",
+                },
+            }
+        )
+
+        events = _emitted_events(emit)
+
+        # Assistant event for broker tracking
+        assistant_events = _events_of_type(emit, "assistant")
+        assert len(assistant_events) >= 2  # Turn start + tool use
+        tool_assistant = [e for e in assistant_events if e.get("message", {}).get("content")]
+        assert len(tool_assistant) >= 1
+        tool_block = tool_assistant[-1]["message"]["content"][0]
+        assert tool_block["name"] == "Bash"
+        assert tool_block["id"] == "cmd-1"
+
+        # content_block_start for tool_use
+        block_starts = _events_of_type(emit, "content_block_start")
+        tool_starts = [b for b in block_starts if b["content_block"].get("type") == "tool_use"]
+        assert len(tool_starts) >= 1
+
+        # Output text shown
+        text_deltas = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        assert any("branch main" in d["delta"]["text"] for d in text_deltas)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -1163,6 +1163,689 @@ class TestFullTurnFlow:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# _send_rpc timeout
+# ---------------------------------------------------------------------------
+
+
+class TestSendRpcTimeout:
+    @pytest.mark.asyncio
+    async def test_send_rpc_timeout_raises_runtime_error(self, tmp_path):
+        """When the RPC future times out, _send_rpc should raise RuntimeError."""
+        t = _make_transport(tmp_path)
+        ws = FakeWebSocket()
+        t._ws = ws
+
+        # Patch wait_for to always raise TimeoutError
+        async def fake_wait_for(fut, timeout):
+            raise TimeoutError
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(asyncio, "wait_for", fake_wait_for)
+            with pytest.raises(RuntimeError, match="RPC timeout"):
+                await t._send_rpc("test/method", {"foo": "bar"})
+
+        # The pending future should have been cleaned up
+        # (the rid was popped from _pending on timeout)
+        assert len(t._pending) == 0
+
+    @pytest.mark.asyncio
+    async def test_send_rpc_ws_none_raises(self, tmp_path):
+        """_send_rpc with no websocket raises RuntimeError."""
+        t = _make_transport(tmp_path)
+        t._ws = None
+
+        with pytest.raises(RuntimeError, match="WebSocket not connected"):
+            await t._send_rpc("test/method")
+
+
+# ---------------------------------------------------------------------------
+# _send_notification when ws is None
+# ---------------------------------------------------------------------------
+
+
+class TestSendNotification:
+    @pytest.mark.asyncio
+    async def test_send_notification_ws_none_is_noop(self, tmp_path):
+        """When ws is None, _send_notification should silently do nothing."""
+        t = _make_transport(tmp_path)
+        t._ws = None
+
+        # Should not raise
+        await t._send_notification("initialized")
+
+    @pytest.mark.asyncio
+    async def test_send_notification_with_ws_sends(self, tmp_path):
+        """When ws is set, _send_notification should send the message."""
+        t = _make_transport(tmp_path)
+        ws = FakeWebSocket()
+        t._ws = ws
+
+        await t._send_notification("initialized")
+
+        assert len(ws.sent) == 1
+        msg = json.loads(ws.sent[0])
+        assert msg["method"] == "initialized"
+        assert "id" not in msg
+
+
+# ---------------------------------------------------------------------------
+# send_message edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageEdgeCases:
+    @pytest.mark.asyncio
+    async def test_send_message_without_model(self, tmp_path):
+        """When model is empty string, params should not include 'model'."""
+        t = _make_transport(tmp_path, model="")
+        t._thread_id = "thread-1"
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {}
+
+        t._send_rpc = fake_send_rpc
+
+        await t.send_message("hello")
+
+        params = calls[0][1]
+        assert "model" not in params
+
+
+# ---------------------------------------------------------------------------
+# _handle_server_message with unknown notification
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownNotification:
+    @pytest.mark.asyncio
+    async def test_unknown_notification_ignored(self, tmp_path):
+        """Unknown notification methods should be silently ignored (no emit)."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {"method": "some/totally/unknown/notification", "params": {}}
+        )
+
+        # Nothing should have been emitted
+        assert emit.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_thread_status_changed_ignored(self, tmp_path):
+        """Informational notifications like thread/status/changed are no-ops."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {"method": "thread/status/changed", "params": {"status": "idle"}}
+        )
+
+        assert emit.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_thread_name_updated_ignored(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {"method": "thread/name/updated", "params": {"name": "new name"}}
+        )
+
+        assert emit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# _resolve_pending edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePendingEdgeCases:
+    @pytest.mark.asyncio
+    async def test_resolve_unknown_id_is_noop(self, tmp_path):
+        """Resolving a response with an unknown id should not raise."""
+        t = _make_transport(tmp_path)
+
+        # No pending futures at all
+        t._resolve_pending({"id": 999, "result": {"ok": True}})
+        # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_resolve_already_done_future_is_noop(self, tmp_path):
+        """If the future is already done (e.g. cancelled), _resolve_pending skips it."""
+        t = _make_transport(tmp_path)
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()
+        fut.cancel()  # Mark as done
+        t._pending[5] = fut
+
+        # Should not raise even though future is cancelled
+        t._resolve_pending({"id": 5, "result": {"ok": True}})
+
+    @pytest.mark.asyncio
+    async def test_resolve_pending_with_no_result_key(self, tmp_path):
+        """Response with 'result' key missing should resolve with empty dict."""
+        t = _make_transport(tmp_path)
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()
+        t._pending[10] = fut
+
+        # data has "id" but result is missing — falls through to data.get("result", {})
+        t._resolve_pending({"id": 10, "jsonrpc": "2.0"})
+
+        assert fut.done()
+        assert fut.result() == {}
+
+
+# ---------------------------------------------------------------------------
+# capabilities property values
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilitiesValues:
+    def test_set_permission_mode_is_false(self, tmp_path):
+        t = _make_transport(tmp_path)
+        assert t.capabilities.set_permission_mode is False
+
+    def test_session_resume_is_true(self, tmp_path):
+        t = _make_transport(tmp_path)
+        assert t.capabilities.session_resume is True
+
+    def test_permission_requests_is_true(self, tmp_path):
+        t = _make_transport(tmp_path)
+        assert t.capabilities.permission_requests is True
+
+
+# ---------------------------------------------------------------------------
+# stop() edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestStopEdgeCases:
+    @pytest.mark.asyncio
+    async def test_stop_already_stopped_is_safe(self, tmp_path):
+        """Calling stop() when already stopped (no ws, no process) should not raise."""
+        t = _make_transport(tmp_path)
+        t._alive = False
+        t._ws = None
+        t._process = None
+        t._receive_task = None
+        t._pending.clear()
+
+        await t.stop()
+
+        assert t._alive is False
+        assert t._ws is None
+        assert t._process is None
+
+    @pytest.mark.asyncio
+    async def test_stop_with_receive_task_already_done(self, tmp_path):
+        """If receive_task is already done, stop() should not try to cancel it."""
+        t = _make_transport(tmp_path)
+        t._alive = True
+        t._ws = None
+        t._process = None
+
+        # Create an already-finished task
+        async def noop():
+            pass
+
+        task = asyncio.ensure_future(noop())
+        await task  # Let it finish
+        t._receive_task = task
+
+        await t.stop()
+        assert t._alive is False
+
+    @pytest.mark.asyncio
+    async def test_stop_ws_close_error_handled(self, tmp_path):
+        """If ws.close() raises, stop() should still complete."""
+        t = _make_transport(tmp_path)
+        t._alive = True
+        t._process = None
+        t._receive_task = None
+
+        ws = FakeWebSocket()
+
+        async def bad_close():
+            raise ConnectionError("already closed")
+
+        ws.close = bad_close
+        t._ws = ws
+
+        await t.stop()
+
+        assert t._ws is None
+        assert t._alive is False
+
+
+# ---------------------------------------------------------------------------
+# _emit_tool_use with different tool types
+# ---------------------------------------------------------------------------
+
+
+class TestEmitToolUse:
+    @pytest.mark.asyncio
+    async def test_emit_tool_use_bash(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._emit_tool_use("id-1", "Bash", {"command": "ls"})
+
+        events = _emitted_events(emit)
+        # Should have: assistant, content_block_start, content_block_delta
+        assert len(events) == 3
+        assert events[0]["type"] == "assistant"
+        assert events[0]["message"]["content"][0]["name"] == "Bash"
+        assert events[1]["type"] == "content_block_start"
+        assert events[1]["content_block"]["name"] == "Bash"
+        assert events[2]["type"] == "content_block_delta"
+        assert events[2]["delta"]["type"] == "input_json_delta"
+
+    @pytest.mark.asyncio
+    async def test_emit_tool_use_edit(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._emit_tool_use("id-2", "Edit", {"path": "foo.py"})
+
+        events = _emitted_events(emit)
+        assert events[0]["message"]["content"][0]["name"] == "Edit"
+        assert events[0]["message"]["content"][0]["input"] == {"path": "foo.py"}
+
+    @pytest.mark.asyncio
+    async def test_emit_tool_use_websearch(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._emit_tool_use("id-3", "WebSearch", {"query": "test"})
+
+        events = _emitted_events(emit)
+        assert events[0]["message"]["content"][0]["name"] == "WebSearch"
+
+    @pytest.mark.asyncio
+    async def test_emit_tool_use_custom_tool(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._emit_tool_use("id-4", "CustomTool", {"key": "value"})
+
+        events = _emitted_events(emit)
+        assert events[0]["message"]["content"][0]["name"] == "CustomTool"
+        # Verify the input_json_delta contains the serialized input
+        partial = json.loads(events[2]["delta"]["partial_json"])
+        assert partial == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# _handle_item_completed for fileChange, webSearch, mcpToolCall
+# ---------------------------------------------------------------------------
+
+
+class TestItemCompletedEdgeCases:
+    @pytest.mark.asyncio
+    async def test_file_change_completed_emits_stop(self, tmp_path):
+        """fileChange completion should emit content_block_stop."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_completed({"type": "fileChange", "id": "fc-1", "changes": []})
+
+        stops = _events_of_type(emit, "content_block_stop")
+        assert len(stops) == 1
+
+    @pytest.mark.asyncio
+    async def test_web_search_completed_emits_stop(self, tmp_path):
+        """webSearch completion should emit content_block_stop."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_completed({"type": "webSearch", "id": "ws-1", "query": "test"})
+
+        stops = _events_of_type(emit, "content_block_stop")
+        assert len(stops) == 1
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_call_completed_emits_stop(self, tmp_path):
+        """mcpToolCall completion should emit content_block_stop."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_completed({"type": "mcpToolCall", "id": "mcp-1", "tool": "read_file"})
+
+        stops = _events_of_type(emit, "content_block_stop")
+        assert len(stops) == 1
+
+    @pytest.mark.asyncio
+    async def test_command_completed_no_output_no_text_block(self, tmp_path):
+        """Command with empty output should still emit stop but no text block."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_completed(
+            {"type": "commandExecution", "id": "cmd-1", "aggregatedOutput": "", "exitCode": 0}
+        )
+
+        events = _emitted_events(emit)
+        stops = _events_of_type(emit, "content_block_stop")
+        # Only one stop (for the tool_use block), no text block started
+        assert len(stops) == 1
+        # No text delta emitted
+        text_deltas = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        assert len(text_deltas) == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_item_completed_no_emit(self, tmp_path):
+        """An unknown item type completing should not emit anything."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_item_completed({"type": "unknownType", "id": "x-1"})
+
+        assert emit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# _send_rpc_response
+# ---------------------------------------------------------------------------
+
+
+class TestSendRpcResponse:
+    @pytest.mark.asyncio
+    async def test_send_rpc_response_sends_json(self, tmp_path):
+        t = _make_transport(tmp_path)
+        ws = FakeWebSocket()
+        t._ws = ws
+
+        await t._send_rpc_response(42, {"decision": "accept"})
+
+        msg = json.loads(ws.sent[0])
+        assert msg["jsonrpc"] == "2.0"
+        assert msg["id"] == 42
+        assert msg["result"]["decision"] == "accept"
+
+    @pytest.mark.asyncio
+    async def test_send_rpc_response_ws_none_is_noop(self, tmp_path):
+        """If ws is None, _send_rpc_response should silently do nothing."""
+        t = _make_transport(tmp_path)
+        t._ws = None
+
+        # Should not raise
+        await t._send_rpc_response(42, {"decision": "accept"})
+
+
+# ---------------------------------------------------------------------------
+# resume edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestResumeEdgeCases:
+    @pytest.mark.asyncio
+    async def test_resume_with_skip_permissions(self, tmp_path):
+        t = _make_transport(tmp_path, skip_permissions=True)
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {"thread": {"id": "resumed-t"}}
+
+        t._send_rpc = fake_send_rpc
+        _collect_emits(t)
+
+        await t.resume("old-id")
+
+        params = calls[0][1]
+        assert params["approvalPolicy"] == "never"
+        assert params["sandbox"] == "danger-full-access"
+
+    @pytest.mark.asyncio
+    async def test_resume_with_model(self, tmp_path):
+        t = _make_transport(tmp_path, model="gpt-4")
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {"thread": {"id": "resumed-t"}}
+
+        t._send_rpc = fake_send_rpc
+        _collect_emits(t)
+
+        await t.resume("old-id")
+
+        params = calls[0][1]
+        assert params["model"] == "gpt-4"
+
+    @pytest.mark.asyncio
+    async def test_resume_without_model(self, tmp_path):
+        t = _make_transport(tmp_path, model="")
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {"thread": {"id": "resumed-t"}}
+
+        t._send_rpc = fake_send_rpc
+        _collect_emits(t)
+
+        await t.resume("old-id")
+
+        params = calls[0][1]
+        assert "model" not in params
+
+    @pytest.mark.asyncio
+    async def test_resume_fallback_thread_id(self, tmp_path):
+        """When the response thread has no id, resume uses the passed thread_id."""
+        t = _make_transport(tmp_path)
+
+        async def fake_send_rpc(method, params=None):
+            return {"thread": {}}  # No "id" in thread
+
+        t._send_rpc = fake_send_rpc
+        _collect_emits(t)
+
+        await t.resume("fallback-id")
+
+        assert t._thread_id == "fallback-id"
+
+
+# ---------------------------------------------------------------------------
+# send_control_response edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSendControlResponseEdgeCases:
+    @pytest.mark.asyncio
+    async def test_unknown_request_id_logs_warning(self, tmp_path):
+        """Responding to an unknown request_id should be a no-op (warning logged)."""
+        t = _make_transport(tmp_path)
+        t._ws = FakeWebSocket()
+
+        await t.send_control_response("nonexistent", {"behavior": "allow"})
+
+        # Nothing sent
+        assert len(t._ws.sent) == 0
+
+    @pytest.mark.asyncio
+    async def test_allow_forever_maps_to_accept(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._ws = FakeWebSocket()
+        t._pending_approvals["10"] = 10
+
+        await t.send_control_response("10", {"behavior": "allowForever"})
+
+        msg = json.loads(t._ws.sent[0])
+        assert msg["result"]["decision"] == "accept"
+
+
+# ---------------------------------------------------------------------------
+# send_control edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestSendControlEdgeCases:
+    @pytest.mark.asyncio
+    async def test_unknown_subtype_is_noop(self, tmp_path):
+        """Unknown control subtypes should not raise."""
+        t = _make_transport(tmp_path)
+        await t.send_control("totally_unknown")
+
+    @pytest.mark.asyncio
+    async def test_set_model_non_string_ignored(self, tmp_path):
+        t = _make_transport(tmp_path, model="o4-mini")
+        await t.send_control("set_model", model=123)
+        assert t._model == "o4-mini"  # Unchanged
+
+    @pytest.mark.asyncio
+    async def test_set_model_none_ignored(self, tmp_path):
+        t = _make_transport(tmp_path, model="o4-mini")
+        await t.send_control("set_model", model=None)
+        assert t._model == "o4-mini"  # Unchanged
+
+
+# ---------------------------------------------------------------------------
+# _handle_server_message dispatches to _handle_server_request
+# ---------------------------------------------------------------------------
+
+
+class TestServerMessageWithId:
+    @pytest.mark.asyncio
+    async def test_message_with_id_dispatches_to_server_request(self, tmp_path):
+        """If a message has both 'method' and 'id' (no result/error), it's a server request."""
+        t = _make_transport(tmp_path)
+        t._ws = FakeWebSocket()
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {
+                "id": 55,
+                "method": "item/commandExecution/requestApproval",
+                "params": {"command": "echo hi"},
+            }
+        )
+
+        event = emit.call_args[0][0]
+        assert event["type"] == "control_request"
+        assert event["tool"] == "Bash"
+
+
+# ---------------------------------------------------------------------------
+# thread/started notification sets thread_id
+# ---------------------------------------------------------------------------
+
+
+class TestThreadStartedNotification:
+    @pytest.mark.asyncio
+    async def test_thread_started_sets_thread_id(self, tmp_path):
+        t = _make_transport(tmp_path)
+        _collect_emits(t)
+
+        await t._handle_server_message(
+            {
+                "method": "thread/started",
+                "params": {"thread": {"id": "new-thread-123"}},
+            }
+        )
+
+        assert t._thread_id == "new-thread-123"
+
+    @pytest.mark.asyncio
+    async def test_thread_started_no_id_keeps_existing(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._thread_id = "existing"
+        _collect_emits(t)
+
+        await t._handle_server_message(
+            {
+                "method": "thread/started",
+                "params": {"thread": {}},
+            }
+        )
+
+        # tid was falsy, so _thread_id not updated
+        assert t._thread_id == "existing"
+
+
+# ---------------------------------------------------------------------------
+# fileChange/outputDelta notification
+# ---------------------------------------------------------------------------
+
+
+class TestFileChangeOutputDelta:
+    @pytest.mark.asyncio
+    async def test_file_change_output_delta_emits_text(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {
+                "method": "item/fileChange/outputDelta",
+                "params": {"delta": "patching file.py"},
+            }
+        )
+
+        events = _emitted_events(emit)
+        assert len(events) == 1
+        assert events[0]["delta"]["text"] == "patching file.py"
+
+    @pytest.mark.asyncio
+    async def test_file_change_output_delta_empty_ignored(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {
+                "method": "item/fileChange/outputDelta",
+                "params": {"delta": ""},
+            }
+        )
+
+        assert emit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# _emit_text_delta edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEmitTextDelta:
+    @pytest.mark.asyncio
+    async def test_empty_text_not_emitted(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._emit_text_delta("")
+
+        assert emit.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_nonempty_text_emitted(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._emit_text_delta("hello")
+
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event["delta"]["type"] == "text_delta"
+        assert event["delta"]["text"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
 class TestConfigIntegration:
     def test_codex_ws_cli_type_resolves_adapter(self):
         from skuld.config import SkuldSettings

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -253,6 +253,7 @@ class TestSendMessage:
         assert params["threadId"] == "thread-1"
         assert params["input"][0]["type"] == "text"
         assert params["input"][0]["text"] == "hello world"
+        assert params["input"][0]["textElements"] == []
 
     @pytest.mark.asyncio
     async def test_send_message_resets_state(self, tmp_path):
@@ -810,7 +811,7 @@ class TestApprovals:
 
         sent = json.loads(t._ws.sent[0])
         assert sent["id"] == 42
-        assert sent["result"]["decision"] == "allow"
+        assert sent["result"]["decision"] == "accept"
         assert "42" not in t._pending_approvals
 
     @pytest.mark.asyncio
@@ -822,7 +823,7 @@ class TestApprovals:
         await t.send_control_response("42", {"behavior": "deny"})
 
         sent = json.loads(t._ws.sent[0])
-        assert sent["result"]["decision"] == "deny"
+        assert sent["result"]["decision"] == "decline"
 
     @pytest.mark.asyncio
     async def test_unknown_request_auto_approved(self, tmp_path):
@@ -840,7 +841,7 @@ class TestApprovals:
 
         sent = json.loads(t._ws.sent[0])
         assert sent["id"] == 77
-        assert sent["result"]["decision"] == "allow"
+        assert sent["result"]["decision"] == "accept"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skuld/test_opencode_transport.py
+++ b/tests/test_skuld/test_opencode_transport.py
@@ -1,0 +1,682 @@
+"""Tests for OpenCodeHttpTransport (OpenCode via HTTP REST + SSE)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from skuld.transports.opencode import OpenCodeHttpTransport, _pick_free_port
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_transport(tmp_path, **kwargs):
+    defaults = {
+        "workspace_dir": str(tmp_path),
+        "model": "",
+        "opencode_port": 19998,
+    }
+    defaults.update(kwargs)
+    return OpenCodeHttpTransport(**defaults)
+
+
+def _collect_emits(transport):
+    mock = AsyncMock()
+    transport._emit = mock
+    return mock
+
+
+def _emitted_events(mock):
+    return [call[0][0] for call in mock.call_args_list]
+
+
+def _events_of_type(mock, event_type):
+    return [e for e in _emitted_events(mock) if e.get("type") == event_type]
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_defaults(self, tmp_path):
+        t = _make_transport(tmp_path)
+        assert t.workspace_dir == str(tmp_path)
+        assert t._opencode_port == 19998
+        assert t.session_id is None
+        assert t.last_result is None
+        assert t.is_alive is False
+
+    def test_capabilities(self, tmp_path):
+        t = _make_transport(tmp_path)
+        caps = t.capabilities
+        assert caps.session_resume is True
+        assert caps.interrupt is True
+        assert caps.set_model is True
+        assert caps.permission_requests is True
+        assert caps.cli_websocket is False
+        assert caps.set_thinking_tokens is False
+        assert caps.rewind_files is False
+        assert caps.mcp_set_servers is False
+
+    def test_pick_free_port(self):
+        port = _pick_free_port()
+        assert 1024 <= port <= 65535
+
+
+# ---------------------------------------------------------------------------
+# SSE event normalization
+# ---------------------------------------------------------------------------
+
+
+class TestSSEEventNormalization:
+    @pytest.mark.asyncio
+    async def test_text_delta(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": "s1",
+                    "messageID": "m1",
+                    "partID": "p1",
+                    "field": "text",
+                    "delta": "Hello ",
+                },
+            }
+        )
+
+        events = _emitted_events(emit)
+        assert len(events) == 1
+        assert events[0]["type"] == "content_block_delta"
+        assert events[0]["delta"]["type"] == "text_delta"
+        assert events[0]["delta"]["text"] == "Hello "
+
+    @pytest.mark.asyncio
+    async def test_thinking_delta(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": "s1",
+                    "messageID": "m1",
+                    "partID": "p1",
+                    "field": "thinking",
+                    "delta": "reasoning...",
+                },
+            }
+        )
+
+        event = emit.call_args[0][0]
+        assert event["delta"]["type"] == "thinking_delta"
+        assert event["delta"]["thinking"] == "reasoning..."
+
+    @pytest.mark.asyncio
+    async def test_empty_delta_ignored(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "message.part.delta",
+                "properties": {"field": "text", "delta": ""},
+            }
+        )
+
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_session_idle_emits_result(self, tmp_path):
+        t = _make_transport(tmp_path, model="claude-sonnet-4-6")
+        t._last_usage = {
+            "claude-sonnet-4-6": {
+                "inputTokens": 100,
+                "outputTokens": 50,
+                "cacheReadInputTokens": 0,
+                "cacheCreationInputTokens": 0,
+            }
+        }
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event({"type": "session.idle", "properties": {"sessionID": "s1"}})
+
+        result = _events_of_type(emit, "result")[0]
+        assert result["stop_reason"] == "end_turn"
+        assert result["modelUsage"]["claude-sonnet-4-6"]["inputTokens"] == 100
+
+    @pytest.mark.asyncio
+    async def test_session_error(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "session.error",
+                "properties": {"error": "model rate limited"},
+            }
+        )
+
+        event = emit.call_args[0][0]
+        assert event["type"] == "error"
+        assert event["error"] == "model rate limited"
+
+    @pytest.mark.asyncio
+    async def test_session_status_analyzing_emits_assistant(self, tmp_path):
+        t = _make_transport(tmp_path, model="gpt-4o")
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "session.status",
+                "properties": {"status": "analyzing"},
+            }
+        )
+
+        assistant_events = _events_of_type(emit, "assistant")
+        assert len(assistant_events) == 1
+        assert assistant_events[0]["message"]["model"] == "gpt-4o"
+
+    @pytest.mark.asyncio
+    async def test_permission_request(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "question.asked",
+                "properties": {
+                    "id": "perm-42",
+                    "tool": "shell",
+                    "question": "Run: rm -rf /tmp/test",
+                },
+            }
+        )
+
+        event = emit.call_args[0][0]
+        assert event["type"] == "control_request"
+        assert event["request_id"] == "perm-42"
+        assert event["tool"] == "Bash"
+        assert "perm-42" in t._pending_permissions
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_ignored(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event({"type": "server.heartbeat", "properties": {}})
+
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connected_ignored(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event({"type": "server.connected", "properties": {}})
+
+        emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Part handling
+# ---------------------------------------------------------------------------
+
+
+class TestPartHandling:
+    @pytest.mark.asyncio
+    async def test_tool_invocation_emits_assistant_and_blocks(self, tmp_path):
+        t = _make_transport(tmp_path, model="gpt-4o")
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {
+                "type": "tool-invocation",
+                "id": "tool-1",
+                "toolName": "shell",
+                "args": {"command": "ls -la"},
+            },
+            {},
+        )
+
+        events = _emitted_events(emit)
+
+        # Assistant event for broker tracking
+        assistant_events = _events_of_type(emit, "assistant")
+        assert len(assistant_events) == 1
+        tool_block = assistant_events[0]["message"]["content"][0]
+        assert tool_block["name"] == "Bash"
+        assert tool_block["input"]["command"] == "ls -la"
+
+        # content_block_start for browser
+        block_starts = _events_of_type(emit, "content_block_start")
+        assert block_starts[0]["content_block"]["type"] == "tool_use"
+
+        # input_json_delta
+        deltas = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "input_json_delta"
+        ]
+        assert len(deltas) == 1
+
+    @pytest.mark.asyncio
+    async def test_tool_result_emits_stop_and_text(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {
+                "type": "tool-result",
+                "result": "file1.py\nfile2.py",
+                "isError": False,
+            },
+            {},
+        )
+
+        events = _emitted_events(emit)
+
+        stops = _events_of_type(emit, "content_block_stop")
+        assert len(stops) >= 1
+
+        text_deltas = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        assert any("file1.py" in d["delta"]["text"] for d in text_deltas)
+
+    @pytest.mark.asyncio
+    async def test_tool_result_error(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {
+                "type": "tool-result",
+                "result": "command not found",
+                "isError": True,
+            },
+            {},
+        )
+
+        text_deltas = [
+            e
+            for e in _emitted_events(emit)
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        assert any("[error]" in d["delta"]["text"] for d in text_deltas)
+
+    @pytest.mark.asyncio
+    async def test_text_part_emits_block_start(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {"type": "text", "text": "Initial text"},
+            {},
+        )
+
+        block_starts = _events_of_type(emit, "content_block_start")
+        assert block_starts[0]["content_block"]["type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_part_emits_thinking_block(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {"type": "reasoning"},
+            {},
+        )
+
+        block_starts = _events_of_type(emit, "content_block_start")
+        assert block_starts[0]["content_block"]["type"] == "thinking"
+
+    @pytest.mark.asyncio
+    async def test_finish_part_saves_usage(self, tmp_path):
+        t = _make_transport(tmp_path, model="gpt-4o")
+        _collect_emits(t)
+
+        await t._handle_part_updated(
+            {"type": "finish", "reason": "end_turn"},
+            {},
+        )
+
+        assert t._last_usage is not None
+        assert "gpt-4o" in t._last_usage
+
+    @pytest.mark.asyncio
+    async def test_block_index_increments(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated({"type": "text", "text": ""}, {})
+        await t._handle_part_updated({"type": "reasoning"}, {})
+
+        block_starts = _events_of_type(emit, "content_block_start")
+        assert block_starts[0]["index"] == 0
+        assert block_starts[1]["index"] == 1
+
+
+# ---------------------------------------------------------------------------
+# send_message
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessage:
+    @pytest.mark.asyncio
+    async def test_send_message_without_session_raises(self, tmp_path):
+        t = _make_transport(tmp_path)
+        with pytest.raises(RuntimeError, match="No active session"):
+            await t.send_message("test")
+
+    @pytest.mark.asyncio
+    async def test_send_message_resets_state(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._session_id = "s1"
+        t._last_result = {"old": True}
+        t._last_usage = {"old": True}
+        t._block_index = 5
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 204
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_message("test")
+
+        assert t._last_result is None
+        assert t._last_usage is None
+        assert t._block_index == 0
+
+    @pytest.mark.asyncio
+    async def test_send_message_posts_prompt_async(self, tmp_path):
+        t = _make_transport(tmp_path, model="gpt-4o", system_prompt="Be helpful")
+        t._session_id = "s1"
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 204
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_message("What is 2+2?")
+
+        mock_client.post.assert_called_once()
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/session/s1/prompt_async"
+        body = call_args[1]["json"]
+        assert body["parts"][0]["type"] == "text"
+        assert body["parts"][0]["text"] == "What is 2+2?"
+        assert body["system"] == "Be helpful"
+        assert body["model"]["modelID"] == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Control: interrupt, set_model, permissions
+# ---------------------------------------------------------------------------
+
+
+class TestControl:
+    @pytest.mark.asyncio
+    async def test_set_model(self, tmp_path):
+        t = _make_transport(tmp_path)
+        await t.send_control("set_model", model="claude-opus-4-6")
+        assert t._model == "claude-opus-4-6"
+
+    @pytest.mark.asyncio
+    async def test_interrupt_posts_abort(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._session_id = "s1"
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_control("interrupt")
+
+        mock_client.post.assert_called_once_with("/session/s1/abort")
+
+
+class TestPermissions:
+    @pytest.mark.asyncio
+    async def test_permission_allow(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._pending_permissions["perm-1"] = {"id": "perm-1"}
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_control_response("perm-1", {"behavior": "allow"})
+
+        call_args = mock_client.post.call_args
+        assert call_args[0][0] == "/permission/perm-1/reply"
+        assert call_args[1]["json"]["reply"] == "allow"
+        assert "perm-1" not in t._pending_permissions
+
+    @pytest.mark.asyncio
+    async def test_permission_deny(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._pending_permissions["perm-2"] = {"id": "perm-2"}
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_control_response("perm-2", {"behavior": "deny"})
+
+        call_args = mock_client.post.call_args
+        assert call_args[1]["json"]["reply"] == "deny"
+
+
+# ---------------------------------------------------------------------------
+# Resume
+# ---------------------------------------------------------------------------
+
+
+class TestResume:
+    @pytest.mark.asyncio
+    async def test_resume(self, tmp_path):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t.resume("existing-session-id")
+
+        assert t._session_id == "existing-session-id"
+        init_event = emit.call_args[0][0]
+        assert init_event["type"] == "system"
+        assert init_event["session_id"] == "existing-session-id"
+
+
+# ---------------------------------------------------------------------------
+# Stop / cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestStopCleanup:
+    @pytest.mark.asyncio
+    async def test_stop_cleans_up(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._alive = True
+
+        mock_client = AsyncMock()
+        t._client = mock_client
+
+        mock_process = MagicMock()
+        mock_process.returncode = None
+        mock_process.terminate = MagicMock()
+        mock_process.kill = MagicMock()
+        mock_process.wait = AsyncMock(return_value=0)
+        mock_process.pid = 12345
+        t._process = mock_process
+
+        await t.stop()
+
+        assert t._alive is False
+        assert t._client is None
+        assert t._process is None
+        mock_client.aclose.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Config integration
+# ---------------------------------------------------------------------------
+
+
+class TestConfigIntegration:
+    def test_opencode_cli_type_resolves_adapter(self):
+        from skuld.config import SkuldSettings
+
+        settings = SkuldSettings(cli_type="opencode")
+        assert settings.transport_adapter == "skuld.transports.opencode.OpenCodeHttpTransport"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full turn simulation
+# ---------------------------------------------------------------------------
+
+
+class TestFullTurnFlow:
+    @pytest.mark.asyncio
+    async def test_text_turn_lifecycle(self, tmp_path):
+        """session.status → text block → deltas → session.idle."""
+        t = _make_transport(tmp_path, model="claude-sonnet-4-6")
+        emit = _collect_emits(t)
+
+        # 1. Status: analyzing
+        await t._handle_sse_event({"type": "session.status", "properties": {"status": "analyzing"}})
+
+        # 2. Text part created
+        await t._handle_sse_event(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "part": {"type": "text", "text": ""},
+                    "sessionID": "s1",
+                    "messageID": "m1",
+                    "partID": "p1",
+                },
+            }
+        )
+
+        # 3. Text deltas
+        await t._handle_sse_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "sessionID": "s1",
+                    "messageID": "m1",
+                    "partID": "p1",
+                    "field": "text",
+                    "delta": "Four.",
+                },
+            }
+        )
+
+        # 4. Finish part
+        await t._handle_sse_event(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "part": {"type": "finish", "reason": "end_turn"},
+                    "sessionID": "s1",
+                    "messageID": "m1",
+                    "partID": "p2",
+                },
+            }
+        )
+
+        # 5. Session idle
+        await t._handle_sse_event({"type": "session.idle", "properties": {"sessionID": "s1"}})
+
+        events = _emitted_events(emit)
+        types = [e["type"] for e in events]
+
+        assert "assistant" in types
+        assert "content_block_start" in types
+        assert "content_block_delta" in types
+        assert "result" in types
+
+        result = _events_of_type(emit, "result")[0]
+        assert result["stop_reason"] == "end_turn"
+        assert "claude-sonnet-4-6" in result["modelUsage"]
+
+    @pytest.mark.asyncio
+    async def test_tool_turn_lifecycle(self, tmp_path):
+        """Tool call: tool-invocation → tool-result → session.idle."""
+        t = _make_transport(tmp_path, model="gpt-4o")
+        emit = _collect_emits(t)
+
+        # Status
+        await t._handle_sse_event({"type": "session.status", "properties": {"status": "executing"}})
+
+        # Tool invocation
+        await t._handle_sse_event(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "part": {
+                        "type": "tool-invocation",
+                        "id": "tool-1",
+                        "toolName": "read_file",
+                        "args": {"path": "/tmp/test.py"},
+                    },
+                    "sessionID": "s1",
+                    "messageID": "m1",
+                    "partID": "p1",
+                },
+            }
+        )
+
+        # Tool result
+        await t._handle_sse_event(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "part": {
+                        "type": "tool-result",
+                        "result": "print('hello')",
+                        "isError": False,
+                    },
+                    "sessionID": "s1",
+                    "messageID": "m1",
+                    "partID": "p2",
+                },
+            }
+        )
+
+        events = _emitted_events(emit)
+
+        # Assistant event for broker
+        assistant_events = _events_of_type(emit, "assistant")
+        assert len(assistant_events) >= 1
+        tool_assistants = [e for e in assistant_events if e.get("message", {}).get("content")]
+        tool_block = tool_assistants[-1]["message"]["content"][0]
+        assert tool_block["name"] == "Read"
+
+        # Output visible
+        text_deltas = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "text_delta"
+        ]
+        assert any("hello" in d["delta"]["text"] for d in text_deltas)

--- a/tests/test_skuld/test_opencode_transport.py
+++ b/tests/test_skuld/test_opencode_transport.py
@@ -554,6 +554,760 @@ class TestConfigIntegration:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# send_message body variants
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageBody:
+    @pytest.mark.asyncio
+    async def test_send_message_with_model_includes_model_field(self, tmp_path):
+        """When model is set, body should contain model.modelID."""
+        t = _make_transport(tmp_path, model="anthropic/claude-sonnet-4-6")
+        t._session_id = "s1"
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 204
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_message("hello")
+
+        body = mock_client.post.call_args[1]["json"]
+        assert body["model"]["modelID"] == "anthropic/claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_send_message_without_model_omits_model_field(self, tmp_path):
+        """When model is empty string, body should not contain model key."""
+        t = _make_transport(tmp_path, model="")
+        t._session_id = "s1"
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 204
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_message("hello")
+
+        body = mock_client.post.call_args[1]["json"]
+        assert "model" not in body
+
+    @pytest.mark.asyncio
+    async def test_send_message_without_system_prompt_omits_system(self, tmp_path):
+        """When system_prompt is empty, body should not contain system key."""
+        t = _make_transport(tmp_path, system_prompt="")
+        t._session_id = "s1"
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 204
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_message("hello")
+
+        body = mock_client.post.call_args[1]["json"]
+        assert "system" not in body
+
+    @pytest.mark.asyncio
+    async def test_send_message_error_response_emits_error(self, tmp_path):
+        """When server returns non-200/204, an error event is emitted."""
+        t = _make_transport(tmp_path)
+        t._session_id = "s1"
+        emit = _collect_emits(t)
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.text = "Internal Server Error"
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_message("hello")
+
+        error_events = _events_of_type(emit, "error")
+        assert len(error_events) == 1
+        assert "Internal Server Error" in error_events[0]["error"]
+
+
+# ---------------------------------------------------------------------------
+# send_control edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestControlEdgeCases:
+    @pytest.mark.asyncio
+    async def test_send_control_unknown_subtype_is_noop(self, tmp_path):
+        """Unknown control subtypes are logged but otherwise ignored."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t.send_control("unknown_subtype", foo="bar")
+
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_without_session_is_noop(self, tmp_path):
+        """Interrupt with no session_id should not call client."""
+        t = _make_transport(tmp_path)
+        t._session_id = None
+
+        mock_client = AsyncMock()
+        t._client = mock_client
+
+        await t.send_control("interrupt")
+
+        mock_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_exception_is_swallowed(self, tmp_path):
+        """If the abort POST throws, the exception is caught."""
+        t = _make_transport(tmp_path)
+        t._session_id = "s1"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=Exception("connection refused"))
+        t._client = mock_client
+
+        # Should not raise
+        await t.send_control("interrupt")
+
+
+# ---------------------------------------------------------------------------
+# send_control_response edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestControlResponseEdgeCases:
+    @pytest.mark.asyncio
+    async def test_permission_not_found_is_noop(self, tmp_path):
+        """Responding to a permission not in pending is still fine (no-op pop)."""
+        t = _make_transport(tmp_path)
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        # No pending permission for "nonexistent"
+        await t.send_control_response("nonexistent", {"behavior": "allow"})
+
+        # Still posts the reply
+        mock_client.post.assert_called_once()
+        assert "nonexistent" not in t._pending_permissions
+
+    @pytest.mark.asyncio
+    async def test_permission_reply_error_status_logged(self, tmp_path):
+        """Non-200/204 reply status is handled gracefully."""
+        t = _make_transport(tmp_path)
+        t._pending_permissions["perm-x"] = {"id": "perm-x"}
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.text = "Not Found"
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        # Should not raise
+        await t.send_control_response("perm-x", {"behavior": "allow"})
+
+    @pytest.mark.asyncio
+    async def test_permission_reply_exception_swallowed(self, tmp_path):
+        """If the permission POST throws, the exception is caught."""
+        t = _make_transport(tmp_path)
+        t._pending_permissions["perm-y"] = {"id": "perm-y"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=Exception("timeout"))
+        t._client = mock_client
+
+        # Should not raise
+        await t.send_control_response("perm-y", {"behavior": "deny"})
+
+    @pytest.mark.asyncio
+    async def test_permission_allow_forever(self, tmp_path):
+        """allowForever maps to 'allow' reply."""
+        t = _make_transport(tmp_path)
+        t._pending_permissions["perm-z"] = {"id": "perm-z"}
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_control_response("perm-z", {"behavior": "allowForever"})
+
+        call_args = mock_client.post.call_args
+        assert call_args[1]["json"]["reply"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# _handle_sse_event: message.updated model tracking
+# ---------------------------------------------------------------------------
+
+
+class TestMessageUpdated:
+    @pytest.mark.asyncio
+    async def test_message_updated_sets_model(self, tmp_path):
+        """message.updated with model should set transport model when unset."""
+        t = _make_transport(tmp_path, model="")
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "message.updated",
+                "properties": {
+                    "info": {
+                        "id": "m1",
+                        "role": "assistant",
+                        "model": "gpt-4o-mini",
+                    }
+                },
+            }
+        )
+
+        assert t._model == "gpt-4o-mini"
+        # message.updated returns early, no emit
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_message_updated_does_not_overwrite_existing_model(self, tmp_path):
+        """message.updated should NOT overwrite an already-set model."""
+        t = _make_transport(tmp_path, model="claude-sonnet-4-6")
+        _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "message.updated",
+                "properties": {
+                    "info": {
+                        "id": "m1",
+                        "role": "assistant",
+                        "model": "gpt-4o",
+                    }
+                },
+            }
+        )
+
+        assert t._model == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_message_updated_tracks_user_message_ids(self, tmp_path):
+        """User messages should be tracked so their deltas are skipped."""
+        t = _make_transport(tmp_path)
+        _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "message.updated",
+                "properties": {
+                    "info": {
+                        "id": "user-msg-1",
+                        "role": "user",
+                    }
+                },
+            }
+        )
+
+        assert "user-msg-1" in t._user_message_ids
+
+    @pytest.mark.asyncio
+    async def test_user_message_deltas_skipped(self, tmp_path):
+        """Deltas for user messages (echoed prompt) should be ignored."""
+        t = _make_transport(tmp_path)
+        t._user_message_ids.add("user-msg-1")
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "messageID": "user-msg-1",
+                    "partID": "p1",
+                    "field": "text",
+                    "delta": "echoed prompt",
+                },
+            }
+        )
+
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_user_message_parts_skipped(self, tmp_path):
+        """Parts for user messages should be ignored."""
+        t = _make_transport(tmp_path)
+        t._user_message_ids.add("user-msg-1")
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "message.part.updated",
+                "properties": {
+                    "messageID": "user-msg-1",
+                    "part": {"type": "text", "text": "echoed"},
+                },
+            }
+        )
+
+        emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# session.status "executing" emits assistant
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStatusExecuting:
+    @pytest.mark.asyncio
+    async def test_session_status_executing_emits_assistant(self, tmp_path):
+        """session.status with status=executing should emit assistant event."""
+        t = _make_transport(tmp_path, model="claude-sonnet-4-6")
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "session.status",
+                "properties": {"status": "executing"},
+            }
+        )
+
+        assistant_events = _events_of_type(emit, "assistant")
+        assert len(assistant_events) == 1
+        assert assistant_events[0]["message"]["model"] == "claude-sonnet-4-6"
+
+    @pytest.mark.asyncio
+    async def test_session_status_other_no_emit(self, tmp_path):
+        """session.status with unknown status should not emit."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event(
+            {
+                "type": "session.status",
+                "properties": {"status": "idle"},
+            }
+        )
+
+        emit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Part handling: tool-invocation with string args
+# ---------------------------------------------------------------------------
+
+
+class TestPartHandlingStringArgs:
+    @pytest.mark.asyncio
+    async def test_tool_invocation_string_args_json_parse(self, tmp_path):
+        """tool-invocation with string args that are valid JSON should be parsed."""
+        t = _make_transport(tmp_path, model="gpt-4o")
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {
+                "type": "tool-invocation",
+                "id": "tool-2",
+                "toolName": "shell",
+                "args": '{"command": "echo hi"}',
+            },
+            {},
+        )
+
+        assistant_events = _events_of_type(emit, "assistant")
+        tool_block = assistant_events[0]["message"]["content"][0]
+        assert tool_block["input"] == {"command": "echo hi"}
+
+    @pytest.mark.asyncio
+    async def test_tool_invocation_string_args_invalid_json(self, tmp_path):
+        """tool-invocation with non-JSON string args wraps in {command: ...}."""
+        t = _make_transport(tmp_path, model="gpt-4o")
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {
+                "type": "tool-invocation",
+                "id": "tool-3",
+                "toolName": "shell",
+                "args": "echo hello world",
+            },
+            {},
+        )
+
+        assistant_events = _events_of_type(emit, "assistant")
+        tool_block = assistant_events[0]["message"]["content"][0]
+        assert tool_block["input"] == {"command": "echo hello world"}
+
+
+# ---------------------------------------------------------------------------
+# Part handling: tool-result with empty content
+# ---------------------------------------------------------------------------
+
+
+class TestPartHandlingEmptyResult:
+    @pytest.mark.asyncio
+    async def test_tool_result_empty_content_only_stop(self, tmp_path):
+        """tool-result with empty content emits only content_block_stop, no text."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {
+                "type": "tool-result",
+                "result": "",
+                "isError": False,
+            },
+            {},
+        )
+
+        events = _emitted_events(emit)
+        # Should only have the stop event, no text block
+        assert len(events) == 1
+        assert events[0]["type"] == "content_block_stop"
+
+    @pytest.mark.asyncio
+    async def test_tool_result_none_content_only_stop(self, tmp_path):
+        """tool-result with no result key emits only stop."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_part_updated(
+            {
+                "type": "tool-result",
+                "isError": False,
+            },
+            {},
+        )
+
+        events = _emitted_events(emit)
+        assert len(events) == 1
+        assert events[0]["type"] == "content_block_stop"
+
+
+# ---------------------------------------------------------------------------
+# stop() edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestStopEdgeCases:
+    @pytest.mark.asyncio
+    async def test_stop_no_process_no_client(self, tmp_path):
+        """stop() with no process and no client should not raise."""
+        t = _make_transport(tmp_path)
+        t._alive = True
+        t._process = None
+        t._client = None
+        t._sse_task = None
+
+        await t.stop()
+
+        assert t._alive is False
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_sse_task(self, tmp_path):
+        """stop() should cancel the SSE task if running."""
+        t = _make_transport(tmp_path)
+        t._alive = True
+        t._process = None
+        t._client = None
+
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        mock_task.cancel = MagicMock()
+        t._sse_task = mock_task
+
+        await t.stop()
+
+        mock_task.cancel.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_skips_done_sse_task(self, tmp_path):
+        """stop() should not cancel an already-done SSE task."""
+        t = _make_transport(tmp_path)
+        t._alive = True
+        t._process = None
+        t._client = None
+
+        mock_task = MagicMock()
+        mock_task.done.return_value = True
+        mock_task.cancel = MagicMock()
+        t._sse_task = mock_task
+
+        await t.stop()
+
+        mock_task.cancel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _emit_text_delta edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEmitTextDelta:
+    @pytest.mark.asyncio
+    async def test_empty_string_noop(self, tmp_path):
+        """_emit_text_delta with empty string should not emit anything."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._emit_text_delta("")
+
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_nonempty_string_emits(self, tmp_path):
+        """_emit_text_delta with content should emit a text_delta event."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._emit_text_delta("hello")
+
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event["type"] == "content_block_delta"
+        assert event["delta"]["type"] == "text_delta"
+        assert event["delta"]["text"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# _next_block_index
+# ---------------------------------------------------------------------------
+
+
+class TestNextBlockIndex:
+    def test_increments_correctly(self, tmp_path):
+        t = _make_transport(tmp_path)
+        assert t._next_block_index() == 0
+        assert t._next_block_index() == 1
+        assert t._next_block_index() == 2
+        assert t._block_index == 3
+
+    @pytest.mark.asyncio
+    async def test_reset_after_send_message(self, tmp_path):
+        """send_message resets _block_index to 0."""
+        t = _make_transport(tmp_path)
+        t._block_index = 5
+        t._session_id = "s1"
+
+        mock_client = AsyncMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 204
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t.send_message("test")
+
+        assert t._block_index == 0
+
+
+# ---------------------------------------------------------------------------
+# Resume
+# ---------------------------------------------------------------------------
+
+
+class TestResumeExtended:
+    @pytest.mark.asyncio
+    async def test_resume_sets_session_id_and_emits_init(self, tmp_path):
+        """resume() sets session_id and emits system/init with model and tools."""
+        t = _make_transport(tmp_path, model="claude-sonnet-4-6")
+        emit = _collect_emits(t)
+
+        await t.resume("resumed-session-42")
+
+        assert t._session_id == "resumed-session-42"
+        events = _emitted_events(emit)
+        assert len(events) == 1
+        init = events[0]
+        assert init["type"] == "system"
+        assert init["subtype"] == "init"
+        assert init["session_id"] == "resumed-session-42"
+        assert init["model"] == "claude-sonnet-4-6"
+        assert init["tools"] == []
+
+
+# ---------------------------------------------------------------------------
+# Reasoning part ID tracking across delta events
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningPartTracking:
+    @pytest.mark.asyncio
+    async def test_reasoning_part_routes_deltas_as_thinking(self, tmp_path):
+        """After a reasoning part.updated, subsequent deltas with field=text
+        should still be routed as thinking_delta because the partID is tracked."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        # Register reasoning part
+        await t._handle_part_updated(
+            {"type": "reasoning", "id": "reason-1"},
+            {"partID": "reason-1"},
+        )
+
+        # Now a delta with field="text" but for a reasoning partID
+        await t._handle_sse_event(
+            {
+                "type": "message.part.delta",
+                "properties": {
+                    "messageID": "m1",
+                    "partID": "reason-1",
+                    "field": "text",
+                    "delta": "deep thought",
+                },
+            }
+        )
+
+        events = _emitted_events(emit)
+        thinking_deltas = [
+            e
+            for e in events
+            if e.get("type") == "content_block_delta"
+            and e.get("delta", {}).get("type") == "thinking_delta"
+        ]
+        assert len(thinking_deltas) == 1
+        assert thinking_deltas[0]["delta"]["thinking"] == "deep thought"
+
+
+# ---------------------------------------------------------------------------
+# Misc coverage: _base_url, unhandled events, set_model edge cases
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# start() and _create_session with mocked internals
+# ---------------------------------------------------------------------------
+
+
+class TestStartAndCreateSession:
+    @pytest.mark.asyncio
+    async def test_start_calls_spawn_connect_create(self, tmp_path):
+        """start() orchestrates _spawn_server, _connect, _create_session."""
+        t = _make_transport(tmp_path)
+        t._spawn_server = AsyncMock()
+        t._connect = AsyncMock()
+        t._create_session = AsyncMock()
+
+        await t.start()
+
+        t._spawn_server.assert_awaited_once()
+        t._connect.assert_awaited_once()
+        t._create_session.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_with_initial_prompt_sends_message(self, tmp_path):
+        """start() with initial_prompt calls send_message after setup."""
+        t = _make_transport(tmp_path, initial_prompt="bootstrap prompt")
+        t._spawn_server = AsyncMock()
+        t._connect = AsyncMock()
+        t._create_session = AsyncMock()
+        t.send_message = AsyncMock()
+
+        await t.start()
+
+        t.send_message.assert_awaited_once_with("bootstrap prompt")
+
+    @pytest.mark.asyncio
+    async def test_start_without_initial_prompt_no_send(self, tmp_path):
+        """start() without initial_prompt does not call send_message."""
+        t = _make_transport(tmp_path, initial_prompt="")
+        t._spawn_server = AsyncMock()
+        t._connect = AsyncMock()
+        t._create_session = AsyncMock()
+        t.send_message = AsyncMock()
+
+        await t.start()
+
+        t.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_create_session_extracts_id(self, tmp_path):
+        """_create_session POSTs to /session and extracts session ID."""
+        t = _make_transport(tmp_path, model="test-model")
+        emit = _collect_emits(t)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "new-session-123"}
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t._create_session()
+
+        assert t._session_id == "new-session-123"
+        mock_client.post.assert_awaited_once_with("/session", json={})
+
+        events = _emitted_events(emit)
+        assert len(events) == 1
+        assert events[0]["type"] == "system"
+        assert events[0]["subtype"] == "init"
+        assert events[0]["session_id"] == "new-session-123"
+
+    @pytest.mark.asyncio
+    async def test_create_session_extracts_session_id_key(self, tmp_path):
+        """_create_session falls back to sessionID key."""
+        t = _make_transport(tmp_path)
+        _collect_emits(t)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"sessionID": "fallback-456"}
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        t._client = mock_client
+
+        await t._create_session()
+
+        assert t._session_id == "fallback-456"
+
+
+class TestMiscCoverage:
+    def test_base_url_property(self, tmp_path):
+        t = _make_transport(tmp_path, opencode_port=12345)
+        assert t._base_url == "http://127.0.0.1:12345"
+
+    @pytest.mark.asyncio
+    async def test_unhandled_event_type_no_emit(self, tmp_path):
+        """Unknown event types are logged but produce no emit."""
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_sse_event({"type": "some.future.event", "properties": {"foo": "bar"}})
+
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_model_non_string_ignored(self, tmp_path):
+        """set_model with non-string model should not update _model."""
+        t = _make_transport(tmp_path, model="original")
+
+        await t.send_control("set_model", model=123)
+
+        assert t._model == "original"
+
+    @pytest.mark.asyncio
+    async def test_set_model_none_ignored(self, tmp_path):
+        """set_model with model=None should not update _model."""
+        t = _make_transport(tmp_path, model="original")
+
+        await t.send_control("set_model", model=None)
+
+        assert t._model == "original"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: full turn simulation
+# ---------------------------------------------------------------------------
+
+
 class TestFullTurnFlow:
     @pytest.mark.asyncio
     async def test_text_turn_lifecycle(self, tmp_path):

--- a/tests/test_skuld/test_transport.py
+++ b/tests/test_skuld/test_transport.py
@@ -1547,6 +1547,7 @@ class TestStopProcess:
     async def test_terminate_succeeds(self):
         proc = MagicMock(spec=asyncio.subprocess.Process)
         proc.returncode = None
+        proc.pid = 12345
         proc.terminate = MagicMock()
 
         wait_future: asyncio.Future[int] = asyncio.get_event_loop().create_future()
@@ -1560,6 +1561,7 @@ class TestStopProcess:
     async def test_kill_on_timeout(self):
         proc = MagicMock(spec=asyncio.subprocess.Process)
         proc.returncode = None
+        proc.pid = 12345
         proc.terminate = MagicMock()
         proc.kill = MagicMock()
 

--- a/tests/test_tyr/test_dispatcher_api.py
+++ b/tests/test_tyr/test_dispatcher_api.py
@@ -115,7 +115,7 @@ class TestGetDispatcherState:
         assert resp.status_code == 200
         data = resp.json()
         assert data["running"] is True
-        assert data["threshold"] == 75.0
+        assert data["threshold"] == 0.75
         assert data["max_concurrent_raids"] == 3
         assert data["auto_continue"] is False
         assert "id" in data
@@ -138,7 +138,7 @@ class TestGetDispatcherState:
         assert resp.status_code == 200
         data = resp.json()
         assert data["running"] is False
-        assert data["threshold"] == 50.0
+        assert data["threshold"] == 0.5
         assert data["max_concurrent_raids"] == 5
         assert data["id"] == str(existing.id)
 
@@ -174,22 +174,9 @@ class TestPatchDispatcherState:
         assert resp.status_code == 200
         data = resp.json()
         assert data["running"] is False
-        assert data["threshold"] == 75.0  # unchanged
+        assert data["threshold"] == 0.75  # unchanged
 
     def test_updates_threshold(self, client: TestClient):
-        client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
-
-        resp = client.patch(
-            "/api/v1/tyr/dispatcher",
-            json={"threshold": 90},
-            headers=_auth_headers(),
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert data["threshold"] == 90.0
-        assert data["running"] is True  # unchanged
-
-    def test_updates_threshold_with_legacy_fraction_payload(self, client: TestClient):
         client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
 
         resp = client.patch(
@@ -198,7 +185,20 @@ class TestPatchDispatcherState:
             headers=_auth_headers(),
         )
         assert resp.status_code == 200
-        assert resp.json()["threshold"] == 90.0
+        data = resp.json()
+        assert data["threshold"] == 0.9
+        assert data["running"] is True  # unchanged
+
+    def test_updates_threshold_boundary(self, client: TestClient):
+        client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
+
+        resp = client.patch(
+            "/api/v1/tyr/dispatcher",
+            json={"threshold": 1.0},
+            headers=_auth_headers(),
+        )
+        assert resp.status_code == 200
+        assert resp.json()["threshold"] == 1.0
 
     def test_updates_max_concurrent_raids(self, client: TestClient):
         client.get("/api/v1/tyr/dispatcher", headers=_auth_headers())
@@ -227,7 +227,7 @@ class TestPatchDispatcherState:
     def test_validates_threshold_range_too_high(self, client: TestClient):
         resp = client.patch(
             "/api/v1/tyr/dispatcher",
-            json={"threshold": 150},
+            json={"threshold": 1.5},
             headers=_auth_headers(),
         )
         assert resp.status_code == 422
@@ -267,7 +267,7 @@ class TestPatchDispatcherState:
         assert resp.status_code == 200
         data = resp.json()
         assert data["running"] is True
-        assert data["threshold"] == 75.0
+        assert data["threshold"] == 0.75
         assert data["max_concurrent_raids"] == 3
         assert data["auto_continue"] is False
 
@@ -276,7 +276,7 @@ class TestPatchDispatcherState:
             "/api/v1/tyr/dispatcher",
             json={
                 "running": False,
-                "threshold": 60,
+                "threshold": 0.6,
                 "max_concurrent_raids": 7,
                 "auto_continue": True,
             },
@@ -285,7 +285,7 @@ class TestPatchDispatcherState:
         assert resp.status_code == 200
         data = resp.json()
         assert data["running"] is False
-        assert data["threshold"] == 60.0
+        assert data["threshold"] == 0.6
         assert data["max_concurrent_raids"] == 7
         assert data["auto_continue"] is True
 

--- a/tests/test_volundr/test_session_definition_contributor.py
+++ b/tests/test_volundr/test_session_definition_contributor.py
@@ -5,7 +5,7 @@ import pytest
 from volundr.adapters.outbound.contributors.session_def import (
     SessionDefinitionContributor,
 )
-from volundr.config import SessionDefinitionConfig
+from volundr.config import SessionDefinitionConfig, _default_session_definitions
 from volundr.domain.ports import SessionContext
 
 
@@ -142,3 +142,42 @@ class TestSessionDefinitionConfig:
         )
         assert config.display_name == "Claude Code"
         assert config.defaults["broker"]["cliType"] == "claude"
+
+
+class TestDefaultSessionDefinitions:
+    def test_returns_three_definitions(self):
+        defs = _default_session_definitions()
+        assert "skuldClaude" in defs
+        assert "skuldCodex" in defs
+        assert "skuldOpenCode" in defs
+
+    def test_all_enabled(self):
+        for defn in _default_session_definitions().values():
+            assert defn.enabled is True
+
+    def test_claude_defaults(self):
+        claude = _default_session_definitions()["skuldClaude"]
+        assert claude.display_name == "Claude Code"
+        assert claude.defaults["broker"]["cliType"] == "claude"
+
+    def test_codex_defaults(self):
+        codex = _default_session_definitions()["skuldCodex"]
+        assert codex.display_name == "OpenAI Codex"
+        assert codex.defaults["broker"]["cliType"] == "codex-ws"
+
+    def test_opencode_defaults(self):
+        opencode = _default_session_definitions()["skuldOpenCode"]
+        assert opencode.display_name == "OpenCode"
+        assert opencode.defaults["broker"]["cliType"] == "opencode"
+
+    @pytest.mark.asyncio
+    async def test_default_definitions_work_with_contributor(self):
+        """Default definitions integrate correctly with the contributor."""
+        defs = _default_session_definitions()
+        contributor = SessionDefinitionContributor(
+            definitions=defs, default_definition="skuldClaude"
+        )
+        # No explicit definition — should fall back to skuldClaude
+        context = SessionContext()
+        result = await contributor.contribute(_mock_session(), context)
+        assert result.values["broker"]["cliType"] == "claude"

--- a/tests/test_volundr/test_session_definition_contributor.py
+++ b/tests/test_volundr/test_session_definition_contributor.py
@@ -1,0 +1,144 @@
+"""Tests for SessionDefinitionContributor."""
+
+import pytest
+
+from volundr.adapters.outbound.contributors.session_def import (
+    SessionDefinitionContributor,
+)
+from volundr.config import SessionDefinitionConfig
+from volundr.domain.ports import SessionContext
+
+
+def _mock_session():
+    """Create a minimal mock session for testing."""
+    from unittest.mock import MagicMock
+
+    session = MagicMock()
+    session.id = "test-session-id"
+    session.name = "test-session"
+    session.model = "claude-sonnet-4-6"
+    return session
+
+
+DEFINITIONS = {
+    "skuldClaude": SessionDefinitionConfig(
+        enabled=True,
+        display_name="Claude Code",
+        description="Anthropic Claude",
+        labels=["session"],
+        default_model="claude-sonnet-4-6",
+        defaults={
+            "broker": {
+                "cliType": "claude",
+                "transportAdapter": "skuld.transports.sdk_websocket.SdkWebSocketTransport",
+            },
+        },
+    ),
+    "skuldCodex": SessionDefinitionConfig(
+        enabled=True,
+        display_name="OpenAI Codex",
+        description="OpenAI Codex via WebSocket",
+        labels=["session"],
+        default_model="",
+        defaults={
+            "broker": {
+                "cliType": "codex-ws",
+                "transportAdapter": "skuld.transports.codex_ws.CodexWebSocketTransport",
+            },
+        },
+    ),
+    "skuldDisabled": SessionDefinitionConfig(
+        enabled=False,
+        display_name="Disabled",
+        description="Should not be used",
+        defaults={"broker": {"cliType": "nope"}},
+    ),
+}
+
+
+class TestSessionDefinitionContributor:
+    @pytest.mark.asyncio
+    async def test_merges_definition_defaults(self):
+        contributor = SessionDefinitionContributor(definitions=DEFINITIONS)
+        context = SessionContext(definition="skuldCodex")
+
+        result = await contributor.contribute(_mock_session(), context)
+
+        assert result.values["broker"]["cliType"] == "codex-ws"
+        assert "transportAdapter" in result.values["broker"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_definition(self):
+        contributor = SessionDefinitionContributor(definitions=DEFINITIONS)
+        context = SessionContext()
+
+        result = await contributor.contribute(_mock_session(), context)
+
+        assert result.values == {}
+
+    @pytest.mark.asyncio
+    async def test_uses_default_definition(self):
+        contributor = SessionDefinitionContributor(
+            definitions=DEFINITIONS, default_definition="skuldClaude"
+        )
+        context = SessionContext()
+
+        result = await contributor.contribute(_mock_session(), context)
+
+        assert result.values["broker"]["cliType"] == "claude"
+
+    @pytest.mark.asyncio
+    async def test_explicit_definition_overrides_default(self):
+        contributor = SessionDefinitionContributor(
+            definitions=DEFINITIONS, default_definition="skuldClaude"
+        )
+        context = SessionContext(definition="skuldCodex")
+
+        result = await contributor.contribute(_mock_session(), context)
+
+        assert result.values["broker"]["cliType"] == "codex-ws"
+
+    @pytest.mark.asyncio
+    async def test_disabled_definition_returns_empty(self):
+        contributor = SessionDefinitionContributor(definitions=DEFINITIONS)
+        context = SessionContext(definition="skuldDisabled")
+
+        result = await contributor.contribute(_mock_session(), context)
+
+        assert result.values == {}
+
+    @pytest.mark.asyncio
+    async def test_unknown_definition_returns_empty(self):
+        contributor = SessionDefinitionContributor(definitions=DEFINITIONS)
+        context = SessionContext(definition="nonexistent")
+
+        result = await contributor.contribute(_mock_session(), context)
+
+        assert result.values == {}
+
+    def test_contributor_name(self):
+        contributor = SessionDefinitionContributor()
+        assert contributor.name == "session_definition"
+
+
+class TestSessionDefinitionConfig:
+    def test_defaults(self):
+        config = SessionDefinitionConfig()
+        assert config.enabled is True
+        assert config.display_name == ""
+        assert config.description == ""
+        assert config.labels == []
+        assert config.default_model == ""
+        assert config.defaults == {}
+
+    def test_from_dict(self):
+        config = SessionDefinitionConfig(
+            enabled=True,
+            display_name="Claude Code",
+            description="Test",
+            labels=["session"],
+            default_model="claude-sonnet-4-6",
+            defaults={"broker": {"cliType": "claude"}},
+        )
+        assert config.display_name == "Claude Code"
+        assert config.defaults["broker"]["cliType"] == "claude"

--- a/web-next/packages/plugin-hello/src/ui/OverlaysPage.test.tsx
+++ b/web-next/packages/plugin-hello/src/ui/OverlaysPage.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { OverlaysPage } from './OverlaysPage';
+
+describe('OverlaysPage', () => {
+  it('renders all four overlay section headings', () => {
+    render(<OverlaysPage />);
+    expect(screen.getByText('Dialog')).toBeInTheDocument();
+    expect(screen.getByText('Drawer')).toBeInTheDocument();
+    expect(screen.getByText('Popover')).toBeInTheDocument();
+    expect(screen.getByText('Tooltip')).toBeInTheDocument();
+  });
+
+  it('opens dialog on trigger click', async () => {
+    render(<OverlaysPage />);
+    fireEvent.click(screen.getByTestId('dialog-trigger'));
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog-body')).toBeInTheDocument();
+    });
+  });
+
+  it('closes dialog on cancel click', async () => {
+    render(<OverlaysPage />);
+    fireEvent.click(screen.getByTestId('dialog-trigger'));
+    await waitFor(() => {
+      expect(screen.getByTestId('dialog-body')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('dialog-cancel'));
+  });
+
+  it('opens popover on trigger click', async () => {
+    render(<OverlaysPage />);
+    fireEvent.click(screen.getByTestId('popover-trigger'));
+    await waitFor(() => {
+      expect(screen.getByTestId('popover-body')).toBeInTheDocument();
+    });
+  });
+});

--- a/web-next/packages/plugin-mimir/src/ui/MimirSubnav.test.tsx
+++ b/web-next/packages/plugin-mimir/src/ui/MimirSubnav.test.tsx
@@ -69,4 +69,34 @@ describe('MimirSubnav', () => {
     const allBtn = screen.getByText('All mounts').closest('button');
     expect(allBtn).toHaveAttribute('aria-pressed', 'true');
   });
+
+  it('clicking a per-mount row calls setTweak with the mount name', async () => {
+    const setTweak = vi.fn();
+    wrap({ tweaks: {}, setTweak });
+    await waitFor(() => expect(screen.getAllByText('local').length).toBeGreaterThan(0));
+    const localBtn = screen.getAllByText('local')[0]!.closest('button')!;
+    fireEvent.click(localBtn);
+    expect(setTweak).toHaveBeenCalledWith('activeMount', 'local');
+  });
+
+  it('clicking Errors navigates', async () => {
+    wrap();
+    fireEvent.click(screen.getByText('Errors'));
+  });
+
+  it('clicking Flagged navigates', async () => {
+    wrap();
+    fireEvent.click(screen.getByText('Flagged'));
+  });
+
+  it('clicking Low confidence navigates', async () => {
+    wrap();
+    fireEvent.click(screen.getByText('Low confidence'));
+  });
+
+  it('clicking a warden navigates', async () => {
+    wrap();
+    await waitFor(() => expect(screen.getByText('ravn-fjolnir')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('ravn-fjolnir'));
+  });
 });

--- a/web-next/packages/plugin-ravn/src/ui/BudgetView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/BudgetView.tsx
@@ -536,7 +536,7 @@ function FullFleetTable({ analysis }: { analysis: Analysis[] }) {
 export function BudgetView() {
   const { data: ravens, isLoading: ravensLoading } = useRavens();
   const { data: fleetBudget, isLoading: fleetLoading } = useFleetBudget();
-  const ravnList = ravens ?? [];
+  const ravnList = useMemo(() => ravens ?? [], [ravens]);
   const budgets = useRavnBudgets(ravnList.map((ravn) => ravn.id));
 
   const analysis = useMemo(

--- a/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/OverviewPage.tsx
@@ -143,8 +143,8 @@ export function OverviewPage() {
   const fleetBudget = useFleetBudget();
   const activityLog = useActivityLog();
 
-  const ravnList = ravens.data ?? [];
-  const sessionList = sessions.data ?? [];
+  const ravnList = useMemo(() => ravens.data ?? [], [ravens.data]);
+  const sessionList = useMemo(() => sessions.data ?? [], [sessions.data]);
   const triggerList = triggers.data ?? [];
   const ravnIds = ravnList.map((ravn) => ravn.id);
   const budgets = useRavnBudgets(ravnIds);

--- a/web-next/packages/plugin-ravn/src/ui/PersonasPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/PersonasPage.tsx
@@ -151,7 +151,7 @@ export function PersonasPage() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const { data: personas, isLoading, isError, error } = usePersonas();
 
-  const personaList = personas ?? [];
+  const personaList = useMemo(() => personas ?? [], [personas]);
 
   useEffect(() => {
     const handleSelect = (event: Event) => {

--- a/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavensPage.tsx
@@ -168,7 +168,7 @@ export function RavensPage() {
   const { data: ravens, isLoading, isError, error } = useRavens();
   const { data: sessions } = useSessions();
 
-  const ravnList = ravens ?? [];
+  const ravnList = useMemo(() => ravens ?? [], [ravens]);
   const budgets = useRavnBudgets(ravnList.map((ravn) => ravn.id));
 
   const sessionCounts = useMemo(() => {

--- a/web-next/packages/plugin-ravn/src/ui/RavnDetail.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/RavnDetail.test.tsx
@@ -104,7 +104,7 @@ describe('RavnDetail', () => {
     const triggersTab = screen.getByTestId('sectab-triggers');
     fireEvent.click(triggersTab);
     expect(triggersTab).toHaveAttribute('aria-selected', 'true');
-    expect(screen.getByTestId('section-body-triggers')).toBeInTheDocument();
+    expect(screen.getByTestId('triggers-section-body')).toBeInTheDocument();
   });
 
   it('persists active tab to localStorage', () => {
@@ -167,7 +167,7 @@ describe('RavnDetail — Overview tab', () => {
 
   it('renders state with StateDot in runtime panel', () => {
     render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
-    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getAllByText('active').length).toBeGreaterThan(0);
   });
 
   it('shows model in runtime panel', () => {
@@ -177,12 +177,14 @@ describe('RavnDetail — Overview tab', () => {
 
   it('shows location when provided', () => {
     render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
-    expect(screen.getByText('eu-west-1')).toBeInTheDocument();
+    // Location appears in the hero subtitle (normalised: hyphens become spaces)
+    expect(screen.getByText(/eu west 1/)).toBeInTheDocument();
   });
 
   it('shows deployment when provided', () => {
     render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
-    expect(screen.getByText('production')).toBeInTheDocument();
+    // Deployment appears in the hero subtitle
+    expect(screen.getByText(/production/)).toBeInTheDocument();
   });
 
   it('shows cascade when provided', () => {
@@ -190,14 +192,15 @@ describe('RavnDetail — Overview tab', () => {
     expect(screen.getByText('sequential')).toBeInTheDocument();
   });
 
-  it('shows iteration budget when provided', () => {
+  it('shows last activity in runtime panel', () => {
     render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
-    expect(screen.getByText('40 iters')).toBeInTheDocument();
+    // The runtime panel displays "last activity" derived from updatedAt or createdAt
+    expect(screen.getByText('last activity')).toBeInTheDocument();
   });
 
   it('shows write routing when provided', () => {
     render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
-    expect(screen.getByText('local')).toBeInTheDocument();
+    expect(screen.getAllByText('local').length).toBeGreaterThan(0);
   });
 
   it('renders mounts panel when mounts are provided', () => {
@@ -248,7 +251,7 @@ describe('RavnDetail — Triggers tab', () => {
     render(<RavnDetail ravn={SAMPLE_RAVN} />, { wrapper: wrap() });
     fireEvent.click(screen.getByTestId('sectab-triggers'));
     await waitFor(() => {
-      expect(screen.getByText('/hooks/dispatch')).toBeInTheDocument();
+      expect(screen.getAllByText('/hooks/dispatch').length).toBeGreaterThan(0);
     });
   });
 

--- a/web-next/packages/plugin-ravn/src/ui/SessionsView.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/SessionsView.tsx
@@ -958,7 +958,7 @@ export function SessionsView() {
   const [filter, setFilter] = useState<TranscriptFilter>('all');
   const transcriptRef = useRef<HTMLDivElement>(null);
 
-  const sessionList = sessions ?? [];
+  const sessionList = useMemo(() => sessions ?? [], [sessions]);
   const sortedSessions = useMemo(
     () => [...sessionList].sort((left, right) => right.createdAt.localeCompare(left.createdAt)),
     [sessionList],

--- a/web-next/packages/plugin-tyr/src/ui/WorkflowBuilder/GraphView.tsx
+++ b/web-next/packages/plugin-tyr/src/ui/WorkflowBuilder/GraphView.tsx
@@ -922,7 +922,7 @@ export function GraphView({
     () => new Map<string, WorkflowNode>(nodes.map((n) => [n.id, n])),
     [nodes],
   );
-  const safeIssues = Array.isArray(issues) ? issues : [];
+  const safeIssues = useMemo(() => (Array.isArray(issues) ? issues : []), [issues]);
   const issueMap = useMemo(() => {
     const levels = new Map<string, 'error' | 'warning'>();
     for (const issue of safeIssues) {

--- a/web-next/packages/plugin-volundr/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/http.test.ts
@@ -104,6 +104,30 @@ describe('buildVolundrHttpAdapter', () => {
     expect(sharedClient.get).toHaveBeenCalledWith('/features');
   });
 
+  it('getSessionDefinitions calls GET /session-definitions and normalizes snake_case', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValueOnce([
+      {
+        key: 'skuld-claude',
+        display_name: 'Claude Code',
+        description: 'Anthropic Claude agent',
+        labels: ['anthropic'],
+        default_model: 'sonnet-primary',
+      },
+    ]);
+    const definitions = await buildVolundrHttpAdapter(client).getSessionDefinitions();
+    expect(client.get).toHaveBeenCalledWith('/session-definitions');
+    expect(definitions).toEqual([
+      {
+        key: 'skuld-claude',
+        displayName: 'Claude Code',
+        description: 'Anthropic Claude agent',
+        labels: ['anthropic'],
+        defaultModel: 'sonnet-primary',
+      },
+    ]);
+  });
+
   it('getRepos uses the shared niuu repo catalog and normalizes grouped provider payloads', async () => {
     const client = makeClientWithBase('http://localhost:8080/api/v1/volundr');
     const svc = buildVolundrHttpAdapter(client);

--- a/web-next/packages/plugin-volundr/src/adapters/http.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/http.ts
@@ -42,6 +42,7 @@ import type {
   SecretType,
   SecretTypeInfo,
   SecretTypeField,
+  SessionDefinition,
   VolundrWorkspace,
   WorkspaceStatus,
   VolundrMember,
@@ -224,6 +225,26 @@ type ApiModelInfo = {
   cost_per_million_tokens?: number | null;
   vram_required?: string | null;
 };
+
+type SessionDefinitionPayload = {
+  key: string;
+  display_name?: string;
+  displayName?: string;
+  description: string;
+  labels: string[];
+  default_model?: string;
+  defaultModel?: string;
+};
+
+function normalizeSessionDefinition(payload: SessionDefinitionPayload): SessionDefinition {
+  return {
+    key: payload.key,
+    displayName: payload.displayName ?? payload.display_name ?? payload.key,
+    description: payload.description,
+    labels: payload.labels,
+    defaultModel: payload.defaultModel ?? payload.default_model ?? '',
+  };
+}
 
 function toEpochMs(value?: number | string | null): number {
   if (typeof value === 'number') return value;
@@ -927,6 +948,10 @@ export function buildVolundrHttpAdapter(
 
   return {
     getFeatures: () => sharedClient.get<VolundrFeatures>('/features'),
+    getSessionDefinitions: async () => {
+      const payload = await forgeClient.get<SessionDefinitionPayload[]>('/session-definitions');
+      return payload.map(normalizeSessionDefinition);
+    },
     getSessions: () => loadSessions('/sessions'),
     getSession: (id) => loadSession(id),
     getActiveSessions: () => loadSessions('/sessions?active=true'),

--- a/web-next/packages/plugin-volundr/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.test.ts
@@ -198,6 +198,20 @@ describe('createMockVolundrService', () => {
     expect(preset.id).toBeTruthy();
     expect(preset.name).toBe('fast');
   });
+
+  it('getSessionDefinitions returns seeded session definitions', async () => {
+    const svc = createMockVolundrService();
+    const definitions = await svc.getSessionDefinitions();
+    expect(definitions.length).toBeGreaterThan(0);
+    expect(definitions[0]).toHaveProperty('key');
+    expect(definitions[0]).toHaveProperty('displayName');
+    expect(definitions[0]).toHaveProperty('description');
+    expect(definitions[0]).toHaveProperty('labels');
+    expect(definitions[0]).toHaveProperty('defaultModel');
+    const keys = definitions.map((d) => d.key);
+    expect(keys).toContain('skuld-claude');
+    expect(keys).toContain('skuld-codex');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/web-next/packages/plugin-volundr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.ts
@@ -15,6 +15,7 @@ import type {
   StoredCredential,
   FeatureModule,
   SecretType,
+  SessionDefinition,
   IntegrationConnection,
   ClusterResourceInfo,
   McpServerConfig,
@@ -1248,6 +1249,37 @@ const SEED_TEMPLATES: Template[] = [
   },
 ];
 
+const SEED_SESSION_DEFINITIONS: SessionDefinition[] = [
+  {
+    key: 'skuld-claude',
+    displayName: 'Claude Code',
+    description: 'Anthropic Claude-powered coding agent with full tool access.',
+    labels: ['anthropic', 'coding'],
+    defaultModel: 'sonnet-primary',
+  },
+  {
+    key: 'skuld-codex',
+    displayName: 'Codex',
+    description: 'OpenAI Codex-powered coding agent for autonomous tasks.',
+    labels: ['openai', 'coding'],
+    defaultModel: 'gpt-5-codex',
+  },
+  {
+    key: 'skuld-gemini',
+    displayName: 'Gemini',
+    description: 'Google Gemini-powered coding agent with multimodal support.',
+    labels: ['google', 'coding', 'multimodal'],
+    defaultModel: 'gemini-primary',
+  },
+  {
+    key: 'skuld-aider',
+    displayName: 'Aider',
+    description: 'Aider CLI coding assistant — model-agnostic pair programmer.',
+    labels: ['open-source', 'coding'],
+    defaultModel: 'sonnet-primary',
+  },
+];
+
 // ---------------------------------------------------------------------------
 // IVolundrService mock
 // ---------------------------------------------------------------------------
@@ -1263,6 +1295,8 @@ export function createMockVolundrService(): IVolundrService {
       fileManagerEnabled: true,
       miniMode: false,
     }),
+
+    getSessionDefinitions: async () => [...SEED_SESSION_DEFINITIONS],
 
     getSessions: async () => sessions,
 

--- a/web-next/packages/plugin-volundr/src/index.ts
+++ b/web-next/packages/plugin-volundr/src/index.ts
@@ -139,4 +139,5 @@ export type {
   StoredCredential,
   SecretType,
   SessionSource,
+  SessionDefinition,
 } from './models/volundr.model';

--- a/web-next/packages/plugin-volundr/src/models/volundr.model.ts
+++ b/web-next/packages/plugin-volundr/src/models/volundr.model.ts
@@ -291,6 +291,18 @@ export interface McpServerConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Session definitions
+// ---------------------------------------------------------------------------
+
+export interface SessionDefinition {
+  key: string;
+  displayName: string;
+  description: string;
+  labels: string[];
+  defaultModel: string;
+}
+
+// ---------------------------------------------------------------------------
 // Templates and presets
 // ---------------------------------------------------------------------------
 

--- a/web-next/packages/plugin-volundr/src/ports/IVolundrService.ts
+++ b/web-next/packages/plugin-volundr/src/ports/IVolundrService.ts
@@ -40,6 +40,7 @@ import type {
   VolundrMember,
   VolundrProvisioningResult,
   SessionSource,
+  SessionDefinition,
   AdminSettings,
   AdminStorageSettings,
   FeatureModule,
@@ -52,6 +53,9 @@ import type {
 export interface IVolundrService {
   // Feature flags
   getFeatures(): Promise<VolundrFeatures>;
+
+  // Session definitions
+  getSessionDefinitions(): Promise<SessionDefinition[]>;
 
   // Sessions
   getSessions(): Promise<VolundrSession[]>;
@@ -95,6 +99,7 @@ export interface IVolundrService {
     model: string;
     templateName?: string;
     presetId?: string;
+    definition?: string;
     taskType?: string;
     trackerIssue?: TrackerIssue;
     terminalRestricted?: boolean;

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.test.tsx
@@ -118,6 +118,7 @@ describe('LaunchWizard', () => {
           source: { type: 'git', repo: 'github.com/niuulabs/volundr', branch: 'main' },
           model: 'sonnet-primary',
           templateName: 'niuu-platform',
+          definition: 'skuld-claude',
           taskType: 'skuld-claude',
           terminalRestricted: true,
           resourceConfig: { cpu: '2', memory: '8Gi' },

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
@@ -11,6 +11,7 @@ import type {
   ClusterResourceInfo,
   McpServerConfig,
   SessionSource,
+  SessionDefinition,
   IntegrationConnection,
   StoredCredential,
   TrackerIssue,
@@ -45,7 +46,7 @@ interface WizardForm {
   mcpServers: McpServerConfig[];
   envVars: Array<{ key: string; value: string }>;
   setupScripts: string[];
-  cli: string;
+  definition: string;
   model: string;
   permission: string;
   cpu: string;
@@ -65,12 +66,35 @@ const STEP_LABELS: Record<string, string> = {
   confirm: 'Confirm',
 };
 
-const CLI_OPTIONS = [
-  { id: 'claude', label: 'Claude Code', rune: '\u16D7' },
-  { id: 'codex', label: 'Codex', rune: '\u16B2' },
-  { id: 'gemini', label: 'Gemini', rune: '\u16C7' },
-  { id: 'aider', label: 'Aider', rune: '\u16A8' },
+/** Map definition keys to runes for visual branding. */
+const DEFINITION_RUNES: Record<string, string> = {
+  'skuld-claude': '\u16D7',
+  'skuld-codex': '\u16B2',
+  'skuld-gemini': '\u16C7',
+  'skuld-aider': '\u16A8',
+  // Legacy short keys
+  claude: '\u16D7',
+  codex: '\u16B2',
+  gemini: '\u16C7',
+  aider: '\u16A8',
+};
+
+const FALLBACK_SESSION_DEFINITIONS: SessionDefinition[] = [
+  { key: 'skuld-claude', displayName: 'Claude Code', description: '', labels: [], defaultModel: '' },
+  { key: 'skuld-codex', displayName: 'Codex', description: '', labels: [], defaultModel: '' },
+  { key: 'skuld-gemini', displayName: 'Gemini', description: '', labels: [], defaultModel: '' },
+  { key: 'skuld-aider', displayName: 'Aider', description: '', labels: [], defaultModel: '' },
 ];
+
+function getDefinitionRune(key: string): string {
+  return DEFINITION_RUNES[key] ?? '\u16A0';
+}
+
+/** Derive a CLI tool name from a definition key for backward compat. */
+function deriveCliTool(definitionKey: string): string {
+  if (definitionKey.startsWith('skuld-')) return definitionKey.slice('skuld-'.length);
+  return definitionKey;
+}
 
 const BOOT_STEPS = [
   { id: 'schedule', label: 'schedule pod' },
@@ -331,8 +355,8 @@ function buildPresetRuntimePayload(
     name: (presetName ?? form.presetId) || 'launch-preset',
     description: '',
     isDefault: false,
-    cliTool: form.cli as VolundrPreset['cliTool'],
-    workloadType: `skuld-${form.cli}`,
+    cliTool: deriveCliTool(form.definition) as VolundrPreset['cliTool'],
+    workloadType: form.definition.startsWith('skuld-') ? form.definition : `skuld-${form.definition}`,
     model: form.model || null,
     systemPrompt: form.systemPrompt || null,
     resourceConfig: buildResourceConfig(form) ?? {},
@@ -394,8 +418,8 @@ function buildPresetComparisonPayload(
 
 function buildYamlRuntimeFields(form: WizardForm) {
   return {
-    cliTool: form.cli as 'claude' | 'codex' | 'gemini' | 'aider',
-    workloadType: `skuld-${form.cli}`,
+    cliTool: deriveCliTool(form.definition) as 'claude' | 'codex' | 'gemini' | 'aider',
+    workloadType: form.definition.startsWith('skuld-') ? form.definition : `skuld-${form.definition}`,
     model: form.model,
     systemPrompt: form.systemPrompt,
     resourceConfig: buildResourceConfig(form) ?? {},
@@ -783,6 +807,7 @@ function RuntimeStep({
   presets,
   selectedPreset,
   availableMcpServers,
+  sessionDefinitions,
   onApplyPreset,
   onSavePreset,
 }: {
@@ -796,6 +821,7 @@ function RuntimeStep({
   presets: VolundrPreset[];
   selectedPreset: VolundrPreset | null;
   availableMcpServers: McpServerConfig[];
+  sessionDefinitions: SessionDefinition[];
   onApplyPreset: (presetId: string) => void;
   onSavePreset: (name: string) => Promise<void>;
 }) {
@@ -865,7 +891,7 @@ function RuntimeStep({
       const parsed = parsePresetYaml(form.yamlContent);
       const patch: Partial<WizardForm> = { yamlMode: false };
 
-      if (parsed.cliTool) patch.cli = parsed.cliTool;
+      if (parsed.cliTool) patch.definition = `skuld-${parsed.cliTool}`;
       if (parsed.model !== undefined) patch.model = parsed.model;
       if (parsed.systemPrompt !== undefined) patch.systemPrompt = parsed.systemPrompt;
       if (parsed.resourceConfig) {
@@ -996,19 +1022,26 @@ function RuntimeStep({
           description="Choose the CLI agent, model, workspace, and launch prompts."
         >
           <div className="niuu-flex niuu-flex-wrap niuu-gap-2">
-            {CLI_OPTIONS.map((opt) => (
+            {sessionDefinitions.map((def) => (
               <button
-                key={opt.id}
+                key={def.key}
                 className={`niuu-flex niuu-items-center niuu-gap-1.5 niuu-rounded-md niuu-border niuu-px-3 niuu-py-2 niuu-text-xs niuu-text-text-primary ${
-                  form.cli === opt.id
+                  form.definition === def.key
                     ? 'niuu-border-brand niuu-bg-bg-tertiary'
                     : 'niuu-border-border-subtle niuu-bg-bg-primary hover:niuu-border-brand hover:niuu-bg-bg-tertiary'
                 }`}
-                onClick={() => update({ cli: opt.id })}
-                data-testid={`cli-option-${opt.id}`}
+                onClick={() => {
+                  const patch: Partial<WizardForm> = { definition: def.key };
+                  if (def.defaultModel && models[def.defaultModel]) {
+                    patch.model = def.defaultModel;
+                  }
+                  update(patch);
+                }}
+                data-testid={`cli-option-${deriveCliTool(def.key)}`}
+                title={def.description || undefined}
               >
-                <span className="niuu-font-mono niuu-text-base">{opt.rune}</span>
-                <span className="niuu-font-mono">{opt.label}</span>
+                <span className="niuu-font-mono niuu-text-base">{getDefinitionRune(def.key)}</span>
+                <span className="niuu-font-mono">{def.displayName}</span>
               </button>
             ))}
           </div>
@@ -1555,14 +1588,18 @@ function ConfirmStep({
   templates,
   models,
   integrations,
+  sessionDefinitions,
 }: {
   form: WizardForm;
   templates: Template[];
   models: Record<string, VolundrModel>;
   integrations: IntegrationConnection[];
+  sessionDefinitions: SessionDefinition[];
 }) {
   const tpl = templates.find((t) => t.id === form.templateId);
   const modelLabel = formatModelOption(form.model, models[form.model]);
+  const definitionLabel =
+    sessionDefinitions.find((d) => d.key === form.definition)?.displayName ?? form.definition;
   const integrationLabels = form.selectedIntegrations.map((id) => {
     const integration = integrations.find((item) => item.id === id);
     return integration ? formatIntegrationLabel(integration) : id;
@@ -1576,7 +1613,7 @@ function ConfirmStep({
         <div className="niuu-flex niuu-flex-col niuu-divide-y niuu-divide-border-subtle">
           <ConfirmRow label="session" value={deriveSessionName(form, tpl)} />
           <ConfirmRow label="template" value={tpl?.name ?? form.templateId} />
-          <ConfirmRow label="cli" value={form.cli} />
+          <ConfirmRow label="definition" value={definitionLabel} />
           <ConfirmRow label="model" value={modelLabel} />
           <ConfirmRow
             label="source"
@@ -1806,6 +1843,7 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
   const [clusterResources, setClusterResources] = useState<ClusterResourceInfo | null>(null);
   const [presets, setPresets] = useState<VolundrPreset[]>([]);
   const [availableMcpServers, setAvailableMcpServers] = useState<McpServerConfig[]>([]);
+  const [sessionDefinitions, setSessionDefinitions] = useState<SessionDefinition[]>([]);
   const [trackerResults, setTrackerResults] = useState<TrackerIssue[]>([]);
   const [trackerLoading, setTrackerLoading] = useState(false);
 
@@ -1828,7 +1866,7 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
     mcpServers: [],
     envVars: [],
     setupScripts: [],
-    cli: 'claude',
+    definition: 'skuld-claude',
     model: 'sonnet-primary',
     permission: 'restricted',
     cpu: '2',
@@ -1861,6 +1899,7 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
       volundr.getClusterResources().catch(() => null),
       volundr.getPresets().catch(() => []),
       volundr.getAvailableMcpServers().catch(() => []),
+      volundr.getSessionDefinitions().catch(() => FALLBACK_SESSION_DEFINITIONS),
     ]).then(
       ([
         nextRepos,
@@ -1871,6 +1910,7 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
         nextClusterResources,
         nextPresets,
         nextMcpServers,
+        nextSessionDefinitions,
       ]) => {
         if (cancelled) return;
         setRepos(nextRepos);
@@ -1881,6 +1921,9 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
         setClusterResources(nextClusterResources);
         setPresets(nextPresets);
         setAvailableMcpServers(nextMcpServers);
+        setSessionDefinitions(
+          nextSessionDefinitions.length > 0 ? nextSessionDefinitions : FALLBACK_SESSION_DEFINITIONS,
+        );
       },
     );
 
@@ -1966,7 +2009,7 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
       setForm((current) => ({
         ...current,
         presetId,
-        cli: preset.cliTool,
+        definition: preset.workloadType || `skuld-${preset.cliTool}`,
         model: preset.model ?? current.model,
         systemPrompt: preset.systemPrompt ?? '',
         selectedCredentials: [...preset.envSecretRefs],
@@ -2113,7 +2156,8 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
         model: form.model.trim(),
         templateName: selectedTemplate?.name,
         presetId,
-        taskType: `skuld-${form.cli}`,
+        definition: form.definition,
+        taskType: form.definition.startsWith('skuld-') ? form.definition : `skuld-${form.definition}`,
         trackerIssue: form.trackerIssue ?? undefined,
         terminalRestricted: form.permission === 'restricted',
         workspaceId: form.workspaceId || undefined,
@@ -2207,6 +2251,9 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
               presets={presets}
               selectedPreset={presets.find((preset) => preset.id === form.presetId) ?? null}
               availableMcpServers={availableMcpServers}
+              sessionDefinitions={
+                sessionDefinitions.length > 0 ? sessionDefinitions : FALLBACK_SESSION_DEFINITIONS
+              }
               onApplyPreset={handleApplyPreset}
               onSavePreset={handleSavePreset}
             />
@@ -2217,6 +2264,9 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
               templates={allTemplates}
               models={models}
               integrations={integrations}
+              sessionDefinitions={
+                sessionDefinitions.length > 0 ? sessionDefinitions : FALLBACK_SESSION_DEFINITIONS
+              }
             />
           )}
           {step === 'booting' && <BootingStep bootStep={bootStep} progress={bootProgress} />}

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
@@ -80,7 +80,13 @@ const DEFINITION_RUNES: Record<string, string> = {
 };
 
 const FALLBACK_SESSION_DEFINITIONS: SessionDefinition[] = [
-  { key: 'skuld-claude', displayName: 'Claude Code', description: '', labels: [], defaultModel: '' },
+  {
+    key: 'skuld-claude',
+    displayName: 'Claude Code',
+    description: '',
+    labels: [],
+    defaultModel: '',
+  },
   { key: 'skuld-codex', displayName: 'Codex', description: '', labels: [], defaultModel: '' },
   { key: 'skuld-gemini', displayName: 'Gemini', description: '', labels: [], defaultModel: '' },
   { key: 'skuld-aider', displayName: 'Aider', description: '', labels: [], defaultModel: '' },
@@ -356,7 +362,9 @@ function buildPresetRuntimePayload(
     description: '',
     isDefault: false,
     cliTool: deriveCliTool(form.definition) as VolundrPreset['cliTool'],
-    workloadType: form.definition.startsWith('skuld-') ? form.definition : `skuld-${form.definition}`,
+    workloadType: form.definition.startsWith('skuld-')
+      ? form.definition
+      : `skuld-${form.definition}`,
     model: form.model || null,
     systemPrompt: form.systemPrompt || null,
     resourceConfig: buildResourceConfig(form) ?? {},
@@ -419,7 +427,9 @@ function buildPresetComparisonPayload(
 function buildYamlRuntimeFields(form: WizardForm) {
   return {
     cliTool: deriveCliTool(form.definition) as 'claude' | 'codex' | 'gemini' | 'aider',
-    workloadType: form.definition.startsWith('skuld-') ? form.definition : `skuld-${form.definition}`,
+    workloadType: form.definition.startsWith('skuld-')
+      ? form.definition
+      : `skuld-${form.definition}`,
     model: form.model,
     systemPrompt: form.systemPrompt,
     resourceConfig: buildResourceConfig(form) ?? {},
@@ -2157,7 +2167,9 @@ export function LaunchWizard({ open, onOpenChange, initialTemplateId }: LaunchWi
         templateName: selectedTemplate?.name,
         presetId,
         definition: form.definition,
-        taskType: form.definition.startsWith('skuld-') ? form.definition : `skuld-${form.definition}`,
+        taskType: form.definition.startsWith('skuld-')
+          ? form.definition
+          : `skuld-${form.definition}`,
         trackerIssue: form.trackerIssue ?? undefined,
         terminalRestricted: form.permission === 'restricted',
         workspaceId: form.workspaceId || undefined,

--- a/web-next/packages/plugin-volundr/src/ui/LiveSessionDetailPage.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LiveSessionDetailPage.test.tsx
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { LiveSessionDetailPage } from './LiveSessionDetailPage';
+import {
+  createMockVolundrService,
+  createMockSessionStore,
+  createMockMetricsStream,
+} from '../adapters/mock';
+import type { IVolundrService } from '../ports/IVolundrService';
+import type { IPtyStream } from '../ports/IPtyStream';
+import type { IFileSystemPort } from '../ports/IFileSystemPort';
+import type { ISessionStore } from '../ports/ISessionStore';
+import type { VolundrSession } from '../models/volundr.model';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    open: vi.fn(),
+    write: vi.fn(),
+    dispose: vi.fn(),
+    loadAddon: vi.fn(),
+    onData: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    options: {},
+  })),
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: vi.fn(),
+    dispose: vi.fn(),
+  })),
+}));
+
+vi.mock('shiki', () => ({
+  codeToHtml: vi.fn().mockResolvedValue('<pre><code>highlighted</code></pre>'),
+}));
+
+class ResizeObserverStub {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+const RUNNING_SESSION: VolundrSession = {
+  id: 'test-session-id-1234',
+  name: 'test-session',
+  source: { type: 'git', repo: 'niuulabs/volundr', branch: 'main' },
+  status: 'running',
+  model: 'claude-sonnet',
+  lastActive: Date.now() - 60_000,
+  messageCount: 10,
+  tokensUsed: 5000,
+  hostname: 'skuld-test.local',
+  chatEndpoint: 'wss://skuld-test.local/session',
+};
+
+const STOPPED_SESSION: VolundrSession = {
+  ...RUNNING_SESSION,
+  status: 'stopped',
+  hostname: undefined,
+  chatEndpoint: undefined,
+};
+
+const STARTING_SESSION: VolundrSession = {
+  ...RUNNING_SESSION,
+  status: 'starting',
+};
+
+const ERROR_SESSION: VolundrSession = {
+  ...RUNNING_SESSION,
+  status: 'error',
+  error: 'OOMKilled',
+};
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function buildPtyStream(): IPtyStream {
+  return {
+    subscribe: vi.fn().mockReturnValue(() => {}),
+    send: vi.fn(),
+  };
+}
+
+function buildFilesystem(): IFileSystemPort {
+  return {
+    listTree: vi.fn().mockResolvedValue([]),
+    expandDirectory: vi.fn().mockResolvedValue([]),
+    readFile: vi.fn().mockResolvedValue(''),
+  };
+}
+
+const SESSION_FEATURES = [
+  { key: 'chat', label: 'Chat', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 10 },
+  { key: 'terminal', label: 'Terminal', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 20 },
+  { key: 'files', label: 'Files', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 40 },
+  { key: 'chronicles', label: 'Chronicle', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 50 },
+  { key: 'logs', label: 'Logs', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 60 },
+];
+
+function buildVolundrService(session: VolundrSession | null = RUNNING_SESSION): IVolundrService {
+  const base = createMockVolundrService();
+  return {
+    ...base,
+    getSession: vi.fn().mockResolvedValue(session),
+    getModels: vi.fn().mockResolvedValue({
+      'claude-sonnet': { name: 'Claude Sonnet', provider: 'cloud', tier: 'balanced', color: '#f59e0b', cost: '$3/MTok' },
+    }),
+    getFeatureModules: vi.fn().mockResolvedValue(SESSION_FEATURES),
+    getUserFeaturePreferences: vi.fn().mockResolvedValue([]),
+    getChronicle: vi.fn().mockResolvedValue(null),
+    getLogs: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function buildSessionStore(session: VolundrSession | null = RUNNING_SESSION): ISessionStore {
+  const base = createMockSessionStore();
+  return {
+    ...base,
+    getSession: vi.fn().mockResolvedValue(
+      session
+        ? {
+            id: session.id,
+            name: session.name,
+            state: session.status === 'running' ? 'active' : 'stopped',
+            clusterId: 'local',
+            events: [],
+          }
+        : null,
+    ),
+  };
+}
+
+function wrap(
+  sessionId: string,
+  opts: { readOnly?: boolean; session?: VolundrSession | null } = {},
+) {
+  const session = opts.session === undefined ? RUNNING_SESSION : opts.session;
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ServicesProvider
+        services={{
+          volundr: buildVolundrService(session),
+          ptyStream: buildPtyStream(),
+          filesystem: buildFilesystem(),
+          sessionStore: buildSessionStore(session),
+          metricsStream: createMockMetricsStream(),
+        }}
+      >
+        <LiveSessionDetailPage sessionId={sessionId} readOnly={opts.readOnly} />
+      </ServicesProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('LiveSessionDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('loading and error states', () => {
+    it('shows loading state initially', () => {
+      wrap('test-session-id-1234');
+      expect(screen.getByText('Loading session…')).toBeInTheDocument();
+    });
+
+    it('resolves past loading into main content', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+    });
+  });
+
+  describe('header rendering', () => {
+    it('shows session name', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getAllByText('test-session').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('shows session id chip', async () => {
+      wrap('test-session-id-1234');
+      const chip = await screen.findByTestId('session-id-label');
+      expect(chip).toBeInTheDocument();
+    });
+
+    it('shows model label', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByText('Claude Sonnet')).toBeInTheDocument();
+    });
+
+    it('shows repo and branch for git source', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByText('niuulabs/volundr')).toBeInTheDocument();
+      expect(screen.getByText('@main')).toBeInTheDocument();
+    });
+
+    it('shows Archived badge in read-only mode', async () => {
+      wrap('test-session-id-1234', { readOnly: true });
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByText('Archived')).toBeInTheDocument();
+    });
+
+    it('does not show Archived badge in normal mode', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.queryByText('Archived')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('status rendering', () => {
+    it('renders running session with status dot', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      // Status dot should have the brand class for running
+      const page = screen.getByTestId('live-session-detail-page');
+      const dot = page.querySelector('.niuu-bg-brand');
+      expect(dot).toBeInTheDocument();
+    });
+
+    it('renders stopped session with faint dot', async () => {
+      wrap('test-session-id-1234', { session: STOPPED_SESSION });
+      await screen.findByTestId('live-session-detail-page');
+      const page = screen.getByTestId('live-session-detail-page');
+      const dot = page.querySelector('.niuu-bg-text-faint');
+      expect(dot).toBeInTheDocument();
+    });
+
+    it('renders starting session with sky dot', async () => {
+      wrap('test-session-id-1234', { session: STARTING_SESSION });
+      await screen.findByTestId('live-session-detail-page');
+      const page = screen.getByTestId('live-session-detail-page');
+      const dot = page.querySelector('.niuu-bg-sky-400');
+      expect(dot).toBeInTheDocument();
+    });
+
+    it('renders error session with rose dot', async () => {
+      wrap('test-session-id-1234', { session: ERROR_SESSION });
+      await screen.findByTestId('live-session-detail-page');
+      const page = screen.getByTestId('live-session-detail-page');
+      const dot = page.querySelector('.niuu-bg-rose-400');
+      expect(dot).toBeInTheDocument();
+    });
+  });
+
+  describe('tabs', () => {
+    it('renders all tab buttons', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByRole('tab', { name: /Chat/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Terminal/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Diffs/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Files/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Chronicle/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Logs/i })).toBeInTheDocument();
+    });
+
+    it('switches to logs tab on click', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      fireEvent.click(screen.getByRole('tab', { name: /Logs/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('live-logs-tab')).toBeInTheDocument();
+      });
+    });
+
+    it('switches to diffs tab on click', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      fireEvent.click(screen.getByRole('tab', { name: /Diffs/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('diffs-tab')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('action buttons', () => {
+    it('shows Stop button for running session', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByRole('button', { name: /Stop/i })).toBeInTheDocument();
+    });
+
+    it('shows Start button for stopped session', async () => {
+      wrap('test-session-id-1234', { session: STOPPED_SESSION });
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByRole('button', { name: /Start/i })).toBeInTheDocument();
+    });
+
+    it('shows delete button', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByTitle(/Delete/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('local mount source', () => {
+    it('shows path for local mount source', async () => {
+      const localSession: VolundrSession = {
+        ...RUNNING_SESSION,
+        source: { type: 'local_mount', path: '/home/user/project' },
+      };
+      wrap('test-session-id-1234', { session: localSession });
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByText('/home/user/project')).toBeInTheDocument();
+    });
+  });
+
+  describe('header metrics', () => {
+    it('shows Active metric', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByText('Active')).toBeInTheDocument();
+    });
+
+    it('shows Msgs metric', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByText('Msgs')).toBeInTheDocument();
+    });
+
+    it('shows Tokens metric', async () => {
+      wrap('test-session-id-1234');
+      await screen.findByTestId('live-session-detail-page');
+      expect(screen.getByText('Tokens')).toBeInTheDocument();
+    });
+  });
+});

--- a/web-next/packages/plugin-volundr/src/ui/LiveSessionDetailPage.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LiveSessionDetailPage.test.tsx
@@ -102,11 +102,56 @@ function buildFilesystem(): IFileSystemPort {
 }
 
 const SESSION_FEATURES = [
-  { key: 'chat', label: 'Chat', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 10 },
-  { key: 'terminal', label: 'Terminal', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 20 },
-  { key: 'files', label: 'Files', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 40 },
-  { key: 'chronicles', label: 'Chronicle', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 50 },
-  { key: 'logs', label: 'Logs', icon: '', scope: 'session' as const, enabled: true, defaultEnabled: true, adminOnly: false, order: 60 },
+  {
+    key: 'chat',
+    label: 'Chat',
+    icon: '',
+    scope: 'session' as const,
+    enabled: true,
+    defaultEnabled: true,
+    adminOnly: false,
+    order: 10,
+  },
+  {
+    key: 'terminal',
+    label: 'Terminal',
+    icon: '',
+    scope: 'session' as const,
+    enabled: true,
+    defaultEnabled: true,
+    adminOnly: false,
+    order: 20,
+  },
+  {
+    key: 'files',
+    label: 'Files',
+    icon: '',
+    scope: 'session' as const,
+    enabled: true,
+    defaultEnabled: true,
+    adminOnly: false,
+    order: 40,
+  },
+  {
+    key: 'chronicles',
+    label: 'Chronicle',
+    icon: '',
+    scope: 'session' as const,
+    enabled: true,
+    defaultEnabled: true,
+    adminOnly: false,
+    order: 50,
+  },
+  {
+    key: 'logs',
+    label: 'Logs',
+    icon: '',
+    scope: 'session' as const,
+    enabled: true,
+    defaultEnabled: true,
+    adminOnly: false,
+    order: 60,
+  },
 ];
 
 function buildVolundrService(session: VolundrSession | null = RUNNING_SESSION): IVolundrService {
@@ -115,7 +160,13 @@ function buildVolundrService(session: VolundrSession | null = RUNNING_SESSION): 
     ...base,
     getSession: vi.fn().mockResolvedValue(session),
     getModels: vi.fn().mockResolvedValue({
-      'claude-sonnet': { name: 'Claude Sonnet', provider: 'cloud', tier: 'balanced', color: '#f59e0b', cost: '$3/MTok' },
+      'claude-sonnet': {
+        name: 'Claude Sonnet',
+        provider: 'cloud',
+        tier: 'balanced',
+        color: '#f59e0b',
+        cost: '$3/MTok',
+      },
     }),
     getFeatureModules: vi.fn().mockResolvedValue(SESSION_FEATURES),
     getUserFeaturePreferences: vi.fn().mockResolvedValue([]),

--- a/web-next/packages/plugin-volundr/src/ui/LiveSessionDetailPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LiveSessionDetailPage.tsx
@@ -1289,8 +1289,11 @@ export function LiveSessionDetailPage({
   const terminalUrl = deriveTerminalWsUrl(chatEndpoint);
   const chat = useSkuldChat(chatEndpoint);
   const sessionName = sessionQuery.data?.personaName ?? liveSession?.name ?? sessionId;
-  const sessionFeatures = sessionFeaturesQuery.data ?? [];
-  const featurePrefs = featurePrefsQuery.data ?? [];
+  const sessionFeatures = useMemo(
+    () => sessionFeaturesQuery.data ?? [],
+    [sessionFeaturesQuery.data],
+  );
+  const featurePrefs = useMemo(() => featurePrefsQuery.data ?? [], [featurePrefsQuery.data]);
   const modelCatalog = modelsQuery.data ?? {};
   const modelInfo = liveSession?.model ? modelCatalog[liveSession.model] : undefined;
   const modelLabel = modelInfo?.name ?? liveSession?.model ?? 'unknown';
@@ -1376,7 +1379,7 @@ export function LiveSessionDetailPage({
             </div>
           )
         : undefined,
-    [chat.pendingPermissions.length],
+    [chat],
   );
 
   async function refreshSessionData() {

--- a/web-next/packages/plugin-volundr/src/ui/LiveSessionDetailPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LiveSessionDetailPage.tsx
@@ -327,6 +327,7 @@ function SessionIdChip({ sessionId }: { sessionId: string }) {
     <button
       type="button"
       title={sessionId}
+      data-testid="session-id-label"
       onClick={async () => {
         try {
           await navigator.clipboard.writeText(sessionId);

--- a/web-next/packages/plugin-volundr/src/ui/SessionTerminalLive.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionTerminalLive.tsx
@@ -157,11 +157,12 @@ export function SessionTerminalLive({ url, readOnly = false }: SessionTerminalLi
   useEffect(() => {
     if (!activeWsUrl || !activeTabId || unavailable) return;
 
+    const currentSocketRefs = socketRefs.current;
     const socket = new WebSocket(
       activeWsUrl +
         (getAccessToken() ? `?access_token=${encodeURIComponent(getAccessToken()!)}` : ''),
     );
-    socketRefs.current.set(activeTabId, socket);
+    currentSocketRefs.set(activeTabId, socket);
 
     socket.onopen = () => {
       setConnected(true);
@@ -191,12 +192,12 @@ export function SessionTerminalLive({ url, readOnly = false }: SessionTerminalLi
 
     socket.onclose = () => {
       setConnected(false);
-      socketRefs.current.delete(activeTabId);
+      currentSocketRefs.delete(activeTabId);
     };
 
     return () => {
       socket.close();
-      socketRefs.current.delete(activeTabId);
+      currentSocketRefs.delete(activeTabId);
     };
   }, [activeTabId, activeWsUrl, unavailable]);
 

--- a/web-next/packages/plugin-volundr/src/ui/hooks/useMetrics.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/hooks/useMetrics.test.ts
@@ -60,11 +60,7 @@ describe('binMetricValues', () => {
 
 function makeStreamWrapper(stream: IMetricsStream) {
   return function Wrapper({ children }: { children: ReactNode }) {
-    return createElement(
-      ServicesProvider,
-      { services: { metricsStream: stream } },
-      children,
-    );
+    return createElement(ServicesProvider, { services: { metricsStream: stream } }, children);
   };
 }
 
@@ -101,7 +97,9 @@ describe('useMetrics', () => {
     });
 
     const point: MetricPoint = { timestamp: 1000, cpu: 0.5, memMi: 256, gpu: 0 };
-    act(() => { callback!(point); });
+    act(() => {
+      callback!(point);
+    });
 
     expect(result.current.points).toHaveLength(1);
     expect(result.current.points[0]).toEqual(point);

--- a/web-next/packages/plugin-volundr/src/ui/hooks/useMetrics.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/hooks/useMetrics.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { binMetricValues } from './useMetrics';
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { useMetrics, binMetricValues } from './useMetrics';
 import type { MetricPoint } from '../../ports/IMetricsStream';
+import type { IMetricsStream } from '../../ports/IMetricsStream';
 
 function makePoints(cpus: number[]): MetricPoint[] {
   return cpus.map((cpu, i) => ({ timestamp: i * 1000, cpu, memMi: cpu * 100, gpu: 0 }));
@@ -50,5 +55,94 @@ describe('binMetricValues', () => {
     const result = binMetricValues(points, (p) => p.cpu, 1);
     expect(result).toHaveLength(1);
     expect(result[0]).toBeCloseTo(0.4, 5);
+  });
+});
+
+function makeStreamWrapper(stream: IMetricsStream) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      ServicesProvider,
+      { services: { metricsStream: stream } },
+      children,
+    );
+  };
+}
+
+describe('useMetrics', () => {
+  it('starts with empty points and undefined latest', () => {
+    const stream: IMetricsStream = { subscribe: vi.fn().mockReturnValue(() => {}) };
+    const { result } = renderHook(() => useMetrics('sess-1'), {
+      wrapper: makeStreamWrapper(stream),
+    });
+
+    expect(result.current.points).toEqual([]);
+    expect(result.current.latest).toBeUndefined();
+  });
+
+  it('subscribes with the given sessionId', () => {
+    const subscribe = vi.fn().mockReturnValue(() => {});
+    const stream: IMetricsStream = { subscribe };
+    renderHook(() => useMetrics('sess-42'), { wrapper: makeStreamWrapper(stream) });
+
+    expect(subscribe).toHaveBeenCalledWith('sess-42', expect.any(Function));
+  });
+
+  it('accumulates metric points from the stream callback', () => {
+    let callback: ((point: MetricPoint) => void) | undefined;
+    const stream: IMetricsStream = {
+      subscribe: vi.fn((_id, cb) => {
+        callback = cb;
+        return () => {};
+      }),
+    };
+
+    const { result } = renderHook(() => useMetrics('sess-1'), {
+      wrapper: makeStreamWrapper(stream),
+    });
+
+    const point: MetricPoint = { timestamp: 1000, cpu: 0.5, memMi: 256, gpu: 0 };
+    act(() => { callback!(point); });
+
+    expect(result.current.points).toHaveLength(1);
+    expect(result.current.points[0]).toEqual(point);
+    expect(result.current.latest).toEqual(point);
+  });
+
+  it('trims points beyond MAX_HISTORY_POINTS (60)', () => {
+    let callback: ((point: MetricPoint) => void) | undefined;
+    const stream: IMetricsStream = {
+      subscribe: vi.fn((_id, cb) => {
+        callback = cb;
+        return () => {};
+      }),
+    };
+
+    const { result } = renderHook(() => useMetrics('sess-1'), {
+      wrapper: makeStreamWrapper(stream),
+    });
+
+    // Push 65 points
+    act(() => {
+      for (let i = 0; i < 65; i++) {
+        callback!({ timestamp: i * 1000, cpu: i / 100, memMi: i, gpu: 0 });
+      }
+    });
+
+    expect(result.current.points).toHaveLength(60);
+    // The first 5 should have been trimmed, so the first point should be i=5
+    expect(result.current.points[0]?.timestamp).toBe(5000);
+    expect(result.current.latest?.timestamp).toBe(64000);
+  });
+
+  it('calls the unsubscribe function on unmount', () => {
+    const unsub = vi.fn();
+    const stream: IMetricsStream = { subscribe: vi.fn().mockReturnValue(unsub) };
+
+    const { unmount } = renderHook(() => useMetrics('sess-1'), {
+      wrapper: makeStreamWrapper(stream),
+    });
+
+    unmount();
+    expect(unsub).toHaveBeenCalled();
   });
 });

--- a/web-next/packages/plugin-volundr/src/ui/hooks/useSkuldChat.ts
+++ b/web-next/packages/plugin-volundr/src/ui/hooks/useSkuldChat.ts
@@ -1023,7 +1023,7 @@ export function useSkuldChat(url: string | null): UseSkuldChatResult {
         }
       }
     },
-    [finalizeStreaming, getDefaultAssistantParticipant],
+    [ensureSingleParticipant, finalizeStreaming, getDefaultAssistantParticipant],
   );
 
   const { sendJson } = useWebSocket(url, {

--- a/web-next/packages/plugin-volundr/src/ui/routes.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/routes.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ServicesProvider } from '@niuulabs/plugin-sdk';
 import { VolundrSessionRoute, VolundrArchivedRoute } from './routes';
-import { createMockSessionStore, createMockMetricsStream } from '../adapters/mock';
+import { createMockVolundrService, createMockSessionStore, createMockMetricsStream } from '../adapters/mock';
 import type { IPtyStream } from '../ports/IPtyStream';
 import type { IFileSystemPort } from '../ports/IFileSystemPort';
 
@@ -70,6 +70,7 @@ function wrap(ui: React.ReactNode) {
     <QueryClientProvider client={client}>
       <ServicesProvider
         services={{
+          volundr: createMockVolundrService(),
           ptyStream: buildPtyStream(),
           filesystem: buildFilesystem(),
           sessionStore: createMockSessionStore(),

--- a/web-next/packages/plugin-volundr/src/ui/routes.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/routes.test.tsx
@@ -3,7 +3,11 @@ import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ServicesProvider } from '@niuulabs/plugin-sdk';
 import { VolundrSessionRoute, VolundrArchivedRoute } from './routes';
-import { createMockVolundrService, createMockSessionStore, createMockMetricsStream } from '../adapters/mock';
+import {
+  createMockVolundrService,
+  createMockSessionStore,
+  createMockMetricsStream,
+} from '../adapters/mock';
 import type { IPtyStream } from '../ports/IPtyStream';
 import type { IFileSystemPort } from '../ports/IFileSystemPort';
 

--- a/web-next/packages/plugin-volundr/src/ui/routes.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/routes.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ServicesProvider } from '@niuulabs/plugin-sdk';
 import { VolundrSessionRoute, VolundrArchivedRoute } from './routes';
@@ -92,25 +92,30 @@ function wrap(ui: React.ReactNode) {
 // ---------------------------------------------------------------------------
 
 describe('VolundrSessionRoute', () => {
-  it('renders the session page with the param sessionId', () => {
+  it('renders the session page with the param sessionId', async () => {
     wrap(<VolundrSessionRoute />);
-    expect(screen.getByTestId('session-id-label')).toHaveTextContent('sess-route-test');
+    const label = await screen.findByTestId('session-id-label');
+    expect(label).toHaveTextContent('sess-rou');
   });
 
-  it('renders in interactive (non-read-only) mode', () => {
+  it('renders in interactive (non-read-only) mode', async () => {
     wrap(<VolundrSessionRoute />);
-    expect(screen.queryByText('archived')).not.toBeInTheDocument();
+    await screen.findByTestId('live-session-detail-page');
+    expect(screen.queryByText('Archived')).not.toBeInTheDocument();
   });
 });
 
 describe('VolundrArchivedRoute', () => {
-  it('renders the session page with the param sessionId', () => {
+  it('renders the session page with the param sessionId', async () => {
     wrap(<VolundrArchivedRoute />);
-    expect(screen.getByTestId('session-id-label')).toHaveTextContent('sess-route-test');
+    const label = await screen.findByTestId('session-id-label');
+    expect(label).toHaveTextContent('sess-rou');
   });
 
-  it('renders with the archived (read-only) badge', () => {
+  it('renders with the archived (read-only) badge', async () => {
     wrap(<VolundrArchivedRoute />);
-    expect(screen.getByText('archived')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Archived')).toBeInTheDocument();
+    });
   });
 });

--- a/web-next/packages/plugin-volundr/src/ui/useTemplates.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/useTemplates.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { createElement } from 'react';
+import type { ReactNode } from 'react';
+import { useTemplates, useUpdateTemplate, useCreateTemplate, useDeleteTemplate } from './useTemplates';
+import type { Template } from '../domain/template';
+import type { PodSpec } from '../domain/pod';
+
+const SAMPLE_SPEC: PodSpec = {
+  image: 'ghcr.io/niuulabs/skuld',
+  tag: 'latest',
+  mounts: [],
+  env: {},
+  envSecretRefs: [],
+  tools: [],
+  mcpServers: [],
+  resources: {
+    cpuRequest: '1',
+    cpuLimit: '2',
+    memRequestMi: 512,
+    memLimitMi: 1024,
+    gpuCount: 0,
+  },
+  ttlSec: 3600,
+  idleTimeoutSec: 600,
+};
+
+const SAMPLE_TEMPLATE: Template = {
+  id: 'tpl-1',
+  name: 'default',
+  version: 1,
+  spec: SAMPLE_SPEC,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+function makeWrapper(store: Record<string, unknown>) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client },
+      createElement(ServicesProvider, { services: { 'volundr.templates': store } }, children),
+    );
+  };
+}
+
+describe('useTemplates', () => {
+  it('returns templates from the store', async () => {
+    const store = { listTemplates: vi.fn().mockResolvedValue([SAMPLE_TEMPLATE]) };
+    const { result } = renderHook(() => useTemplates(), { wrapper: makeWrapper(store) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0]?.name).toBe('default');
+    expect(store.listTemplates).toHaveBeenCalled();
+  });
+
+  it('starts in loading state', () => {
+    const store = { listTemplates: vi.fn().mockReturnValue(new Promise(() => undefined)) };
+    const { result } = renderHook(() => useTemplates(), { wrapper: makeWrapper(store) });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('enters error state when store rejects', async () => {
+    const store = { listTemplates: vi.fn().mockRejectedValue(new Error('store down')) };
+    const { result } = renderHook(() => useTemplates(), { wrapper: makeWrapper(store) });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
+
+describe('useUpdateTemplate', () => {
+  it('calls updateTemplate and invalidates queries on success', async () => {
+    const updatedTemplate = { ...SAMPLE_TEMPLATE, version: 2 };
+    const store = {
+      listTemplates: vi.fn().mockResolvedValue([SAMPLE_TEMPLATE]),
+      updateTemplate: vi.fn().mockResolvedValue(updatedTemplate),
+    };
+    const { result } = renderHook(() => useUpdateTemplate(), { wrapper: makeWrapper(store) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'tpl-1', spec: SAMPLE_SPEC });
+    });
+
+    expect(store.updateTemplate).toHaveBeenCalledWith('tpl-1', SAMPLE_SPEC);
+  });
+});
+
+describe('useCreateTemplate', () => {
+  it('calls createTemplate and invalidates queries on success', async () => {
+    const store = {
+      listTemplates: vi.fn().mockResolvedValue([]),
+      createTemplate: vi.fn().mockResolvedValue(SAMPLE_TEMPLATE),
+    };
+    const { result } = renderHook(() => useCreateTemplate(), { wrapper: makeWrapper(store) });
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'new-tpl', spec: SAMPLE_SPEC });
+    });
+
+    expect(store.createTemplate).toHaveBeenCalledWith('new-tpl', SAMPLE_SPEC);
+  });
+});
+
+describe('useDeleteTemplate', () => {
+  it('calls deleteTemplate and invalidates queries on success', async () => {
+    const store = {
+      listTemplates: vi.fn().mockResolvedValue([SAMPLE_TEMPLATE]),
+      deleteTemplate: vi.fn().mockResolvedValue(undefined),
+    };
+    const { result } = renderHook(() => useDeleteTemplate(), { wrapper: makeWrapper(store) });
+
+    await act(async () => {
+      await result.current.mutateAsync('tpl-1');
+    });
+
+    expect(store.deleteTemplate).toHaveBeenCalledWith('tpl-1');
+  });
+});

--- a/web-next/packages/plugin-volundr/src/ui/useTemplates.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/useTemplates.test.ts
@@ -4,7 +4,12 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ServicesProvider } from '@niuulabs/plugin-sdk';
 import { createElement } from 'react';
 import type { ReactNode } from 'react';
-import { useTemplates, useUpdateTemplate, useCreateTemplate, useDeleteTemplate } from './useTemplates';
+import {
+  useTemplates,
+  useUpdateTemplate,
+  useCreateTemplate,
+  useDeleteTemplate,
+} from './useTemplates';
 import type { Template } from '../domain/template';
 import type { PodSpec } from '../domain/pod';
 

--- a/web-next/packages/plugin-volundr/src/utils/presetYaml.test.ts
+++ b/web-next/packages/plugin-volundr/src/utils/presetYaml.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { serializePresetYaml, parsePresetYaml } from './presetYaml';
+import type { PresetRuntimeFields } from './presetYaml';
+
+const FULL_FIELDS: PresetRuntimeFields = {
+  cliTool: 'claude',
+  workloadType: 'skuld-claude',
+  model: 'sonnet-primary',
+  systemPrompt: 'Review changes carefully.',
+  resourceConfig: { cpu: '4', memory: '16Gi' },
+  mcpServers: [
+    {
+      name: 'filesystem',
+      type: 'stdio',
+      command: 'uvx',
+      args: ['mcp-filesystem', '/workspace'],
+      env: { LOG_LEVEL: 'debug' },
+    },
+    { name: 'remote', type: 'sse', url: 'https://mcp.example.com' },
+  ],
+  terminalSidecar: { enabled: true, allowedCommands: ['git', 'pnpm'] },
+  skills: [{ name: 'review', path: '/skills/review.md' }],
+  rules: [{ inline: 'always use early returns' }],
+  envVars: { NODE_ENV: 'production' },
+  envSecretRefs: ['anthropic-key'],
+  source: { type: 'git', repo: 'github.com/niuulabs/volundr', branch: 'main' },
+  integrationIds: ['github-primary'],
+  setupScripts: ['pnpm install'],
+  workloadConfig: { timeout: 300 },
+};
+
+const EMPTY_FIELDS: PresetRuntimeFields = {
+  cliTool: 'aider',
+  workloadType: 'skuld-aider',
+  model: '',
+  systemPrompt: '',
+  resourceConfig: {},
+  mcpServers: [],
+  terminalSidecar: { enabled: false, allowedCommands: [] },
+  skills: [],
+  rules: [],
+  envVars: {},
+  envSecretRefs: [],
+  source: null,
+  integrationIds: [],
+  setupScripts: [],
+  workloadConfig: {},
+};
+
+describe('serializePresetYaml', () => {
+  it('serialises full fields to valid YAML', () => {
+    const yaml = serializePresetYaml(FULL_FIELDS);
+    expect(yaml).toContain('cli_tool: claude');
+    expect(yaml).toContain('workload_type: skuld-claude');
+    expect(yaml).toContain('model: sonnet-primary');
+    expect(yaml).toContain('system_prompt: Review changes carefully.');
+  });
+
+  it('includes mcp_servers with command, url, args, and env', () => {
+    const yaml = serializePresetYaml(FULL_FIELDS);
+    expect(yaml).toContain('name: filesystem');
+    expect(yaml).toContain('command: uvx');
+    expect(yaml).toContain('- mcp-filesystem');
+    expect(yaml).toContain('LOG_LEVEL: debug');
+    expect(yaml).toContain('name: remote');
+    expect(yaml).toContain('url: https://mcp.example.com');
+  });
+
+  it('includes terminal_sidecar, skills, rules, env_vars, env_secret_refs', () => {
+    const yaml = serializePresetYaml(FULL_FIELDS);
+    expect(yaml).toContain('enabled: true');
+    expect(yaml).toContain('- git');
+    expect(yaml).toContain('- pnpm');
+    expect(yaml).toContain('name: review');
+    expect(yaml).toContain('inline: always use early returns');
+    expect(yaml).toContain('NODE_ENV: production');
+    expect(yaml).toContain('- anthropic-key');
+  });
+
+  it('includes source, integration_ids, setup_scripts, workload_config', () => {
+    const yaml = serializePresetYaml(FULL_FIELDS);
+    expect(yaml).toContain('type: git');
+    expect(yaml).toContain('repo: github.com/niuulabs/volundr');
+    expect(yaml).toContain('- github-primary');
+    expect(yaml).toContain('- pnpm install');
+    expect(yaml).toContain('timeout: 300');
+  });
+
+  it('omits optional collections when empty', () => {
+    const yaml = serializePresetYaml(EMPTY_FIELDS);
+    expect(yaml).not.toContain('mcp_servers');
+    expect(yaml).not.toContain('skills');
+    expect(yaml).not.toContain('rules');
+    expect(yaml).not.toContain('env_vars');
+    expect(yaml).not.toContain('env_secret_refs');
+    expect(yaml).not.toContain('integration_ids');
+    expect(yaml).not.toContain('setup_scripts');
+    expect(yaml).not.toContain('workload_config');
+    expect(yaml).not.toContain('resource_config');
+    expect(yaml).not.toContain('source');
+  });
+
+  it('sets model and system_prompt to null when empty strings', () => {
+    const yaml = serializePresetYaml(EMPTY_FIELDS);
+    expect(yaml).toContain('model: null');
+    expect(yaml).toContain('system_prompt: null');
+  });
+});
+
+describe('parsePresetYaml', () => {
+  it('round-trips through serialize and parse', () => {
+    const yaml = serializePresetYaml(FULL_FIELDS);
+    const parsed = parsePresetYaml(yaml);
+
+    expect(parsed.cliTool).toBe('claude');
+    expect(parsed.workloadType).toBe('skuld-claude');
+    expect(parsed.model).toBe('sonnet-primary');
+    expect(parsed.systemPrompt).toBe('Review changes carefully.');
+    expect(parsed.resourceConfig).toEqual({ cpu: '4', memory: '16Gi' });
+    expect(parsed.mcpServers).toHaveLength(2);
+    expect(parsed.mcpServers?.[0]?.name).toBe('filesystem');
+    expect(parsed.mcpServers?.[0]?.command).toBe('uvx');
+    expect(parsed.mcpServers?.[0]?.args).toEqual(['mcp-filesystem', '/workspace']);
+    expect(parsed.mcpServers?.[0]?.env).toEqual({ LOG_LEVEL: 'debug' });
+    expect(parsed.mcpServers?.[1]?.url).toBe('https://mcp.example.com');
+    expect(parsed.terminalSidecar?.enabled).toBe(true);
+    expect(parsed.terminalSidecar?.allowedCommands).toEqual(['git', 'pnpm']);
+    expect(parsed.skills).toHaveLength(1);
+    expect(parsed.rules).toHaveLength(1);
+    expect(parsed.envVars).toEqual({ NODE_ENV: 'production' });
+    expect(parsed.envSecretRefs).toEqual(['anthropic-key']);
+    expect(parsed.integrationIds).toEqual(['github-primary']);
+    expect(parsed.setupScripts).toEqual(['pnpm install']);
+    expect(parsed.workloadConfig).toEqual({ timeout: 300 });
+  });
+
+  it('returns empty object for empty/null YAML', () => {
+    expect(parsePresetYaml('')).toEqual({});
+    expect(parsePresetYaml('null')).toEqual({});
+  });
+
+  it('returns empty object for non-object YAML', () => {
+    expect(parsePresetYaml('42')).toEqual({});
+    expect(parsePresetYaml('"just a string"')).toEqual({});
+  });
+
+  it('parses model null as empty string', () => {
+    const parsed = parsePresetYaml('model: null');
+    expect(parsed.model).toBe('');
+  });
+
+  it('parses system_prompt null as empty string', () => {
+    const parsed = parsePresetYaml('system_prompt: null');
+    expect(parsed.systemPrompt).toBe('');
+  });
+
+  it('parses source as null when explicitly set', () => {
+    const parsed = parsePresetYaml('source: null');
+    expect(parsed.source).toBeNull();
+  });
+
+  it('parses terminal_sidecar with default allowed_commands', () => {
+    const parsed = parsePresetYaml('terminal_sidecar:\n  enabled: true\n');
+    expect(parsed.terminalSidecar?.enabled).toBe(true);
+    expect(parsed.terminalSidecar?.allowedCommands).toEqual([]);
+  });
+
+  it('returns partial result when only some fields present', () => {
+    const parsed = parsePresetYaml('cli_tool: codex\nworkload_type: skuld-codex\n');
+    expect(parsed.cliTool).toBe('codex');
+    expect(parsed.workloadType).toBe('skuld-codex');
+    expect(parsed.model).toBeUndefined();
+    expect(parsed.mcpServers).toBeUndefined();
+  });
+});

--- a/web-next/packages/shell/src/Shell.test.tsx
+++ b/web-next/packages/shell/src/Shell.test.tsx
@@ -169,7 +169,9 @@ describe('Shell', () => {
       expect(screen.getByTestId('flat-content')).toBeInTheDocument();
     });
     const subnav = document.querySelector('.niuu-shell__subnav');
-    expect(subnav?.classList.contains('niuu-shell__subnav--collapsed')).toBe(true);
+    expect(subnav).toBeInTheDocument();
+    // No subnav content renders — the :empty CSS pseudo-class collapses the nav
+    expect(subnav?.childElementCount).toBe(0);
   });
 
   it('does not collapse subnav when plugin has subnav', async () => {
@@ -178,16 +180,19 @@ describe('Shell', () => {
       expect(screen.getByTestId('tabbed-content')).toBeInTheDocument();
     });
     const subnav = document.querySelector('.niuu-shell__subnav');
-    expect(subnav?.classList.contains('niuu-shell__subnav--collapsed')).toBe(false);
+    expect(subnav).toBeInTheDocument();
+    // Subnav has content rendered by the plugin
+    expect(subnav?.childElementCount).toBeGreaterThan(0);
   });
 
-  it('renders subnav collapsed element when no subnav content', async () => {
+  it('renders subnav element when no subnav content', async () => {
     wrap(<Shell plugins={[pluginNoSubnav]} _testHistory={memHistory('/flat')} />);
     await waitFor(() => {
       expect(screen.getByTestId('flat-content')).toBeInTheDocument();
     });
     const subnav = document.querySelector('.niuu-shell__subnav');
     expect(subnav).toBeInTheDocument();
-    expect(subnav?.classList.contains('niuu-shell__subnav--collapsed')).toBe(true);
+    // Empty subnav — collapsed via :empty CSS rule
+    expect(subnav?.childElementCount).toBe(0);
   });
 });

--- a/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
+++ b/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
@@ -129,7 +129,9 @@ describe('ChatInput', () => {
   it('calls onSendDirected when agent mentions present', () => {
     const onSend = vi.fn();
     const onSendDirected = vi.fn();
-    const participants = new Map([['p1', { peerId: 'p1', persona: 'Ada', participantType: 'ravn' }]]);
+    const participants = new Map([
+      ['p1', { peerId: 'p1', persona: 'Ada', participantType: 'ravn' }],
+    ]);
     render(
       <ChatInput
         {...defaultProps}

--- a/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
+++ b/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
@@ -129,7 +129,7 @@ describe('ChatInput', () => {
   it('calls onSendDirected when agent mentions present', () => {
     const onSend = vi.fn();
     const onSendDirected = vi.fn();
-    const participants = new Map([['p1', { peerId: 'p1', persona: 'Ada' }]]);
+    const participants = new Map([['p1', { peerId: 'p1', persona: 'Ada', participantType: 'ravn' }]]);
     render(
       <ChatInput
         {...defaultProps}

--- a/web-next/packages/ui/src/chat/components/SessionChat/SessionChat.test.tsx
+++ b/web-next/packages/ui/src/chat/components/SessionChat/SessionChat.test.tsx
@@ -482,11 +482,7 @@ describe('SessionChat', () => {
   it('delegates to onCopy callback when provided', () => {
     const onCopy = vi.fn();
     render(
-      <SessionChat
-        {...defaultProps}
-        messages={[userMessage, assistantMessage]}
-        onCopy={onCopy}
-      />,
+      <SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} onCopy={onCopy} />,
     );
     const copyBtn = screen.getByTitle('Copy');
     fireEvent.click(copyBtn);
@@ -601,7 +597,12 @@ describe('SessionChat', () => {
   it('does not render permission UI when no pending permissions', () => {
     const renderPermissions = vi.fn().mockReturnValue(<div data-testid="perm-ui">Allow?</div>);
     render(
-      <SessionChat {...defaultProps} connected pendingPermissions={[]} renderPermissions={renderPermissions} />,
+      <SessionChat
+        {...defaultProps}
+        connected
+        pendingPermissions={[]}
+        renderPermissions={renderPermissions}
+      />,
     );
     expect(screen.queryByTestId('perm-ui')).not.toBeInTheDocument();
   });
@@ -695,12 +696,7 @@ describe('SessionChat', () => {
 
   it('does not show internal toggle in single-participant mode', () => {
     render(
-      <SessionChat
-        {...defaultProps}
-        messages={[userMessage]}
-        connected
-        participants={new Map()}
-      />,
+      <SessionChat {...defaultProps} messages={[userMessage]} connected participants={new Map()} />,
     );
     expect(screen.queryByTestId('internal-toggle')).not.toBeInTheDocument();
   });
@@ -745,12 +741,7 @@ describe('SessionChat', () => {
       },
     ];
     render(
-      <SessionChat
-        {...defaultProps}
-        messages={[userMessage]}
-        connected
-        meshEvents={events}
-      />,
+      <SessionChat {...defaultProps} messages={[userMessage]} connected meshEvents={events} />,
     );
     const outerGrid = screen.getByTestId('session-chat');
     expect(outerGrid).toHaveAttribute('data-right-panel');
@@ -1060,27 +1051,19 @@ describe('SessionChat', () => {
   });
 
   it('hides model switch when onSetModel is not provided', () => {
-    render(
-      <SessionChat {...defaultProps} connected capabilities={{ set_model: true }} />,
-    );
+    render(<SessionChat {...defaultProps} connected capabilities={{ set_model: true }} />);
     expect(screen.queryByTestId('model-switch-toggle')).not.toBeInTheDocument();
   });
 
   it('hides thinking toggle when onSetThinkingTokens is not provided', () => {
     render(
-      <SessionChat
-        {...defaultProps}
-        connected
-        capabilities={{ set_thinking_tokens: true }}
-      />,
+      <SessionChat {...defaultProps} connected capabilities={{ set_thinking_tokens: true }} />,
     );
     expect(screen.queryByTestId('thinking-budget-toggle')).not.toBeInTheDocument();
   });
 
   it('hides rewind files when onRewindFiles is not provided', () => {
-    render(
-      <SessionChat {...defaultProps} connected capabilities={{ rewind_files: true }} />,
-    );
+    render(<SessionChat {...defaultProps} connected capabilities={{ rewind_files: true }} />);
     expect(screen.queryByTestId('rewind-files')).not.toBeInTheDocument();
   });
 });

--- a/web-next/packages/ui/src/chat/components/SessionChat/SessionChat.test.tsx
+++ b/web-next/packages/ui/src/chat/components/SessionChat/SessionChat.test.tsx
@@ -1,12 +1,15 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SessionChat } from './SessionChat';
-import type { AgentInternalEvent, ChatMessage, RoomParticipant } from '../../types';
+import type {
+  AgentInternalEvent,
+  ChatMessage,
+  MeshOutcomeEvent,
+  PermissionRequest,
+  RoomParticipant,
+} from '../../types';
 
-class ResizeObserverMock {
-  observe() {}
-  disconnect() {}
-}
+/* ── Shared fixtures ── */
 
 const participant: RoomParticipant = {
   peerId: 'peer-1',
@@ -17,16 +20,65 @@ const participant: RoomParticipant = {
   status: 'thinking',
 };
 
-const messages: ChatMessage[] = [
-  {
-    id: 'm1',
-    role: 'assistant',
-    content: 'Need to inspect the config first.',
-    createdAt: new Date('2026-04-26T12:00:00Z'),
-    status: 'done',
-    participant,
-  },
-];
+const participant2: RoomParticipant = {
+  peerId: 'peer-2',
+  persona: 'Ravn-B',
+  displayName: 'Builder',
+  color: 'cyan',
+  participantType: 'ravn',
+  status: 'idle',
+};
+
+const skuldParticipant: RoomParticipant = {
+  peerId: 'skuld-1',
+  persona: 'Skuld',
+  displayName: 'Skuld',
+  color: 'indigo',
+  participantType: 'skuld',
+  status: 'idle',
+};
+
+const now = new Date('2026-04-26T12:00:00Z');
+
+const userMessage: ChatMessage = {
+  id: 'u1',
+  role: 'user',
+  content: 'Please review the config.',
+  createdAt: now,
+};
+
+const assistantMessage: ChatMessage = {
+  id: 'a1',
+  role: 'assistant',
+  content: 'I have reviewed the config.',
+  createdAt: new Date('2026-04-26T12:00:05Z'),
+  status: 'done',
+};
+
+const roomAssistantMessage: ChatMessage = {
+  id: 'm1',
+  role: 'assistant',
+  content: 'Need to inspect the config first.',
+  createdAt: now,
+  status: 'done',
+  participant,
+};
+
+const systemMessage: ChatMessage = {
+  id: 's1',
+  role: 'system',
+  content: 'Session started',
+  createdAt: now,
+  metadata: { messageType: 'system' },
+};
+
+const runningMessage: ChatMessage = {
+  id: 'r1',
+  role: 'assistant',
+  content: 'Working on it...',
+  createdAt: now,
+  status: 'running',
+};
 
 const agentEvents = new Map<string, AgentInternalEvent[]>([
   [
@@ -43,24 +95,556 @@ const agentEvents = new Map<string, AgentInternalEvent[]>([
   ],
 ]);
 
+const defaultProps = {
+  messages: [] as ChatMessage[],
+  onSend: vi.fn(),
+};
+
 describe('SessionChat', () => {
   beforeEach(() => {
-    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    vi.clearAllMocks();
+    localStorage.clear();
   });
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
+  /* ── Basic rendering ── */
+
+  it('renders with data-testid', () => {
+    render(<SessionChat {...defaultProps} />);
+    expect(screen.getByTestId('session-chat')).toBeInTheDocument();
   });
+
+  it('applies optional className', () => {
+    render(<SessionChat {...defaultProps} className="custom-class" />);
+    expect(screen.getByTestId('session-chat')).toHaveClass('custom-class');
+  });
+
+  /* ── Connection status ── */
+
+  it('shows Disconnected when not connected', () => {
+    render(<SessionChat {...defaultProps} connected={false} />);
+    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+  });
+
+  it('shows Connected when connected', () => {
+    render(<SessionChat {...defaultProps} connected />);
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+  });
+
+  /* ── History loading ── */
+
+  it('shows loading indicator when history not loaded and connected', () => {
+    render(<SessionChat {...defaultProps} connected historyLoaded={false} />);
+    expect(screen.getByTestId('history-loading')).toBeInTheDocument();
+    expect(screen.getByText('Loading conversation...')).toBeInTheDocument();
+  });
+
+  it('does not show loading indicator when history is loaded', () => {
+    render(<SessionChat {...defaultProps} connected historyLoaded />);
+    expect(screen.queryByTestId('history-loading')).not.toBeInTheDocument();
+  });
+
+  it('does not show loading indicator when disconnected even if history not loaded', () => {
+    render(<SessionChat {...defaultProps} connected={false} historyLoaded={false} />);
+    expect(screen.queryByTestId('history-loading')).not.toBeInTheDocument();
+  });
+
+  /* ── Empty state ── */
+
+  it('shows empty state when there are no messages', () => {
+    render(<SessionChat {...defaultProps} connected />);
+    expect(screen.getByTestId('session-empty-chat')).toBeInTheDocument();
+  });
+
+  it('uses sessionName in empty state', () => {
+    render(<SessionChat {...defaultProps} connected sessionName="My Session" />);
+    expect(screen.getByText('My Session')).toBeInTheDocument();
+  });
+
+  it('sends message when empty state suggestion is clicked', () => {
+    const onSend = vi.fn();
+    render(<SessionChat {...defaultProps} onSend={onSend} connected />);
+    fireEvent.click(screen.getByText('Review the code and suggest improvements'));
+    expect(onSend).toHaveBeenCalledWith('Review the code and suggest improvements', []);
+  });
+
+  /* ── Message count ── */
+
+  it('shows message count as singular for 1 message', () => {
+    render(<SessionChat {...defaultProps} messages={[userMessage]} />);
+    expect(screen.getByText('1 message')).toBeInTheDocument();
+  });
+
+  it('shows message count as plural for multiple messages', () => {
+    render(<SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} />);
+    expect(screen.getByText('2 messages')).toBeInTheDocument();
+  });
+
+  it('shows 0 messages for empty list', () => {
+    render(<SessionChat {...defaultProps} />);
+    expect(screen.getByText('0 messages')).toBeInTheDocument();
+  });
+
+  /* ── onMessageCountChange ── */
+
+  it('calls onMessageCountChange with visible message count', () => {
+    const onMessageCountChange = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[userMessage, assistantMessage]}
+        onMessageCountChange={onMessageCountChange}
+      />,
+    );
+    expect(onMessageCountChange).toHaveBeenCalledWith(2);
+  });
+
+  /* ── Clear button ── */
+
+  it('shows clear button when messages exist and onClear provided', () => {
+    const onClear = vi.fn();
+    render(<SessionChat {...defaultProps} messages={[userMessage]} onClear={onClear} />);
+    const clearBtn = screen.getByTestId('clear-chat');
+    fireEvent.click(clearBtn);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides clear button when no messages', () => {
+    render(<SessionChat {...defaultProps} onClear={vi.fn()} />);
+    expect(screen.queryByTestId('clear-chat')).not.toBeInTheDocument();
+  });
+
+  it('hides clear button when onClear is not provided', () => {
+    render(<SessionChat {...defaultProps} messages={[userMessage]} />);
+    expect(screen.queryByTestId('clear-chat')).not.toBeInTheDocument();
+  });
+
+  /* ── Model switch ── */
+
+  it('shows model switch toggle when capability enabled and connected', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_model: true }}
+        onSetModel={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('model-switch-toggle')).toBeInTheDocument();
+  });
+
+  it('hides model switch toggle when disconnected', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected={false}
+        capabilities={{ set_model: true }}
+        onSetModel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('model-switch-toggle')).not.toBeInTheDocument();
+  });
+
+  it('opens and closes model input bar', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_model: true }}
+        onSetModel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('model-input-bar')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('model-switch-toggle'));
+    expect(screen.getByTestId('model-input-bar')).toBeInTheDocument();
+
+    // Toggle off
+    fireEvent.click(screen.getByTestId('model-switch-toggle'));
+    expect(screen.queryByTestId('model-input-bar')).not.toBeInTheDocument();
+  });
+
+  it('submits model via Enter key', () => {
+    const onSetModel = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_model: true }}
+        onSetModel={onSetModel}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('model-switch-toggle'));
+
+    const input = screen.getByLabelText('Model ID input');
+    fireEvent.change(input, { target: { value: 'claude-opus-4-6' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSetModel).toHaveBeenCalledWith('claude-opus-4-6');
+    expect(screen.queryByTestId('model-input-bar')).not.toBeInTheDocument();
+  });
+
+  it('submits model via Switch button', () => {
+    const onSetModel = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_model: true }}
+        onSetModel={onSetModel}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('model-switch-toggle'));
+
+    const input = screen.getByLabelText('Model ID input');
+    fireEvent.change(input, { target: { value: 'claude-sonnet' } });
+    fireEvent.click(screen.getByTestId('model-submit'));
+
+    expect(onSetModel).toHaveBeenCalledWith('claude-sonnet');
+  });
+
+  it('does not submit empty model name', () => {
+    const onSetModel = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_model: true }}
+        onSetModel={onSetModel}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('model-switch-toggle'));
+
+    const input = screen.getByLabelText('Model ID input');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onSetModel).not.toHaveBeenCalled();
+  });
+
+  it('closes model input on Escape', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_model: true }}
+        onSetModel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('model-switch-toggle'));
+    expect(screen.getByTestId('model-input-bar')).toBeInTheDocument();
+
+    const input = screen.getByLabelText('Model ID input');
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.queryByTestId('model-input-bar')).not.toBeInTheDocument();
+  });
+
+  /* ── Thinking budget ── */
+
+  it('shows thinking budget toggle when capability enabled and connected', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_thinking_tokens: true }}
+        onSetThinkingTokens={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('thinking-budget-toggle')).toBeInTheDocument();
+  });
+
+  it('opens thinking menu and selects a preset', () => {
+    const onSetThinkingTokens = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_thinking_tokens: true }}
+        onSetThinkingTokens={onSetThinkingTokens}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('thinking-budget-toggle'));
+    expect(screen.getByTestId('thinking-menu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('thinking-8K'));
+    expect(onSetThinkingTokens).toHaveBeenCalledWith(8192);
+    expect(screen.queryByTestId('thinking-menu')).not.toBeInTheDocument();
+  });
+
+  it('toggles thinking menu closed on second click', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_thinking_tokens: true }}
+        onSetThinkingTokens={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('thinking-budget-toggle'));
+    expect(screen.getByTestId('thinking-menu')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('thinking-budget-toggle'));
+    expect(screen.queryByTestId('thinking-menu')).not.toBeInTheDocument();
+  });
+
+  /* ── Rewind files ── */
+
+  it('shows rewind files button when capability enabled and connected', () => {
+    const onRewindFiles = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ rewind_files: true }}
+        onRewindFiles={onRewindFiles}
+      />,
+    );
+    const btn = screen.getByTestId('rewind-files');
+    fireEvent.click(btn);
+    expect(onRewindFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides rewind files button when capability disabled', () => {
+    render(<SessionChat {...defaultProps} connected capabilities={{}} onRewindFiles={vi.fn()} />);
+    expect(screen.queryByTestId('rewind-files')).not.toBeInTheDocument();
+  });
+
+  /* ── Message rendering ── */
+
+  it('renders user and assistant messages', () => {
+    render(<SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} />);
+    expect(screen.getByText('Please review the config.')).toBeInTheDocument();
+    expect(screen.getByTestId('assistant-message')).toBeInTheDocument();
+  });
+
+  it('filters out system-type messages from visible list', () => {
+    // System messages (metadata.messageType === 'system') are excluded from
+    // visibleMessages by useRoomState, so they never render in the chat.
+    render(<SessionChat {...defaultProps} messages={[userMessage, systemMessage]} />);
+    expect(screen.queryByText('Session started')).not.toBeInTheDocument();
+    // But the user message should still be there
+    expect(screen.getByText('Please review the config.')).toBeInTheDocument();
+  });
+
+  it('renders running assistant message as streaming', () => {
+    render(<SessionChat {...defaultProps} messages={[userMessage, runningMessage]} />);
+    expect(screen.getByText('Working on it...')).toBeInTheDocument();
+  });
+
+  /* ── Streaming indicator ── */
+
+  it('shows streaming message when streamingContent is provided', () => {
+    render(
+      <SessionChat {...defaultProps} messages={[userMessage]} streamingContent="Thinking..." />,
+    );
+    expect(screen.getByText('Thinking...')).toBeInTheDocument();
+  });
+
+  it('shows streaming message when streamingParts are provided', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[userMessage]}
+        streamingParts={[{ type: 'text', text: 'Part content' }]}
+      />,
+    );
+    // Streaming message should be rendered (exact rendering depends on StreamingMessage)
+    expect(screen.queryByTestId('session-empty-chat')).not.toBeInTheDocument();
+  });
+
+  it('does not show streaming indicator when a running message already exists', () => {
+    // When hasRunningAssistantMessage is true, isStreaming should be false
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[userMessage, runningMessage]}
+        streamingContent="Should not appear as separate streaming"
+      />,
+    );
+    // The running message is rendered, but no extra streaming indicator
+    expect(screen.getByText('Working on it...')).toBeInTheDocument();
+  });
+
+  /* ── handleSend ── */
+
+  it('calls onSend when sending a message', () => {
+    const onSend = vi.fn();
+    render(<SessionChat {...defaultProps} onSend={onSend} connected />);
+
+    // Click a suggestion in empty state to trigger handleSend
+    fireEvent.click(screen.getByText('Run the test suite and fix failures'));
+    expect(onSend).toHaveBeenCalledWith('Run the test suite and fix failures', []);
+  });
+
+  /* ── handleCopy ── */
+
+  it('delegates to onCopy callback when provided', () => {
+    const onCopy = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[userMessage, assistantMessage]}
+        onCopy={onCopy}
+      />,
+    );
+    const copyBtn = screen.getByTitle('Copy');
+    fireEvent.click(copyBtn);
+    expect(onCopy).toHaveBeenCalledWith(assistantMessage.content);
+  });
+
+  it('falls back to navigator.clipboard when onCopy not provided', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} />);
+    const copyBtn = screen.getByTitle('Copy');
+    fireEvent.click(copyBtn);
+    expect(writeText).toHaveBeenCalledWith(assistantMessage.content);
+  });
+
+  /* ── handleRegenerate ── */
+
+  it('delegates to onRegenerate callback when provided', () => {
+    const onRegenerate = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[userMessage, assistantMessage]}
+        onRegenerate={onRegenerate}
+      />,
+    );
+    const regenerateBtn = screen.getByTitle('Regenerate');
+    fireEvent.click(regenerateBtn);
+    expect(onRegenerate).toHaveBeenCalledWith(assistantMessage.id);
+  });
+
+  it('falls back to resending last user message when onRegenerate not provided', () => {
+    const onSend = vi.fn();
+    render(
+      <SessionChat {...defaultProps} onSend={onSend} messages={[userMessage, assistantMessage]} />,
+    );
+    const regenerateBtn = screen.getByTitle('Regenerate');
+    fireEvent.click(regenerateBtn);
+    expect(onSend).toHaveBeenCalledWith(userMessage.content, []);
+  });
+
+  it('does nothing on regenerate fallback when no preceding user message found', () => {
+    const onSend = vi.fn();
+    render(<SessionChat {...defaultProps} onSend={onSend} messages={[assistantMessage]} />);
+    const regenerateBtn = screen.getByTitle('Regenerate');
+    fireEvent.click(regenerateBtn);
+    // Should not call onSend since there is no user message before the assistant message
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  /* ── handleBookmark ── */
+
+  it('delegates to onBookmark callback when provided', () => {
+    const onBookmark = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[userMessage, assistantMessage]}
+        onBookmark={onBookmark}
+      />,
+    );
+    const bookmarkBtn = screen.getByTitle('Bookmark');
+    fireEvent.click(bookmarkBtn);
+    expect(onBookmark).toHaveBeenCalledWith(assistantMessage.id, true);
+  });
+
+  it('falls back to localStorage when onBookmark not provided', () => {
+    render(<SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} />);
+    const bookmarkBtn = screen.getByTitle('Bookmark');
+    fireEvent.click(bookmarkBtn);
+    expect(localStorage.getItem(`bookmark:${assistantMessage.id}`)).toBe('1');
+  });
+
+  it('removes bookmark from localStorage on unbookmark', () => {
+    localStorage.setItem(`bookmark:${assistantMessage.id}`, '1');
+    render(<SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} />);
+    // Message should show as bookmarked, so the title changes to "Remove bookmark"
+    const bookmarkBtn = screen.getByTitle('Remove bookmark');
+    fireEvent.click(bookmarkBtn);
+    expect(localStorage.getItem(`bookmark:${assistantMessage.id}`)).toBeNull();
+  });
+
+  /* ── Permissions rendering ── */
+
+  it('renders permission UI via renderPermissions slot', () => {
+    const permissions: PermissionRequest[] = [
+      { requestId: 'perm-1', toolName: 'file_write', description: 'Write to disk' },
+    ];
+    const onPermissionRespond = vi.fn();
+    const renderPermissions = vi.fn().mockReturnValue(<div data-testid="perm-ui">Allow?</div>);
+
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        pendingPermissions={permissions}
+        onPermissionRespond={onPermissionRespond}
+        renderPermissions={renderPermissions}
+      />,
+    );
+
+    expect(screen.getByTestId('perm-ui')).toBeInTheDocument();
+    expect(renderPermissions).toHaveBeenCalledWith(permissions, expect.any(Function));
+
+    // Test that the respond callback delegates to onPermissionRespond
+    const respondFn = renderPermissions.mock.calls[0][1];
+    respondFn('perm-1', 'allow_once');
+    expect(onPermissionRespond).toHaveBeenCalledWith('perm-1', 'allow_once');
+  });
+
+  it('does not render permission UI when no pending permissions', () => {
+    const renderPermissions = vi.fn().mockReturnValue(<div data-testid="perm-ui">Allow?</div>);
+    render(
+      <SessionChat {...defaultProps} connected pendingPermissions={[]} renderPermissions={renderPermissions} />,
+    );
+    expect(screen.queryByTestId('perm-ui')).not.toBeInTheDocument();
+  });
+
+  /* ── Room mode / MeshSidebar ── */
+
+  it('renders MeshSidebar when a ravn participant exists', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[roomAssistantMessage]}
+        connected
+        participants={new Map([[participant.peerId, participant]])}
+      />,
+    );
+    const outerGrid = screen.getByTestId('session-chat');
+    expect(outerGrid).toHaveAttribute('data-has-sidebar');
+  });
+
+  it('does not render sidebar when no ravn participants', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[roomAssistantMessage]}
+        connected
+        participants={new Map([[skuldParticipant.peerId, skuldParticipant]])}
+      />,
+    );
+    const outerGrid = screen.getByTestId('session-chat');
+    expect(outerGrid).not.toHaveAttribute('data-has-sidebar');
+  });
+
+  /* ── Agent detail panel ── */
 
   it('opens the agent detail panel from a room message', () => {
     render(
       <SessionChat
-        messages={messages}
+        {...defaultProps}
+        messages={[roomAssistantMessage]}
         connected
         historyLoaded
         participants={new Map([[participant.peerId, participant]])}
         agentEvents={agentEvents}
-        onSend={() => undefined}
       />,
     );
 
@@ -68,5 +652,435 @@ describe('SessionChat', () => {
 
     expect(screen.getByTestId('agent-detail-panel')).toBeInTheDocument();
     expect(screen.getByText('Checking compose and runtime settings.')).toBeInTheDocument();
+  });
+
+  it('closes the agent detail panel', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[roomAssistantMessage]}
+        connected
+        historyLoaded
+        participants={new Map([[participant.peerId, participant]])}
+        agentEvents={agentEvents}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('View event stream for Ravn-A'));
+    expect(screen.getByTestId('agent-detail-panel')).toBeInTheDocument();
+
+    // Close the detail panel
+    const closeBtn = screen.getByLabelText('Close agent detail panel');
+    fireEvent.click(closeBtn);
+    expect(screen.queryByTestId('agent-detail-panel')).not.toBeInTheDocument();
+  });
+
+  /* ── Internal message toggle (room mode) ── */
+
+  it('shows internal toggle in room mode with multiple participants', () => {
+    const participants = new Map([
+      [participant.peerId, participant],
+      [participant2.peerId, participant2],
+    ]);
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[roomAssistantMessage]}
+        connected
+        participants={participants}
+      />,
+    );
+    expect(screen.getByTestId('internal-toggle')).toBeInTheDocument();
+  });
+
+  it('does not show internal toggle in single-participant mode', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[userMessage]}
+        connected
+        participants={new Map()}
+      />,
+    );
+    expect(screen.queryByTestId('internal-toggle')).not.toBeInTheDocument();
+  });
+
+  it('toggles internal visibility', () => {
+    const participants = new Map([
+      [participant.peerId, participant],
+      [participant2.peerId, participant2],
+    ]);
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[roomAssistantMessage]}
+        connected
+        participants={participants}
+      />,
+    );
+    const toggle = screen.getByTestId('internal-toggle');
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  /* ── MeshCascadePanel ── */
+
+  it('renders MeshCascadePanel when mesh events exist', () => {
+    const events: MeshOutcomeEvent[] = [
+      {
+        id: 'me-1',
+        type: 'outcome',
+        timestamp: now,
+        participantId: 'peer-1',
+        participant: { color: 'amber' },
+        persona: 'Ravn-A',
+        eventType: 'code_review',
+        verdict: 'approve',
+        summary: 'Looks good',
+      },
+    ];
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[userMessage]}
+        connected
+        meshEvents={events}
+      />,
+    );
+    const outerGrid = screen.getByTestId('session-chat');
+    expect(outerGrid).toHaveAttribute('data-right-panel');
+  });
+
+  it('does not render right panel when no mesh events and no detail panel', () => {
+    render(<SessionChat {...defaultProps} messages={[userMessage]} connected />);
+    const outerGrid = screen.getByTestId('session-chat');
+    expect(outerGrid).not.toHaveAttribute('data-right-panel');
+  });
+
+  /* ── handleOutcomeClick ── */
+
+  it('scrolls to closest message on outcome click', () => {
+    const events: MeshOutcomeEvent[] = [
+      {
+        id: 'me-1',
+        type: 'outcome',
+        timestamp: new Date('2026-04-26T12:00:04Z'),
+        participantId: 'peer-1',
+        participant: { color: 'amber' },
+        persona: 'Ravn-A',
+        eventType: 'code_review',
+        verdict: 'approve',
+        summary: 'Approved the change',
+      },
+    ];
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[roomAssistantMessage]}
+        connected
+        participants={new Map([[participant.peerId, participant]])}
+        meshEvents={events}
+      />,
+    );
+    // MeshCascadePanel should render and contain the event card
+    expect(screen.getByText('Approved the change')).toBeInTheDocument();
+  });
+
+  /* ── handleSelectAgent ── */
+
+  it('filters messages when agent is selected in sidebar', () => {
+    const participants = new Map([
+      [participant.peerId, participant],
+      [participant2.peerId, participant2],
+    ]);
+    const msg1: ChatMessage = {
+      ...roomAssistantMessage,
+      id: 'ma1',
+      content: 'Message from Ravn-A',
+      participant,
+    };
+    const msg2: ChatMessage = {
+      id: 'ma2',
+      role: 'assistant',
+      content: 'Message from Ravn-B',
+      createdAt: now,
+      status: 'done',
+      participant: participant2,
+    };
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[msg1, msg2]}
+        connected
+        participants={participants}
+      />,
+    );
+    // Both messages should be visible initially
+    expect(screen.getByText('Message from Ravn-A')).toBeInTheDocument();
+    expect(screen.getByText('Message from Ravn-B')).toBeInTheDocument();
+  });
+
+  /* ── Room message rendering ── */
+
+  it('renders room messages with participant info when in room session', () => {
+    const participants = new Map([[participant.peerId, participant]]);
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[roomAssistantMessage]}
+        connected
+        participants={participants}
+      />,
+    );
+    expect(screen.getByText('Need to inspect the config first.')).toBeInTheDocument();
+  });
+
+  /* ── handleSendDirected ── */
+
+  it('passes onSendDirected callback through', () => {
+    const onSendDirected = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        onSendDirected={onSendDirected}
+        participants={new Map([[participant.peerId, participant]])}
+      />,
+    );
+    // onSendDirected is passed to ChatInput; we just verify the component renders
+    expect(screen.getByTestId('session-chat')).toBeInTheDocument();
+  });
+
+  /* ── onStop ── */
+
+  it('passes onStop to ChatInput', () => {
+    const onStop = vi.fn();
+    render(<SessionChat {...defaultProps} connected onStop={onStop} />);
+    expect(screen.getByTestId('session-chat')).toBeInTheDocument();
+  });
+
+  /* ── Thread groups ── */
+
+  it('renders thread groups in room mode with internal messages', () => {
+    const participants = new Map([
+      [participant.peerId, participant],
+      [participant2.peerId, participant2],
+    ]);
+    const internalMsgs: ChatMessage[] = [
+      {
+        id: 'int-1',
+        role: 'assistant',
+        content: 'Internal msg 1',
+        createdAt: now,
+        status: 'done',
+        visibility: 'internal',
+        threadId: 'thread-A',
+        participant,
+      },
+      {
+        id: 'int-2',
+        role: 'assistant',
+        content: 'Internal msg 2',
+        createdAt: new Date('2026-04-26T12:00:01Z'),
+        status: 'done',
+        visibility: 'internal',
+        threadId: 'thread-A',
+        participant,
+      },
+      {
+        id: 'ext-1',
+        role: 'user',
+        content: 'External message',
+        createdAt: new Date('2026-04-26T12:00:02Z'),
+      },
+    ];
+
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={internalMsgs}
+        connected
+        participants={participants}
+      />,
+    );
+
+    // External message should always be visible
+    expect(screen.getByText('External message')).toBeInTheDocument();
+
+    // Internal messages are hidden by default in room mode
+    // Toggle internal to show them
+    fireEvent.click(screen.getByTestId('internal-toggle'));
+    expect(screen.getByText('Internal msg 1')).toBeInTheDocument();
+  });
+
+  /* ── isRoomSession detection ── */
+
+  it('treats session as room session when participant has non-skuld type', () => {
+    // Even with single participant, if participantType !== 'skuld', it's a room session
+    const participants = new Map([[participant.peerId, participant]]);
+    const msgWithParticipant: ChatMessage = {
+      ...userMessage,
+      participant,
+    };
+    render(
+      <SessionChat
+        {...defaultProps}
+        messages={[msgWithParticipant]}
+        connected
+        participants={participants}
+      />,
+    );
+    expect(screen.getByText('Please review the config.')).toBeInTheDocument();
+  });
+
+  /* ── Capabilities hidden when disconnected ── */
+
+  it('hides toolbar controls when disconnected', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected={false}
+        capabilities={{ set_model: true, set_thinking_tokens: true, rewind_files: true }}
+        onSetModel={vi.fn()}
+        onSetThinkingTokens={vi.fn()}
+        onRewindFiles={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('model-switch-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('thinking-budget-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('rewind-files')).not.toBeInTheDocument();
+  });
+
+  /* ── All thinking presets ── */
+
+  it('renders all four thinking presets', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_thinking_tokens: true }}
+        onSetThinkingTokens={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('thinking-budget-toggle'));
+    expect(screen.getByTestId('thinking-4K')).toBeInTheDocument();
+    expect(screen.getByTestId('thinking-8K')).toBeInTheDocument();
+    expect(screen.getByTestId('thinking-16K')).toBeInTheDocument();
+    expect(screen.getByTestId('thinking-32K')).toBeInTheDocument();
+  });
+
+  it('calls onSetThinkingTokens with correct values for each preset', () => {
+    const onSetThinkingTokens = vi.fn();
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_thinking_tokens: true }}
+        onSetThinkingTokens={onSetThinkingTokens}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('thinking-budget-toggle'));
+    fireEvent.click(screen.getByTestId('thinking-4K'));
+    expect(onSetThinkingTokens).toHaveBeenCalledWith(4096);
+
+    fireEvent.click(screen.getByTestId('thinking-budget-toggle'));
+    fireEvent.click(screen.getByTestId('thinking-16K'));
+    expect(onSetThinkingTokens).toHaveBeenCalledWith(16384);
+
+    fireEvent.click(screen.getByTestId('thinking-budget-toggle'));
+    fireEvent.click(screen.getByTestId('thinking-32K'));
+    expect(onSetThinkingTokens).toHaveBeenCalledWith(32768);
+  });
+
+  /* ── hasConversation logic ── */
+
+  it('shows messages container when conversation exists', () => {
+    render(<SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} />);
+    // Should not show empty state
+    expect(screen.queryByTestId('session-empty-chat')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when only system messages exist', () => {
+    render(<SessionChat {...defaultProps} messages={[systemMessage]} />);
+    // System-only messages don't count as "conversation"
+    expect(screen.getByTestId('session-empty-chat')).toBeInTheDocument();
+  });
+
+  /* ── localStorage error handling in bookmark ── */
+
+  it('handles localStorage errors gracefully in bookmark fallback', () => {
+    const origSetItem = localStorage.setItem.bind(localStorage);
+    localStorage.setItem = () => {
+      throw new Error('Storage full');
+    };
+
+    render(<SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} />);
+    const bookmarkBtn = screen.getByTitle('Bookmark');
+    // Should not throw — the catch block swallows the error
+    expect(() => fireEvent.click(bookmarkBtn)).not.toThrow();
+
+    localStorage.setItem = origSetItem;
+  });
+
+  /* ── localStorage error in reading bookmark state ── */
+
+  it('handles localStorage errors gracefully when reading bookmark state', () => {
+    const origGetItem = localStorage.getItem.bind(localStorage);
+    localStorage.getItem = () => {
+      throw new Error('Access denied');
+    };
+
+    // Should render without throwing — the IIFE catch returns false
+    const { container } = render(
+      <SessionChat {...defaultProps} messages={[userMessage, assistantMessage]} />,
+    );
+    expect(container).toBeTruthy();
+
+    localStorage.getItem = origGetItem;
+  });
+
+  /* ── Capability combinations ── */
+
+  it('hides model switch when set_model is false', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_model: false }}
+        onSetModel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId('model-switch-toggle')).not.toBeInTheDocument();
+  });
+
+  it('hides model switch when onSetModel is not provided', () => {
+    render(
+      <SessionChat {...defaultProps} connected capabilities={{ set_model: true }} />,
+    );
+    expect(screen.queryByTestId('model-switch-toggle')).not.toBeInTheDocument();
+  });
+
+  it('hides thinking toggle when onSetThinkingTokens is not provided', () => {
+    render(
+      <SessionChat
+        {...defaultProps}
+        connected
+        capabilities={{ set_thinking_tokens: true }}
+      />,
+    );
+    expect(screen.queryByTestId('thinking-budget-toggle')).not.toBeInTheDocument();
+  });
+
+  it('hides rewind files when onRewindFiles is not provided', () => {
+    render(
+      <SessionChat {...defaultProps} connected capabilities={{ rewind_files: true }} />,
+    );
+    expect(screen.queryByTestId('rewind-files')).not.toBeInTheDocument();
   });
 });

--- a/web/src/modules/volundr/adapters/api/volundr.adapter.ts
+++ b/web/src/modules/volundr/adapters/api/volundr.adapter.ts
@@ -81,6 +81,7 @@ import type {
   ApiClusterResourceInfo,
   ApiFeatureModuleResponse,
   ApiUserFeaturePreferenceResponse,
+  ApiSessionDefinitionResponse,
 } from './volundr.types';
 
 /**
@@ -521,6 +522,21 @@ export class ApiVolundrService implements IVolundrService {
   private cachedSessions: VolundrSession[] = [];
   private cachedStats: VolundrStats | null = null;
 
+  async getSessionDefinitions(): Promise<import('@/modules/volundr/models').SessionDefinition[]> {
+    try {
+      const response = await api.get<ApiSessionDefinitionResponse[]>('/session-definitions');
+      return response.map(d => ({
+        key: d.key,
+        displayName: d.display_name,
+        description: d.description,
+        labels: d.labels,
+        defaultModel: d.default_model,
+      }));
+    } catch {
+      return [];
+    }
+  }
+
   async getSessions(): Promise<VolundrSession[]> {
     const response = await api.get<ApiSessionResponse[]>('/sessions');
     this.cachedSessions = response.map(transformSession);
@@ -778,6 +794,7 @@ export class ApiVolundrService implements IVolundrService {
     model: string;
     templateName?: string;
     taskType?: string;
+    definition?: string;
     terminalRestricted?: boolean;
     workspaceId?: string;
     credentialNames?: string[];
@@ -793,6 +810,7 @@ export class ApiVolundrService implements IVolundrService {
       source: config.source,
       template_name: config.templateName ?? null,
       task_type: config.taskType ?? null,
+      definition: config.definition ?? null,
       terminal_restricted: config.terminalRestricted ?? false,
       workspace_id: config.workspaceId ?? null,
       credential_names: config.credentialNames?.length ? config.credentialNames : undefined,

--- a/web/src/modules/volundr/adapters/api/volundr.types.ts
+++ b/web/src/modules/volundr/adapters/api/volundr.types.ts
@@ -97,6 +97,7 @@ export interface ApiSessionCreate {
   source: ApiSessionSource;
   template_name?: string | null;
   task_type?: string | null;
+  definition?: string | null;
   terminal_restricted?: boolean;
   workspace_id?: string | null;
   credential_names?: string[];
@@ -106,6 +107,17 @@ export interface ApiSessionCreate {
   initial_prompt?: string;
   issue_id?: string | null;
   issue_url?: string | null;
+}
+
+/**
+ * Session definition response from API
+ */
+export interface ApiSessionDefinitionResponse {
+  key: string;
+  display_name: string;
+  description: string;
+  labels: string[];
+  default_model: string;
 }
 
 /**

--- a/web/src/modules/volundr/adapters/mock/volundr.adapter.ts
+++ b/web/src/modules/volundr/adapters/mock/volundr.adapter.ts
@@ -102,6 +102,25 @@ export class MockVolundrService implements IVolundrService {
     }
   }
 
+  async getSessionDefinitions(): Promise<import('@/modules/volundr/models').SessionDefinition[]> {
+    return [
+      {
+        key: 'skuldClaude',
+        displayName: 'Claude Code',
+        description: 'Anthropic Claude CLI agent',
+        labels: ['claude', 'anthropic'],
+        defaultModel: 'claude-sonnet',
+      },
+      {
+        key: 'skuldCodex',
+        displayName: 'Codex',
+        description: 'OpenAI Codex CLI agent',
+        labels: ['codex', 'openai'],
+        defaultModel: 'codex',
+      },
+    ];
+  }
+
   async getSessions(): Promise<VolundrSession[]> {
     return this.sessions.map(s => ({ ...s }));
   }
@@ -254,6 +273,7 @@ export class MockVolundrService implements IVolundrService {
     model: string;
     templateName?: string;
     taskType?: string;
+    definition?: string;
     trackerIssue?: TrackerIssue;
     terminalRestricted?: boolean;
     credentialNames?: string[];

--- a/web/src/modules/volundr/components/LaunchWizard/LaunchWizard.test.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/LaunchWizard.test.tsx
@@ -78,6 +78,22 @@ const mockService = {
   getIntegrations: vi.fn().mockResolvedValue([]),
   getFeatures: vi.fn().mockResolvedValue({ localMountsEnabled: false, miniMode: false }),
   getClusterResources: vi.fn().mockResolvedValue({ resourceTypes: [], nodes: [] }),
+  getSessionDefinitions: vi.fn().mockResolvedValue([
+    {
+      key: 'skuldClaude',
+      displayName: 'Claude Code',
+      description: 'Anthropic Claude CLI agent',
+      labels: ['claude'],
+      defaultModel: 'claude-sonnet',
+    },
+    {
+      key: 'skuldCodex',
+      displayName: 'Codex',
+      description: 'OpenAI Codex CLI agent',
+      labels: ['codex'],
+      defaultModel: 'codex',
+    },
+  ]),
 } as unknown as import('@/ports').IVolundrService;
 
 const defaultProps = {
@@ -231,6 +247,7 @@ describe('LaunchWizard', () => {
           name: 'test-session',
           model: 'claude-sonnet',
           source: { type: 'git', repo: 'https://github.com/org/repo.git', branch: 'develop' },
+          definition: 'skuldClaude',
           terminalRestricted: false,
         })
       );
@@ -292,6 +309,7 @@ describe('LaunchWizard', () => {
       const miniService = {
         ...mockService,
         getFeatures: vi.fn().mockResolvedValue({ localMountsEnabled: true, miniMode: true }),
+        getSessionDefinitions: vi.fn().mockResolvedValue([]),
       } as unknown as import('@/ports').IVolundrService;
 
       render(<LaunchWizard {...defaultProps} repos={[]} service={miniService} />);

--- a/web/src/modules/volundr/components/LaunchWizard/LaunchWizard.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/LaunchWizard.tsx
@@ -25,6 +25,7 @@ export interface LaunchConfig {
   templateName?: string;
   presetId?: string;
   taskType?: string;
+  definition?: string;
   trackerIssue?: TrackerIssue;
   terminalRestricted?: boolean;
   workspaceId?: string;
@@ -47,6 +48,7 @@ export interface WizardState {
   mountPaths: MountMapping[];
   model: string;
   taskType: string;
+  definition: string;
   trackerIssue?: TrackerIssue;
   workspaceId?: string;
   terminalRestricted: boolean;
@@ -104,6 +106,7 @@ function buildInitialState(template: VolundrTemplate, repos: VolundrRepo[]): Wiz
     mountPaths: [{ host_path: '', mount_path: '', read_only: true }],
     model: template.model ?? '',
     taskType: `skuld-${template.cliTool}`,
+    definition: template.cliTool === 'codex' ? 'skuldCodex' : 'skuldClaude',
     mcpServers: [...template.mcpServers],
     resourceConfig: { ...template.resourceConfig },
     envVars: { ...template.envVars },
@@ -201,6 +204,7 @@ export function LaunchWizard(props: LaunchWizardProps) {
       templateName: state.template.name || undefined,
       presetId: state.preset?.id,
       taskType: state.taskType || undefined,
+      definition: state.definition || 'skuldClaude',
       trackerIssue: state.trackerIssue,
       terminalRestricted: state.terminalRestricted,
       workspaceId: state.workspaceId,

--- a/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.test.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.test.tsx
@@ -85,10 +85,12 @@ function buildState(overrides: Partial<WizardState> = {}): WizardState {
     mountPaths: [],
     model: '',
     taskType: '',
+    definition: 'skuldClaude',
     mcpServers: [],
     resourceConfig: {},
     envVars: {},
     systemPrompt: '',
+    initialPrompt: '',
     setupScripts: [],
     preset: null,
     selectedCredentials: [],
@@ -137,6 +139,22 @@ const mockService = {
   getCredentials: vi.fn().mockResolvedValue([]),
   getIntegrations: vi.fn().mockResolvedValue([]),
   getClusterResources: vi.fn().mockResolvedValue({ resourceTypes: [], nodes: [] }),
+  getSessionDefinitions: vi.fn().mockResolvedValue([
+    {
+      key: 'skuldClaude',
+      displayName: 'Claude Code',
+      description: 'Anthropic Claude CLI agent',
+      labels: ['claude'],
+      defaultModel: 'claude-sonnet',
+    },
+    {
+      key: 'skuldCodex',
+      displayName: 'Codex',
+      description: 'OpenAI Codex CLI agent',
+      labels: ['codex'],
+      defaultModel: 'codex',
+    },
+  ]),
 } as unknown as import('@/ports').IVolundrService;
 
 function renderStep(overrides: Partial<ConfigureStepProps> = {}) {
@@ -175,6 +193,7 @@ describe('ConfigureStep', () => {
 
       expect(onChange).toHaveBeenCalledWith(
         expect.objectContaining({
+          definition: 'skuldCodex',
           template: expect.objectContaining({ cliTool: 'codex' }),
         })
       );
@@ -738,6 +757,7 @@ describe('ConfigureStep', () => {
           model: 'claude-opus',
           systemPrompt: 'Be concise.',
           taskType: 'skuld-claude',
+          definition: 'skuldClaude',
         })
       );
     });

--- a/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.tsx
+++ b/web/src/modules/volundr/components/LaunchWizard/steps/ConfigureStep.tsx
@@ -29,15 +29,14 @@ import type {
   VolundrModel,
   McpServerConfig,
   McpServerType,
-  CliTool,
   TrackerIssue,
   RepoProvider,
   VolundrWorkspace,
   StoredCredential,
   IntegrationConnection,
   ClusterResourceInfo,
+  SessionDefinition,
 } from '@/modules/volundr/models';
-import { CLI_TOOL_LABELS } from '@/modules/volundr/models';
 import type { SourceType } from '../LaunchWizard';
 import type { IVolundrService } from '@/modules/volundr/ports';
 import { TrackerIssueSearch } from '@/modules/volundr/components/molecules/TrackerIssueSearch';
@@ -102,16 +101,20 @@ function workspaceLabel(ws: VolundrWorkspace): string {
   return ws.pvcName;
 }
 
-const CLI_TOOLS: { value: CliTool; label: string; description: string }[] = [
+const FALLBACK_DEFINITIONS: SessionDefinition[] = [
   {
-    value: 'claude',
-    label: CLI_TOOL_LABELS['claude'] ?? 'claude',
+    key: 'skuldClaude',
+    displayName: 'Claude Code',
     description: 'Anthropic Claude CLI agent',
+    labels: ['claude'],
+    defaultModel: 'claude-sonnet',
   },
   {
-    value: 'codex',
-    label: CLI_TOOL_LABELS['codex'] ?? 'codex',
+    key: 'skuldCodex',
+    displayName: 'Codex',
     description: 'OpenAI Codex CLI agent',
+    labels: ['codex'],
+    defaultModel: 'codex',
   },
 ];
 
@@ -159,6 +162,8 @@ export function ConfigureStep({
   const [credentials, setCredentials] = useState<StoredCredential[]>([]);
   const [integrations, setIntegrations] = useState<IntegrationConnection[]>([]);
   const [clusterResources, setClusterResources] = useState<ClusterResourceInfo | null>(null);
+  const [sessionDefinitions, setSessionDefinitions] =
+    useState<SessionDefinition[]>(FALLBACK_DEFINITIONS);
 
   useEffect(() => {
     Promise.all([service.listWorkspaces('archived'), service.listWorkspaces('active')])
@@ -175,6 +180,14 @@ export function ConfigureStep({
     service
       .getClusterResources()
       .then(setClusterResources)
+      .catch(() => {});
+    service
+      .getSessionDefinitions()
+      .then(defs => {
+        if (defs.length > 0) {
+          setSessionDefinitions(defs);
+        }
+      })
       .catch(() => {});
   }, [service]);
 
@@ -287,10 +300,13 @@ export function ConfigureStep({
       }
 
       const warnings: string[] = [];
+      // Find matching definition for the preset's CLI tool
+      const matchedDef = sessionDefinitions.find(d => d.labels.includes(preset.cliTool));
       const updates: Partial<WizardState> = {
         preset,
         model: preset.model ?? '',
         taskType: `skuld-${preset.cliTool}`,
+        definition: matchedDef?.key ?? (preset.cliTool === 'codex' ? 'skuldCodex' : 'skuldClaude'),
         systemPrompt: preset.systemPrompt ?? '',
         mcpServers: [...preset.mcpServers],
         resourceConfig: { ...preset.resourceConfig },
@@ -352,7 +368,7 @@ export function ConfigureStep({
       setPresetWarnings(warnings);
       onChange(updates);
     },
-    [presets, repos, availableSecrets, integrations, state.template, onChange]
+    [presets, repos, availableSecrets, integrations, sessionDefinitions, state.template, onChange]
   );
 
   const handleToggleYaml = useCallback(() => {
@@ -726,27 +742,28 @@ export function ConfigureStep({
         </div>
       )}
 
-      {/* CLI Tool selector */}
+      {/* Session Definition selector */}
       <div className={styles.cliToolSection}>
         <span className={styles.sectionLabel}>CLI Tool</span>
         <div className={styles.cliToolGrid}>
-          {CLI_TOOLS.map(tool => (
+          {sessionDefinitions.map(def => (
             <button
-              key={tool.value}
+              key={def.key}
               className={cn(
                 styles.cliToolCard,
-                state.template.cliTool === tool.value && styles.cliToolCardActive
+                state.definition === def.key && styles.cliToolCardActive
               )}
               onClick={() =>
                 onChange({
-                  taskType: `skuld-${tool.value}`,
-                  template: { ...state.template, cliTool: tool.value },
+                  definition: def.key,
+                  taskType: `skuld-${def.labels[0] ?? def.key}`,
+                  template: { ...state.template, cliTool: def.labels[0] ?? def.key },
                 })
               }
               type="button"
             >
-              <span className={styles.cliToolLabel}>{tool.label}</span>
-              <span className={styles.cliToolDescription}>{tool.description}</span>
+              <span className={styles.cliToolLabel}>{def.displayName}</span>
+              <span className={styles.cliToolDescription}>{def.description}</span>
             </button>
           ))}
         </div>

--- a/web/src/modules/volundr/hooks/useVolundr.ts
+++ b/web/src/modules/volundr/hooks/useVolundr.ts
@@ -37,6 +37,7 @@ interface UseVolundrResult {
     source: SessionSource;
     model: string;
     templateName?: string;
+    definition?: string;
     taskType?: string;
     trackerIssue?: TrackerIssue;
     terminalRestricted?: boolean;

--- a/web/src/modules/volundr/models/index.ts
+++ b/web/src/modules/volundr/models/index.ts
@@ -131,6 +131,7 @@ export type {
   UserFeaturePreference,
   PersonalAccessToken,
   CreatePATResult,
+  SessionDefinition,
 } from './volundr.model';
 
 export { TASK_TYPES, CLI_TOOL_LABELS } from './volundr.model';

--- a/web/src/modules/volundr/models/volundr.model.ts
+++ b/web/src/modules/volundr/models/volundr.model.ts
@@ -106,6 +106,14 @@ export const TASK_TYPES: Record<string, TaskType> = {
   },
 };
 
+export interface SessionDefinition {
+  key: string;
+  displayName: string;
+  description: string;
+  labels: string[];
+  defaultModel: string;
+}
+
 export interface VolundrSession {
   id: string;
   name: string;

--- a/web/src/modules/volundr/pages/Volundr/Volundr.test.tsx
+++ b/web/src/modules/volundr/pages/Volundr/Volundr.test.tsx
@@ -140,12 +140,32 @@ vi.mock('@/modules/volundr/components/LaunchWizard', () => ({
               branch: 'main',
             },
             model: 'qwen3-coder:70b',
+            definition: 'skuldClaude',
             templateName: templates[0]?.name ?? '',
           })
         }
         disabled={isLaunching}
       >
         {isLaunching ? 'Launching...' : 'Launch Session'}
+      </button>
+      <button
+        data-testid="wizard-launch-codex"
+        onClick={() =>
+          onLaunch({
+            name: 'codex-session',
+            source: {
+              type: 'git',
+              repo: 'https://github.com/kanuckvalley/my-repo.git',
+              branch: 'main',
+            },
+            model: 'gpt-5.4',
+            definition: 'skuldCodex',
+            templateName: templates[0]?.name ?? '',
+          })
+        }
+        disabled={isLaunching}
+      >
+        Launch Codex
       </button>
     </div>
   ),
@@ -931,7 +951,7 @@ describe('VolundrPage', () => {
 
   // Tests for launch wizard integration
   describe('Launch wizard integration', () => {
-    it('calls startSession when wizard launches', async () => {
+    it('calls startSession with claude definition when wizard launches', async () => {
       startSession.mockResolvedValue(mockSessions[0]);
       vi.mocked(useVolundr).mockReturnValue(createMockHookReturn());
 
@@ -945,16 +965,38 @@ describe('VolundrPage', () => {
       fireEvent.click(screen.getByTestId('wizard-launch'));
 
       await waitFor(() => {
-        expect(startSession).toHaveBeenCalledWith({
-          name: 'test-session',
-          source: {
-            type: 'git',
-            repo: 'https://github.com/kanuckvalley/my-repo.git',
-            branch: 'main',
-          },
-          model: 'qwen3-coder:70b',
-          templateName: 'full-stack-dev',
-        });
+        expect(startSession).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'test-session',
+            model: 'qwen3-coder:70b',
+            definition: 'skuldClaude',
+            templateName: 'full-stack-dev',
+          })
+        );
+      });
+    });
+
+    it('calls startSession with codex definition when codex is selected', async () => {
+      startSession.mockResolvedValue(mockSessions[0]);
+      vi.mocked(useVolundr).mockReturnValue(createMockHookReturn());
+
+      render(
+        <MemoryRouter>
+          <VolundrPage />
+        </MemoryRouter>
+      );
+
+      fireEvent.click(screen.getByTitle('New Session'));
+      fireEvent.click(screen.getByTestId('wizard-launch-codex'));
+
+      await waitFor(() => {
+        expect(startSession).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'codex-session',
+            model: 'gpt-5.4',
+            definition: 'skuldCodex',
+          })
+        );
       });
     });
 

--- a/web/src/modules/volundr/pages/Volundr/index.tsx
+++ b/web/src/modules/volundr/pages/Volundr/index.tsx
@@ -628,6 +628,7 @@ export function VolundrPage() {
           source: config.source,
           model: config.model,
           templateName: config.templateName,
+          definition: config.definition,
           taskType: config.taskType,
           trackerIssue: config.trackerIssue,
           terminalRestricted: config.terminalRestricted,

--- a/web/src/modules/volundr/ports/volundr.port.ts
+++ b/web/src/modules/volundr/ports/volundr.port.ts
@@ -40,6 +40,7 @@ import type {
   UserFeaturePreference,
   PersonalAccessToken,
   CreatePATResult,
+  SessionDefinition,
 } from '@/modules/volundr/models';
 
 /**
@@ -47,6 +48,11 @@ import type {
  * Manages Claude Code sessions
  */
 export interface IVolundrService {
+  /**
+   * Get available session definitions from the server
+   */
+  getSessionDefinitions(): Promise<SessionDefinition[]>;
+
   /**
    * Get feature flags from the server
    */
@@ -163,6 +169,7 @@ export interface IVolundrService {
     model: string;
     templateName?: string;
     taskType?: string;
+    definition?: string;
     trackerIssue?: TrackerIssue;
     terminalRestricted?: boolean;
     workspaceId?: string;


### PR DESCRIPTION
## Summary

- Add `CodexWebSocketTransport` that spawns `codex app-server --listen ws://...` and communicates via JSON-RPC 2.0 over WebSocket
- Full streaming support: text deltas, reasoning/thinking, tool calls, command output, file changes
- Session resume, turn interrupt, model switching, and permission approval flow
- Event normalization for both browser rendering (`content_block_start/delta/stop`) and broker artifact tracking (`assistant` with `message.content`)
- Verified against actual Codex Rust source code (`openai/codex`) for correct field names, enum values, and serde serialization
- Default Codex session definition updated to use WebSocket transport

## What changed

| File | Change |
|------|--------|
| `src/skuld/transports/codex_ws.py` | New transport (~500 lines) |
| `src/skuld/transports/__init__.py` | Export `CodexWebSocketTransport` |
| `src/skuld/config.py` | Map `cli_type: codex-ws` to new transport |
| `charts/volundr/values.yaml` | Default codex sessions to `codex-ws` |
| `tests/test_skuld/test_codex_ws_transport.py` | 48 unit tests |

## Config

```yaml
cli_type: codex-ws   # or env: SKULD__CLI_TYPE=codex-ws
session:
  model: ""          # let Codex pick based on subscription
```

Codex auth: `codex login` (ChatGPT subscription) or `codex login --with-api-key` (API key).

## Test plan

- [x] 48 unit tests (handshake, events, tool lifecycle, approvals, resume, e2e flows)
- [x] 149 total transport tests pass (including existing transports)
- [x] Live integration test: Skuld → Codex app-server → OpenAI → streaming response
- [x] Protocol verified against `openai/codex` Rust source (field casing, enum values, serde config)
- [x] Duplicate text fix verified with real weather query

🤖 Generated with [Claude Code](https://claude.com/claude-code)