### PR TITLE
feat(skuld): add SDKTransport using claude-agent-sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "pyyaml>=6.0",
+    "claude-agent-sdk==0.1.74",
     "asyncpg>=0.31.0",
     "httpx>=0.28.1",
     "fastapi>=0.109",

--- a/src/niuu/ports/cli/transport.py
+++ b/src/niuu/ports/cli/transport.py
@@ -60,6 +60,10 @@ class CLITransport(ABC):
     async def send_message(self, content: str) -> None:
         """Send a user message to the CLI."""
 
+    async def interrupt(self) -> None:
+        """Cancel the in-flight turn, if any. Default no-op."""
+        return None
+
     async def send_control_response(self, request_id: str, response: dict) -> None:
         """Respond to a CLI-initiated control request."""
 

--- a/src/skuld/transports/__init__.py
+++ b/src/skuld/transports/__init__.py
@@ -22,6 +22,7 @@ from skuld.transports.opencode import OpenCodeHttpTransport  # noqa: E402
 from skuld.transports.persistent_subprocess import (  # noqa: E402
     PersistentSubprocessTransport,
 )
+from skuld.transports.sdk import SDKTransport  # noqa: E402
 from skuld.transports.sdk_websocket import SdkWebSocketTransport  # noqa: E402
 from skuld.transports.subprocess import SubprocessTransport  # noqa: E402
 
@@ -32,6 +33,7 @@ __all__ = [
     "EventCallback",
     "OpenCodeHttpTransport",
     "PersistentSubprocessTransport",
+    "SDKTransport",
     "SdkWebSocketTransport",
     "SubprocessTransport",
     "TransportCapabilities",

--- a/src/skuld/transports/mcp_config.py
+++ b/src/skuld/transports/mcp_config.py
@@ -58,6 +58,34 @@ def build_claude_mcp_config(raw_servers: object) -> str | None:
     return json.dumps(payload)
 
 
+def build_sdk_mcp_servers(raw_servers: object) -> dict[str, dict[str, Any]]:
+    """Translate MCP servers into ``ClaudeAgentOptions.mcp_servers`` format."""
+    servers = normalize_mcp_servers(raw_servers)
+    if not servers:
+        return {}
+
+    payload: dict[str, dict[str, Any]] = {}
+    for server in servers:
+        name = server["name"]
+        if server.get("url"):
+            server_type = str(server.get("type") or "sse")
+            if server_type == "http":
+                payload[name] = {"type": "http", "url": server["url"]}
+                continue
+            payload[name] = {"type": "sse", "url": server["url"]}
+            continue
+
+        entry: dict[str, Any] = {"command": server.get("command") or ""}
+        if server.get("type") == "stdio":
+            entry["type"] = "stdio"
+        if server.get("args"):
+            entry["args"] = list(server["args"])
+        if server.get("env"):
+            entry["env"] = dict(server["env"])
+        payload[name] = entry
+    return payload
+
+
 def build_codex_mcp_overrides(raw_servers: object) -> list[tuple[str, str]]:
     """Translate MCP servers into ``codex -c key=value`` override pairs."""
     servers = normalize_mcp_servers(raw_servers)

--- a/src/skuld/transports/sdk.py
+++ b/src/skuld/transports/sdk.py
@@ -1,0 +1,348 @@
+"""SDKTransport — Claude SDK adapter with stream-json compatibility.
+
+Uses ``claude-agent-sdk`` to manage the underlying Claude CLI lifecycle while
+converting typed SDK messages back into the dict events Skuld already emits.
+
+Known gaps versus ``PersistentSubprocessTransport``:
+
+- No session resume after process death; the Python SDK does not expose
+  ``--resume`` recovery.
+- No slash-command transport surface such as ``/clear`` or ``/compact``.
+- Mid-turn injection still requires ``interrupt()`` followed by a new query,
+  which drops the in-flight partial assistant turn per SDK semantics.
+- The SDK is alpha software; this adapter is pinned to the 0.1.x line.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import asdict
+from typing import Any
+
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+from claude_agent_sdk.types import (
+    AssistantMessage,
+    RateLimitEvent,
+    ResultMessage,
+    ServerToolResultBlock,
+    ServerToolUseBlock,
+    StreamEvent,
+    SystemMessage,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+
+from niuu.adapters.cli.runtime import filter_cli_event as _filter_event
+from niuu.ports.cli import CLITransport, TransportCapabilities
+from skuld.transports.mcp_config import build_sdk_mcp_servers
+
+logger = logging.getLogger("skuld.transport")
+
+_DEFAULT_PERMISSION_MODE = "bypassPermissions"
+
+
+def _content_block_to_dict(block: object) -> dict[str, Any]:
+    """Translate SDK content blocks into Anthropic-style stream-json blocks."""
+    if isinstance(block, TextBlock):
+        return {"type": "text", "text": block.text}
+    if isinstance(block, ThinkingBlock):
+        return {
+            "type": "thinking",
+            "thinking": block.thinking,
+            "signature": block.signature,
+        }
+    if isinstance(block, ToolUseBlock):
+        return {
+            "type": "tool_use",
+            "id": block.id,
+            "name": block.name,
+            "input": block.input,
+        }
+    if isinstance(block, ToolResultBlock):
+        payload: dict[str, Any] = {
+            "type": "tool_result",
+            "tool_use_id": block.tool_use_id,
+        }
+        if block.content is not None:
+            payload["content"] = block.content
+        if block.is_error is not None:
+            payload["is_error"] = block.is_error
+        return payload
+    if isinstance(block, ServerToolUseBlock):
+        return {
+            "type": "server_tool_use",
+            "id": block.id,
+            "name": block.name,
+            "input": block.input,
+        }
+    if isinstance(block, ServerToolResultBlock):
+        return {
+            "type": "advisor_tool_result",
+            "tool_use_id": block.tool_use_id,
+            "content": block.content,
+        }
+    raise TypeError(f"Unsupported SDK content block: {type(block).__name__}")
+
+
+def _to_stream_json(message: object) -> dict[str, Any] | None:
+    """Convert an SDK message object into the broker's existing dict event shape."""
+    if isinstance(message, UserMessage):
+        content = message.content
+        if isinstance(content, list):
+            content = [_content_block_to_dict(block) for block in content]
+
+        payload: dict[str, Any] = {
+            "type": "user",
+            "message": {"role": "user", "content": content},
+        }
+        if message.parent_tool_use_id:
+            payload["parent_tool_use_id"] = message.parent_tool_use_id
+        if message.tool_use_result is not None:
+            payload["tool_use_result"] = message.tool_use_result
+        if message.uuid:
+            payload["uuid"] = message.uuid
+        return payload
+
+    if isinstance(message, AssistantMessage):
+        payload = {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [_content_block_to_dict(block) for block in message.content],
+                "model": message.model,
+            },
+        }
+        if message.parent_tool_use_id:
+            payload["parent_tool_use_id"] = message.parent_tool_use_id
+        if message.error is not None:
+            payload["error"] = message.error
+        if message.usage is not None:
+            payload["message"]["usage"] = message.usage
+        if message.message_id:
+            payload["message"]["id"] = message.message_id
+        if message.stop_reason:
+            payload["message"]["stop_reason"] = message.stop_reason
+        if message.session_id:
+            payload["session_id"] = message.session_id
+        if message.uuid:
+            payload["uuid"] = message.uuid
+        return payload
+
+    if isinstance(message, SystemMessage):
+        return dict(message.data)
+
+    if isinstance(message, ResultMessage):
+        payload = {
+            "type": "result",
+            "subtype": message.subtype,
+            "duration_ms": message.duration_ms,
+            "duration_api_ms": message.duration_api_ms,
+            "is_error": message.is_error,
+            "num_turns": message.num_turns,
+            "session_id": message.session_id,
+        }
+        if message.stop_reason is not None:
+            payload["stop_reason"] = message.stop_reason
+        if message.total_cost_usd is not None:
+            payload["total_cost_usd"] = message.total_cost_usd
+        if message.usage is not None:
+            payload["usage"] = message.usage
+        if message.result is not None:
+            payload["result"] = message.result
+        if message.structured_output is not None:
+            payload["structured_output"] = message.structured_output
+        if message.model_usage is not None:
+            payload["modelUsage"] = message.model_usage
+        if message.permission_denials is not None:
+            payload["permission_denials"] = message.permission_denials
+        if message.deferred_tool_use is not None:
+            payload["deferred_tool_use"] = asdict(message.deferred_tool_use)
+        if message.errors is not None:
+            payload["errors"] = message.errors
+        if message.uuid:
+            payload["uuid"] = message.uuid
+        return payload
+
+    if isinstance(message, StreamEvent):
+        event = dict(message.event)
+        event.setdefault("session_id", message.session_id)
+        event.setdefault("uuid", message.uuid)
+        if message.parent_tool_use_id is not None:
+            event.setdefault("parent_tool_use_id", message.parent_tool_use_id)
+        return event
+
+    if isinstance(message, RateLimitEvent):
+        return {
+            "type": "rate_limit_event",
+            "rate_limit_info": {
+                "status": message.rate_limit_info.status,
+                "resetsAt": message.rate_limit_info.resets_at,
+                "rateLimitType": message.rate_limit_info.rate_limit_type,
+                "utilization": message.rate_limit_info.utilization,
+                "overageStatus": message.rate_limit_info.overage_status,
+                "overageResetsAt": message.rate_limit_info.overage_resets_at,
+                "overageDisabledReason": message.rate_limit_info.overage_disabled_reason,
+                **message.rate_limit_info.raw,
+            },
+            "session_id": message.session_id,
+            "uuid": message.uuid,
+        }
+
+    logger.debug("Skipping unsupported SDK message: %s", type(message).__name__)
+    return None
+
+
+class SDKTransport(CLITransport):
+    """Claude SDK-backed transport that preserves existing broker event shapes."""
+
+    def __init__(
+        self,
+        workspace_dir: str,
+        model: str = "",
+        skip_permissions: bool = True,
+        agent_teams: bool = False,
+        system_prompt: str = "",
+        initial_prompt: str = "",
+        mcp_servers: list[dict] | None = None,
+    ) -> None:
+        super().__init__()
+        self.workspace_dir = workspace_dir
+        self._model = model
+        self._skip_permissions = skip_permissions
+        self._agent_teams = agent_teams
+        self._system_prompt = system_prompt
+        self._initial_prompt = initial_prompt
+        self._mcp_servers = build_sdk_mcp_servers(mcp_servers or [])
+        self._initial_prompt_sent = False
+        self._send_lock = asyncio.Lock()
+        self._client: ClaudeSDKClient | None = None
+        self._connected = False
+        self._session_id: str | None = None
+        self._last_result: dict[str, Any] | None = None
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(
+            session_resume=False,
+            interrupt=True,
+            set_model=True,
+            set_permission_mode=True,
+        )
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_id
+
+    @property
+    def last_result(self) -> dict[str, Any] | None:
+        return self._last_result
+
+    @property
+    def is_alive(self) -> bool:
+        return self._connected and self._client is not None
+
+    async def start(self) -> None:
+        """Connect the SDK client and optionally send the initial prompt."""
+        if not self.is_alive:
+            await self._connect_client()
+        if not self._initial_prompt or self._initial_prompt_sent:
+            return
+        self._initial_prompt_sent = True
+        try:
+            await self.send_message(self._initial_prompt)
+        except Exception:
+            self._initial_prompt_sent = False
+            raise
+
+    async def stop(self) -> None:
+        """Disconnect the SDK client and unblock any pending turn."""
+        client = self._client
+        self._connected = False
+        if client is None:
+            return
+        try:
+            await client.__aexit__(None, None, None)
+        except Exception:
+            logger.debug("Error stopping Claude SDK client", exc_info=True)
+        self._client = None
+
+    async def send_message(self, content: str) -> None:
+        """Send a user turn and emit SDK responses as stream-json dicts."""
+        async with self._send_lock:
+            if not self.is_alive:
+                await self._connect_client()
+            client = self._client
+            if client is None:
+                raise RuntimeError("Claude SDK client not connected")
+
+            await client.query(content)
+            async for message in client.receive_response():
+                await self._handle_sdk_message(message)
+                if isinstance(message, ResultMessage):
+                    return
+
+    async def interrupt(self) -> None:
+        """Interrupt the in-flight turn if the SDK client is connected.
+
+        Per SDK semantics, the partial assistant turn is dropped while the
+        conversation session remains usable for follow-up turns.
+        """
+        client = self._client
+        if client is None:
+            return
+        await client.interrupt()
+
+    async def _connect_client(self) -> None:
+        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        if self._agent_teams:
+            env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
+
+        options = ClaudeAgentOptions(
+            model=self._model or None,
+            system_prompt=self._system_prompt or None,
+            permission_mode=(_DEFAULT_PERMISSION_MODE if self._skip_permissions else "default"),
+            cwd=self.workspace_dir,
+            mcp_servers=self._mcp_servers,
+            env=env,
+        )
+        client = ClaudeSDKClient(options)
+        self._client = await client.__aenter__()
+        self._connected = True
+
+    async def _handle_sdk_message(self, message: object) -> None:
+        self._capture_session_id(message)
+
+        event = _to_stream_json(message)
+        if event is None:
+            return
+
+        filtered = _filter_event(event)
+        if filtered is not None:
+            try:
+                await self._emit(filtered)
+            except Exception:
+                logger.warning(
+                    "on_event handler raised for type=%s",
+                    filtered.get("type"),
+                    exc_info=True,
+                )
+
+        if isinstance(message, ResultMessage):
+            self._last_result = event
+
+    def _capture_session_id(self, message: object) -> None:
+        session_id = getattr(message, "session_id", None)
+        if isinstance(session_id, str) and session_id:
+            self._session_id = session_id
+            return
+
+        if not isinstance(message, SystemMessage):
+            return
+        raw_session_id = message.data.get("session_id")
+        if isinstance(raw_session_id, str) and raw_session_id:
+            self._session_id = raw_session_id

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -23,6 +23,7 @@ from skuld.broker import (
 from skuld.config import SkuldSettings
 from skuld.transports import (
     CodexSubprocessTransport,
+    SDKTransport,
     SdkWebSocketTransport,
     SubprocessTransport,
     TransportCapabilities,
@@ -136,6 +137,15 @@ class TestBroker:
 
         mock_import.assert_called_once_with("skuld.transports.subprocess.SubprocessTransport")
         assert isinstance(transport, SubprocessTransport)
+
+    def test_create_transport_sdk_adapter_path(self, tmp_path):
+        settings = SkuldSettings(
+            transport_adapter="skuld.transports.sdk.SDKTransport",
+            session={"id": "s1", "workspace_dir": str(tmp_path)},
+        )
+        b = Broker(settings=settings)
+        transport = b._create_transport()
+        assert isinstance(transport, SDKTransport)
 
     def test_create_transport_invalid_adapter_path(self, tmp_path):
         """Invalid adapter path (no dot) raises ValueError."""

--- a/tests/test_skuld/transports/test_sdk.py
+++ b/tests/test_skuld/transports/test_sdk.py
@@ -1,0 +1,596 @@
+"""Tests for the Claude SDK-backed transport."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock
+
+import pytest
+from claude_agent_sdk.types import (
+    AssistantMessage,
+    DeferredToolUse,
+    RateLimitEvent,
+    RateLimitInfo,
+    ResultMessage,
+    ServerToolResultBlock,
+    ServerToolUseBlock,
+    StreamEvent,
+    SystemMessage,
+    TextBlock,
+    ThinkingBlock,
+    ToolResultBlock,
+    ToolUseBlock,
+    UserMessage,
+)
+
+from niuu.adapters.cli.runtime import filter_cli_event
+from skuld.transports.mcp_config import build_sdk_mcp_servers
+from skuld.transports.sdk import SDKTransport, _content_block_to_dict, _to_stream_json
+
+
+def _assistant_message(*blocks: object, session_id: str | None = None) -> AssistantMessage:
+    return AssistantMessage(
+        content=list(blocks),
+        model="claude-opus-4-20250514",
+        usage={"input_tokens": 10, "output_tokens": 5},
+        session_id=session_id,
+    )
+
+
+def _result_message(
+    *,
+    session_id: str = "sdk-session",
+    result: str = "done",
+) -> ResultMessage:
+    return ResultMessage(
+        subtype="success",
+        duration_ms=12,
+        duration_api_ms=8,
+        is_error=False,
+        num_turns=1,
+        session_id=session_id,
+        total_cost_usd=0.01,
+        usage={"input_tokens": 10, "output_tokens": 5},
+        result=result,
+    )
+
+
+class _FakeClient:
+    def __init__(self, responses: list[list[object]]) -> None:
+        self._responses = [list(batch) for batch in responses]
+        self.entered = False
+        self.exited = False
+        self.query = AsyncMock()
+        self.interrupt = AsyncMock()
+
+    async def __aenter__(self) -> _FakeClient:
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        self.exited = True
+        return False
+
+    async def receive_response(self) -> AsyncIterator[object]:
+        batch = self._responses.pop(0) if self._responses else []
+        for message in batch:
+            yield message
+
+
+class _ClientFactory:
+    def __init__(self, responses: list[list[object]]) -> None:
+        self._responses = responses
+        self.client: _FakeClient | None = None
+        self.options = None
+
+    def __call__(self, options) -> _FakeClient:
+        self.options = options
+        self.client = _FakeClient(self._responses)
+        return self.client
+
+
+@pytest.mark.asyncio
+async def test_construction_accepts_standard_kwargs(tmp_path) -> None:
+    transport = SDKTransport(
+        workspace_dir=str(tmp_path),
+        model="claude-opus-4-20250514",
+        skip_permissions=False,
+        agent_teams=True,
+        system_prompt="Be precise.",
+        initial_prompt="Warm up.",
+        mcp_servers=[{"name": "linear", "command": "uvx", "args": ["linear-mcp"]}],
+    )
+
+    assert transport.workspace_dir == str(tmp_path)
+    assert transport.session_id is None
+    assert transport.last_result is None
+    assert transport.is_alive is False
+
+
+@pytest.mark.asyncio
+async def test_start_and_stop_manage_sdk_context(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(
+        workspace_dir=str(tmp_path),
+        model="claude-opus-4-20250514",
+        skip_permissions=True,
+        agent_teams=True,
+        system_prompt="System prompt",
+        mcp_servers=[{"name": "linear", "command": "uvx", "args": ["linear-mcp"]}],
+    )
+
+    await transport.start()
+
+    assert factory.client is not None
+    assert factory.client.entered is True
+    assert transport.is_alive is True
+    assert factory.options.model == "claude-opus-4-20250514"
+    assert factory.options.permission_mode == "bypassPermissions"
+    assert factory.options.system_prompt == "System prompt"
+    assert factory.options.cwd == str(tmp_path)
+    assert factory.options.mcp_servers == {
+        "linear": {"command": "uvx", "args": ["linear-mcp"]},
+    }
+    assert factory.options.env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"
+
+    await transport.stop()
+
+    assert factory.client.exited is True
+    assert transport.is_alive is False
+
+
+@pytest.mark.asyncio
+async def test_send_message_emits_stream_json_events_and_tracks_last_result(
+    monkeypatch, tmp_path
+) -> None:
+    factory = _ClientFactory(
+        [
+            [
+                UserMessage(content="hello"),
+                _assistant_message(TextBlock(text="world"), session_id="sdk-session"),
+                _result_message(result="world"),
+            ]
+        ]
+    )
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    received: list[dict] = []
+
+    async def on_event(event: dict) -> None:
+        received.append(event)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    transport.on_event(on_event)
+
+    await transport.start()
+    await transport.send_message("hello")
+
+    assert factory.client is not None
+    factory.client.query.assert_awaited_once_with("hello")
+    assert [event["type"] for event in received] == ["user", "assistant", "result"]
+    assert received[0]["message"] == {"role": "user", "content": "hello"}
+    assert received[1]["message"]["content"] == [{"type": "text", "text": "world"}]
+    assert received[2]["result"] == "world"
+    assert transport.last_result == received[2]
+    assert transport.session_id == "sdk-session"
+
+
+@pytest.mark.asyncio
+async def test_tool_use_block_mapping(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory(
+        [
+            [
+                _assistant_message(
+                    ToolUseBlock(id="tool-1", name="read_file", input={"path": "README.md"})
+                ),
+                _result_message(),
+            ]
+        ]
+    )
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    received: list[dict] = []
+
+    async def on_event(event: dict) -> None:
+        received.append(event)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    transport.on_event(on_event)
+
+    await transport.start()
+    await transport.send_message("inspect")
+
+    assert received[0] == {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tool-1",
+                    "name": "read_file",
+                    "input": {"path": "README.md"},
+                }
+            ],
+            "model": "claude-opus-4-20250514",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_interrupt_calls_sdk_and_is_safe_when_disconnected(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+
+    await transport.interrupt()
+    await transport.start()
+    await transport.interrupt()
+
+    assert factory.client is not None
+    factory.client.interrupt.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_session_id_captured_from_system_message(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory(
+        [
+            [
+                SystemMessage(
+                    subtype="init",
+                    data={"type": "system", "subtype": "init", "session_id": "system-session"},
+                ),
+                _result_message(session_id="system-session"),
+            ]
+        ]
+    )
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    await transport.start()
+    await transport.send_message("hello")
+
+    assert transport.session_id == "system-session"
+
+
+@pytest.mark.asyncio
+async def test_event_callback_registration_receives_every_message(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory(
+        [
+            [
+                UserMessage(content="hello"),
+                _assistant_message(TextBlock(text="world")),
+                _result_message(),
+            ]
+        ]
+    )
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    seen: list[str] = []
+
+    async def on_event(event: dict) -> None:
+        seen.append(event["type"])
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    transport.on_event(on_event)
+
+    await transport.start()
+    await transport.send_message("hello")
+
+    assert seen == ["user", "assistant", "result"]
+
+
+def test_capabilities() -> None:
+    caps = SDKTransport("/tmp").capabilities
+
+    assert caps.interrupt is True
+    assert caps.session_resume is False
+    assert caps.set_model is True
+    assert caps.set_permission_mode is True
+
+
+@pytest.mark.asyncio
+async def test_sdk_events_pass_existing_runtime_filter(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory(
+        [
+            [
+                _assistant_message(TextBlock(text="filtered")),
+                _result_message(result="filtered"),
+            ]
+        ]
+    )
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    received: list[dict] = []
+
+    async def on_event(event: dict) -> None:
+        filtered = filter_cli_event(event)
+        if filtered is not None:
+            received.append(filtered)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    transport.on_event(on_event)
+
+    await transport.start()
+    await transport.send_message("hello")
+
+    assert received == [
+        {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "filtered"}],
+                "model": "claude-opus-4-20250514",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "duration_ms": 12,
+            "duration_api_ms": 8,
+            "is_error": False,
+            "num_turns": 1,
+            "session_id": "sdk-session",
+            "total_cost_usd": 0.01,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+            "result": "filtered",
+        },
+    ]
+
+
+def test_build_sdk_mcp_servers() -> None:
+    payload = build_sdk_mcp_servers(
+        [
+            {"name": "stdio", "type": "stdio", "command": "uvx", "args": ["mcp-stdio"]},
+            {"name": "sse", "type": "sse", "url": "http://localhost:8000/sse"},
+            {"name": "http", "type": "http", "url": "http://localhost:8000/mcp"},
+        ]
+    )
+
+    assert payload == {
+        "stdio": {"type": "stdio", "command": "uvx", "args": ["mcp-stdio"]},
+        "sse": {"type": "sse", "url": "http://localhost:8000/sse"},
+        "http": {"type": "http", "url": "http://localhost:8000/mcp"},
+    }
+
+
+def test_content_block_and_message_conversion_helpers() -> None:
+    assert _content_block_to_dict(TextBlock(text="text")) == {"type": "text", "text": "text"}
+    assert _content_block_to_dict(ThinkingBlock(thinking="plan", signature="sig")) == {
+        "type": "thinking",
+        "thinking": "plan",
+        "signature": "sig",
+    }
+    assert _content_block_to_dict(ToolUseBlock(id="tool-1", name="read", input={"a": 1})) == {
+        "type": "tool_use",
+        "id": "tool-1",
+        "name": "read",
+        "input": {"a": 1},
+    }
+    assert _content_block_to_dict(
+        ToolResultBlock(tool_use_id="tool-1", content="ok", is_error=False)
+    ) == {
+        "type": "tool_result",
+        "tool_use_id": "tool-1",
+        "content": "ok",
+        "is_error": False,
+    }
+    assert _content_block_to_dict(
+        ServerToolUseBlock(id="srv-1", name="advisor", input={"topic": "sdk"})
+    ) == {
+        "type": "server_tool_use",
+        "id": "srv-1",
+        "name": "advisor",
+        "input": {"topic": "sdk"},
+    }
+    assert _content_block_to_dict(
+        ServerToolResultBlock(tool_use_id="srv-1", content={"type": "advisor_result"})
+    ) == {
+        "type": "advisor_tool_result",
+        "tool_use_id": "srv-1",
+        "content": {"type": "advisor_result"},
+    }
+
+    with pytest.raises(TypeError, match="Unsupported SDK content block"):
+        _content_block_to_dict(object())
+
+    user = UserMessage(
+        content=[TextBlock(text="hello")],
+        uuid="user-uuid",
+        parent_tool_use_id="parent-1",
+        tool_use_result={"ok": True},
+    )
+    assert _to_stream_json(user) == {
+        "type": "user",
+        "message": {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+        "parent_tool_use_id": "parent-1",
+        "tool_use_result": {"ok": True},
+        "uuid": "user-uuid",
+    }
+
+    assistant = AssistantMessage(
+        content=[
+            TextBlock(text="answer"),
+            ThinkingBlock(thinking="reason", signature="sig"),
+            ToolResultBlock(tool_use_id="tool-1", content="done"),
+            ServerToolUseBlock(id="srv-1", name="advisor", input={"topic": "sdk"}),
+            ServerToolResultBlock(tool_use_id="srv-1", content={"type": "advisor_result"}),
+        ],
+        model="claude-opus-4-20250514",
+        parent_tool_use_id="parent-1",
+        error="rate_limit",
+        usage={"input_tokens": 1},
+        message_id="msg-1",
+        stop_reason="end_turn",
+        session_id="sess-1",
+        uuid="assistant-uuid",
+    )
+    assert _to_stream_json(assistant) == {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "answer"},
+                {"type": "thinking", "thinking": "reason", "signature": "sig"},
+                {"type": "tool_result", "tool_use_id": "tool-1", "content": "done"},
+                {
+                    "type": "server_tool_use",
+                    "id": "srv-1",
+                    "name": "advisor",
+                    "input": {"topic": "sdk"},
+                },
+                {
+                    "type": "advisor_tool_result",
+                    "tool_use_id": "srv-1",
+                    "content": {"type": "advisor_result"},
+                },
+            ],
+            "model": "claude-opus-4-20250514",
+            "usage": {"input_tokens": 1},
+            "id": "msg-1",
+            "stop_reason": "end_turn",
+        },
+        "parent_tool_use_id": "parent-1",
+        "error": "rate_limit",
+        "session_id": "sess-1",
+        "uuid": "assistant-uuid",
+    }
+
+    result = ResultMessage(
+        subtype="success",
+        duration_ms=12,
+        duration_api_ms=8,
+        is_error=False,
+        num_turns=1,
+        session_id="sess-1",
+        stop_reason="end_turn",
+        total_cost_usd=0.01,
+        usage={"input_tokens": 1},
+        result="done",
+        structured_output={"ok": True},
+        model_usage={"claude-opus": {"input_tokens": 1}},
+        permission_denials=[{"tool": "edit"}],
+        deferred_tool_use=DeferredToolUse(id="tool-2", name="edit", input={"path": "a.txt"}),
+        errors=["soft warning"],
+        uuid="result-uuid",
+    )
+    assert _to_stream_json(result) == {
+        "type": "result",
+        "subtype": "success",
+        "duration_ms": 12,
+        "duration_api_ms": 8,
+        "is_error": False,
+        "num_turns": 1,
+        "session_id": "sess-1",
+        "stop_reason": "end_turn",
+        "total_cost_usd": 0.01,
+        "usage": {"input_tokens": 1},
+        "result": "done",
+        "structured_output": {"ok": True},
+        "modelUsage": {"claude-opus": {"input_tokens": 1}},
+        "permission_denials": [{"tool": "edit"}],
+        "deferred_tool_use": {"id": "tool-2", "name": "edit", "input": {"path": "a.txt"}},
+        "errors": ["soft warning"],
+        "uuid": "result-uuid",
+    }
+
+    assert _to_stream_json(
+        StreamEvent(
+            uuid="stream-uuid",
+            session_id="sess-1",
+            event={"type": "content_block_delta", "delta": {"text": "part"}},
+            parent_tool_use_id="parent-1",
+        )
+    ) == {
+        "type": "content_block_delta",
+        "delta": {"text": "part"},
+        "session_id": "sess-1",
+        "uuid": "stream-uuid",
+        "parent_tool_use_id": "parent-1",
+    }
+
+    assert _to_stream_json(
+        RateLimitEvent(
+            rate_limit_info=RateLimitInfo(
+                status="allowed_warning",
+                resets_at=123,
+                rate_limit_type="requests_per_minute",
+                utilization=0.9,
+                overage_status="allowed",
+                overage_resets_at=456,
+                overage_disabled_reason=None,
+                raw={"status": "allowed_warning", "custom": "value"},
+            ),
+            uuid="rate-uuid",
+            session_id="sess-1",
+        )
+    ) == {
+        "type": "rate_limit_event",
+        "rate_limit_info": {
+            "status": "allowed_warning",
+            "resetsAt": 123,
+            "rateLimitType": "requests_per_minute",
+            "utilization": 0.9,
+            "overageStatus": "allowed",
+            "overageResetsAt": 456,
+            "overageDisabledReason": None,
+            "custom": "value",
+        },
+        "session_id": "sess-1",
+        "uuid": "rate-uuid",
+    }
+
+    assert _to_stream_json(SystemMessage(subtype="init", data={"type": "system"})) == {
+        "type": "system"
+    }
+    assert _to_stream_json(object()) is None
+
+
+@pytest.mark.asyncio
+async def test_start_resets_initial_prompt_flag_when_send_fails(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path), initial_prompt="setup")
+    transport.send_message = AsyncMock(side_effect=RuntimeError("boom"))  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await transport.start()
+
+    assert transport._initial_prompt_sent is False
+
+
+@pytest.mark.asyncio
+async def test_stop_swallows_client_exit_errors(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    await transport.start()
+    assert factory.client is not None
+
+    factory.client.__aexit__ = AsyncMock(side_effect=RuntimeError("stop failed"))  # type: ignore[method-assign]
+
+    await transport.stop()
+
+    assert transport.is_alive is False
+
+
+@pytest.mark.asyncio
+async def test_handle_sdk_message_ignores_unknown_messages_and_callback_failures(tmp_path) -> None:
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+
+    async def bad_callback(event: dict) -> None:
+        raise RuntimeError(f"bad callback for {event['type']}")
+
+    transport.on_event(bad_callback)
+
+    await transport._handle_sdk_message(_assistant_message(TextBlock(text="hello")))
+    await transport._handle_sdk_message(object())
+
+    assert transport.last_result is None


### PR DESCRIPTION
## Summary
- add `skuld.transports.sdk.SDKTransport` backed by `claude-agent-sdk==0.1.74`
- preserve the existing broker event contract by converting SDK messages back into the stream-json dict shape
- add SDK-native MCP config translation, transport-layer `interrupt()`, and transport tests including broker selection and event-filter compatibility

## Why
The current persistent Claude subprocess transport hand-parses stream-json and cannot interrupt an in-flight turn. The SDK provides typed messages, lifecycle management, and first-class `interrupt()` support while still using the Claude CLI under the hood.

## User / Developer Impact
- sessions can opt into the new adapter with `transport_adapter: "skuld.transports.sdk.SDKTransport"`
- the broker and existing event handlers do not need changes for the new adapter
- `PersistentSubprocessTransport` remains available for crash-resume scenarios

## Validation
- `ruff check src/niuu/ports/cli/transport.py src/skuld/transports/mcp_config.py src/skuld/transports/sdk.py src/skuld/transports/__init__.py tests/test_skuld/test_broker.py tests/test_skuld/transports/test_sdk.py`
- `pytest tests/test_skuld/test_broker.py::TestBroker::test_create_transport_sdk_adapter_path tests/test_skuld/transports/test_sdk.py -q`
- `pytest tests/test_skuld/transports/test_sdk.py tests/test_skuld/test_persistent_subprocess.py -q`
- `pytest --cov=skuld.transports.sdk --cov-report=term-missing tests/test_skuld/transports/test_sdk.py -q` (`sdk.py` coverage: 95%)

## Known Gaps / Risks
1. No session resume in the Python SDK. If the CLI process dies, `SDKTransport` cannot recover the conversation. `PersistentSubprocessTransport` remains the fallback for crash-resume workflows.
2. Slash commands are not exposed by the SDK, so flows that need `/clear`, `/compact`, or similar must keep using a subprocess transport.
3. Mid-turn message injection is still lossy: the SDK path supports `interrupt() + query()` but drops the in-flight partial assistant turn.
4. `claude-agent-sdk` is still alpha (`0.1.x`), so the dependency is pinned to `0.1.74`.

## Notes
- local `make verify` is blocked by existing repo-wide formatting drift outside this ticket; the changed files are lint-clean and the relevant transport tests pass.
