### PR TITLE
docs: research thread-based human interface patterns for active sessions

### DIFF
--- a/wiki/index.md
+++ b/wiki/index.md
@@ -10,6 +10,7 @@ Auto-updated content catalog. Last refreshed: 2026-05-04T01:02:30Z
 ## Research
 
 - [Best Practices for Agent-Written Mimir Pages](research/best-practices-agent-mimir-pages.md)
+- [Thread-Based Human Interface Patterns for Active Sessions](research/thread-based-human-interface-patterns.md)
 
 ## Projects
 

--- a/wiki/research/thread-based-human-interface-patterns.md
+++ b/wiki/research/thread-based-human-interface-patterns.md
@@ -14,14 +14,14 @@ source_ids: [src_niu777_telegram_bot_api, src_niu777_slack_api, src_niu777_disco
 
 ### Recommended Generic Routing Model
 
-The routing layer sits between the session broker and platform-specific channel adapters. Every active session maintains zero or more `CommunicationRoute` records that describe where human-facing messages should be sent and where inbound replies should be dispatched.
+The routing layer sits between the session broker and platform-specific channel adapters. Every active session maintains zero or more `CommunicationRoute` records describing where human-facing messages are sent and where inbound replies are dispatched.
 
 **Route lifecycle:**
 
-1. **Bind** — When a session starts with a channel configured, the adapter resolves or creates a platform thread and registers a `CommunicationRoute` on the broker.
-2. **Dispatch outbound** — The broker filters events through a mirror policy (see below), formats surviving events via the adapter's formatter, and sends them to the thread identified by the route.
-3. **Dispatch inbound** — The adapter receives platform events (webhook, polling, or gateway), matches them to a session via the route's thread identifier, validates the sender, and injects the message into the session's input stream.
-4. **Unbind** — When the session stops, the route is deregistered. The platform thread may be closed, archived, or left open depending on adapter policy.
+1. **Bind** — Adapter resolves or creates a platform thread and registers a `CommunicationRoute` on the broker.
+2. **Dispatch outbound** — Broker filters events through a mirror policy, formats via the adapter's formatter, and sends to the thread.
+3. **Dispatch inbound** — Adapter receives platform events, matches to a session via the route's thread identifier, validates the sender, and injects into the session's input stream.
+4. **Unbind** — Route is deregistered on session stop. The platform thread may be closed, archived, or left open depending on adapter policy.
 
 **Route envelope (generic):**
 
@@ -41,15 +41,9 @@ CommunicationRoute {
 }
 ```
 
-This aligns with the existing `TelegramChannel.communication_route()` return shape in `src/skuld/channels.py` and generalises it for multi-platform use.
+This extends the shape returned by `TelegramChannel.communication_route()` in `src/skuld/channels.py`, adding fields needed for multi-platform routing.
 
-**Inbound routing algorithm:**
-
-1. Extract `(platform, conversation_id, thread_id)` from the inbound event.
-2. Look up the matching `CommunicationRoute` in the broker's route table.
-3. If no match, drop the message (or queue it for a configurable grace period if a session is starting).
-4. Validate the sender against the session's ACL (owner, allowed operators).
-5. Inject the message as a `user_confirmed` event with `metadata.source_platform` set — this prevents echo loops where mirrored output is re-ingested.
+**Inbound routing algorithm:** Extract `(platform, conversation_id, thread_id)` from the inbound event → look up the matching route → validate sender against the session's ACL → inject as a `user_confirmed` event with `metadata.source_platform` set (prevents echo loops). If no route matches, queue for a short grace period or drop.
 
 ### Platform Thread Identifier Reference
 
@@ -74,36 +68,33 @@ This aligns with the existing `TelegramChannel.communication_route()` return sha
 **Slack**
 - Threads are implicit: post a message, then reply to its `ts`. No explicit "create thread" API.
 - Recommended pattern: post a session-start message to the channel, capture its `ts`, use it as `thread_ts` for all subsequent messages.
-- `reply_broadcast: true` can surface key messages (session start, final outcome) in the main channel timeline, but use sparingly — it creates noise.
-- Thread replies arrive as `message` events with `thread_ts` present. Filter: `thread_ts != ts` means it is a reply.
-- New commercial non-Marketplace apps face aggressive rate limits on `conversations.replies` (1 request/minute, 15 results/page as of 2025). Prefer event-driven inbound over polling.
+- `reply_broadcast: true` can surface key messages in the main channel timeline — use sparingly.
+- Thread replies arrive as `message` events with `thread_ts` present (`thread_ts != ts` means reply).
+- Aggressive rate limits on `conversations.replies` for non-Marketplace apps (1 req/min as of 2025). Prefer event-driven inbound over polling.
 - No thread-specific subscription filter — the app receives all channel events and must route by `thread_ts`.
 
 **Discord**
 - Threads are first-class Channel objects (types 10, 11, 12). Public and private thread types exist.
-- Auto-archive after inactivity: 60 min, 24 h, 3 days, or 7 days. Set `auto_archive_duration` to 10080 (7 days) for sessions and extend on activity.
-- Thread members must be explicitly added or must post to join. Bots need `SEND_MESSAGES_IN_THREADS` permission.
-- Messages arrive via standard `MESSAGE_CREATE` gateway event — the `channel_id` is the thread ID.
-- Global rate limit: 50 requests/second per bot. Per-route limits returned in response headers.
+- Set `auto_archive_duration` to 10080 (7 days) for sessions and extend on activity.
+- Bots need `SEND_MESSAGES_IN_THREADS` permission. Messages arrive via `MESSAGE_CREATE` gateway event where `channel_id` is the thread ID.
+- Global rate limit: 50 req/s per bot; per-route limits in response headers.
 - Forum channels are a natural fit for topic-per-session: each session becomes a forum post with its own thread.
 
 **Microsoft Teams**
 - Thread identity is embedded in `conversation.id` as a `messageid=` suffix — extract this, not `replyToId` (which is unreliable for inbound activities).
 - Bots only receive messages when **@mentioned** unless the app has RSC `ChannelMessage.Read.Group` permission.
-- Proactive messaging requires a stored `ConversationReference` with valid `serviceUrl`, `conversationId`, and `tenantId`.
-- Rate limit: ~4 messages/second per conversation.
-- No native "close thread" concept. Session end must be signalled by a final message rather than thread state change.
+- Proactive messaging requires a stored `ConversationReference` with valid `serviceUrl`, `conversationId`, and `tenantId`. Rate limit: ~4 msg/s per conversation.
+- No native "close thread" concept — signal session end via a final message.
 
 **Matrix**
 - Threads use the `m.thread` relation type (stable since spec v1.4, September 2022).
 - Nested threads are explicitly forbidden — the root must be a non-thread event.
-- Thread root events include aggregated metadata (`unsigned.m.relations.m.thread.count`, `latest_event`).
 - Application services are typically exempt from rate limiting, making Matrix well-suited for high-throughput mirroring.
-- Fetch thread history via `GET /rooms/{roomId}/relations/{eventId}/m.thread` (paginated).
+- Thread history: `GET /rooms/{roomId}/relations/{eventId}/m.thread` (paginated).
 
 ### Required Route Metadata
 
-The minimum metadata a channel adapter must persist or provide to enable reliable routing:
+Minimum metadata for reliable routing:
 
 | Field | Purpose | Where stored |
 |---|---|---|
@@ -133,38 +124,31 @@ The minimum metadata a channel adapter must persist or provide to enable reliabl
 
 | Event type | Rationale |
 |---|---|
-| `content_block_delta` (thinking) | Internal reasoning — noisy, often large, and exposes chain-of-thought |
-| `assistant` tool_use blocks | Tool invocations are implementation detail — surface only via formatted summaries if desired |
-| `room_message` (visibility=internal) | Inter-agent coordination, not for human consumption |
+| `content_block_delta` (thinking) | Internal reasoning — noisy and exposes chain-of-thought |
+| `assistant` tool_use blocks | Implementation detail |
+| `room_message` (visibility=internal) | Inter-agent coordination |
 | `room_mesh_message` | Delegation/orchestration traffic between agents |
-| `result` | Raw result payloads — prefer the formatted `room_outcome` |
-| `system` | Internal lifecycle events (session start, contributor pipeline) |
+| `result` | Raw payloads — prefer formatted `room_outcome` |
+| `system` | Internal lifecycle events |
 
-**Configurable (adapter or user preference):**
-
-| Event type | Default | Notes |
-|---|---|---|
-| Tool call summaries | Off | Compact `[tool] name: detail` lines can be useful for debugging but create noise during normal operation |
-| Streaming text deltas | Buffer then send | Buffer `content_block_delta` text fragments and flush periodically (existing pattern: 1.5s flush interval) rather than sending each delta |
-| Session lifecycle | Start + stop only | Post a message at session start and end; intermediate state transitions are internal |
+**Configurable (adapter or user preference):** Tool call summaries (off by default), streaming text deltas (buffer then flush at the existing 1.5s interval rather than sending each delta), and session lifecycle events (start + stop only by default).
 
 ### Failure Modes and Permission Concerns
 
 **Failure modes:**
 
-- **Thread not found / deleted** — The platform thread may be deleted or archived externally. Adapters must handle `404`/`not_found` errors gracefully: log, deregister the route, and optionally notify via a fallback channel.
-- **Rate limiting** — All platforms impose rate limits. Outbound messages must pass through a per-platform rate limiter with exponential backoff. Inbound processing is less constrained but should still respect API polling limits (relevant for Slack `conversations.replies`).
-- **Echo loops** — If mirrored output is re-ingested as user input, it creates an infinite loop. The `source_platform` stamp on inbound events prevents this: the broker ignores `user_confirmed` events where `source_platform` matches the originating channel.
-- **Session start race** — An inbound message may arrive before the session's route is fully registered (e.g., user replies to a topic-creation message). A short grace-period queue (configurable, default ~5 seconds) absorbs this race.
+- **Thread not found / deleted** — Adapters must handle `404`/`not_found` errors gracefully: log, deregister the route, and optionally notify via a fallback channel.
+- **Rate limiting** — Outbound messages must pass through a per-platform rate limiter with exponential backoff.
+- **Echo loops** — The `source_platform` stamp on inbound events prevents mirrored output from being re-ingested as user input.
+- **Session start race** — Inbound messages arriving before route registration are absorbed by a short grace-period queue (default ~5s).
 - **Stale routes** — If the session crashes without clean shutdown, routes become orphaned. A periodic reconciler should scan for routes whose `session_id` is no longer active and clean them up.
-- **Message ordering** — Platform delivery order is not guaranteed under load. For critical sequences (permission request followed by action), use explicit request IDs rather than relying on message order.
 
 **Permission concerns:**
 
-- **Thread-level ACL** — Not all platform users in a chat should be able to inject commands into a session. The route's sender validation step must check the user against the session's owner and any configured operator list.
-- **Bot permissions** — Creating threads requires elevated bot permissions on most platforms (admin on Telegram, `CREATE_*_THREADS` on Discord, app installation on Teams). Adapters should detect missing permissions at bind time and fall back to `shared_chat` mode with a warning.
-- **Cross-tenant isolation** — In multi-tenant deployments, a route must be scoped to its tenant. A thread in Tenant A's Slack workspace must never route to a session owned by Tenant B. Enforce this by including `tenant_id` in route lookup keys.
-- **Credential scoping** — Bot tokens used by channel adapters must be scoped to the minimum permissions required. Telegram bots should not have `can_delete_messages` unless thread cleanup is explicitly enabled. Slack apps should request only `chat:write` and `channels:history`, not `admin.*`.
+- **Thread-level ACL** — The route's sender validation must check users against the session's owner and configured operator list.
+- **Bot permissions** — Creating threads requires elevated bot permissions on most platforms (admin on Telegram, `CREATE_*_THREADS` on Discord, app installation on Teams). Adapters should detect missing permissions at bind time and fall back to `shared_chat` mode.
+- **Cross-tenant isolation** — A route must be scoped to its tenant. Enforce this by including `tenant_id` in route lookup keys.
+- **Credential scoping** — Bot tokens must be scoped to minimum permissions. Telegram bots should not have `can_delete_messages` unless thread cleanup is explicitly enabled.
 
 ## Sources
 

--- a/wiki/research/thread-based-human-interface-patterns.md
+++ b/wiki/research/thread-based-human-interface-patterns.md
@@ -3,106 +3,175 @@ type: research
 confidence: high
 produced_by_thread: true
 related_entities: []
-source_ids: [src_telegram_bot_api, src_slack_api, src_discord_api, src_teams_bot_framework]
+source_ids: [src_niu777_telegram_bot_api, src_niu777_slack_api, src_niu777_discord_api, src_niu777_teams_bot_fw, src_niu777_matrix_spec]
 ---
 
 # Thread-Based Human Interface Patterns for Active Sessions
 
-> **TL;DR** — Map each active agent session to exactly one platform thread using a `(platform, conversation_id, thread_id)` route tuple. Decouple route lifetime from session lifetime so threads survive restarts. Mirror public room events outward; keep internal deliberation, tool calls, and thinking blocks internal.
+> **TL;DR** — Map each agent session to exactly one platform thread using a generic `CommunicationRoute` envelope that carries platform, conversation ID, thread ID, and direction metadata. Mirror public-facing agent output and human-approval prompts; keep internal tool calls, thinking blocks, and inter-agent mesh traffic internal.
 
 ## Compiled Truth
 
 ### Recommended Generic Routing Model
 
-The routing model centres on a **communication route** — a persistent record that binds an external thread to a session:
+The routing layer sits between the session broker and platform-specific channel adapters. Every active session maintains zero or more `CommunicationRoute` records that describe where human-facing messages should be sent and where inbound replies should be dispatched.
 
-| Field | Type | Purpose |
-|---|---|---|
-| `platform` | enum | Channel type (`telegram`, `slack`, `discord`, `teams`) |
-| `conversation_id` | string | Top-level channel or chat identifier |
-| `thread_id` | string or null | Platform-specific thread/topic identifier |
-| `session_id` | UUID | Target Volundr session |
-| `owner_id` | string | User who established the route |
-| `mode` | enum | `room` (broadcast) or `directed` (single peer) |
-| `active` | bool | Whether the route is accepting messages |
-| `metadata` | JSON | Platform-specific extras (topic name, parse mode, etc.) |
+**Route lifecycle:**
 
-**Lookup path:** Inbound message arrives with `(platform, conversation_id, thread_id)`. The route repository resolves this to a `session_id` using an exact match (with `IS NOT DISTINCT FROM` semantics on nullable `thread_id`). The most recently updated active route wins when multiple matches exist.
+1. **Bind** — When a session starts with a channel configured, the adapter resolves or creates a platform thread and registers a `CommunicationRoute` on the broker.
+2. **Dispatch outbound** — The broker filters events through a mirror policy (see below), formats surviving events via the adapter's formatter, and sends them to the thread identified by the route.
+3. **Dispatch inbound** — The adapter receives platform events (webhook, polling, or gateway), matches them to a session via the route's thread identifier, validates the sender, and injects the message into the session's input stream.
+4. **Unbind** — When the session stops, the route is deregistered. The platform thread may be closed, archived, or left open depending on adapter policy.
 
-**Thread-per-session is the default topology.** Each session creates or claims one thread at start time. This avoids cross-talk between sessions and gives humans a clear navigational anchor. The three supported modes are:
+**Route envelope (generic):**
 
-- **`topic_per_session`** — Bot creates a new thread/topic when the session starts. Best for ongoing work where each session deserves its own conversation space.
-- **`fixed_topic`** — Session binds to a pre-existing thread. Useful for long-lived channels where a human pre-creates the topic.
-- **`shared_chat`** — No threading; all messages land in the main chat. Acceptable for single-session use cases but does not scale.
+```
+CommunicationRoute {
+  platform:        string        // "telegram" | "slack" | "discord" | "teams" | "matrix"
+  conversation_id: string        // chat/channel/room — the parent container
+  thread_id:       string | null // platform-specific thread identifier
+  direction:       "bidirectional" | "outbound_only"
+  session_id:      string        // the Volundr session this route is bound to
+  metadata: {
+    topic_mode:    string        // how the thread was created
+    topic_name:    string | null // display name if created by the adapter
+    notify_only:   bool          // true = suppress inbound handling
+    created_by:    string        // "adapter" | "user" | "pre-existing"
+  }
+}
+```
 
-**Route lifecycle should outlive sessions.** Routes are currently deactivated when a session stops. To support session restart and reforge, routes should transition to a `dormant` state rather than being deactivated. On restart, the session reclaims its dormant route and resumes posting to the same thread. This preserves conversation continuity for humans who are following the thread.
+This aligns with the existing `TelegramChannel.communication_route()` return shape in `src/skuld/channels.py` and generalises it for multi-platform use.
 
-### Inbound Reply Routing
+**Inbound routing algorithm:**
 
-When a human replies inside a thread, the platform delivers the message to the bot with the thread identifier attached. The ingress service normalises this into an `InboundCommunicationMessage` with platform, conversation_id, thread_id, sender identity, and text. The route lookup then maps it to the correct session.
+1. Extract `(platform, conversation_id, thread_id)` from the inbound event.
+2. Look up the matching `CommunicationRoute` in the broker's route table.
+3. If no match, drop the message (or queue it for a configurable grace period if a session is starting).
+4. Validate the sender against the session's ACL (owner, allowed operators).
+5. Inject the message as a `user_confirmed` event with `metadata.source_platform` set — this prevents echo loops where mirrored output is re-ingested.
 
-**Safety rules for inbound routing:**
+### Platform Thread Identifier Reference
 
-- **Validate sender identity.** Only route messages from users authorised for the session's tenant. Drop messages from unknown senders with a log entry.
-- **Rate-limit inbound messages.** Apply per-route rate limiting to prevent a human from flooding a session. A reasonable default is 10 messages per minute per route.
-- **Tag source platform on injected messages.** When an inbound message enters the session room, include `source_platform` and `sender_external_id` in metadata so agents and the room UI can attribute it correctly.
-- **Directed routing.** If the message starts with `@peer_name`, route it to that specific participant. Otherwise broadcast to the room.
-
-### Required Route Metadata
-
-Beyond the core tuple, each route should carry platform-specific metadata:
-
-| Platform | Required metadata |
-|---|---|
-| Telegram | `topic_mode`, `topic_name`, `notify_only`, `bot_token_ref` |
-| Slack | `workspace_id`, `bot_user_id`, `reply_broadcast` (bool) |
-| Discord | `guild_id`, `parent_channel_id`, `auto_archive_duration` |
-| Teams | `service_url`, `tenant_id`, `bot_app_id` |
-
-All platforms should also store `created_at` and `last_message_at` for staleness detection.
-
-### Mirroring Rules — What Goes Out, What Stays In
-
-| Event type | Mirror to thread? | Rationale |
-|---|---|---|
-| Room messages (public) | Yes | Human-visible agent output |
-| Room notifications | Yes | Alerts that need human attention |
-| Room outcomes | Yes | Final results, verdicts, summaries |
-| User-confirmed prompts | Yes (from non-platform sources) | Shows human inputs from other surfaces |
-| Error events | Yes | Humans need to see failures |
-| Thinking blocks | No | Internal reasoning, not actionable |
-| Tool calls / results | No (summary only) | Raw tool traffic is noisy; optionally send a one-line `[tool] name: detail` summary |
-| Internal room messages | No | Agent-to-agent coordination |
-| Content block deltas | Buffer, then send | Stream as periodic flushes, not per-delta |
-| Permission requests | Yes (with action buttons) | Humans must be able to approve/deny |
-
-**Principle:** Mirror everything a human sitting in front of the session UI would see. Suppress everything that belongs to the agent's internal working process.
+| Platform | Thread ID field | Type | Create method | Inbound delivery |
+|---|---|---|---|---|
+| Telegram | `message_thread_id` | Integer | `createForumTopic` | Webhook / `getUpdates` — filter by `message_thread_id` |
+| Slack | `thread_ts` | String | `chat.postMessage` with `thread_ts` of parent | Events API `message` event with `thread_ts` present |
+| Discord | Channel `id` | Snowflake (String) | `POST /channels/{id}/threads` | Gateway `MESSAGE_CREATE` in thread channel |
+| Teams | `conversation.id` (contains `messageid=`) | String | `CreateConversationAsync` / Bot Framework | Bot Framework webhook Activity |
+| Matrix | `event_id` of root | String | Send event with `m.relates_to.rel_type: "m.thread"` | `/sync` or appservice transaction — filter `m.relates_to` |
 
 ### Per-Platform Notes
 
-**Telegram.** Forum topics are the natural thread primitive. Topics use integer `message_thread_id` values derived from the topic creation message. The General topic (id=1) cannot be deleted. Rate limits are approximately 20 messages per minute per group. Messages exceeding 4096 characters must be split. Topics are flat — no nested threading. Bot must be admin with `can_manage_topics` to create topics (Telegram Bot API, retrieved 2026-05-05).
+**Telegram**
+- Forum topics require a **supergroup** with forum mode enabled and bot **admin rights**.
+- The General topic has a fixed `message_thread_id = 1` and cannot be deleted.
+- Topic name max: 128 characters. Truncate session names before using as topic names.
+- Rate limit: ~30 messages/second globally, ~1 message/second per chat. Buffer and batch outbound messages.
+- Three topic modes apply: `shared_chat` (no threading), `fixed_topic` (pre-configured thread), `topic_per_session` (adapter creates a topic on session start). The existing `TelegramChannel` already implements all three.
+- Closing a topic via `closeForumTopic` signals session end without deleting history — preferred for archival.
 
-**Slack.** Threads are implicit — the first reply to a message creates a thread, identified by the parent message's `thread_ts` (a string timestamp like `"1503435956.000247"`). There is no explicit create/close/archive API for threads. `reply_broadcast=true` surfaces a reply in the main channel timeline. Rate limit is approximately 1 message per second per channel. Passing an invalid `thread_ts` silently creates a new top-level message rather than erroring (Slack API docs, retrieved 2026-05-05).
+**Slack**
+- Threads are implicit: post a message, then reply to its `ts`. No explicit "create thread" API.
+- Recommended pattern: post a session-start message to the channel, capture its `ts`, use it as `thread_ts` for all subsequent messages.
+- `reply_broadcast: true` can surface key messages (session start, final outcome) in the main channel timeline, but use sparingly — it creates noise.
+- Thread replies arrive as `message` events with `thread_ts` present. Filter: `thread_ts != ts` means it is a reply.
+- New commercial non-Marketplace apps face aggressive rate limits on `conversations.replies` (1 request/minute, 15 results/page as of 2025). Prefer event-driven inbound over polling.
+- No thread-specific subscription filter — the app receives all channel events and must route by `thread_ts`.
 
-**Discord.** Threads are full channel objects with Snowflake IDs. Forum channels are thread-only — every post is a thread. Auto-archive durations are 60 minutes, 1 day, 3 days, or 7 days. Sending a message to an archived thread auto-unarchives it (unless locked). Global rate limit is 50 requests per second per bot. Bots cannot create forum channels via API — they must be created manually (Discord API docs, retrieved 2026-05-05).
+**Discord**
+- Threads are first-class Channel objects (types 10, 11, 12). Public and private thread types exist.
+- Auto-archive after inactivity: 60 min, 24 h, 3 days, or 7 days. Set `auto_archive_duration` to 10080 (7 days) for sessions and extend on activity.
+- Thread members must be explicitly added or must post to join. Bots need `SEND_MESSAGES_IN_THREADS` permission.
+- Messages arrive via standard `MESSAGE_CREATE` gateway event — the `channel_id` is the thread ID.
+- Global rate limit: 50 requests/second per bot. Per-route limits returned in response headers.
+- Forum channels are a natural fit for topic-per-session: each session becomes a forum post with its own thread.
 
-**Microsoft Teams.** Threading uses `conversationId` + `activityId` as a composite identifier. `replyToId` is unreliable — Teams often omits it on inbound activities even within a thread. Bots only receive messages when @mentioned unless RSC permission `ChannelMessage.Read.Group` is granted. Private channel messaging is not supported. The `serviceUrl` can change between messages, so it must be refreshed from recent activities (Microsoft Bot Framework docs, retrieved 2026-05-05).
+**Microsoft Teams**
+- Thread identity is embedded in `conversation.id` as a `messageid=` suffix — extract this, not `replyToId` (which is unreliable for inbound activities).
+- Bots only receive messages when **@mentioned** unless the app has RSC `ChannelMessage.Read.Group` permission.
+- Proactive messaging requires a stored `ConversationReference` with valid `serviceUrl`, `conversationId`, and `tenantId`.
+- Rate limit: ~4 messages/second per conversation.
+- No native "close thread" concept. Session end must be signalled by a final message rather than thread state change.
+
+**Matrix**
+- Threads use the `m.thread` relation type (stable since spec v1.4, September 2022).
+- Nested threads are explicitly forbidden — the root must be a non-thread event.
+- Thread root events include aggregated metadata (`unsigned.m.relations.m.thread.count`, `latest_event`).
+- Application services are typically exempt from rate limiting, making Matrix well-suited for high-throughput mirroring.
+- Fetch thread history via `GET /rooms/{roomId}/relations/{eventId}/m.thread` (paginated).
+
+### Required Route Metadata
+
+The minimum metadata a channel adapter must persist or provide to enable reliable routing:
+
+| Field | Purpose | Where stored |
+|---|---|---|
+| `platform` | Adapter selection | Route record |
+| `conversation_id` | Parent chat/channel/room for API calls | Route record |
+| `thread_id` | Thread-level targeting for send and receive | Route record |
+| `session_id` | Maps inbound messages to the correct session | Route record |
+| `topic_mode` | Controls thread lifecycle (create, reuse, shared) | Route metadata |
+| `created_by` | Distinguishes adapter-created threads from user-provided ones — affects cleanup policy | Route metadata |
+| `notify_only` | Suppresses inbound dispatch for observe-only channels | Route metadata |
+| `source_platform` | Stamped on injected inbound messages — prevents echo loops | Event metadata |
+
+### Mirror Policy: What To Surface vs. Keep Internal
+
+**Mirror outbound (send to human thread):**
+
+| Event type | Rationale |
+|---|---|
+| `room_message` (visibility=public) | Agent's public-facing output — the primary human interface |
+| `room_notification` | Alerts requiring human attention (blocked, needs approval) |
+| `room_outcome` | Session results, verdicts, summaries |
+| `user_confirmed` (from browser) | Echo user prompts so the thread reads as a conversation |
+| `error` | Critical failures the operator should see |
+| Permission requests | Approval/deny prompts via inline controls (buttons, reactions) |
+
+**Keep internal (do not mirror):**
+
+| Event type | Rationale |
+|---|---|
+| `content_block_delta` (thinking) | Internal reasoning — noisy, often large, and exposes chain-of-thought |
+| `assistant` tool_use blocks | Tool invocations are implementation detail — surface only via formatted summaries if desired |
+| `room_message` (visibility=internal) | Inter-agent coordination, not for human consumption |
+| `room_mesh_message` | Delegation/orchestration traffic between agents |
+| `result` | Raw result payloads — prefer the formatted `room_outcome` |
+| `system` | Internal lifecycle events (session start, contributor pipeline) |
+
+**Configurable (adapter or user preference):**
+
+| Event type | Default | Notes |
+|---|---|---|
+| Tool call summaries | Off | Compact `[tool] name: detail` lines can be useful for debugging but create noise during normal operation |
+| Streaming text deltas | Buffer then send | Buffer `content_block_delta` text fragments and flush periodically (existing pattern: 1.5s flush interval) rather than sending each delta |
+| Session lifecycle | Start + stop only | Post a message at session start and end; intermediate state transitions are internal |
 
 ### Failure Modes and Permission Concerns
 
-- **Thread creation failure.** If topic/thread creation fails (permissions, rate limit, API error), fall back to `shared_chat` mode and log a warning. Do not block session start.
-- **Route collision.** Two sessions claiming the same thread should be prevented by the uniqueness constraint on `(platform, conversation_id, thread_id, active=true)`. If a collision is detected, the newer session should fail to bind and surface an error.
-- **Stale routes.** Routes whose `last_message_at` exceeds a configurable threshold (e.g. 24 hours) should be eligible for automatic deactivation to prevent orphaned threads from accumulating.
-- **Permission escalation.** Inbound messages must not bypass session-level authorization. The route's `owner_id` establishes the trust boundary — messages from senders outside the session's tenant should be dropped.
-- **Platform API outages.** Outbound message failures should be retried with exponential backoff (max 3 retries). Persistent failures should degrade the channel to `notify_only` mode rather than crashing the session.
-- **Message ordering.** Platform APIs do not guarantee delivery order. For critical sequences (e.g. permission request → response), include correlation IDs and validate ordering on receipt.
+**Failure modes:**
+
+- **Thread not found / deleted** — The platform thread may be deleted or archived externally. Adapters must handle `404`/`not_found` errors gracefully: log, deregister the route, and optionally notify via a fallback channel.
+- **Rate limiting** — All platforms impose rate limits. Outbound messages must pass through a per-platform rate limiter with exponential backoff. Inbound processing is less constrained but should still respect API polling limits (relevant for Slack `conversations.replies`).
+- **Echo loops** — If mirrored output is re-ingested as user input, it creates an infinite loop. The `source_platform` stamp on inbound events prevents this: the broker ignores `user_confirmed` events where `source_platform` matches the originating channel.
+- **Session start race** — An inbound message may arrive before the session's route is fully registered (e.g., user replies to a topic-creation message). A short grace-period queue (configurable, default ~5 seconds) absorbs this race.
+- **Stale routes** — If the session crashes without clean shutdown, routes become orphaned. A periodic reconciler should scan for routes whose `session_id` is no longer active and clean them up.
+- **Message ordering** — Platform delivery order is not guaranteed under load. For critical sequences (permission request followed by action), use explicit request IDs rather than relying on message order.
+
+**Permission concerns:**
+
+- **Thread-level ACL** — Not all platform users in a chat should be able to inject commands into a session. The route's sender validation step must check the user against the session's owner and any configured operator list.
+- **Bot permissions** — Creating threads requires elevated bot permissions on most platforms (admin on Telegram, `CREATE_*_THREADS` on Discord, app installation on Teams). Adapters should detect missing permissions at bind time and fall back to `shared_chat` mode with a warning.
+- **Cross-tenant isolation** — In multi-tenant deployments, a route must be scoped to its tenant. A thread in Tenant A's Slack workspace must never route to a session owned by Tenant B. Enforce this by including `tenant_id` in route lookup keys.
+- **Credential scoping** — Bot tokens used by channel adapters must be scoped to the minimum permissions required. Telegram bots should not have `can_delete_messages` unless thread cleanup is explicitly enabled. Slack apps should request only `chat:write` and `channels:history`, not `admin.*`.
 
 ## Sources
 
-- Telegram Bot API — Forum topic methods (core.telegram.org/bots/api, retrieved 2026-05-05)
-- Slack API — chat.postMessage, conversations.replies (docs.slack.dev, retrieved 2026-05-05)
-- Discord API — Threads documentation (docs.discord.com/developers/topics/threads, retrieved 2026-05-05)
-- Microsoft Bot Framework — Channel and group conversations (learn.microsoft.com, retrieved 2026-05-05)
-- Volundr codebase — `src/skuld/channels.py`, `src/volundr/domain/services/communication_ingress.py`, `src/volundr/domain/models.py` (internal, 2026-05-05)
+- Telegram Bot API — Forum Topics (core.telegram.org/bots/api, retrieved 2026-05-05)
+- Slack API — chat.postMessage, conversations.replies, Events API (docs.slack.dev, retrieved 2026-05-05)
+- Discord Developer Docs — Threads, Gateway Events, Rate Limits (docs.discord.com/developers, retrieved 2026-05-05)
+- Microsoft Teams — Bot Framework Channel Conversations (learn.microsoft.com, retrieved 2026-05-05)
+- Matrix Spec v1.13 — Threading via m.thread relation (spec.matrix.org/v1.13, retrieved 2026-05-05)
 
-<!-- sources: src_telegram_bot_api, src_slack_api, src_discord_api, src_teams_bot_framework -->
+<!-- sources: src_niu777_telegram_bot_api, src_niu777_slack_api, src_niu777_discord_api, src_niu777_teams_bot_fw, src_niu777_matrix_spec -->

--- a/wiki/research/thread-based-human-interface-patterns.md
+++ b/wiki/research/thread-based-human-interface-patterns.md
@@ -1,0 +1,108 @@
+---
+type: research
+confidence: high
+produced_by_thread: true
+related_entities: []
+source_ids: [src_telegram_bot_api, src_slack_api, src_discord_api, src_teams_bot_framework]
+---
+
+# Thread-Based Human Interface Patterns for Active Sessions
+
+> **TL;DR** — Map each active agent session to exactly one platform thread using a `(platform, conversation_id, thread_id)` route tuple. Decouple route lifetime from session lifetime so threads survive restarts. Mirror public room events outward; keep internal deliberation, tool calls, and thinking blocks internal.
+
+## Compiled Truth
+
+### Recommended Generic Routing Model
+
+The routing model centres on a **communication route** — a persistent record that binds an external thread to a session:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `platform` | enum | Channel type (`telegram`, `slack`, `discord`, `teams`) |
+| `conversation_id` | string | Top-level channel or chat identifier |
+| `thread_id` | string or null | Platform-specific thread/topic identifier |
+| `session_id` | UUID | Target Volundr session |
+| `owner_id` | string | User who established the route |
+| `mode` | enum | `room` (broadcast) or `directed` (single peer) |
+| `active` | bool | Whether the route is accepting messages |
+| `metadata` | JSON | Platform-specific extras (topic name, parse mode, etc.) |
+
+**Lookup path:** Inbound message arrives with `(platform, conversation_id, thread_id)`. The route repository resolves this to a `session_id` using an exact match (with `IS NOT DISTINCT FROM` semantics on nullable `thread_id`). The most recently updated active route wins when multiple matches exist.
+
+**Thread-per-session is the default topology.** Each session creates or claims one thread at start time. This avoids cross-talk between sessions and gives humans a clear navigational anchor. The three supported modes are:
+
+- **`topic_per_session`** — Bot creates a new thread/topic when the session starts. Best for ongoing work where each session deserves its own conversation space.
+- **`fixed_topic`** — Session binds to a pre-existing thread. Useful for long-lived channels where a human pre-creates the topic.
+- **`shared_chat`** — No threading; all messages land in the main chat. Acceptable for single-session use cases but does not scale.
+
+**Route lifecycle should outlive sessions.** Routes are currently deactivated when a session stops. To support session restart and reforge, routes should transition to a `dormant` state rather than being deactivated. On restart, the session reclaims its dormant route and resumes posting to the same thread. This preserves conversation continuity for humans who are following the thread.
+
+### Inbound Reply Routing
+
+When a human replies inside a thread, the platform delivers the message to the bot with the thread identifier attached. The ingress service normalises this into an `InboundCommunicationMessage` with platform, conversation_id, thread_id, sender identity, and text. The route lookup then maps it to the correct session.
+
+**Safety rules for inbound routing:**
+
+- **Validate sender identity.** Only route messages from users authorised for the session's tenant. Drop messages from unknown senders with a log entry.
+- **Rate-limit inbound messages.** Apply per-route rate limiting to prevent a human from flooding a session. A reasonable default is 10 messages per minute per route.
+- **Tag source platform on injected messages.** When an inbound message enters the session room, include `source_platform` and `sender_external_id` in metadata so agents and the room UI can attribute it correctly.
+- **Directed routing.** If the message starts with `@peer_name`, route it to that specific participant. Otherwise broadcast to the room.
+
+### Required Route Metadata
+
+Beyond the core tuple, each route should carry platform-specific metadata:
+
+| Platform | Required metadata |
+|---|---|
+| Telegram | `topic_mode`, `topic_name`, `notify_only`, `bot_token_ref` |
+| Slack | `workspace_id`, `bot_user_id`, `reply_broadcast` (bool) |
+| Discord | `guild_id`, `parent_channel_id`, `auto_archive_duration` |
+| Teams | `service_url`, `tenant_id`, `bot_app_id` |
+
+All platforms should also store `created_at` and `last_message_at` for staleness detection.
+
+### Mirroring Rules — What Goes Out, What Stays In
+
+| Event type | Mirror to thread? | Rationale |
+|---|---|---|
+| Room messages (public) | Yes | Human-visible agent output |
+| Room notifications | Yes | Alerts that need human attention |
+| Room outcomes | Yes | Final results, verdicts, summaries |
+| User-confirmed prompts | Yes (from non-platform sources) | Shows human inputs from other surfaces |
+| Error events | Yes | Humans need to see failures |
+| Thinking blocks | No | Internal reasoning, not actionable |
+| Tool calls / results | No (summary only) | Raw tool traffic is noisy; optionally send a one-line `[tool] name: detail` summary |
+| Internal room messages | No | Agent-to-agent coordination |
+| Content block deltas | Buffer, then send | Stream as periodic flushes, not per-delta |
+| Permission requests | Yes (with action buttons) | Humans must be able to approve/deny |
+
+**Principle:** Mirror everything a human sitting in front of the session UI would see. Suppress everything that belongs to the agent's internal working process.
+
+### Per-Platform Notes
+
+**Telegram.** Forum topics are the natural thread primitive. Topics use integer `message_thread_id` values derived from the topic creation message. The General topic (id=1) cannot be deleted. Rate limits are approximately 20 messages per minute per group. Messages exceeding 4096 characters must be split. Topics are flat — no nested threading. Bot must be admin with `can_manage_topics` to create topics (Telegram Bot API, retrieved 2026-05-05).
+
+**Slack.** Threads are implicit — the first reply to a message creates a thread, identified by the parent message's `thread_ts` (a string timestamp like `"1503435956.000247"`). There is no explicit create/close/archive API for threads. `reply_broadcast=true` surfaces a reply in the main channel timeline. Rate limit is approximately 1 message per second per channel. Passing an invalid `thread_ts` silently creates a new top-level message rather than erroring (Slack API docs, retrieved 2026-05-05).
+
+**Discord.** Threads are full channel objects with Snowflake IDs. Forum channels are thread-only — every post is a thread. Auto-archive durations are 60 minutes, 1 day, 3 days, or 7 days. Sending a message to an archived thread auto-unarchives it (unless locked). Global rate limit is 50 requests per second per bot. Bots cannot create forum channels via API — they must be created manually (Discord API docs, retrieved 2026-05-05).
+
+**Microsoft Teams.** Threading uses `conversationId` + `activityId` as a composite identifier. `replyToId` is unreliable — Teams often omits it on inbound activities even within a thread. Bots only receive messages when @mentioned unless RSC permission `ChannelMessage.Read.Group` is granted. Private channel messaging is not supported. The `serviceUrl` can change between messages, so it must be refreshed from recent activities (Microsoft Bot Framework docs, retrieved 2026-05-05).
+
+### Failure Modes and Permission Concerns
+
+- **Thread creation failure.** If topic/thread creation fails (permissions, rate limit, API error), fall back to `shared_chat` mode and log a warning. Do not block session start.
+- **Route collision.** Two sessions claiming the same thread should be prevented by the uniqueness constraint on `(platform, conversation_id, thread_id, active=true)`. If a collision is detected, the newer session should fail to bind and surface an error.
+- **Stale routes.** Routes whose `last_message_at` exceeds a configurable threshold (e.g. 24 hours) should be eligible for automatic deactivation to prevent orphaned threads from accumulating.
+- **Permission escalation.** Inbound messages must not bypass session-level authorization. The route's `owner_id` establishes the trust boundary — messages from senders outside the session's tenant should be dropped.
+- **Platform API outages.** Outbound message failures should be retried with exponential backoff (max 3 retries). Persistent failures should degrade the channel to `notify_only` mode rather than crashing the session.
+- **Message ordering.** Platform APIs do not guarantee delivery order. For critical sequences (e.g. permission request → response), include correlation IDs and validate ordering on receipt.
+
+## Sources
+
+- Telegram Bot API — Forum topic methods (core.telegram.org/bots/api, retrieved 2026-05-05)
+- Slack API — chat.postMessage, conversations.replies (docs.slack.dev, retrieved 2026-05-05)
+- Discord API — Threads documentation (docs.discord.com/developers/topics/threads, retrieved 2026-05-05)
+- Microsoft Bot Framework — Channel and group conversations (learn.microsoft.com, retrieved 2026-05-05)
+- Volundr codebase — `src/skuld/channels.py`, `src/volundr/domain/services/communication_ingress.py`, `src/volundr/domain/models.py` (internal, 2026-05-05)
+
+<!-- sources: src_telegram_bot_api, src_slack_api, src_discord_api, src_teams_bot_framework -->


### PR DESCRIPTION
## Summary

- Adds a Mimir research page (`wiki/research/thread-based-human-interface-patterns.md`) investigating how threaded human communication surfaces map onto active agent sessions
- Covers a recommended generic routing model using `(platform, conversation_id, thread_id)` tuples, with thread-per-session as the default topology
- Documents per-platform thread semantics for Telegram (forum topics), Slack (`thread_ts`), Discord (thread channels), and Microsoft Teams (reply chains)
- Defines required route metadata per platform, mirroring rules (what goes out vs stays internal), and failure modes including route collisions, stale routes, and permission escalation
- Updates `wiki/index.md` to include the new research page

## Test plan

- [ ] Verify the research page follows Mimir format conventions (frontmatter, Compiled Truth zone, Sources)
- [ ] Verify `wiki/index.md` links correctly to the new page
- [ ] Confirm no existing pages are duplicated or contradicted
- [ ] CI checks pass (lint, tests)

Closes NIU-777

🤖 Generated with [Claude Code](https://claude.com/claude-code)