### PR TITLE
docs(research): research persona evaluation rubric (NIU-778)

### DIFF
--- a/wiki/research/research-persona-evaluation-rubric.md
+++ b/wiki/research/research-persona-evaluation-rubric.md
@@ -2,13 +2,15 @@
 type: research
 confidence: high
 produced_by_thread: true
-related_entities: []
+related_entities: [best-practices-agent-mimir-pages, thread-based-human-interface-patterns]
 source_ids: [src_niu778_internal_mimir, src_niu778_mt_bench, src_niu778_position_bias, src_niu778_alpacaeval_length, src_niu778_benchmark_contamination]
 ---
 
 # Evaluation Rubric for Claude vs Codex Research Personas
 
 > **TL;DR** — Compare research personas with blinded pairwise review on the same prompt, score mostly for factual grounding and usefulness, track cost and process hygiene separately, and rerun a small 6-task benchmark each week with a larger hidden set monthly.
+
+> **See also:** [Best Practices for Agent-Written Mimir Pages](best-practices-agent-mimir-pages.md) — conventions this rubric assumes (front matter, structure, lint checklist). [Thread-Based Human Interface Patterns](thread-based-human-interface-patterns.md) — how research sessions are surfaced to human reviewers during evaluation runs.
 
 ## Compiled Truth
 


### PR DESCRIPTION
## Summary

- Adds `wiki/research/research-persona-evaluation-rubric.md` — a Mimir page defining a practical evaluation rubric for comparing Claude vs Codex research personas
- Rubric covers five weighted dimensions (factual grounding 30%, usefulness 25%, structure 15%, synthesis 15%, process hygiene 15%) with 1–5 anchored scoring
- Distinguishes human-judged headline quality from auto-measurable diagnostics (runtime, cost, citation coverage, format compliance)
- Defines a 6-task recurring benchmark with 4 stable + 2 rotating prompts to limit overfitting, plus weekly/monthly cadence guidance
- Adds cross-links to `best-practices-agent-mimir-pages.md` and `thread-based-human-interface-patterns.md` per Mimir duplicate-avoidance conventions

## References

- NIU-778: https://linear.app/niuu/issue/NIU-778/research-an-evaluation-rubric-for-claude-vs-codex-research-personas
- External: Zheng et al. MT-Bench (arXiv 2306.05685), Shi et al. position-bias (arXiv 2406.07791), Dubois et al. AlpacaEval (COLM 2024), Choi et al. benchmark contamination (PMLR 2025)

## Test plan

- [ ] Page renders correctly in Mimir (front matter, TL;DR, Compiled Truth, Timeline, Sources sections present)
- [ ] `related_entities` entries resolve to existing pages
- [ ] No duplicate coverage with existing research pages
- [ ] CI passes (markdown lint, no broken links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)