### PR TITLE
docs: refine Mimir mount selection guidance

### DIFF
--- a/wiki/research/mimir-mount-selection.md
+++ b/wiki/research/mimir-mount-selection.md
@@ -3,140 +3,109 @@ type: research
 confidence: high
 produced_by_thread: true
 related_entities: [best-practices-agent-mimir-pages]
-source_ids: [src_niu775_composite_adapter, src_niu775_domain_models, src_niu775_mimir_tools, src_niu775_mcp_server, src_niu775_registry]
+source_ids: [src_niu775_composite_adapter, src_niu775_domain_models, src_niu775_mimir_tools, src_niu775_registry, src_niu775_mcp_tools_spec, src_niu775_mcp_architecture]
 ---
 
 # Mimir Mount Selection for Agents
 
-> **TL;DR** — Use a single composite Mimir MCP server with three named mount roles (`local`, `shared`, `domain`). Reads fan out automatically; writes default to `local`. Agents promote content to `shared` via the explicit `mimir="shared"` override. Name mounts and their tool descriptions to make the right choice obvious without agent deliberation.
+> **TL;DR** — Expose one composite Mimir MCP server, let reads fan out across all mounts, default writes to `local`, and use an explicit `mimir="shared"` override only when promoting vetted output. Do not make agents choose by MCP server name.
 
-## Compiled Truth
+## Recommended Routing Model
 
-### Mount Roles and When to Use Each
+| Mount | Use it for | Agent write behavior |
+|---|---|---|
+| `local` | Scratch notes, drafts, session-only work, uncertain synthesis | Default target |
+| `shared` | Reusable pages other agents should trust | Write only via explicit promotion |
+| `domain-*` | Read-only corpora such as vendor docs, code snapshots, policy archives | Never agent-write by default |
 
-The codebase (`src/ravn/domain/mimir.py`) defines three canonical roles with conventional read priorities:
+Recommended behavior:
 
-| Role | `read_priority` | When to use | Who writes |
-|---|---|---|---|
-| `local` | 0 (highest) | In-progress notes, scratch work, session-scoped drafts | Agent freely |
-| `shared` | 1 | Vetted cross-agent knowledge, final research pages | Agent via explicit override after quality check |
-| `domain` | 2 | External/specialized corpora (e.g. codebase snapshots, vendor docs) | Rarely — usually ingested by operators |
+1. Reads stay implicit. `CompositeMimirAdapter` already searches mounts in `read_priority` order and de-duplicates by path, so the agent should call `mimir_search` and `mimir_read` without choosing a mount first.
+2. Writes default to `local`. `WriteRouting` falls back to `["local"]` when no rule matches, which is the safest default for research and scratch work.
+3. Promotion to `shared` is explicit. `mimir_write(..., mimir="shared")` bypasses prefix routing and makes the promotion step deliberate.
+4. `domain-*` mounts stay read-only and operator-managed. They are useful context, not a destination for routine agent output.
 
-**Decision heuristic:**
-1. Is the content ephemeral or draft-quality? → `local`
-2. Is it vetted, well-sourced, and useful to other agents? → `shared`
-3. Is it a read-only external corpus? → `domain` (operator-managed, agents read only)
+Recommended Niuu routing:
 
-### Recommended Routing Model
-
-The `CompositeMimirAdapter` (`src/ravn/adapters/mimir/composite.py`) implements a three-tier write routing model that should be the standard for Niuu:
-
-**Tier 1 — Explicit agent override** (`mimir="shared"`)
-The `mimir_write` tool accepts an optional `mimir` parameter. When set, it bypasses all routing rules and writes directly to the named mount. Use this for deliberate promotion (e.g. "I'm confident this is ready for shared knowledge").
-
-**Tier 2 — Category-prefix rules** (configured via `WriteRouting`)
-Path prefixes map to mount names. First match wins. Current production rules:
+```python
+WriteRouting(
+    rules=[
+        ("self/", ["local"]),
+        ("technical/", ["local", "shared"]),
+        ("household/", ["shared"]),
+    ],
+    default=["local"],
+)
 ```
-("self/",       ["local"])
-("technical/",  ["local", "shared"])
-("household/",  ["shared"])
-```
-Paths without a matching prefix (including `research/`) fall through to the default (`["local"]`). See the Recommendation section below for a proposed `research/` rule.
 
-**Tier 3 — Default fallback**
-Any path not matched by a prefix rule goes to `local`. This is the safe default — no unintended promotion.
+For `research/`, keep the default `local` write path and promote only the final distilled page to `shared`. This is a better fit than the older docs example that routes `research/` to `["shared", "domain"]`, because it avoids auto-writing into read-mostly corpora and keeps promotion intentional.
 
-**Read fan-out** is transparent: `CompositeMimirAdapter` queries all mounts in priority order and deduplicates by page path. Agents call `mimir_search` and `mimir_read` without thinking about which mount holds the data.
+## Naming and Description Scheme
 
-### Naming and Description Scheme
+Mount names should encode role first, corpus second.
 
-Names and descriptions are the primary signals an agent uses when choosing mounts. Make them self-explanatory:
+| Name | Description shown to the model |
+|---|---|
+| `local` | Session scratch Mimir. Use for drafts, notes, and uncertain work. |
+| `shared` | Team shared Mimir. Use only for vetted pages worth reusing. |
+| `domain-product-docs` | Read-only product documentation corpus. Search and read; do not write. |
+| `domain-codebase-snapshots` | Read-only codebase reference corpus. Use for background context only. |
 
-| Mount name | `desc` in registry | What to write there |
+Guidelines:
+
+- Prefer short role-first names: `local`, `shared`, `domain-*`.
+- Put the write policy in the description, not just the name.
+- Make `domain-*` descriptions explicitly say `read-only`.
+- Keep the `mimir_write` tool description aligned with the same language so the model sees one consistent routing story.
+
+## Implicit vs Explicit vs Server-Name-Based
+
+| Choice | Recommendation | Why |
 |---|---|---|
-| `local` | "This session's scratch pad — ephemeral, not shared" | Drafts, working notes, in-progress research |
-| `shared` | "Organization-wide knowledge base — vetted pages only" | Finalized research, decisions, entity pages |
-| `domain-{corpus}` | "Read-only corpus: {corpus description}" | Never write; read for background context |
+| Implicit path-based routing | Yes, as the default | Lowest cognitive load; safe default writes |
+| Explicit `mimir` parameter | Yes, for promotion and exceptions | Makes cross-mount intent deliberate and auditable |
+| Separate-server choice by server name | No | MCP clients aggregate tools from multiple servers into one registry, and the MCP spec says server names are not guaranteed to be unique |
 
-The `mimir_write` tool description already models this pattern:
-> "Use the optional 'mimir' parameter to route the write to a specific instance (e.g. 'shared' to promote to the shared Mímir), bypassing category routing."
+Best contract for agents:
 
-This phrasing should be preserved — it teaches the agent the promotion idiom without requiring it to learn routing internals.
+- `mimir_search` / `mimir_read`: no mount parameter
+- `mimir_write`: optional `mimir` parameter
+- registry/mount metadata: clear `name`, `role`, `desc`, and read priority
 
-### Implicit vs. Explicit vs. Server-Name-Based Selection
+That gives the model one normal path and one explicit escape hatch, instead of forcing it to reason about infrastructure topology on every write.
 
-| Mechanism | How it works | Best for |
+## One Composite Server vs Multiple MCP Servers
+
+| Option | Benefits | Costs |
 |---|---|---|
-| **Implicit (category prefix)** | `WriteRouting` rules match path prefix → mounts | Common cases where path encodes intent |
-| **Explicit (`mimir=` param)** | Agent passes mount name directly | Deliberate promotion to `shared`; exceptional routing |
-| **Server-name-based (separate MCP servers)** | Agent picks which MCP server to call | Not recommended (see trade-offs below) |
+| One composite Mimir MCP server | One tool set, transparent read fan-out, centralized routing, fewer tool slots | Requires server-side routing logic and mount metadata discipline |
+| Separate MCP server per mount | Strong isolation, per-server auth boundaries | Higher agent confusion, more tools, duplicated `search/read/write`, weaker defaults |
 
-Recommendation: **implicit routing as the default, explicit override for promotion**. Never require agents to remember server names or call different MCP endpoints for different mounts.
+Use multiple MCP servers only when mounts truly cannot share one trust boundary or one routing layer. Otherwise, a composite server is better for both agent accuracy and operator control.
 
-### Multiple MCP Servers vs. One Composite
+## Risks and Edge Cases
 
-| Dimension | Multiple MCP servers | One composite MCP server |
-|---|---|---|
-| Agent cognitive load | High — agent must choose which server | Low — one `mimir_write` tool, one `mimir_search` |
-| Read transparency | Agent must fan out manually or miss mounts | Transparent fan-out at adapter layer |
-| Misconfiguration risk | Agent may write to wrong server; silent data loss | Routing misconfiguration is centralized and auditable |
-| Operational complexity | N servers to deploy, monitor, auth | One server; internal mount config |
-| Tool namespace pollution | 6 tools × N servers = N×6 tool slots consumed | Always 6 tools regardless of mount count |
-| Routing auditability | Distributed; hard to inspect | `WriteRouting.rules` is a single inspectable list |
+- Unknown mount names are only logged today. A bad routing config can silently skip writes.
+- A stale `local` page shadows a fresher `shared` page because lower `read_priority` wins.
+- Dual-write routing can leave `local` and `shared` inconsistent after partial failure.
+- An explicit `mimir="domain-*"` override can bypass policy unless the domain adapter is actually read-only.
+- If mount descriptions drift away from routing behavior, the model will make the wrong choice even when the code is correct.
 
-**Verdict: always use one composite MCP server.** Multiple MCP servers are only justified if mounts have completely disjoint auth domains that cannot be bridged server-side (e.g. different SPIFFE trust domains with no federation).
+## Recommendation for Niuu
 
-### Risks and Edge Cases
-
-**Silent write loss**
-If a mount name in `WriteRouting` does not match any mount in `_mount_map`, `CompositeMimirAdapter.upsert_page` logs a warning and silently skips the mount. Agents never see an error. Mitigation: validate routing config at startup; add a health check that reads back a just-written test page.
-
-**Dual-write consistency**
-When a path prefix routes to both `local` and `shared`, partial failure (one mount down) produces split state. An agent reading back may get the `local` version (priority 0) even though the `shared` write failed. Mitigation: treat dual-write as best-effort; require agents to use `mimir_lint` after bulk writes to detect divergence.
-
-**Stale `local` shadowing `shared`**
-If `local` has an outdated version of a page and `shared` has the canonical version, the `local` copy always wins (priority 0). Agents may work from stale data. Mitigation: periodically purge or sync `local` scratch content; use `mimir_lint` L08 (stale content) to flag old local pages.
-
-**Explicit override bypasses all safety**
-`mimir="domain"` would write directly to a domain mount even if it is meant to be read-only. There is no write-guard at the adapter level. Mitigation: operators should configure domain mounts with a no-op `upsert_page` that raises `PermissionError`, or use a read-only `HttpMimirAdapter` pointing to a read-only endpoint.
-
-**Tool description drift**
-If mount descriptions in the registry diverge from actual routing rules, agents will make wrong decisions. Mitigation: keep `desc` fields in `MimirRegistryEntry` synchronized with `WriteRouting` rules; treat the registry as the single source of truth for human-readable mount semantics.
-
-**Agent over-promotion**
-An agent that applies `mimir="shared"` too freely floods the shared knowledge base with low-quality content. Mitigation: require `produced_by_thread: true` and non-empty `source_ids` in frontmatter for any `research/` page (already enforced by `MimirWriteTool._validate_research_page_provenance`); extend this check to `shared` mount writes.
-
-### Recommendation for Niuu
-
-1. **Deploy one composite Mimir MCP server per agent persona** — never expose raw per-mount MCP servers to agents.
-2. **Use three mounts** — `local` (priority 0), `shared` (priority 1), and optionally one `domain-*` per specialized corpus.
-3. **Write routing config** (extends current rules with a `research/` dual-write):
-   ```python
-   WriteRouting(
-       rules=[
-           ("self/",       ["local"]),
-           ("research/",   ["local", "shared"]),
-           ("technical/",  ["local", "shared"]),
-           ("household/",  ["shared"]),
-       ],
-       default=["local"],
-   )
-   ```
-4. **Name mounts with role-first names** (`local`, `shared`, `domain-{name}`) and populate `desc` in the registry with one sentence stating what belongs there.
-5. **Teach promotion via tool description**, not separate tools or servers — the `mimir=` parameter is the right mechanism.
-6. **Guard domain mounts at the adapter layer** — return `PermissionError` from `upsert_page` on any mount that should be read-only.
-
-## Timeline
-
-- 2026-05-05: Audited `CompositeMimirAdapter`, `WriteRouting`, `MimirMount`, `MimirWriteTool`, `MimirRegistryEntry`, and `MimirMcpServer` in the Volundr repo. No existing Mimir page covered mount selection. [Source: niuulabs/volundr codebase, 2026-05-05]
-- 2026-05-05: Synthesized routing model, naming scheme, trade-off table, and risks from code analysis. Confirmed composite-server approach is already the production implementation. [Source: NIU-775 task, 2026-05-05]
+1. Keep one composite Mimir MCP server per persona or runtime, not one server per mount.
+2. Standardize on `local`, `shared`, and optional `domain-*` mounts.
+3. Make `local` the default write target for `research/` and require explicit promotion to `shared`.
+4. Keep `domain-*` read-only at the adapter level, not just by convention.
+5. Treat mount descriptions as part of the tool contract and keep them synchronized with routing rules.
 
 ## Sources
 
-- `src/ravn/adapters/mimir/composite.py` — CompositeMimirAdapter: fan-out reads, routed writes (niuulabs/volundr, retrieved 2026-05-05)
-- `src/ravn/domain/mimir.py` — MimirMount, WriteRouting: role, read_priority, routing resolution (niuulabs/volundr, retrieved 2026-05-05)
-- `src/ravn/adapters/tools/mimir_tools.py` — MimirWriteTool: explicit mimir= override, research provenance validation (niuulabs/volundr, retrieved 2026-05-05)
-- `src/mimir/mcp.py` — MimirMcpServer: six tools, single server wrapping MimirPort (niuulabs/volundr, retrieved 2026-05-05)
-- `src/mimir/registry.py` — MimirRegistryEntry: name, role, desc, default_read_priority fields (niuulabs/volundr, retrieved 2026-05-05)
+- `src/ravn/domain/mimir.py` — `MimirMount` and `WriteRouting` define role, read priority, and explicit routing override behavior. (niuulabs/volundr, retrieved 2026-05-05)
+- `src/ravn/adapters/mimir/composite.py` — `CompositeMimirAdapter` fans out reads and routes writes by explicit `mimir`, then prefix rules, then default fallback. (niuulabs/volundr, retrieved 2026-05-05)
+- `src/ravn/adapters/tools/mimir_tools.py` — `mimir_write` exposes the optional `mimir` parameter and already describes promotion to `shared`. (niuulabs/volundr, retrieved 2026-05-05)
+- `src/mimir/registry.py` — registry entries carry `name`, `role`, `desc`, and read-priority metadata that should guide mount selection. (niuulabs/volundr, retrieved 2026-05-05)
+- MCP tools specification — tools are selected by name, description, and input schema; server names are not a safe disambiguation mechanism. (https://modelcontextprotocol.io/specification/draft/server/tools, retrieved 2026-05-05)
+- MCP architecture overview — MCP hosts combine tools from all connected servers into a unified registry visible to the model. (https://modelcontextprotocol.io/docs/learn/architecture, retrieved 2026-05-05)
 
-<!-- sources: src_niu775_composite_adapter, src_niu775_domain_models, src_niu775_mimir_tools, src_niu775_mcp_server, src_niu775_registry -->
+<!-- sources: src_niu775_composite_adapter, src_niu775_domain_models, src_niu775_mimir_tools, src_niu775_registry, src_niu775_mcp_tools_spec, src_niu775_mcp_architecture -->

--- a/wiki/research/mimir-mount-selection.md
+++ b/wiki/research/mimir-mount-selection.md
@@ -10,7 +10,9 @@ source_ids: [src_niu775_composite_adapter, src_niu775_domain_models, src_niu775_
 
 > **TL;DR** — Expose one composite Mimir MCP server, let reads fan out across all mounts, default writes to `local`, and use an explicit `mimir="shared"` override only when promoting vetted output. Do not make agents choose by MCP server name.
 
-## Recommended Routing Model
+## Compiled Truth
+
+### Recommended Routing Model
 
 | Mount | Use it for | Agent write behavior |
 |---|---|---|
@@ -40,7 +42,7 @@ WriteRouting(
 
 For `research/`, keep the default `local` write path and promote only the final distilled page to `shared`. This is a better fit than the older docs example that routes `research/` to `["shared", "domain"]`, because it avoids auto-writing into read-mostly corpora and keeps promotion intentional.
 
-## Naming and Description Scheme
+### Naming and Description Scheme
 
 Mount names should encode role first, corpus second.
 
@@ -58,7 +60,7 @@ Guidelines:
 - Make `domain-*` descriptions explicitly say `read-only`.
 - Keep the `mimir_write` tool description aligned with the same language so the model sees one consistent routing story.
 
-## Implicit vs Explicit vs Server-Name-Based
+### Implicit vs Explicit vs Server-Name-Based
 
 | Choice | Recommendation | Why |
 |---|---|---|
@@ -74,7 +76,7 @@ Best contract for agents:
 
 That gives the model one normal path and one explicit escape hatch, instead of forcing it to reason about infrastructure topology on every write.
 
-## One Composite Server vs Multiple MCP Servers
+### One Composite Server vs Multiple MCP Servers
 
 | Option | Benefits | Costs |
 |---|---|---|
@@ -83,7 +85,7 @@ That gives the model one normal path and one explicit escape hatch, instead of f
 
 Use multiple MCP servers only when mounts truly cannot share one trust boundary or one routing layer. Otherwise, a composite server is better for both agent accuracy and operator control.
 
-## Risks and Edge Cases
+### Risks and Edge Cases
 
 - Unknown mount names are only logged today. A bad routing config can silently skip writes.
 - A stale `local` page shadows a fresher `shared` page because lower `read_priority` wins.
@@ -91,7 +93,7 @@ Use multiple MCP servers only when mounts truly cannot share one trust boundary 
 - An explicit `mimir="domain-*"` override can bypass policy unless the domain adapter is actually read-only.
 - If mount descriptions drift away from routing behavior, the model will make the wrong choice even when the code is correct.
 
-## Recommendation for Niuu
+### Recommendation for Niuu
 
 1. Keep one composite Mimir MCP server per persona or runtime, not one server per mount.
 2. Standardize on `local`, `shared`, and optional `domain-*` mounts.


### PR DESCRIPTION
## Summary
- rewrite the existing `wiki/research/mimir-mount-selection.md` page instead of creating a duplicate
- recommend one composite Mimir MCP server with implicit reads, default-local writes, and explicit promotion to `shared`
- add concrete mount naming/description examples, server-vs-contract guidance, risks, and a clear Niuu recommendation
- anchor the recommendation in current code paths plus current MCP specification guidance on tool discovery and server-name disambiguation

## Validation
- `pytest tests/ravn/unit/test_composite_mimir.py -q`
- `pytest tests/ravn/unit/test_composite_mimir.py --cov=ravn.adapters.mimir.composite --cov=ravn.domain.mimir --cov-report=term-missing -q` *(module-focused coverage check for context; docs-only change)*
