### PR TITLE
Backport steerable sessions to old UI

### DIFF
--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -865,14 +865,11 @@ sessionDefinitions:
       broker:
         # -- AI CLI backend: "claude" (Claude Code)
         cliType: claude
-        # -- CLI transport mode for Claude Code sessions.
-        # "persistent_subprocess" keeps one Claude process across all
-        # turns (multi-turn over a held-open stdin pipe) — no per-turn
-        # spawn cost, no --resume reload between turns. The legacy
-        # "subprocess" mode (spawn-per-turn) still works as a fallback.
-        transport: persistent_subprocess
+        # -- Claude Agent SDK transport keeps a live controllable session
+        # for interrupts, model changes, and steering redirects.
+        transport: sdk
         # -- Fully-qualified transport adapter class path
-        transportAdapter: "skuld.transports.persistent_subprocess.PersistentSubprocessTransport"
+        transportAdapter: "skuld.transports.sdk.SDKTransport"
         # -- Skip tool permission prompts (--dangerously-skip-permissions)
         skipPermissions: true
         # -- Enable Claude Code experimental Agent Teams

--- a/src/niuu/ports/cli/transport.py
+++ b/src/niuu/ports/cli/transport.py
@@ -17,6 +17,8 @@ class TransportCapabilities:
     cli_websocket: bool = False
     session_resume: bool = False
     interrupt: bool = False
+    steer: bool = False
+    steering_mode: str = "none"
     set_model: bool = False
     set_thinking_tokens: bool = False
     set_permission_mode: bool = False
@@ -84,6 +86,11 @@ class CLITransport(ABC):
     @abstractmethod
     def is_alive(self) -> bool:
         """Whether the transport is connected and operational."""
+
+    @property
+    def is_turn_active(self) -> bool:
+        """Whether the transport is currently executing a turn."""
+        return False
 
     @property
     def capabilities(self) -> TransportCapabilities:

--- a/src/ravn/adapters/executors/cli.py
+++ b/src/ravn/adapters/executors/cli.py
@@ -125,6 +125,16 @@ class CliTransportAgent(ExecutionAgentPort):
     def task_id(self) -> str:
         return self._task_id
 
+    @property
+    def supports_steering(self) -> bool:
+        return self._transport is not None and self._transport.capabilities.steer
+
+    @property
+    def steering_mode(self) -> str:
+        if self._transport is None:
+            return "none"
+        return self._transport.capabilities.steering_mode
+
     def interrupt(self, reason: InterruptReason) -> None:
         if self._interrupt_reason is None:
             self._interrupt_reason = reason
@@ -133,6 +143,18 @@ class CliTransportAgent(ExecutionAgentPort):
             return
 
         asyncio.create_task(self._transport.send_control("interrupt"))
+
+    async def steer(self, content: str) -> bool:
+        transport = self._transport
+        if (
+            transport is None
+            or not transport.capabilities.steer
+            or not transport.is_turn_active
+            or not content.strip()
+        ):
+            return False
+        await transport.send_control("steer", content=content)
+        return True
 
     async def run_turn(self, user_input: str) -> TurnResult:
         if self._interrupt_reason is not None:

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -408,6 +408,7 @@ class DriveLoop:
         # (priority, counter, AgentTask)
         self._queue: asyncio.PriorityQueue = asyncio.PriorityQueue(maxsize=config.task_queue_max)
         self._active_tasks: dict[str, asyncio.Task] = {}
+        self._active_agents: dict[str, object] = {}
         self._semaphore = asyncio.Semaphore(config.max_concurrent_tasks)
         self._journal_path = Path(config.queue_journal_path).expanduser()
         self._source_id = "drive_loop"
@@ -616,6 +617,9 @@ class DriveLoop:
 
     async def _handle_directed_message(self, content: str) -> None:
         """Enqueue a directed message from the browser as an agent task."""
+        if await self._try_steer_active_agent(content):
+            return
+
         import time
 
         task_id = f"task_{int(time.time() * 1000):x}_{self._next_counter()}"
@@ -631,6 +635,32 @@ class DriveLoop:
         )
         logger.info("drive_loop: directed message enqueued as task %s", task_id)
         await self.enqueue(task)
+
+    async def _try_steer_active_agent(self, content: str) -> bool:
+        """Attempt to steer the current active agent instead of queueing work."""
+        if not content.strip():
+            return False
+
+        steerable = [
+            agent
+            for agent in self._active_agents.values()
+            if getattr(agent, "supports_steering", False) and getattr(agent, "steering_mode", "")
+        ]
+        if len(steerable) != 1:
+            return False
+
+        agent = steerable[0]
+        steer = getattr(agent, "steer", None)
+        if steer is None:
+            return False
+        try:
+            steered = await steer(content)
+        except Exception:
+            logger.warning("drive_loop: active agent steering failed; falling back to enqueue")
+            return False
+        if steered:
+            logger.info("drive_loop: directed message applied as live steering")
+        return bool(steered)
 
     # ------------------------------------------------------------------
     # Main run loop
@@ -777,6 +807,7 @@ class DriveLoop:
                 channel = SilentChannel()
         agent = self._agent_factory(channel, task.task_id, task.persona, task.triggered_by)
         prompt = build_initiative_prompt(task)
+        self._active_agents[task.task_id] = agent
 
         logger.info(
             "drive_loop: executing task %s (%r) triggered_by=%r",
@@ -812,106 +843,109 @@ class DriveLoop:
             )
         )
 
-        success = False
         try:
-            turn_result = await agent.run_turn(prompt)  # type: ignore[attr-defined]
-            success = True
-            self._record_task_cost(task, turn_result)
-            await self._maybe_publish_budget_warning(task)
-            self._save_task_output(task, capture_channel or channel)
-            response_text = capture_channel.response_text if capture_channel else ""
-            if response_text:
-                logger.info(
-                    "drive_loop: task %s output: %s",
-                    task.task_id,
-                    response_text[:500],
+            success = False
+            try:
+                turn_result = await agent.run_turn(prompt)  # type: ignore[attr-defined]
+                success = True
+                self._record_task_cost(task, turn_result)
+                await self._maybe_publish_budget_warning(task)
+                self._save_task_output(task, capture_channel or channel)
+                response_text = capture_channel.response_text if capture_channel else ""
+                if response_text:
+                    logger.info(
+                        "drive_loop: task %s output: %s",
+                        task.task_id,
+                        response_text[:500],
+                    )
+            except asyncio.CancelledError:
+                logger.info("drive_loop: task %s cancelled mid-turn", task.task_id)
+                self._result_store.set_status(task.task_id, "cancelled")
+                await self._event_publisher.publish(
+                    RavnEvent(
+                        type=RavnEventType.TASK_COMPLETE,
+                        source=self._source_id,
+                        payload={"task_id": task.task_id, "success": False},
+                        timestamp=datetime.now(UTC),
+                        urgency=0.7,
+                        correlation_id=task.task_id,
+                        session_id=task.session_id,
+                        task_id=task.task_id,
+                    )
                 )
-        except asyncio.CancelledError:
-            logger.info("drive_loop: task %s cancelled mid-turn", task.task_id)
-            self._result_store.set_status(task.task_id, "cancelled")
+                emit_fn = getattr(agent, "emit_session_ended", None)
+                if emit_fn is not None and asyncio.iscoroutinefunction(emit_fn):
+                    try:
+                        await emit_fn("interrupted")
+                    except Exception:
+                        logger.warning("emit_session_ended failed; continuing", exc_info=True)
+                await self._emit_sleipnir_task_completed(task, "interrupted")
+                if task.triggered_by and task.triggered_by.startswith("thread:"):
+                    thread_path = task.triggered_by.removeprefix("thread:")
+                    await self._finalise_thread(thread_path, False)
+                return
+            except Exception as exc:
+                logger.error("drive_loop: task %s failed: %s", task.task_id, exc)
+                self._result_store.set_status(task.task_id, "failed")
+                await channel.emit(
+                    RavnEvent.error(
+                        source=self._source_id,
+                        message=self._format_task_error(task, exc),
+                        correlation_id=task.task_id,
+                        session_id=task.session_id or task.task_id,
+                        task_id=task.task_id,
+                    )
+                )
+
+            outcome = "success" if success else "error"
+            emit_fn = getattr(agent, "emit_session_ended", None)
+            if emit_fn is not None and asyncio.iscoroutinefunction(emit_fn):
+                try:
+                    await emit_fn(outcome)
+                except Exception:
+                    logger.warning("emit_session_ended failed; continuing", exc_info=True)
+            await self._emit_sleipnir_task_completed(task, outcome)
+
+            # Publish outcome event to mesh for other agents to consume
+            response_text = capture_channel.response_text if capture_channel else ""
+            await self._emit_mesh_outcome_event(task, response_text, success)
+
             await self._event_publisher.publish(
                 RavnEvent(
                     type=RavnEventType.TASK_COMPLETE,
                     source=self._source_id,
-                    payload={"task_id": task.task_id, "success": False},
+                    payload={"task_id": task.task_id, "success": success},
                     timestamp=datetime.now(UTC),
-                    urgency=0.7,
+                    urgency=0.2 if success else 0.7,
                     correlation_id=task.task_id,
                     session_id=task.session_id,
                     task_id=task.task_id,
                 )
             )
-            emit_fn = getattr(agent, "emit_session_ended", None)
-            if emit_fn is not None and asyncio.iscoroutinefunction(emit_fn):
-                try:
-                    await emit_fn("interrupted")
-                except Exception:
-                    logger.warning("emit_session_ended failed; continuing", exc_info=True)
-            await self._emit_sleipnir_task_completed(task, "interrupted")
-            if task.triggered_by and task.triggered_by.startswith("thread:"):
-                thread_path = task.triggered_by.removeprefix("thread:")
-                await self._finalise_thread(thread_path, False)
-            return
-        except Exception as exc:
-            logger.error("drive_loop: task %s failed: %s", task.task_id, exc)
-            self._result_store.set_status(task.task_id, "failed")
             await channel.emit(
-                RavnEvent.error(
+                RavnEvent.task_complete(
                     source=self._source_id,
-                    message=self._format_task_error(task, exc),
+                    success=success,
                     correlation_id=task.task_id,
                     session_id=task.session_id or task.task_id,
                     task_id=task.task_id,
                 )
             )
 
-        outcome = "success" if success else "error"
-        emit_fn = getattr(agent, "emit_session_ended", None)
-        if emit_fn is not None and asyncio.iscoroutinefunction(emit_fn):
-            try:
-                await emit_fn(outcome)
-            except Exception:
-                logger.warning("emit_session_ended failed; continuing", exc_info=True)
-        await self._emit_sleipnir_task_completed(task, outcome)
+            if capture_channel and capture_channel.surface_triggered:
+                await self._re_deliver_surface(task, capture_channel.response_text)
+            elif (
+                capture_channel is None
+                and getattr(channel, "surface_triggered", False)
+                and hasattr(channel, "response_text")
+            ):
+                await self._re_deliver_surface(task, channel.response_text)
 
-        # Publish outcome event to mesh for other agents to consume
-        response_text = capture_channel.response_text if capture_channel else ""
-        await self._emit_mesh_outcome_event(task, response_text, success)
-
-        await self._event_publisher.publish(
-            RavnEvent(
-                type=RavnEventType.TASK_COMPLETE,
-                source=self._source_id,
-                payload={"task_id": task.task_id, "success": success},
-                timestamp=datetime.now(UTC),
-                urgency=0.2 if success else 0.7,
-                correlation_id=task.task_id,
-                session_id=task.session_id,
-                task_id=task.task_id,
-            )
-        )
-        await channel.emit(
-            RavnEvent.task_complete(
-                source=self._source_id,
-                success=success,
-                correlation_id=task.task_id,
-                session_id=task.session_id or task.task_id,
-                task_id=task.task_id,
-            )
-        )
-
-        if capture_channel and capture_channel.surface_triggered:
-            await self._re_deliver_surface(task, capture_channel.response_text)
-        elif (
-            capture_channel is None
-            and getattr(channel, "surface_triggered", False)
-            and hasattr(channel, "response_text")
-        ):
-            await self._re_deliver_surface(task, channel.response_text)
-
-        if task.triggered_by and task.triggered_by.startswith("thread:"):
-            thread_path = task.triggered_by.removeprefix("thread:")
-            await self._finalise_thread(thread_path, success)
+            if task.triggered_by and task.triggered_by.startswith("thread:"):
+                thread_path = task.triggered_by.removeprefix("thread:")
+                await self._finalise_thread(thread_path, success)
+        finally:
+            self._active_agents.pop(task.task_id, None)
 
     def _format_task_error(self, task: AgentTask, exc: Exception) -> str:
         """Render a user-visible task failure message for live room chat."""

--- a/src/ravn/ports/executor.py
+++ b/src/ravn/ports/executor.py
@@ -20,12 +20,17 @@ class ExecutionAgentPort(Protocol):
     task_id: str
     _tools: dict[str, object]
     _interrupt_reason: InterruptReason | None
+    supports_steering: bool
+    steering_mode: str
 
     async def run_turn(self, user_input: str) -> object:
         """Execute one turn and return a turn result."""
 
     def interrupt(self, reason: InterruptReason) -> None:
         """Signal the agent to stop at the next safe interruption point."""
+
+    async def steer(self, content: str) -> bool:
+        """Attempt to steer an active turn and return whether it was applied."""
 
 
 class ExecutorPort(ABC):

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -1407,6 +1407,7 @@ class Broker:
     # must be True for the control to be forwarded.
     _CONTROL_CAPABILITY_MAP: dict[str, str] = {
         "interrupt": "interrupt",
+        "steer_active_turn": "steer",
         "set_model": "set_model",
         "set_max_thinking_tokens": "set_thinking_tokens",
         "set_permission_mode": "set_permission_mode",
@@ -1456,6 +1457,12 @@ class Broker:
             # Phase 3: interrupt current turn
             case "interrupt":
                 await self._transport.send_control("interrupt")
+
+            # Phase 3: steer the active turn with new guidance
+            case "steer_active_turn":
+                content = str(data.get("content") or "").strip()
+                if content:
+                    await self._transport.send_control("steer", content=content)
 
             # Phase 3: change model mid-session
             case "set_model":
@@ -1557,6 +1564,20 @@ class Broker:
                     }
                 )
 
+                if (
+                    getattr(self._transport.capabilities, "steer", False) is True
+                    and getattr(self._transport, "is_turn_active", False) is True
+                ):
+                    asyncio.create_task(
+                        self._safe_transport_control(
+                            self._transport,
+                            "steer",
+                            content=message,
+                        ),
+                        name=f"transport-steer-{msg_id}",
+                    )
+                    return
+
                 # send_message holds a per-instance lock for the entire
                 # turn. Awaiting inline blocks the WS receive loop, so the
                 # user can't queue a follow-up while Claude is running.
@@ -1567,6 +1588,22 @@ class Broker:
                     self._safe_transport_send(self._transport, message),
                     name=f"transport-send-{msg_id}",
                 )
+
+    async def _safe_transport_control(
+        self,
+        transport: object,
+        subtype: str,
+        **kwargs: object,
+    ) -> None:
+        """Wrap background transport control so failures surface to the browser."""
+        try:
+            await transport.send_control(subtype, **kwargs)  # type: ignore[attr-defined]
+        except Exception as exc:
+            logger.exception("Transport send_control failed in background task")
+            try:
+                await self._channels.broadcast({"type": "error", "content": str(exc)})
+            except Exception:
+                logger.debug("Failed to broadcast transport control error", exc_info=True)
 
     async def _safe_transport_send(
         self, transport: object, message: str

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -94,7 +94,6 @@ class CodexWebSocketTransport(CLITransport):
         self._last_usage: dict | None = None
         self._alive = False
         self._block_index: int = 0
-
         # Pending RPC response futures keyed by request id.
         self._pending: dict[int, asyncio.Future] = {}
         # Pending approval RPC ids keyed by string request_id.
@@ -755,6 +754,54 @@ class CodexWebSocketTransport(CLITransport):
                 )
             return
 
+        if subtype == "steer":
+            content = str(kwargs.get("content") or "").strip()
+            if content and self._thread_id and self._current_turn_id:
+                logger.info(
+                    "Codex steer requested (thread=%s turn=%s)",
+                    self._thread_id,
+                    self._current_turn_id,
+                )
+                await self._send_rpc(
+                    "turn/steer",
+                    {
+                        "threadId": self._thread_id,
+                        "expectedTurnId": self._current_turn_id,
+                        "input": [{"type": "text", "text": content}],
+                    },
+                )
+            return
+
+        if subtype == "redirect":
+            content = str(kwargs.get("content") or "").strip()
+            if not content:
+                return
+            if not self._thread_id or not self._current_turn_id:
+                await self.send_message(content)
+                return
+            logger.info(
+                "Codex redirect requested as live steer (thread=%s turn=%s)",
+                self._thread_id,
+                self._current_turn_id,
+            )
+            await self._send_rpc(
+                "turn/steer",
+                {
+                    "threadId": self._thread_id,
+                    "expectedTurnId": self._current_turn_id,
+                    "input": [
+                        {
+                            "type": "text",
+                            "text": (
+                                "Change of plans. Stop what you are doing and follow this "
+                                f"instead:\n{content}"
+                            ),
+                        }
+                    ],
+                },
+            )
+            return
+
         if subtype == "set_model":
             model = kwargs.get("model")
             if model and isinstance(model, str):
@@ -776,11 +823,17 @@ class CodexWebSocketTransport(CLITransport):
         return self._alive
 
     @property
+    def is_turn_active(self) -> bool:
+        return bool(self._thread_id and self._current_turn_id)
+
+    @property
     def capabilities(self) -> TransportCapabilities:
         return TransportCapabilities(
             cli_websocket=False,  # We don't expose a /ws/cli endpoint
             session_resume=True,
             interrupt=True,
+            steer=True,
+            steering_mode="live",
             set_model=True,
             set_thinking_tokens=False,
             set_permission_mode=False,

--- a/src/skuld/transports/sdk.py
+++ b/src/skuld/transports/sdk.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 from dataclasses import asdict
 from typing import Any
 
@@ -44,6 +45,12 @@ from skuld.transports.mcp_config import build_sdk_mcp_servers
 logger = logging.getLogger("skuld.transport")
 
 _DEFAULT_PERMISSION_MODE = "bypassPermissions"
+_TRANSIENT_ERROR_RE = re.compile(
+    r"(internal server error|server-side issue|try again in a moment|"
+    r"status\.claude\.com|overloaded)",
+    re.IGNORECASE,
+)
+_MAX_TRANSIENT_RETRIES = 1
 
 
 def _content_block_to_dict(block: object) -> dict[str, Any]:
@@ -170,6 +177,34 @@ def _to_stream_json(message: object) -> dict[str, Any] | None:
 
     if isinstance(message, StreamEvent):
         event = dict(message.event)
+        event_type = event.get("type")
+
+        # Claude SDK partial streaming uses Anthropic wire events like
+        # ``message_start`` and ``content_block_delta``. Normalize the start
+        # event into the Skuld-style ``assistant`` frame so existing UIs know
+        # when to create a running assistant bubble before the deltas arrive.
+        if event_type == "message_start":
+            raw_message = event.get("message", {})
+            if isinstance(raw_message, dict):
+                payload: dict[str, Any] = {
+                    "type": "assistant",
+                    "message": {
+                        "role": "assistant",
+                        "content": raw_message.get("content", []),
+                        "model": raw_message.get("model"),
+                    },
+                }
+                usage = raw_message.get("usage")
+                if usage is not None:
+                    payload["message"]["usage"] = usage
+                message_id = raw_message.get("id")
+                if isinstance(message_id, str) and message_id:
+                    payload["message"]["id"] = message_id
+                stop_reason = raw_message.get("stop_reason")
+                if stop_reason is not None:
+                    payload["message"]["stop_reason"] = stop_reason
+                event = payload
+
         event.setdefault("session_id", message.session_id)
         event.setdefault("uuid", message.uuid)
         if message.parent_tool_use_id is not None:
@@ -224,12 +259,17 @@ class SDKTransport(CLITransport):
         self._connected = False
         self._session_id: str | None = None
         self._last_result: dict[str, Any] | None = None
+        self._turn_active = False
+        self._pending_steers: list[str] = []
+        self._steer_interrupt_requested = False
 
     @property
     def capabilities(self) -> TransportCapabilities:
         return TransportCapabilities(
             session_resume=False,
             interrupt=True,
+            steer=True,
+            steering_mode="interrupt_resume",
             set_model=True,
             set_permission_mode=True,
         )
@@ -245,6 +285,10 @@ class SDKTransport(CLITransport):
     @property
     def is_alive(self) -> bool:
         return self._connected and self._client is not None
+
+    @property
+    def is_turn_active(self) -> bool:
+        return self._turn_active
 
     async def start(self) -> None:
         """Connect the SDK client and optionally send the initial prompt."""
@@ -279,12 +323,60 @@ class SDKTransport(CLITransport):
             client = self._client
             if client is None:
                 raise RuntimeError("Claude SDK client not connected")
+            prompt = content
+            while True:
+                self._turn_active = True
+                self._steer_interrupt_requested = False
+                attempt = 0
+                try:
+                    while True:
+                        last_result_message: ResultMessage | None = None
+                        last_result_event: dict[str, Any] | None = None
+                        visible_output_emitted = False
 
-            await client.query(content)
-            async for message in client.receive_response():
-                await self._handle_sdk_message(message)
-                if isinstance(message, ResultMessage):
+                        await client.query(prompt)
+                        async for message in client.receive_response():
+                            event = await self._translate_sdk_message(message)
+                            if isinstance(message, ResultMessage):
+                                last_result_message = message
+                                if event is not None:
+                                    last_result_event = event
+                                break
+                            if event is not None:
+                                await self._emit_event(event)
+                                if self._is_visible_output_event(event):
+                                    visible_output_emitted = True
+
+                        if (
+                            last_result_message is not None
+                            and last_result_event is not None
+                            and self._should_retry_transient_result(
+                                last_result_message, last_result_event
+                            )
+                            and attempt < _MAX_TRANSIENT_RETRIES
+                            and not visible_output_emitted
+                        ):
+                            attempt += 1
+                            logger.warning(
+                                "Claude SDK transport: retrying transient provider error "
+                                "on attempt %s",
+                                attempt,
+                            )
+                            await asyncio.sleep(1.0)
+                            continue
+
+                        if last_result_event is not None:
+                            await self._emit_event(last_result_event)
+                            self._last_result = last_result_event
+                        break
+                finally:
+                    self._turn_active = False
+
+                next_prompt = self._consume_pending_steers()
+                if next_prompt is None:
                     return
+                logger.info("Claude SDK transport: continuing interrupted turn with steering")
+                prompt = next_prompt
 
     async def interrupt(self) -> None:
         """Interrupt the in-flight turn if the SDK client is connected.
@@ -297,6 +389,52 @@ class SDKTransport(CLITransport):
             return
         await client.interrupt()
 
+    async def send_control(self, subtype: str, **kwargs: object) -> None:
+        """Handle runtime control messages against the live SDK session."""
+        client = self._client
+        if client is None:
+            return
+
+        if subtype == "interrupt":
+            await self.interrupt()
+            return
+
+        if subtype == "set_model":
+            model = kwargs.get("model")
+            if model is None or isinstance(model, str):
+                self._model = model or ""
+                await client.set_model(model or None)
+            return
+
+        if subtype == "set_permission_mode":
+            mode = kwargs.get("permissionMode")
+            if isinstance(mode, str) and mode:
+                await client.set_permission_mode(mode)
+            return
+
+        if subtype == "rewind_files":
+            user_message_id = kwargs.get("user_message_id")
+            if isinstance(user_message_id, str) and user_message_id:
+                await client.rewind_files(user_message_id)
+            return
+
+        if subtype in {"steer", "redirect"}:
+            content = str(kwargs.get("content") or "").strip()
+            if not content:
+                return
+            if not self._turn_active:
+                if subtype == "redirect":
+                    await self.send_message(content)
+                else:
+                    logger.info("Claude SDK transport: steer requested without an active turn")
+                return
+            self._pending_steers.append(content)
+            if self._steer_interrupt_requested:
+                return
+            self._steer_interrupt_requested = True
+            await client.interrupt()
+            return
+
     async def _connect_client(self) -> None:
         env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
         if self._agent_teams:
@@ -308,30 +446,44 @@ class SDKTransport(CLITransport):
             permission_mode=(_DEFAULT_PERMISSION_MODE if self._skip_permissions else "default"),
             cwd=self.workspace_dir,
             mcp_servers=self._mcp_servers,
+            include_partial_messages=True,
+            thinking={"type": "adaptive", "display": "summarized"},
             env=env,
         )
         client = ClaudeSDKClient(options)
         self._client = await client.__aenter__()
         self._connected = True
 
-    async def _handle_sdk_message(self, message: object) -> None:
+    async def _translate_sdk_message(self, message: object) -> dict[str, Any] | None:
         self._capture_session_id(message)
 
         event = _to_stream_json(message)
         if event is None:
-            return
+            return None
 
         filtered = _filter_event(event)
-        if filtered is not None:
-            try:
-                await self._emit(filtered)
-            except Exception:
-                logger.warning(
-                    "on_event handler raised for type=%s",
-                    filtered.get("type"),
-                    exc_info=True,
-                )
+        return filtered
 
+    async def _emit_event(self, event: dict[str, Any]) -> None:
+        try:
+            await self._emit(event)
+        except Exception:
+            logger.warning(
+                "on_event handler raised for type=%s",
+                event.get("type"),
+                exc_info=True,
+            )
+
+    async def _handle_sdk_message(self, message: object) -> None:
+        """Translate and emit one SDK message event.
+
+        Kept as a small wrapper so older tests and callers do not need to know
+        about the newer translate/emit split.
+        """
+        event = await self._translate_sdk_message(message)
+        if event is None:
+            return
+        await self._emit_event(event)
         if isinstance(message, ResultMessage):
             self._last_result = event
 
@@ -346,3 +498,51 @@ class SDKTransport(CLITransport):
         raw_session_id = message.data.get("session_id")
         if isinstance(raw_session_id, str) and raw_session_id:
             self._session_id = raw_session_id
+
+    def _consume_pending_steers(self) -> str | None:
+        """Drain steering updates into the next continuation prompt."""
+        self._steer_interrupt_requested = False
+        if not self._pending_steers:
+            return None
+
+        if len(self._pending_steers) == 1:
+            return self._pending_steers.pop(0)
+
+        pending = list(self._pending_steers)
+        self._pending_steers.clear()
+        lines = [
+            "The user sent multiple steering updates while you were working.",
+            "Continue the same task and incorporate all of them in order:",
+        ]
+        lines.extend(f"- {item}" for item in pending)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _is_visible_output_event(event: dict[str, Any]) -> bool:
+        event_type = event.get("type")
+        if event_type == "assistant":
+            message = event.get("message", {})
+            if not isinstance(message, dict):
+                return False
+            content = message.get("content", [])
+            return bool(content)
+        if event_type == "content_block_start":
+            return True
+        if event_type == "content_block_delta":
+            delta = event.get("delta", {})
+            if not isinstance(delta, dict):
+                return False
+            return bool(delta.get("text") or delta.get("thinking") or delta.get("partial_json"))
+        return False
+
+    @staticmethod
+    def _should_retry_transient_result(
+        message: ResultMessage,
+        event: dict[str, Any],
+    ) -> bool:
+        if not message.is_error:
+            return False
+        result_text = str(event.get("result") or message.result or "").strip()
+        if not result_text:
+            return False
+        return bool(_TRANSIENT_ERROR_RE.search(result_text))

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -1832,13 +1832,9 @@ def create_router(
 
         try:
             async with connect(ws_url, **connect_kwargs) as ws:
-                # Drain any pending messages from the server
-                try:
-                    while True:
-                        await asyncio.wait_for(ws.recv(), timeout=1)
-                except TimeoutError:
-                    pass
-                # Send the user message
+                # Send immediately. Draining startup traffic here can delay or
+                # drop the first user turn for transports that emit welcome or
+                # capability events while still coming online.
                 await ws.send(json.dumps({"type": "user", "content": content}))
         except Exception as e:
             raise HTTPException(

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -211,11 +211,8 @@ def _default_session_definitions() -> dict[str, SessionDefinitionConfig]:
             defaults={
                 "broker": {
                     "cliType": "claude",
-                    "transport": "persistent_subprocess",
-                    "transportAdapter": (
-                        "skuld.transports.persistent_subprocess."
-                        "PersistentSubprocessTransport"
-                    ),
+                    "transport": "sdk",
+                    "transportAdapter": "skuld.transports.sdk.SDKTransport",
                     "skipPermissions": True,
                     "agentTeams": False,
                 },

--- a/src/volundr/domain/services/forge.py
+++ b/src/volundr/domain/services/forge.py
@@ -91,6 +91,7 @@ class ForgeService:
         *,
         principal: Principal | None = None,
     ) -> Session:
+        resolved_definition = self._resolve_session_definition(data.model, data.definition)
         session = await self._session_service.create_session(
             name=data.name,
             model=data.model,
@@ -104,7 +105,7 @@ class ForgeService:
         )
         return await self._session_service.start_session(
             session.id,
-            definition=data.definition,
+            definition=resolved_definition,
             profile_name=data.profile_name,
             template_name=data.template_name,
             principal=principal,
@@ -117,6 +118,25 @@ class ForgeService:
             workload_type=data.workload_type,
             workload_config=data.workload_config or None,
         )
+
+    def _resolve_session_definition(
+        self,
+        model: str,
+        explicit_definition: str | None,
+    ) -> str | None:
+        if explicit_definition:
+            return explicit_definition
+        if self._pricing_provider is None:
+            return None
+        normalized_model = str(model or "").strip()
+        if not normalized_model:
+            return None
+        for candidate in self._pricing_provider.list_models():
+            if str(getattr(candidate, "id", "") or "").strip() != normalized_model:
+                continue
+            definition = str(getattr(candidate, "session_definition", "") or "").strip()
+            return definition or None
+        return None
 
     async def get_session(self, session_id: UUID) -> Session | None:
         return await self._session_service.get_session(session_id)

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -1004,6 +1004,143 @@ async def test_drive_loop_cancel_unknown_task_is_no_op(tmp_path: Path) -> None:
     await loop.cancel("nonexistent_task_id")
 
 
+@pytest.mark.asyncio
+async def test_directed_message_steers_single_active_agent(tmp_path: Path) -> None:
+    loop, _ = _make_drive_loop(tmp_path)
+    loop.enqueue = AsyncMock()
+
+    steerable = MagicMock()
+    steerable.supports_steering = True
+    steerable.steering_mode = "live"
+    steerable.steer = AsyncMock(return_value=True)
+    loop._active_agents["task-1"] = steerable
+
+    await loop._handle_directed_message("Change course")
+
+    steerable.steer.assert_awaited_once_with("Change course")
+    loop.enqueue.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_directed_message_falls_back_to_enqueue_when_steering_unavailable(
+    tmp_path: Path,
+) -> None:
+    loop, _ = _make_drive_loop(tmp_path)
+    loop.enqueue = AsyncMock()
+
+    first = MagicMock()
+    first.supports_steering = True
+    first.steering_mode = "live"
+    first.steer = AsyncMock(return_value=True)
+
+    second = MagicMock()
+    second.supports_steering = True
+    second.steering_mode = "live"
+    second.steer = AsyncMock(return_value=True)
+
+    loop._active_agents = {"task-1": first, "task-2": second}
+
+    await loop._handle_directed_message("Queue this instead")
+
+    loop.enqueue.assert_awaited_once()
+    first.steer.assert_not_called()
+    second.steer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_try_steer_active_agent_handles_blank_missing_and_errors(tmp_path: Path) -> None:
+    loop, _ = _make_drive_loop(tmp_path)
+
+    assert await loop._try_steer_active_agent("   ") is False
+
+    class _NoSteer:
+        supports_steering = True
+        steering_mode = "live"
+
+    loop._active_agents = {"task-1": _NoSteer()}
+    assert await loop._try_steer_active_agent("Keep going") is False
+
+    class _BrokenSteer:
+        supports_steering = True
+        steering_mode = "live"
+
+        async def steer(self, content: str) -> bool:
+            raise RuntimeError("boom")
+
+    loop._active_agents = {"task-1": _BrokenSteer()}
+    assert await loop._try_steer_active_agent("Keep going") is False
+
+
+@pytest.mark.asyncio
+async def test_run_task_removes_active_agent_after_interrupted_turn(tmp_path: Path) -> None:
+    loop, factory = _make_drive_loop(tmp_path)
+
+    async def _cancelled(prompt: str) -> None:
+        raise asyncio.CancelledError()
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = _cancelled
+    mock_agent.emit_session_ended = AsyncMock()
+    factory.return_value = mock_agent
+
+    task = _make_task()
+    await loop._run_task(task)
+
+    assert task.task_id not in loop._active_agents
+    mock_agent.emit_session_ended.assert_awaited_once_with("interrupted")
+
+
+@pytest.mark.asyncio
+async def test_run_task_logs_response_and_redelivers_surface_output(tmp_path: Path) -> None:
+    journal = tmp_path / "queue.json"
+    config = _make_initiative_config(queue_journal_path=str(journal))
+    settings = Settings()
+    settings.cascade.enabled = True
+    emitted_channels: list = []
+
+    def agent_factory(channel, task_id=None, persona=None, triggered_by=None):
+        emitted_channels.append(channel)
+
+        async def _run_turn(prompt: str) -> None:
+            await channel.emit(
+                RavnEvent.response(
+                    "agent",
+                    "[SURFACE] Show this to the user",
+                    correlation_id=task_id or "task",
+                    session_id=task_id or "task",
+                    task_id=task_id or "task",
+                )
+            )
+
+        agent = AsyncMock()
+        agent.run_turn = _run_turn
+        agent.emit_session_ended = AsyncMock()
+        return agent
+
+    loop = DriveLoop(agent_factory=agent_factory, config=config, settings=settings)
+    loop._re_deliver_surface = AsyncMock()  # type: ignore[method-assign]
+
+    task = _make_task(output_mode=OutputMode.SURFACE)
+    await loop._run_task(task)
+
+    loop._re_deliver_surface.assert_awaited_once_with(task, "[SURFACE] Show this to the user")
+
+
+@pytest.mark.asyncio
+async def test_run_task_swallows_emit_session_ended_errors(tmp_path: Path) -> None:
+    loop, factory = _make_drive_loop(tmp_path)
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = AsyncMock(return_value=None)
+    mock_agent.emit_session_ended = AsyncMock(side_effect=RuntimeError("boom"))
+    factory.return_value = mock_agent
+
+    task = _make_task()
+    await loop._run_task(task)
+
+    assert task.task_id not in loop._active_agents
+
+
 # ---------------------------------------------------------------------------
 # DriveLoop — integration: cron trigger fires run_turn
 # ---------------------------------------------------------------------------
@@ -1095,6 +1232,7 @@ async def test_finalise_thread_success_closes_thread(tmp_path: Path) -> None:
 
     mock_agent = AsyncMock()
     mock_agent.run_turn = AsyncMock(return_value=None)
+    mock_agent.emit_session_ended = AsyncMock()
     factory.return_value = mock_agent
 
     task = _make_thread_task("threads/my-thread")
@@ -1102,6 +1240,28 @@ async def test_finalise_thread_success_closes_thread(tmp_path: Path) -> None:
 
     mock_mimir.update_thread_state.assert_awaited_once_with("threads/my-thread", ThreadState.closed)
     mock_mimir.assign_thread_owner.assert_not_awaited()
+    mock_agent.emit_session_ended.assert_awaited_once_with("success")
+    assert task.task_id not in loop._active_agents
+
+
+@pytest.mark.asyncio
+async def test_finalise_thread_interrupted_swallow_emit_session_ended_errors(
+    tmp_path: Path,
+) -> None:
+    loop, factory, mock_mimir = _make_drive_loop_with_mimir(tmp_path)
+
+    async def _cancelled(prompt: str) -> None:
+        raise asyncio.CancelledError()
+
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = _cancelled
+    mock_agent.emit_session_ended = AsyncMock(side_effect=RuntimeError("boom"))
+    factory.return_value = mock_agent
+
+    task = _make_thread_task("threads/my-thread")
+    await loop._run_task(task)
+
+    mock_mimir.update_thread_state.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_charts/test_volundr_chart.py
+++ b/tests/test_charts/test_volundr_chart.py
@@ -135,12 +135,10 @@ class TestValuesDefaults:
         assert broker["cliType"] == "claude"
 
     def test_skuld_claude_broker_transport_adapter(self, values_yaml):
-        """Test skuld-claude broker defaults to the persistent subprocess adapter."""
+        """Test skuld-claude broker defaults to the SDK adapter."""
         broker = values_yaml["sessionDefinitions"]["skuldClaude"]["defaults"]["broker"]
-        assert broker["transport"] == "persistent_subprocess"
-        assert broker["transportAdapter"] == (
-            "skuld.transports.persistent_subprocess.PersistentSubprocessTransport"
-        )
+        assert broker["transport"] == "sdk"
+        assert broker["transportAdapter"] == "skuld.transports.sdk.SDKTransport"
 
     def test_skuld_codex_broker_cli_type(self, values_yaml):
         """Test skuld-codex broker cliType is codex-ws (WebSocket transport)."""

--- a/tests/test_domain/test_forge_service.py
+++ b/tests/test_domain/test_forge_service.py
@@ -64,6 +64,44 @@ async def test_create_and_start_session_delegates_to_session_service() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_and_start_session_resolves_definition_from_model_catalog() -> None:
+    session_service = AsyncMock(spec=SessionService)
+    created = SimpleNamespace(id=uuid4())
+    started = SimpleNamespace(id=created.id)
+    session_service.create_session.return_value = created
+    session_service.start_session.return_value = started
+    pricing_provider = SimpleNamespace(
+        list_models=lambda: [SimpleNamespace(id="gpt-5.5", session_definition="skuldCodex")]
+    )
+    forge = ForgeService(session_service, pricing_provider=pricing_provider)
+    data = SimpleNamespace(
+        name="codex",
+        model="gpt-5.5",
+        source=SimpleNamespace(),
+        definition=None,
+        template_name=None,
+        preset_id=None,
+        workspace_id=None,
+        issue_id=None,
+        issue_url=None,
+        profile_name=None,
+        terminal_restricted=False,
+        credential_names=[],
+        integration_ids=[],
+        resource_config=None,
+        system_prompt=None,
+        initial_prompt=None,
+        workload_type="interactive",
+        workload_config=None,
+    )
+
+    await forge.create_and_start_session(data)
+
+    session_service.start_session.assert_awaited_once()
+    assert session_service.start_session.await_args.kwargs["definition"] == "skuldCodex"
+
+
+@pytest.mark.asyncio
 async def test_record_usage_delegates_to_token_service() -> None:
     session_service = AsyncMock(spec=SessionService)
     token_service = AsyncMock(spec=TokenService)

--- a/tests/test_domain/test_forge_service.py
+++ b/tests/test_domain/test_forge_service.py
@@ -102,6 +102,155 @@ async def test_create_and_start_session_resolves_definition_from_model_catalog()
 
 
 @pytest.mark.asyncio
+async def test_create_and_start_session_prefers_explicit_definition_over_catalog() -> None:
+    session_service = AsyncMock(spec=SessionService)
+    created = SimpleNamespace(id=uuid4())
+    started = SimpleNamespace(id=created.id)
+    session_service.create_session.return_value = created
+    session_service.start_session.return_value = started
+    pricing_provider = SimpleNamespace(
+        list_models=lambda: [SimpleNamespace(id="gpt-5.5", session_definition="skuldCodex")]
+    )
+    forge = ForgeService(session_service, pricing_provider=pricing_provider)
+    data = SimpleNamespace(
+        name="codex",
+        model="gpt-5.5",
+        source=SimpleNamespace(),
+        definition="manualDefinition",
+        template_name=None,
+        preset_id=None,
+        workspace_id=None,
+        issue_id=None,
+        issue_url=None,
+        profile_name=None,
+        terminal_restricted=False,
+        credential_names=[],
+        integration_ids=[],
+        resource_config=None,
+        system_prompt=None,
+        initial_prompt=None,
+        workload_type="interactive",
+        workload_config=None,
+    )
+
+    await forge.create_and_start_session(data)
+
+    assert session_service.start_session.await_args.kwargs["definition"] == "manualDefinition"
+
+
+@pytest.mark.asyncio
+async def test_create_and_start_session_leaves_definition_none_when_catalog_has_no_match() -> None:
+    session_service = AsyncMock(spec=SessionService)
+    created = SimpleNamespace(id=uuid4())
+    started = SimpleNamespace(id=created.id)
+    session_service.create_session.return_value = created
+    session_service.start_session.return_value = started
+    pricing_provider = SimpleNamespace(
+        list_models=lambda: [
+            SimpleNamespace(id="claude-sonnet-4-6", session_definition="skuldClaude")
+        ]
+    )
+    forge = ForgeService(session_service, pricing_provider=pricing_provider)
+    data = SimpleNamespace(
+        name="codex",
+        model="gpt-5.5",
+        source=SimpleNamespace(),
+        definition=None,
+        template_name=None,
+        preset_id=None,
+        workspace_id=None,
+        issue_id=None,
+        issue_url=None,
+        profile_name=None,
+        terminal_restricted=False,
+        credential_names=[],
+        integration_ids=[],
+        resource_config=None,
+        system_prompt=None,
+        initial_prompt=None,
+        workload_type="interactive",
+        workload_config=None,
+    )
+
+    await forge.create_and_start_session(data)
+
+    assert session_service.start_session.await_args.kwargs["definition"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_and_start_session_leaves_definition_none_without_pricing_provider() -> None:
+    session_service = AsyncMock(spec=SessionService)
+    created = SimpleNamespace(id=uuid4())
+    started = SimpleNamespace(id=created.id)
+    session_service.create_session.return_value = created
+    session_service.start_session.return_value = started
+    forge = ForgeService(session_service)
+    data = SimpleNamespace(
+        name="claude",
+        model="claude-sonnet-4-6",
+        source=SimpleNamespace(),
+        definition=None,
+        template_name=None,
+        preset_id=None,
+        workspace_id=None,
+        issue_id=None,
+        issue_url=None,
+        profile_name=None,
+        terminal_restricted=False,
+        credential_names=[],
+        integration_ids=[],
+        resource_config=None,
+        system_prompt=None,
+        initial_prompt=None,
+        workload_type="interactive",
+        workload_config=None,
+    )
+
+    await forge.create_and_start_session(data)
+
+    assert session_service.start_session.await_args.kwargs["definition"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_and_start_session_leaves_definition_none_for_blank_model() -> None:
+    session_service = AsyncMock(spec=SessionService)
+    created = SimpleNamespace(id=uuid4())
+    started = SimpleNamespace(id=created.id)
+    session_service.create_session.return_value = created
+    session_service.start_session.return_value = started
+    pricing_provider = SimpleNamespace(
+        list_models=lambda: [
+            SimpleNamespace(id="claude-sonnet-4-6", session_definition="skuldClaude")
+        ]
+    )
+    forge = ForgeService(session_service, pricing_provider=pricing_provider)
+    data = SimpleNamespace(
+        name="blank",
+        model="   ",
+        source=SimpleNamespace(),
+        definition=None,
+        template_name=None,
+        preset_id=None,
+        workspace_id=None,
+        issue_id=None,
+        issue_url=None,
+        profile_name=None,
+        terminal_restricted=False,
+        credential_names=[],
+        integration_ids=[],
+        resource_config=None,
+        system_prompt=None,
+        initial_prompt=None,
+        workload_type="interactive",
+        workload_config=None,
+    )
+
+    await forge.create_and_start_session(data)
+
+    assert session_service.start_session.await_args.kwargs["definition"] is None
+
+
+@pytest.mark.asyncio
 async def test_record_usage_delegates_to_token_service() -> None:
     session_service = AsyncMock(spec=SessionService)
     token_service = AsyncMock(spec=TokenService)

--- a/tests/test_ravn/test_executor_cli.py
+++ b/tests/test_ravn/test_executor_cli.py
@@ -45,6 +45,7 @@ class FakeResumableTransport(CLITransport):
         self.sent_messages: list[str] = []
         self._last_result: dict | None = None
         self.control_calls: list[tuple[str, dict]] = []
+        self._turn_active = False
 
     async def start(self) -> None:
         return None
@@ -54,6 +55,7 @@ class FakeResumableTransport(CLITransport):
 
     async def send_message(self, content: str) -> None:
         self.sent_messages.append(content)
+        self._turn_active = True
         await self._emit(
             {"type": "content_block_delta", "delta": {"type": "text_delta", "text": "Working "}}
         )
@@ -97,6 +99,7 @@ class FakeResumableTransport(CLITransport):
             },
         }
         await self._emit(self._last_result)
+        self._turn_active = False
 
     async def send_control(self, subtype: str, **kwargs: object) -> None:
         self.control_calls.append((subtype, kwargs))
@@ -115,7 +118,16 @@ class FakeResumableTransport(CLITransport):
 
     @property
     def capabilities(self) -> TransportCapabilities:
-        return TransportCapabilities(session_resume=True, interrupt=True)
+        return TransportCapabilities(
+            session_resume=True,
+            interrupt=True,
+            steer=True,
+            steering_mode="live",
+        )
+
+    @property
+    def is_turn_active(self) -> bool:
+        return self._turn_active
 
 
 class FakeStatelessTransport(CLITransport):
@@ -353,6 +365,39 @@ async def test_cli_transport_agent_helper_paths_and_failures() -> None:
         agent._raise_if_transport_failed({"stop_reason": "error", "result": "boom"})
     with pytest.raises(RuntimeError, match="bad news"):
         agent._raise_if_transport_failed({"is_error": True, "content": "bad news"})
+
+
+@pytest.mark.asyncio
+async def test_cli_transport_agent_steers_active_transport() -> None:
+    agent, _ = _make_agent(binding=_TransportBinding(FakeResumableTransport, True))
+
+    assert agent.supports_steering is False
+    assert agent.steering_mode == "none"
+
+    await agent._ensure_transport()
+    transport = agent._transport
+    assert transport is not None
+    transport._turn_active = True
+
+    assert agent.supports_steering is True
+    assert agent.steering_mode == "live"
+    assert await agent.steer("Focus on the tests") is True
+    assert transport.control_calls[-1] == ("steer", {"content": "Focus on the tests"})
+
+
+@pytest.mark.asyncio
+async def test_cli_transport_agent_steer_requires_active_transport_and_content() -> None:
+    agent, _ = _make_agent(binding=_TransportBinding(FakeResumableTransport, True))
+
+    assert await agent.steer("ignored") is False
+
+    await agent._ensure_transport()
+    transport = agent._transport
+    assert transport is not None
+
+    assert await agent.steer("   ") is False
+    assert await agent.steer("Ship it") is False
+    assert transport.control_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -569,6 +569,17 @@ class TestDispatchBrowserMessage:
         test_broker._transport.send_message.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_dispatch_explicit_steer_active_turn_message(self, test_broker):
+        await test_broker._dispatch_browser_message(
+            {"type": "steer_active_turn", "content": "abort the search"}
+        )
+
+        test_broker._transport.send_control.assert_awaited_once_with(
+            "steer",
+            content="abort the search",
+        )
+
+    @pytest.mark.asyncio
     async def test_dispatch_user_message_empty_ignored(self, test_broker):
         await test_broker._dispatch_browser_message({"content": ""})
         test_broker._transport.send_message.assert_not_called()
@@ -619,6 +630,36 @@ class TestDispatchBrowserMessage:
                 "behavior": "allow",
                 "updatedInput": {"command": "ls -la"},
             },
+        )
+
+    @pytest.mark.asyncio
+    async def test_safe_transport_control_broadcasts_background_errors(self, test_broker):
+        bad_transport = AsyncMock()
+        bad_transport.send_control.side_effect = RuntimeError("boom")
+        test_broker._channels = AsyncMock()
+
+        await test_broker._safe_transport_control(
+            bad_transport,
+            "steer",
+            content="reroute the task",
+        )
+
+        test_broker._channels.broadcast.assert_awaited_once()
+        payload = test_broker._channels.broadcast.await_args.args[0]
+        assert payload["type"] == "error"
+        assert "boom" in payload["content"]
+
+    @pytest.mark.asyncio
+    async def test_safe_transport_control_swallows_broadcast_failures(self, test_broker):
+        bad_transport = AsyncMock()
+        bad_transport.send_control.side_effect = RuntimeError("boom")
+        test_broker._channels = AsyncMock()
+        test_broker._channels.broadcast.side_effect = RuntimeError("offline")
+
+        await test_broker._safe_transport_control(
+            bad_transport,
+            "steer",
+            content="reroute the task",
         )
 
     @pytest.mark.asyncio

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -555,6 +555,20 @@ class TestDispatchBrowserMessage:
         test_broker._transport.send_message.assert_called_once_with("hello")
 
     @pytest.mark.asyncio
+    async def test_dispatch_user_message_steers_active_turn(self, test_broker):
+        test_broker._transport.capabilities = TransportCapabilities(steer=True)
+        test_broker._transport.is_turn_active = True
+
+        await test_broker._dispatch_browser_message({"content": "change direction"})
+        await asyncio.sleep(0)
+
+        test_broker._transport.send_control.assert_called_once_with(
+            "steer",
+            content="change direction",
+        )
+        test_broker._transport.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_dispatch_user_message_empty_ignored(self, test_broker):
         await test_broker._dispatch_browser_message({"content": ""})
         test_broker._transport.send_message.assert_not_called()

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -863,6 +863,17 @@ class TestControl:
             "Write BETA to /tmp/proof.txt"
         )
 
+    @pytest.mark.asyncio
+    async def test_redirect_falls_back_to_send_message_without_active_turn(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t.send_message = AsyncMock()  # type: ignore[method-assign]
+
+        await t.send_control("redirect", content="Write BETA to /tmp/proof.txt")
+        await t.send_control("redirect", content="")
+
+        t.send_message.assert_awaited_once_with("Write BETA to /tmp/proof.txt")
+        assert t.is_turn_active is False
+
 
 # ---------------------------------------------------------------------------
 # Approval / permission requests

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -815,6 +815,54 @@ class TestControl:
         await t.send_control("set_model", model="o3")
         assert t._model == "o3"
 
+    @pytest.mark.asyncio
+    async def test_steer_sends_expected_turn_id_and_input(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._thread_id = "thread-1"
+        t._current_turn_id = "turn-5"
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {}
+
+        t._send_rpc = fake_send_rpc
+
+        await t.send_control("steer", content="Actually focus on tests first.")
+
+        assert calls[0][0] == "turn/steer"
+        assert calls[0][1]["threadId"] == "thread-1"
+        assert calls[0][1]["expectedTurnId"] == "turn-5"
+        assert calls[0][1]["input"] == [
+            {"type": "text", "text": "Actually focus on tests first."}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_redirect_uses_live_steer_with_change_of_plans_prefix(self, tmp_path):
+        t = _make_transport(tmp_path)
+        t._thread_id = "thread-1"
+        t._current_turn_id = "turn-5"
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            return {}
+
+        t._send_rpc = fake_send_rpc
+
+        await t.send_control("redirect", content="Write BETA to /tmp/proof.txt")
+
+        assert calls[0][0] == "turn/steer"
+        assert calls[0][1]["threadId"] == "thread-1"
+        assert calls[0][1]["expectedTurnId"] == "turn-5"
+        assert (
+            calls[0][1]["input"][0]["text"]
+            == "Change of plans. Stop what you are doing and follow this instead:\n"
+            "Write BETA to /tmp/proof.txt"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Approval / permission requests

--- a/tests/test_skuld/test_transport.py
+++ b/tests/test_skuld/test_transport.py
@@ -33,6 +33,8 @@ class TestTransportCapabilities:
         assert caps.cli_websocket is False
         assert caps.session_resume is False
         assert caps.interrupt is False
+        assert caps.steer is False
+        assert caps.steering_mode == "none"
         assert caps.set_model is False
         assert caps.set_thinking_tokens is False
         assert caps.set_permission_mode is False
@@ -1148,6 +1150,13 @@ class TestSdkWebSocketTransport:
         t = SubprocessTransport("/tmp")
         # Should not raise
         await t.send_control("interrupt")
+
+    def test_base_transport_reports_turn_inactive(self):
+        """Base CLITransport.is_turn_active defaults to False."""
+        from skuld.transports import SubprocessTransport
+
+        t = SubprocessTransport("/tmp")
+        assert t.is_turn_active is False
 
     # --- Phase 4: Agent Teams ---
 

--- a/tests/test_skuld/transports/test_sdk.py
+++ b/tests/test_skuld/transports/test_sdk.py
@@ -41,12 +41,14 @@ def _result_message(
     *,
     session_id: str = "sdk-session",
     result: str = "done",
+    is_error: bool = False,
+    subtype: str | None = None,
 ) -> ResultMessage:
     return ResultMessage(
-        subtype="success",
+        subtype=subtype or ("error_during_execution" if is_error else "success"),
         duration_ms=12,
         duration_api_ms=8,
-        is_error=False,
+        is_error=is_error,
         num_turns=1,
         session_id=session_id,
         total_cost_usd=0.01,
@@ -62,6 +64,9 @@ class _FakeClient:
         self.exited = False
         self.query = AsyncMock()
         self.interrupt = AsyncMock()
+        self.set_model = AsyncMock()
+        self.set_permission_mode = AsyncMock()
+        self.rewind_files = AsyncMock()
 
     async def __aenter__(self) -> _FakeClient:
         self.entered = True
@@ -288,6 +293,8 @@ def test_capabilities() -> None:
     caps = SDKTransport("/tmp").capabilities
 
     assert caps.interrupt is True
+    assert caps.steer is True
+    assert caps.steering_mode == "interrupt_resume"
     assert caps.session_resume is False
     assert caps.set_model is True
     assert caps.set_permission_mode is True
@@ -515,6 +522,35 @@ def test_content_block_and_message_conversion_helpers() -> None:
     }
 
     assert _to_stream_json(
+        StreamEvent(
+            uuid="start-uuid",
+            session_id="sess-2",
+            event={
+                "type": "message_start",
+                "message": {
+                    "id": "msg_123",
+                    "content": [],
+                    "model": "claude-sonnet-4-6",
+                    "usage": {"input_tokens": 2},
+                    "stop_reason": "end_turn",
+                },
+            },
+        )
+    ) == {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [],
+            "model": "claude-sonnet-4-6",
+            "usage": {"input_tokens": 2},
+            "id": "msg_123",
+            "stop_reason": "end_turn",
+        },
+        "session_id": "sess-2",
+        "uuid": "start-uuid",
+    }
+
+    assert _to_stream_json(
         RateLimitEvent(
             rate_limit_info=RateLimitInfo(
                 status="allowed_warning",
@@ -594,3 +630,162 @@ async def test_handle_sdk_message_ignores_unknown_messages_and_callback_failures
     await transport._handle_sdk_message(object())
 
     assert transport.last_result is None
+
+
+@pytest.mark.asyncio
+async def test_send_control_updates_sdk_client_and_buffers_active_steers(
+    monkeypatch, tmp_path
+) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    await transport.start()
+    assert factory.client is not None
+
+    await transport.send_control("set_model", model="claude-sonnet-4-6")
+    await transport.send_control("set_permission_mode", permissionMode="plan")
+    await transport.send_control("rewind_files", user_message_id="msg_123")
+
+    transport._turn_active = True
+    await transport.send_control("steer", content="Focus on tests first")
+    await transport.send_control("steer", content="Then summarize the findings")
+
+    factory.client.set_model.assert_awaited_once_with("claude-sonnet-4-6")
+    factory.client.set_permission_mode.assert_awaited_once_with("plan")
+    factory.client.rewind_files.assert_awaited_once_with("msg_123")
+    factory.client.interrupt.assert_awaited_once()
+    assert transport._pending_steers == [
+        "Focus on tests first",
+        "Then summarize the findings",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_control_redirect_without_active_turn_uses_send_message(
+    monkeypatch, tmp_path
+) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    await transport.start()
+    transport.send_message = AsyncMock()  # type: ignore[method-assign]
+
+    await transport.send_control("redirect", content="Use the fallback plan")
+    await transport.send_control("steer", content="")  # no-op branch
+
+    transport.send_message.assert_awaited_once_with("Use the fallback plan")
+
+
+@pytest.mark.asyncio
+async def test_send_control_handles_disconnect_and_interrupt_variants(
+    monkeypatch, tmp_path
+) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    assert transport.is_turn_active is False
+    await transport.send_control("interrupt")
+
+    await transport.start()
+    assert factory.client is not None
+
+    await transport.send_control("interrupt")
+    await transport.send_control("steer", content="Stay focused")
+
+    factory.client.interrupt.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_message_retries_transient_provider_errors_without_visible_output(
+    monkeypatch, tmp_path
+) -> None:
+    factory = _ClientFactory(
+        [
+            [_result_message(result="Internal server error, try again in a moment", is_error=True)],
+            [_assistant_message(TextBlock(text="Recovered")), _result_message(result="Recovered")],
+        ]
+    )
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr("skuld.transports.sdk.asyncio.sleep", sleep_mock)
+
+    received: list[dict] = []
+
+    async def on_event(event: dict) -> None:
+        received.append(event)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    transport.on_event(on_event)
+
+    await transport.start()
+    await transport.send_message("hello")
+
+    assert factory.client is not None
+    assert factory.client.query.await_count == 2
+    sleep_mock.assert_awaited_once_with(1.0)
+    assert received[-1]["result"] == "Recovered"
+    assert transport.last_result == received[-1]
+
+
+@pytest.mark.asyncio
+async def test_send_message_consumes_pending_steers_as_continuation(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory(
+        [
+            [_result_message(result="first")],
+            [_result_message(result="second")],
+        ]
+    )
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    transport._pending_steers = ["follow the new direction"]
+
+    await transport.start()
+    await transport.send_message("initial prompt")
+
+    assert factory.client is not None
+    assert [call.args[0] for call in factory.client.query.await_args_list] == [
+        "initial prompt",
+        "follow the new direction",
+    ]
+
+
+def test_pending_steers_and_visibility_helpers() -> None:
+    transport = SDKTransport("/tmp")
+    transport._pending_steers = ["one", "two"]
+
+    merged = transport._consume_pending_steers()
+    assert "multiple steering updates" in merged
+    assert "- one" in merged
+    assert "- two" in merged
+    assert transport._consume_pending_steers() is None
+
+    assert (
+        transport._is_visible_output_event(
+            {"type": "assistant", "message": {"content": []}}
+        )
+        is False
+    )
+    assert transport._is_visible_output_event(
+        {"type": "content_block_start", "content_block": {"type": "thinking"}}
+    ) is True
+    assert transport._is_visible_output_event(
+        {"type": "content_block_delta", "delta": {"thinking": "plan"}}
+    ) is True
+    assert transport._should_retry_transient_result(
+        _result_message(result="status.claude.com says overloaded", is_error=True),
+        {"type": "result", "result": "status.claude.com says overloaded"},
+    ) is True
+    assert transport._should_retry_transient_result(
+        _result_message(result="hard failure", is_error=False),
+        {"type": "result", "result": "hard failure"},
+    ) is False
+    assert transport._should_retry_transient_result(
+        _result_message(result="", is_error=True),
+        {"type": "result", "result": ""},
+    ) is False
+    assert transport._is_visible_output_event({"type": "assistant", "message": "bad"}) is False
+    assert transport._is_visible_output_event({"type": "content_block_delta", "delta": []}) is False

--- a/tests/test_volundr/test_session_definition_contributor.py
+++ b/tests/test_volundr/test_session_definition_contributor.py
@@ -30,9 +30,7 @@ DEFINITIONS = {
         defaults={
             "broker": {
                 "cliType": "claude",
-                "transportAdapter": (
-                    "skuld.transports.persistent_subprocess.PersistentSubprocessTransport"
-                ),
+                "transportAdapter": "skuld.transports.sdk.SDKTransport",
             },
         },
     ),
@@ -161,11 +159,8 @@ class TestDefaultSessionDefinitions:
         claude = _default_session_definitions()["skuldClaude"]
         assert claude.display_name == "Claude Code"
         assert claude.defaults["broker"]["cliType"] == "claude"
-        assert claude.defaults["broker"]["transport"] == "persistent_subprocess"
-        assert (
-            claude.defaults["broker"]["transportAdapter"]
-            == "skuld.transports.persistent_subprocess.PersistentSubprocessTransport"
-        )
+        assert claude.defaults["broker"]["transport"] == "sdk"
+        assert claude.defaults["broker"]["transportAdapter"] == "skuld.transports.sdk.SDKTransport"
 
     def test_codex_defaults(self):
         codex = _default_session_definitions()["skuldCodex"]

--- a/uv.lock
+++ b/uv.lock
@@ -9,15 +9,15 @@ resolution-markers = [
 
 [[package]]
 name = "aio-pika"
-version = "9.6.1"
+version = "9.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiormq" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/3e/8e8513214ed7ceed6bad8b71f7fe196d54ef2277c135bf7960ed715d4227/aio_pika-9.6.1.tar.gz", hash = "sha256:7a130c51a413cfcd04c3322f6a0ab08c38eb9918de1e476f6d34bbf41fc8d2b0", size = 66809, upload-time = "2026-02-23T15:41:52.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/63/56354526f2e6e915c93bee6e4dedb35888fe82d6bc1a19f35f5a77e795ff/aio_pika-9.6.2.tar.gz", hash = "sha256:c49e9246080dc8ffa1bb0e4aca407bf3d8ad78c3ee3a93df88b68fe65d7a49b9", size = 70851, upload-time = "2026-03-22T19:03:20.878Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/24/59a1644995f7a0245588a1761d4b515fc63b7a6038310ead2b07eb44cd8b/aio_pika-9.6.1-py3-none-any.whl", hash = "sha256:0fda50fbbdeb6c5b7399730a2286751074dfe6e52a20119a71aef112d4863fd1", size = 52022, upload-time = "2026-02-23T15:41:51.357Z" },
+    { url = "https://files.pythonhosted.org/packages/25/05/256fa313f48bed075056d13593b92ce804be05d75f4f312be24edb82860a/aio_pika-9.6.2-py3-none-any.whl", hash = "sha256:2a5478af920d169795071c9c09c7542cd8cdece60438cf7804533dcbcce93b7f", size = 56269, upload-time = "2026-03-22T19:03:19.558Z" },
 ]
 
 [[package]]
@@ -335,20 +335,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.74"
+version = "0.1.75"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/8e/51749a75a0908e0bb71b77ae289b0f2357381903ba43fe6d17bd13b9f8c8/claude_agent_sdk-0.1.74.tar.gz", hash = "sha256:412308bab715133894126e882fcc8778e281a7a76e74264e3a428a233eeaf768", size = 246973, upload-time = "2026-05-06T01:51:52.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/3f/f7f5931c9df6f8185b45bed15546c6e3f6ce773db97c064c65f388e4fa27/claude_agent_sdk-0.1.75.tar.gz", hash = "sha256:ab28c69391675dcffd5c0e622b350ce5c9a811b2715a81c847477c1dfcedf361", size = 246971, upload-time = "2026-05-06T07:59:30.754Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/79/b0c858d9d6af1ce118bf4d1d0c92f0e46f37c4dc89a132321a745959a961/claude_agent_sdk-0.1.74-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6b850008b9241c76c4b645159685ba8382075d3e7253e3de969dd3a1a438e296", size = 64039705, upload-time = "2026-05-06T01:51:55.562Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/02/c885e736ae24cd6c8243312637ac32ca8a46f9aa482386b6b4cbe8185879/claude_agent_sdk-0.1.74-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:aec9ec939dc9da3c93186b3a66507e3b4507d2be36a31d96562d6af1ca0427e5", size = 65881226, upload-time = "2026-05-06T01:51:59.016Z" },
-    { url = "https://files.pythonhosted.org/packages/44/f7/ae42174c4db6bcc2e8e821d1deec395a29353fc9f2691bc754a2f3392d0f/claude_agent_sdk-0.1.74-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:56889dc56556f515561ffe8cecce37c319a0d3d608258fb7af9ad7e52cce355b", size = 77211570, upload-time = "2026-05-06T01:52:02.9Z" },
-    { url = "https://files.pythonhosted.org/packages/47/a8/e5ae47a9b4a351de46728cf23f407ff9e823acc8fe1918a894065830f02b/claude_agent_sdk-0.1.74-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:c45fd2b6abb534865d79d058a375a825e1aef9d12d22b1419ec45ea432ed1f5d", size = 77357370, upload-time = "2026-05-06T01:52:06.524Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ca/5c2e501e51a978c203e7441e8b643a2c196e3a63d8cb33d7f043d4621793/claude_agent_sdk-0.1.74-py3-none-win_amd64.whl", hash = "sha256:65becad62edf1e5d39cb9014b70942c8657504b0840e2359ffd7479ef73eb09f", size = 78765668, upload-time = "2026-05-06T01:52:10.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/9e/2d5eae0f1ee7273fe60e27efbe066a74c8329cd86c25ad908953d5fc0474/claude_agent_sdk-0.1.75-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4343a4fe1f4d2bf74aeed84ff177ad7c296c82532d4acc73a670ffaa105a0a4", size = 64001809, upload-time = "2026-05-06T07:59:33.867Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ae/f4727ec93a457f09820b26ff87a639cf2734b461792c5e0ee8016872b542/claude_agent_sdk-0.1.75-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:bb7db09e6825db8f6bdbd51fb208870efabe66321281136ddcbac948e019a67c", size = 65849171, upload-time = "2026-05-06T07:59:38.167Z" },
+    { url = "https://files.pythonhosted.org/packages/32/c4/ede5c3231cfff481eda49c6425274c47f48e9922ebf171565472051d8c50/claude_agent_sdk-0.1.75-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:c724c5dd0986774f2c9f9fffc47991d3cca1c2342822602702b98003a985e67f", size = 77181298, upload-time = "2026-05-06T07:59:41.745Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b0/9351431cd9984bc057ed219f615cc8d0a33348f4088658d1479896ebdc3d/claude_agent_sdk-0.1.75-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:6903ec35c8b74233574615a47535ff2f8db58c4eec2f4307f94a932baa64c517", size = 77328964, upload-time = "2026-05-06T07:59:45.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/cc/3a7c95d40c98995d9c8aa0193b0f1c841ab9f691c3f98feda98e2872ace9/claude_agent_sdk-0.1.75-py3-none-win_amd64.whl", hash = "sha256:bceae9ccab5903660ad940823db67e0e317ed6d6fe4ec9e3c6104c6ea828fac2", size = 78730050, upload-time = "2026-05-06T07:59:48.904Z" },
 ]
 
 [[package]]
@@ -1253,9 +1253,9 @@ wheels = [
 
 [[package]]
 name = "nuitka"
-version = "4.0.7"
+version = "4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/0e/2537066db2458843e4a1edfc524409069ad58a456fc4b312b18b1d327431/nuitka-4.0.7.tar.gz", hash = "sha256:26543bfed6009a466ae8608bdc643add81a497e8662e4aaf157cd00aa7fd5b9f", size = 4421537, upload-time = "2026-03-24T13:26:43.368Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/db/b7a344ad688cd6d8547746869f904b105674ff529a24fa5a3d7bdd95560a/nuitka-4.1.tar.gz", hash = "sha256:99092d26f5f8d5264186924451f7df5872bf6a922297062ace2798ecec7cfa0f", size = 4543258, upload-time = "2026-05-11T07:16:35.483Z" }
 
 [[package]]
 name = "opentelemetry-api"
@@ -2404,9 +2404,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=9.0" },
+    { name = "aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=9.6.2" },
     { name = "asyncpg", specifier = ">=0.31.0" },
-    { name = "claude-agent-sdk", specifier = "==0.1.74" },
+    { name = "claude-agent-sdk", specifier = "==0.1.75" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = ">=48.0.0" },
     { name = "cryptography", marker = "extra == 'encryption'", specifier = ">=48.0.0" },
     { name = "fastapi", specifier = ">=0.109" },
@@ -2416,7 +2416,7 @@ requires-dist = [
     { name = "msgpack", specifier = ">=1.1.2" },
     { name = "nats-py", marker = "extra == 'dev'", specifier = ">=2.14.0" },
     { name = "nats-py", marker = "extra == 'nats'", specifier = ">=2.14.0" },
-    { name = "nuitka", marker = "extra == 'cli'", specifier = ">=2.1" },
+    { name = "nuitka", marker = "extra == 'cli'", specifier = ">=4.0.8" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.25" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "extra == 'otel'", specifier = ">=1.25" },
     { name = "opentelemetry-sdk", marker = "extra == 'otel'", specifier = ">=1.41.1" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,6 +41,7 @@
         "@codingame/monaco-vscode-java-default-extension": "^28.4.1",
         "@codingame/monaco-vscode-javascript-default-extension": "^28.4.1",
         "@codingame/monaco-vscode-json-default-extension": "^28.4.1",
+        "@codingame/monaco-vscode-keybindings-service-override": "^32.0.2",
         "@codingame/monaco-vscode-language-detection-worker-service-override": "^30.0.0",
         "@codingame/monaco-vscode-languages-service-override": "^28.4.1",
         "@codingame/monaco-vscode-less-default-extension": "^30.0.0",
@@ -1167,13 +1168,96 @@
       }
     },
     "node_modules/@codingame/monaco-vscode-keybindings-service-override": {
-      "version": "28.4.1",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-28.4.1.tgz",
-      "integrity": "sha512-3aHMncxPZrpdNbd6wLZXWQuAbq2JNocxxkSMMscTXIWSoE1gHuJfMwjUdIMGHKgxsIj19dOfyP5No9v5pZJ6vA==",
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-32.0.2.tgz",
+      "integrity": "sha512-Cd1F/A2V+sWcsLtE/STsrlG4eR1NbyLnu22jtaK6nXd1ow7pstaUQiQbsl7VFYIKWwrknA++CYT1Kl7gT6amgA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "28.4.1",
-        "@codingame/monaco-vscode-files-service-override": "28.4.1"
+        "@codingame/monaco-vscode-api": "32.0.2",
+        "@codingame/monaco-vscode-files-service-override": "32.0.2"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override/node_modules/@codingame/monaco-vscode-api": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-32.0.2.tgz",
+      "integrity": "sha512-ydnJX26VylmHjlRV0qdGBeGJuOxpJqtkXKDZwHClte724YNqEK7IDEQEarxre7PDy62RfCMsveRU47+jrwP7lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-base-service-override": "32.0.2",
+        "@codingame/monaco-vscode-environment-service-override": "32.0.2",
+        "@codingame/monaco-vscode-extensions-service-override": "32.0.2",
+        "@codingame/monaco-vscode-files-service-override": "32.0.2",
+        "@codingame/monaco-vscode-host-service-override": "32.0.2",
+        "@codingame/monaco-vscode-layout-service-override": "32.0.2",
+        "@codingame/monaco-vscode-quickaccess-service-override": "32.0.2",
+        "@vscode/iconv-lite-umd": "0.7.1",
+        "dompurify": "3.4.3",
+        "jschardet": "3.1.4",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override/node_modules/@codingame/monaco-vscode-base-service-override": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-32.0.2.tgz",
+      "integrity": "sha512-QFhFslYORx+WLL8XVkk+2NWL3Q9u3VNMpzPkwcnKMCQ9A9XYiHr5h4wYtlsDtukNK4g3wxxv9ood5usQsWFOJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "32.0.2"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override/node_modules/@codingame/monaco-vscode-environment-service-override": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-32.0.2.tgz",
+      "integrity": "sha512-2N3jIJmHzPSEjoUIXKQGdzmyVjjWnafxr/GxTYE4BWfTO+mgdy/hdjFrQPPVSKlbvDA8NxkpOfX6pXnmnn9SVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "32.0.2"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override/node_modules/@codingame/monaco-vscode-extensions-service-override": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-32.0.2.tgz",
+      "integrity": "sha512-w81565arhmMxOL0UPviOi1eENwsCLUgbZA6A04LHlPYX/1AC/gxtEvhE65K7FnoQXqDpb0ibg9Ri28ga8L9TlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "32.0.2",
+        "@codingame/monaco-vscode-files-service-override": "32.0.2"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override/node_modules/@codingame/monaco-vscode-files-service-override": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-32.0.2.tgz",
+      "integrity": "sha512-kB/lvPQmLTo79rc7FQ1/3lSf6SWRkFImEZO+TfU0OpaKPfT4a7jT0xgPiDRuzBi2tH8EcHbb17YgAIHQAbWEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "32.0.2"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override/node_modules/@codingame/monaco-vscode-host-service-override": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-32.0.2.tgz",
+      "integrity": "sha512-v+JoXdWRnsXE1/EW2EbmrL459hd8aFvbXBQ2YfhZiFxq8m9MZTZk2Dx66mp6lh9w/+Q61BLPrt4wbHpdJB7O9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "32.0.2"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override/node_modules/@codingame/monaco-vscode-layout-service-override": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-32.0.2.tgz",
+      "integrity": "sha512-iYAxJaamDqdref6TMS4KyVn/nFAmMVz6x/35DNYGIOs1e55D8T5r1nIpCPCEZk21dDElHVycwD04I0GLDoTFVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "32.0.2"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-keybindings-service-override/node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-32.0.2.tgz",
+      "integrity": "sha512-7mOvuK5BwCs4g0JFg5mErQcGlo6C4S0iToKEZm0AadxxU5E+p2blphxaj5SdDcT5UsbMlariq69MyAdIzB8lig==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "32.0.2"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-detection-worker-service-override": {
@@ -2408,6 +2492,16 @@
         "@codingame/monaco-vscode-view-common-service-override": "28.4.1"
       }
     },
+    "node_modules/@codingame/monaco-vscode-views-service-override/node_modules/@codingame/monaco-vscode-keybindings-service-override": {
+      "version": "28.4.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-28.4.1.tgz",
+      "integrity": "sha512-3aHMncxPZrpdNbd6wLZXWQuAbq2JNocxxkSMMscTXIWSoE1gHuJfMwjUdIMGHKgxsIj19dOfyP5No9v5pZJ6vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.4.1",
+        "@codingame/monaco-vscode-files-service-override": "28.4.1"
+      }
+    },
     "node_modules/@codingame/monaco-vscode-welcome-service-override": {
       "version": "30.0.0",
       "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-welcome-service-override/-/monaco-vscode-welcome-service-override-30.0.0.tgz",
@@ -2513,6 +2607,16 @@
         "@codingame/monaco-vscode-view-common-service-override": "28.4.1",
         "@codingame/monaco-vscode-view-status-bar-service-override": "28.4.1",
         "@codingame/monaco-vscode-view-title-bar-service-override": "28.4.1"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-workbench-service-override/node_modules/@codingame/monaco-vscode-keybindings-service-override": {
+      "version": "28.4.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-28.4.1.tgz",
+      "integrity": "sha512-3aHMncxPZrpdNbd6wLZXWQuAbq2JNocxxkSMMscTXIWSoE1gHuJfMwjUdIMGHKgxsIj19dOfyP5No9v5pZJ6vA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "28.4.1",
+        "@codingame/monaco-vscode-files-service-override": "28.4.1"
       }
     },
     "node_modules/@codingame/monaco-vscode-working-copy-service-override": {

--- a/web/package.json
+++ b/web/package.json
@@ -95,6 +95,7 @@
     "@codingame/monaco-vscode-java-default-extension": "^28.4.1",
     "@codingame/monaco-vscode-javascript-default-extension": "^28.4.1",
     "@codingame/monaco-vscode-json-default-extension": "^28.4.1",
+    "@codingame/monaco-vscode-keybindings-service-override": "^32.0.2",
     "@codingame/monaco-vscode-language-detection-worker-service-override": "^30.0.0",
     "@codingame/monaco-vscode-languages-service-override": "^28.4.1",
     "@codingame/monaco-vscode-less-default-extension": "^30.0.0",

--- a/web/src/hooks/useBroadcastChannel.ts
+++ b/web/src/hooks/useBroadcastChannel.ts
@@ -7,13 +7,19 @@ interface BroadcastMessage<T = unknown> {
   sourceId: string;
 }
 
+function generateSourceId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
+  );
+}
+
 /**
  * Hook for cross-window communication using BroadcastChannel API.
  * Messages are automatically ignored from the same source.
  */
 export function useBroadcastChannel<T = unknown>(channelName: string) {
   const channelRef = useRef<BroadcastChannel | null>(null);
-  const sourceId = useRef(crypto.randomUUID());
+  const sourceId = useRef(generateSourceId());
   const listenersRef = useRef<Set<(msg: BroadcastMessage<T>) => void>>(new Set());
 
   useEffect(() => {

--- a/web/src/hooks/useWebSocket.test.ts
+++ b/web/src/hooks/useWebSocket.test.ts
@@ -173,18 +173,80 @@ describe('useWebSocket', () => {
     expect(latestSocket().send).toHaveBeenCalledWith(JSON.stringify(payload));
   });
 
-  // ---- 8. send/sendJson are no-ops when not connected ---------------------
+  // ---- 8. send/sendJson queue until connected -----------------------------
 
-  it('should not send when readyState is not OPEN', () => {
+  it('should queue outbound messages until the socket opens', () => {
     const { result } = renderHook(() => useWebSocket('ws://localhost:8080'));
 
-    // Socket is still in CONNECTING state, never opened
     act(() => {
-      result.current.send('should not go');
+      result.current.send('queued-string');
+    });
+
+    const payload = { should: 'queue' };
+    act(() => {
+      result.current.sendJson(payload);
+    });
+
+    expect(latestSocket().send).not.toHaveBeenCalled();
+
+    act(() => {
+      latestSocket().simulateOpen();
+    });
+
+    expect(latestSocket().send).toHaveBeenNthCalledWith(1, 'queued-string');
+    expect(latestSocket().send).toHaveBeenNthCalledWith(2, JSON.stringify(payload));
+  });
+
+  it('should flush queued messages after reconnect', () => {
+    const { result } = renderHook(() =>
+      useWebSocket('ws://localhost:8080', {
+        reconnect: true,
+        reconnectBaseDelay: 1000,
+      })
+    );
+
+    act(() => {
+      latestSocket().simulateOpen();
     });
 
     act(() => {
-      result.current.sendJson({ should: 'not go' });
+      latestSocket().simulateClose(1006, 'abnormal');
+    });
+
+    act(() => {
+      result.current.sendJson({ type: 'steer_active_turn', content: 'follow-up' });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(2);
+    expect(latestSocket().send).not.toHaveBeenCalled();
+
+    act(() => {
+      latestSocket().simulateOpen();
+    });
+
+    expect(latestSocket().send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'steer_active_turn', content: 'follow-up' })
+    );
+  });
+
+  it('should drop outbound messages while disconnected when queueing is disabled', () => {
+    const { result } = renderHook(() =>
+      useWebSocket('ws://localhost:8080', { queueWhenDisconnected: false })
+    );
+
+    act(() => {
+      result.current.send('do-not-queue');
+      result.current.sendJson({ type: 'do-not-queue' });
+    });
+
+    expect(latestSocket().send).not.toHaveBeenCalled();
+
+    act(() => {
+      latestSocket().simulateOpen();
     });
 
     expect(latestSocket().send).not.toHaveBeenCalled();

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -20,6 +20,8 @@ interface UseWebSocketOptions {
   reconnectBaseDelay?: number;
   /** Max delay in ms for exponential backoff (default: 30000) */
   reconnectMaxDelay?: number;
+  /** Whether to queue outbound messages while disconnected (default: true) */
+  queueWhenDisconnected?: boolean;
 }
 
 interface UseWebSocketReturn {
@@ -51,12 +53,14 @@ export function useWebSocket(
     maxReconnectAttempts = 10,
     reconnectBaseDelay = 1000,
     reconnectMaxDelay = 30000,
+    queueWhenDisconnected = true,
   } = options;
 
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const intentionalCloseRef = useRef(false);
+  const pendingMessagesRef = useRef<string[]>([]);
 
   // Keep latest callbacks in refs so we don't re-connect on callback changes
   const onOpenRef = useRef(onOpen);
@@ -85,6 +89,7 @@ export function useWebSocket(
   const maxReconnectAttemptsRef = useRef(maxReconnectAttempts);
   const reconnectBaseDelayRef = useRef(reconnectBaseDelay);
   const reconnectMaxDelayRef = useRef(reconnectMaxDelay);
+  const queueWhenDisconnectedRef = useRef(queueWhenDisconnected);
 
   useEffect(() => {
     reconnectRef.current = reconnect;
@@ -102,10 +107,26 @@ export function useWebSocket(
     reconnectMaxDelayRef.current = reconnectMaxDelay;
   }, [reconnectMaxDelay]);
 
+  useEffect(() => {
+    queueWhenDisconnectedRef.current = queueWhenDisconnected;
+  }, [queueWhenDisconnected]);
+
   const clearReconnectTimer = useCallback(() => {
     if (reconnectTimerRef.current !== null) {
       clearTimeout(reconnectTimerRef.current);
       reconnectTimerRef.current = null;
+    }
+  }, []);
+
+  const flushPendingMessages = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN || pendingMessagesRef.current.length === 0) {
+      return;
+    }
+
+    const pending = pendingMessagesRef.current.splice(0, pendingMessagesRef.current.length);
+    for (const message of pending) {
+      ws.send(message);
     }
   }, []);
 
@@ -142,6 +163,7 @@ export function useWebSocket(
 
       ws.onopen = () => {
         reconnectAttemptsRef.current = 0;
+        flushPendingMessages();
         onOpenRef.current?.();
       };
 
@@ -189,27 +211,49 @@ export function useWebSocket(
     return () => {
       intentionalCloseRef.current = true;
       clearReconnectTimer();
+      pendingMessagesRef.current = [];
       wsRef.current?.close();
       wsRef.current = null;
       reconnectAttemptsRef.current = 0;
     };
-  }, [url, clearReconnectTimer]);
+  }, [url, clearReconnectTimer, flushPendingMessages]);
 
-  const send = useCallback((data: string) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(data);
-    }
-  }, []);
+  const enqueueOrSend = useCallback(
+    (message: string) => {
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(message);
+        return;
+      }
+      if (!url || intentionalCloseRef.current) {
+        return;
+      }
+      if (!queueWhenDisconnectedRef.current) {
+        return;
+      }
+      pendingMessagesRef.current.push(message);
+    },
+    [url]
+  );
 
-  const sendJson = useCallback((data: unknown) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify(data));
-    }
-  }, []);
+  const send = useCallback(
+    (data: string) => {
+      enqueueOrSend(data);
+    },
+    [enqueueOrSend]
+  );
+
+  const sendJson = useCallback(
+    (data: unknown) => {
+      enqueueOrSend(JSON.stringify(data));
+    },
+    [enqueueOrSend]
+  );
 
   const close = useCallback(() => {
     intentionalCloseRef.current = true;
     clearReconnectTimer();
+    pendingMessagesRef.current = [];
     wsRef.current?.close();
   }, [clearReconnectTimer]);
 

--- a/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.module.css
+++ b/web/src/modules/shared/components/SessionChat/AgentDetailPanel/AgentDetailPanel.module.css
@@ -193,7 +193,7 @@
 }
 
 .eventItem[data-type='thought'] {
-  border-left: 2px solid var(--color-accent-purple);
+  border-left: 2px solid var(--color-brand);
 }
 
 .eventItem[data-type='tool_start'] {

--- a/web/src/modules/shared/components/SessionChat/ChatMessages.module.css
+++ b/web/src/modules/shared/components/SessionChat/ChatMessages.module.css
@@ -207,19 +207,19 @@
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-1) var(--space-3);
-  color: color-mix(in srgb, var(--color-accent-purple) 80%, var(--color-text-muted));
+  color: color-mix(in srgb, var(--color-brand) 80%, var(--color-text-muted));
   font-size: var(--text-xs);
   font-family: var(--font-sans);
-  background: color-mix(in srgb, var(--color-accent-purple) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 20%, transparent);
+  background: color-mix(in srgb, var(--color-brand) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-brand) 20%, transparent);
   border-radius: var(--radius-full);
   transition: all var(--transition-fast);
 }
 
 .reasoningTrigger:hover {
-  background: color-mix(in srgb, var(--color-accent-purple) 18%, transparent);
-  border-color: color-mix(in srgb, var(--color-accent-purple) 35%, transparent);
-  color: var(--color-accent-purple);
+  background: color-mix(in srgb, var(--color-brand) 18%, transparent);
+  border-color: color-mix(in srgb, var(--color-brand) 35%, transparent);
+  color: var(--color-brand);
 }
 
 .reasoningChevron {
@@ -232,7 +232,7 @@
   width: 12px;
   height: 12px;
   flex-shrink: 0;
-  color: var(--color-accent-purple);
+  color: var(--color-brand);
 }
 
 .reasoningLabel {
@@ -245,12 +245,12 @@
   margin-top: var(--space-2);
   padding: 10px 14px;
   border-radius: var(--radius-lg);
-  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 15%, transparent);
-  background-color: color-mix(in srgb, var(--color-accent-purple) 5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-brand) 15%, transparent);
+  background-color: color-mix(in srgb, var(--color-brand) 5%, transparent);
   max-height: 300px;
   overflow-y: auto;
   scrollbar-width: thin;
-  scrollbar-color: color-mix(in srgb, var(--color-accent-purple) 20%, transparent) transparent;
+  scrollbar-color: color-mix(in srgb, var(--color-brand) 20%, transparent) transparent;
 }
 
 .reasoningText {

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.module.css
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.module.css
@@ -6,6 +6,58 @@
   line-height: 1.625;
 }
 
+.summaryCard {
+  margin-top: var(--space-3);
+  margin-bottom: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--color-brand) 18%, var(--color-border-subtle));
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-brand) 7%, transparent),
+      color-mix(in srgb, var(--color-bg-primary) 86%, transparent)
+    ),
+    color-mix(in srgb, var(--color-bg-primary) 78%, var(--color-bg-secondary) 22%);
+}
+
+.summaryEyebrow {
+  margin-bottom: var(--space-2);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-faint);
+}
+
+.summaryBody {
+  color: var(--color-text-primary);
+}
+
+.summarySection {
+  margin-top: var(--space-4);
+}
+
+.summaryHeading {
+  margin-bottom: var(--space-2);
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-faint);
+}
+
+.summaryList {
+  margin: 0;
+  padding-left: var(--space-5);
+  list-style-type: disc;
+}
+
+.summaryListItem {
+  margin-top: var(--space-1);
+  margin-bottom: var(--space-1);
+}
+
 /* ── Paragraphs ──────────────────────────────────────────── */
 
 .paragraph {

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.test.tsx
@@ -223,6 +223,33 @@ describe('MarkdownContent', () => {
     // Code content should include line10
     expect(screen.getByText(/line10/)).toBeInTheDocument();
   });
+
+  it('renders archived summary JSON as a recap card', () => {
+    render(
+      <MarkdownContent
+        content={JSON.stringify({
+          summary: 'The assistant completed the task.',
+          key_changes: ['Updated the CLI transport', 'Verified steering end to end'],
+          unfinished_work: null,
+        })}
+      />
+    );
+
+    expect(screen.getByText('Session summary')).toBeInTheDocument();
+    expect(screen.getByText('The assistant completed the task.')).toBeInTheDocument();
+    expect(screen.getByText('Key changes')).toBeInTheDocument();
+    expect(screen.getByText('Updated the CLI transport')).toBeInTheDocument();
+    expect(screen.getByText('Verified steering end to end')).toBeInTheDocument();
+  });
+
+  it('leaves summary-like JSON with extra keys alone', () => {
+    const raw =
+      '{"summary":"Looks like a summary","key_changes":["one"],"extra":"should stay raw"}';
+    render(<MarkdownContent content={raw} />);
+
+    expect(screen.queryByText('Session summary')).not.toBeInTheDocument();
+    expect(screen.getByText(raw)).toBeInTheDocument();
+  });
 });
 
 /* ================================================================== */

--- a/web/src/modules/shared/components/SessionChat/MarkdownContent.tsx
+++ b/web/src/modules/shared/components/SessionChat/MarkdownContent.tsx
@@ -8,6 +8,12 @@ import styles from './MarkdownContent.module.css';
 
 const COLLAPSE_LINE_THRESHOLD = 25;
 
+interface ArchivedSummaryPayload {
+  readonly summary: string;
+  readonly key_changes?: readonly string[];
+  readonly unfinished_work?: readonly string[];
+}
+
 /* ------------------------------------------------------------------ */
 /*  Code block with copy button                                        */
 /* ------------------------------------------------------------------ */
@@ -129,6 +135,59 @@ interface MarkdownContentProps {
   className?: string;
 }
 
+function parseArchivedSummary(raw: string): ArchivedSummaryPayload | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    const allowed = new Set(['summary', 'key_changes', 'unfinished_work']);
+    if (!Object.keys(parsed).every(key => allowed.has(key))) {
+      return null;
+    }
+    if (typeof parsed.summary !== 'string' || !parsed.summary.trim()) {
+      return null;
+    }
+
+    const keyChanges =
+      Array.isArray(parsed.key_changes) &&
+      parsed.key_changes.every(item => typeof item === 'string' && item.trim().length > 0)
+        ? (parsed.key_changes as string[])
+        : undefined;
+
+    const unfinished =
+      parsed.unfinished_work === null || parsed.unfinished_work === undefined
+        ? undefined
+        : typeof parsed.unfinished_work === 'string'
+          ? parsed.unfinished_work.trim()
+            ? [parsed.unfinished_work]
+            : undefined
+          : Array.isArray(parsed.unfinished_work) &&
+              parsed.unfinished_work.every(
+                item => typeof item === 'string' && item.trim().length > 0
+              )
+            ? (parsed.unfinished_work as string[])
+            : undefined;
+
+    return {
+      summary: parsed.summary.trim(),
+      key_changes: keyChanges,
+      unfinished_work: unfinished,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function SummaryMarkdown({ content }: { content: string }) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+      {content}
+    </ReactMarkdown>
+  );
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const markdownComponents: Record<string, React.ComponentType<any>> = {
   p: ({ children }: { children?: React.ReactNode }) => (
@@ -207,6 +266,45 @@ export function MarkdownContent({ content, isStreaming, className }: MarkdownCon
           return <OutcomeCard key={`outcome-${i}`} yaml={match[1]} />;
         }
         if (!segment.trim()) return null;
+        const archivedSummary = parseArchivedSummary(segment);
+        if (archivedSummary) {
+          const unfinished =
+            archivedSummary.unfinished_work && archivedSummary.unfinished_work.length > 0
+              ? archivedSummary.unfinished_work
+              : null;
+          return (
+            <section key={`summary-${i}`} className={styles.summaryCard}>
+              <div className={styles.summaryEyebrow}>Session summary</div>
+              <div className={styles.summaryBody}>
+                <SummaryMarkdown content={archivedSummary.summary} />
+              </div>
+              {archivedSummary.key_changes && archivedSummary.key_changes.length > 0 && (
+                <div className={styles.summarySection}>
+                  <div className={styles.summaryHeading}>Key changes</div>
+                  <ul className={styles.summaryList}>
+                    {archivedSummary.key_changes.map(item => (
+                      <li key={item} className={styles.summaryListItem}>
+                        <SummaryMarkdown content={item} />
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {unfinished && (
+                <div className={styles.summarySection}>
+                  <div className={styles.summaryHeading}>Unfinished work</div>
+                  <ul className={styles.summaryList}>
+                    {unfinished.map(item => (
+                      <li key={item} className={styles.summaryListItem}>
+                        <SummaryMarkdown content={item} />
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </section>
+          );
+        }
         return (
           <ReactMarkdown
             key={`md-${i}`}

--- a/web/src/modules/shared/components/SessionChat/SessionChat.module.css
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.module.css
@@ -179,8 +179,8 @@
 }
 
 .thinkingOption:hover {
-  background-color: color-mix(in srgb, var(--color-accent-purple) 15%, transparent);
-  color: var(--color-accent-purple);
+  background-color: color-mix(in srgb, var(--color-brand) 15%, transparent);
+  color: var(--color-brand);
 }
 
 /* ── Model Input Bar ─────────────────────────────────────── */
@@ -209,7 +209,7 @@
 }
 
 .modelInput:focus {
-  border-color: color-mix(in srgb, var(--color-accent-purple) 60%, transparent);
+  border-color: color-mix(in srgb, var(--color-brand) 60%, transparent);
 }
 
 .modelInput::placeholder {
@@ -218,10 +218,10 @@
 
 .modelSubmitBtn {
   padding: var(--space-1) var(--space-3);
-  border: 1px solid color-mix(in srgb, var(--color-accent-purple) 40%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-brand) 40%, transparent);
   border-radius: var(--radius-sm);
-  background-color: color-mix(in srgb, var(--color-accent-purple) 15%, transparent);
-  color: var(--color-accent-purple);
+  background-color: color-mix(in srgb, var(--color-brand) 15%, transparent);
+  color: var(--color-brand);
   font-size: var(--text-xs);
   font-weight: 500;
   font-family: var(--font-sans);
@@ -230,8 +230,8 @@
 }
 
 .modelSubmitBtn:hover {
-  background-color: color-mix(in srgb, var(--color-accent-purple) 25%, transparent);
-  border-color: color-mix(in srgb, var(--color-accent-purple) 60%, transparent);
+  background-color: color-mix(in srgb, var(--color-brand) 25%, transparent);
+  border-color: color-mix(in srgb, var(--color-brand) 60%, transparent);
 }
 
 /* ── History Loading ─────────────────────────────────────── */

--- a/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.test.tsx
@@ -221,20 +221,34 @@ describe('SessionChat', () => {
     mockSkuldChat();
     render(<SessionChat url="wss://my-host/session" />);
 
-    expect(useSkuldChat).toHaveBeenCalledWith('wss://my-host/session', {
-      historyEndpoint: null,
-      cacheKey: 'wss://my-host/session',
-    });
+    expect(useSkuldChat).toHaveBeenCalledWith(
+      'wss://my-host/session',
+      expect.objectContaining({
+        historyEndpoint: null,
+        cacheKey: 'wss://my-host/session',
+        hydrateFromCache: false,
+        persistCache: false,
+        reconcileConversationHistory: false,
+        queueOutgoingWhileDisconnected: false,
+      })
+    );
   });
 
   it('passes null url to useSkuldChat', () => {
     mockSkuldChat();
     render(<SessionChat url={null} />);
 
-    expect(useSkuldChat).toHaveBeenCalledWith(null, {
-      historyEndpoint: null,
-      cacheKey: null,
-    });
+    expect(useSkuldChat).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        historyEndpoint: null,
+        cacheKey: null,
+        hydrateFromCache: true,
+        persistCache: true,
+        reconcileConversationHistory: true,
+        queueOutgoingWhileDisconnected: true,
+      })
+    );
   });
 
   it('passes history endpoint through to useSkuldChat', () => {
@@ -246,10 +260,17 @@ describe('SessionChat', () => {
       />
     );
 
-    expect(useSkuldChat).toHaveBeenCalledWith(null, {
-      historyEndpoint: '/api/v1/volundr/sessions/test-session/conversation',
-      cacheKey: '/api/v1/volundr/sessions/test-session/conversation',
-    });
+    expect(useSkuldChat).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        historyEndpoint: '/api/v1/volundr/sessions/test-session/conversation',
+        cacheKey: '/api/v1/volundr/sessions/test-session/conversation',
+        hydrateFromCache: true,
+        persistCache: true,
+        reconcileConversationHistory: true,
+        queueOutgoingWhileDisconnected: true,
+      })
+    );
   });
 
   it('renders the chat input', () => {

--- a/web/src/modules/shared/components/SessionChat/SessionChat.tsx
+++ b/web/src/modules/shared/components/SessionChat/SessionChat.tsx
@@ -83,7 +83,14 @@ export function SessionChat({
     clearMessages,
     availableCommands,
     capabilities,
-  } = useSkuldChat(url, { historyEndpoint, cacheKey: historyEndpoint ?? url });
+  } = useSkuldChat(url, {
+    historyEndpoint,
+    cacheKey: historyEndpoint ?? url,
+    hydrateFromCache: !url,
+    persistCache: !url,
+    reconcileConversationHistory: !url,
+    queueOutgoingWhileDisconnected: !url,
+  });
 
   const {
     isRoomMode,
@@ -475,7 +482,7 @@ export function SessionChat({
               type="button"
               className={cn(styles.controlBtn, showInternal && styles.controlBtnActive)}
               onClick={toggleInternal}
-              title={showInternal ? 'Hide tool calls and results' : 'Show tool calls and results'}
+              title={showInternal ? 'Hide internal messages' : 'Show internal messages'}
               aria-pressed={showInternal}
               data-testid="internal-toggle"
             >

--- a/web/src/modules/shared/hooks/useRoomState.test.ts
+++ b/web/src/modules/shared/hooks/useRoomState.test.ts
@@ -166,16 +166,23 @@ describe('useRoomState', () => {
     });
   });
 
-  describe('passthrough in single-agent mode', () => {
+  describe('single-agent internal filtering', () => {
     const singleParticipant = makeParticipantsMap([makeParticipant()]);
     const messages = [
       makeMessage({ id: 'msg-1', visibility: 'internal' }),
       makeMessage({ id: 'msg-2', visibility: 'public' }),
     ];
 
-    it('returns all messages unfiltered when not room mode', () => {
+    it('hides internal messages until showInternal is enabled', () => {
       const { result } = renderHook(() => useRoomState(messages, singleParticipant));
-      expect(result.current.filteredMessages).toHaveLength(2);
+
+      expect(result.current.filteredMessages.map(m => m.id)).toEqual(['msg-2']);
+
+      act(() => {
+        result.current.toggleInternal();
+      });
+
+      expect(result.current.filteredMessages.map(m => m.id)).toEqual(['msg-1', 'msg-2']);
     });
   });
 

--- a/web/src/modules/shared/hooks/useRoomState.ts
+++ b/web/src/modules/shared/hooks/useRoomState.ts
@@ -74,7 +74,7 @@ export function useRoomState(
   const filteredMessages = useMemo<readonly SkuldChatMessage[]>(() => {
     const out: SkuldChatMessage[] = [];
     for (const msg of messages) {
-      if (isRoomMode && !showInternal && msg.visibility === 'internal') continue;
+      if (!showInternal && msg.visibility === 'internal') continue;
       if (isRoomMode && activeFilter !== FILTER_ALL && msg.participantId !== activeFilter) {
         continue;
       }

--- a/web/src/modules/shared/hooks/useSkuldChat.test.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.test.ts
@@ -70,11 +70,11 @@ function setupMock() {
 
 // ── Helpers to build Claude CLI stream-json events ──────────
 
-function assistantEvent(model = 'claude-sonnet-4-5-20250514', inputTokens = 100) {
+function assistantEvent(model = 'claude-sonnet-4-5-20250514', inputTokens = 100, id = 'msg_test') {
   return JSON.stringify({
     type: 'assistant',
     message: {
-      id: 'msg_test',
+      id,
       role: 'assistant',
       model,
       content: [],
@@ -458,6 +458,7 @@ describe('useSkuldChat', () => {
     expect(result.current.messages[0].content).toBe(
       'Session initialized · claude-sonnet-4-5-20250929 · 5 tools'
     );
+    expect(result.current.messages[0].visibility).toBe('internal');
     expect(result.current.messages[0].metadata?.messageType).toBe('system');
     expect(result.current.messages[0].metadata?.systemSubtype).toBe('init');
   });
@@ -1765,6 +1766,57 @@ describe('useSkuldChat', () => {
       vi.unstubAllGlobals();
     });
 
+    it('does not merge cached local user messages into a stopped-session transcript', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            turns: [
+              {
+                id: 'turn-1',
+                role: 'assistant',
+                content: 'Saved transcript answer',
+                parts: [],
+                created_at: '2026-05-15T12:00:00Z',
+                metadata: {},
+              },
+            ],
+            is_active: false,
+            last_activity: '',
+          }),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const { storeMock } = setupMock();
+      storeMock.getMessages.mockReturnValue([
+        {
+          id: 'cached-user',
+          role: 'user',
+          content: 'Locally echoed prompt',
+          createdAt: new Date('2026-05-15T12:05:00Z'),
+          status: 'complete',
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        useSkuldChat(null, {
+          historyEndpoint: '/api/v1/volundr/sessions/test-session/conversation',
+          cacheKey: '/api/v1/volundr/sessions/test-session/conversation',
+          hydrateFromCache: true,
+          persistCache: true,
+        })
+      );
+
+      await vi.waitFor(() => {
+        expect(result.current.historyLoaded).toBe(true);
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0].content).toBe('Saved transcript answer');
+
+      vi.unstubAllGlobals();
+    });
+
     it('falls back to sessionStorage on fetch failure', async () => {
       const fetchMock = vi.fn().mockRejectedValue(new Error('Network error'));
       vi.stubGlobal('fetch', fetchMock);
@@ -1789,6 +1841,35 @@ describe('useSkuldChat', () => {
       // Should have used cached messages
       expect(result.current.messages).toHaveLength(1);
       expect(result.current.messages[0].content).toBe('Cached message');
+
+      vi.unstubAllGlobals();
+    });
+
+    it('does not fall back to sessionStorage when cache hydration is disabled', async () => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error('Network error'));
+      vi.stubGlobal('fetch', fetchMock);
+
+      const { storeMock } = setupMock();
+      storeMock.getMessages.mockReturnValue([
+        {
+          id: 'cached-disabled-1',
+          role: 'assistant',
+          content: 'Should stay hidden',
+          createdAt: new Date(),
+          status: 'complete',
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        useSkuldChat('wss://test-host/session', { hydrateFromCache: false })
+      );
+
+      await vi.waitFor(() => {
+        expect(result.current.historyLoaded).toBe(true);
+      });
+
+      expect(result.current.messages).toEqual([]);
+      expect(storeMock.getMessages).not.toHaveBeenCalled();
 
       vi.unstubAllGlobals();
     });
@@ -2003,14 +2084,14 @@ describe('useSkuldChat', () => {
     act(() => handlers.onOpen?.());
 
     // First assistant turn
-    act(() => handlers.onMessage?.(assistantEvent('claude-sonnet-4-5-20250514', 100)));
+    act(() => handlers.onMessage?.(assistantEvent('claude-sonnet-4-5-20250514', 100, 'msg_1')));
     act(() => handlers.onMessage?.(contentBlockDelta('First response')));
 
     expect(result.current.messages).toHaveLength(1);
     expect(result.current.messages[0].status).toBe('running');
 
     // Second assistant event arrives without a result event for the first
-    act(() => handlers.onMessage?.(assistantEvent('claude-sonnet-4-5-20250514', 200)));
+    act(() => handlers.onMessage?.(assistantEvent('claude-sonnet-4-5-20250514', 200, 'msg_2')));
 
     // First message should be finalized
     expect(result.current.messages[0].status).toBe('complete');
@@ -2019,6 +2100,35 @@ describe('useSkuldChat', () => {
     // Second message should be running
     expect(result.current.messages).toHaveLength(2);
     expect(result.current.messages[1].status).toBe('running');
+  });
+
+  it('merges a same-id assistant snapshot into the active streaming message', () => {
+    const { handlers } = setupMock();
+    const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+    act(() => handlers.onOpen?.());
+    act(() => handlers.onMessage?.(assistantEvent('claude-sonnet-4-5-20250514', 100, 'msg_same')));
+    act(() => handlers.onMessage?.(contentBlockStart(0, 'text')));
+    act(() => handlers.onMessage?.(contentBlockDelta('Streaming text')));
+
+    act(() =>
+      handlers.onMessage?.(
+        JSON.stringify({
+          type: 'assistant',
+          message: {
+            id: 'msg_same',
+            role: 'assistant',
+            model: 'claude-sonnet-4-5-20250514',
+            content: [{ type: 'text', text: 'Streaming text' }],
+            usage: { input_tokens: 100, output_tokens: 12 },
+          },
+        })
+      )
+    );
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].status).toBe('running');
+    expect(result.current.messages[0].content).toBe('Streaming text');
   });
 
   it('handles result event with is_error and result text', () => {
@@ -2097,6 +2207,82 @@ describe('useSkuldChat', () => {
     act(() => handlers.onMessage?.(JSON.stringify({ type: 'user_confirmed' })));
 
     expect(result.current.messages).toEqual([]);
+  });
+
+  it('reconciles conversation_history events into visible messages', () => {
+    const { handlers } = setupMock();
+    const { result } = renderHook(() => useSkuldChat('wss://test/session'));
+
+    act(() => handlers.onOpen?.());
+
+    act(() =>
+      handlers.onMessage?.(
+        JSON.stringify({
+          type: 'conversation_history',
+          turns: [
+            {
+              id: 'turn-1',
+              role: 'user',
+              content: 'Start the search',
+              parts: [],
+              created_at: '2026-05-16T23:00:00.000Z',
+              metadata: {},
+            },
+            {
+              id: 'turn-2',
+              role: 'assistant',
+              content: 'Searching now',
+              parts: [],
+              created_at: '2026-05-16T23:00:01.000Z',
+              metadata: {},
+            },
+          ],
+        })
+      )
+    );
+
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.messages[0].content).toBe('Start the search');
+    expect(result.current.messages[1].content).toBe('Searching now');
+  });
+
+  it('ignores conversation_history events when reconciliation is disabled', () => {
+    const { handlers } = setupMock();
+    const { result } = renderHook(() =>
+      useSkuldChat('wss://test/session', { reconcileConversationHistory: false })
+    );
+
+    act(() => handlers.onOpen?.());
+    act(() => result.current.sendMessage('Newest prompt'));
+
+    act(() =>
+      handlers.onMessage?.(
+        JSON.stringify({
+          type: 'conversation_history',
+          turns: [
+            {
+              id: 'turn-old-1',
+              role: 'user',
+              content: 'Old prompt',
+              parts: [],
+              created_at: '2026-05-16T22:00:00.000Z',
+              metadata: {},
+            },
+            {
+              id: 'turn-old-2',
+              role: 'assistant',
+              content: 'Old answer',
+              parts: [],
+              created_at: '2026-05-16T22:00:01.000Z',
+              metadata: {},
+            },
+          ],
+        })
+      )
+    );
+
+    expect(result.current.messages).toHaveLength(1);
+    expect(result.current.messages[0].content).toBe('Newest prompt');
   });
 
   // ── Capabilities ────────────────────────────────────────────

--- a/web/src/modules/shared/hooks/useSkuldChat.ts
+++ b/web/src/modules/shared/hooks/useSkuldChat.ts
@@ -17,7 +17,16 @@ interface CliStreamEvent {
     id?: string;
     role?: string;
     model?: string;
-    content?: Array<{ type: string; text?: string }>;
+    content?: Array<{
+      type: string;
+      text?: string;
+      thinking?: string;
+      id?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+      tool_use_id?: string;
+      content?: string;
+    }>;
     usage?: { input_tokens?: number; output_tokens?: number };
   };
 
@@ -216,6 +225,14 @@ interface UseSkuldChatOptions {
   historyEndpoint?: string | null;
   /** Optional storage key for persisted chat state */
   cacheKey?: string | null;
+  /** Whether to hydrate the initial state from session storage */
+  hydrateFromCache?: boolean;
+  /** Whether to persist chat state into session storage */
+  persistCache?: boolean;
+  /** Whether to reconcile server-pushed conversation history events */
+  reconcileConversationHistory?: boolean;
+  /** Whether websocket sends may queue while the socket is disconnected */
+  queueOutgoingWhileDisconnected?: boolean;
 }
 
 interface ConversationTurn {
@@ -229,6 +246,24 @@ interface ConversationTurn {
   participant_meta?: Record<string, unknown>;
   thread_id?: string;
   visibility?: string;
+}
+
+function mergeServerTurnsWithLocal(
+  serverTurns: ConversationTurn[],
+  localMessages: SkuldChatMessage[]
+): SkuldChatMessage[] {
+  const serverMessages = transformTurns(serverTurns);
+  const lastServerTime =
+    serverMessages.length > 0 ? serverMessages[serverMessages.length - 1].createdAt.getTime() : 0;
+
+  const localPending = localMessages.filter(message => {
+    if (message.status === 'running') {
+      return true;
+    }
+    return message.role === 'user' && message.createdAt.getTime() > lastServerTime;
+  });
+
+  return [...serverMessages, ...localPending];
 }
 
 /**
@@ -378,6 +413,58 @@ function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function assistantBlocksToParts(
+  blocks:
+    | Array<{
+        type: string;
+        text?: string;
+        thinking?: string;
+        id?: string;
+        name?: string;
+        input?: Record<string, unknown>;
+        tool_use_id?: string;
+        content?: string;
+      }>
+    | undefined
+): SkuldChatMessagePart[] {
+  if (!Array.isArray(blocks)) {
+    return [];
+  }
+  const parts: SkuldChatMessagePart[] = [];
+  for (const block of blocks) {
+    if (!block || typeof block !== 'object') continue;
+    if (block.type === 'text' && typeof block.text === 'string' && block.text) {
+      parts.push({ type: 'text', text: block.text });
+      continue;
+    }
+    if (block.type === 'thinking' && typeof block.thinking === 'string' && block.thinking) {
+      parts.push({ type: 'reasoning', text: block.thinking });
+      continue;
+    }
+    if (
+      block.type === 'tool_use' &&
+      typeof block.id === 'string' &&
+      typeof block.name === 'string'
+    ) {
+      parts.push({
+        type: 'tool_use',
+        id: block.id,
+        name: block.name,
+        input: (block.input ?? {}) as Record<string, unknown>,
+      });
+      continue;
+    }
+    if (block.type === 'tool_result' && typeof block.tool_use_id === 'string') {
+      parts.push({
+        type: 'tool_result',
+        tool_use_id: block.tool_use_id,
+        content: typeof block.content === 'string' ? block.content : '',
+      });
+    }
+  }
+  return parts;
+}
+
 /**
  * Manages a Skuld chat session over WebSocket.
  *
@@ -398,6 +485,10 @@ export function useSkuldChat(
     onDisconnect,
     historyEndpoint = null,
     cacheKey = historyEndpoint ?? url,
+    hydrateFromCache = true,
+    persistCache = true,
+    reconcileConversationHistory = true,
+    queueOutgoingWhileDisconnected = true,
   } = options;
 
   const {
@@ -409,7 +500,7 @@ export function useSkuldChat(
   } = useChatStore();
 
   const [messages, setMessages] = useState<SkuldChatMessage[]>(() => {
-    if (!cacheKey) return [];
+    if (!cacheKey || !hydrateFromCache) return [];
     return getMessages(cacheKey);
   });
   const [participants, setParticipants] = useState<Map<string, RoomParticipant>>(new Map());
@@ -427,7 +518,7 @@ export function useSkuldChat(
   }
   const internalStreamsRef = useRef<Map<string, InternalStreamState>>(new Map());
   const [meshEvents, setMeshEvents] = useState<MeshEvent[]>(() => {
-    if (!cacheKey) return [];
+    if (!cacheKey || !hydrateFromCache) return [];
     return getStoredMeshEvents(cacheKey);
   });
   const [agentEvents, setAgentEvents] = useState<Map<string, AgentInternalEvent[]>>(new Map());
@@ -440,7 +531,6 @@ export function useSkuldChat(
   // REST endpoint changes, historyLoadedForKey will no longer match.
   const [historyLoadedForKey, setHistoryLoadedForKey] = useState<string | null>(null);
   const historyLoaded = historyLoadedForKey === cacheKey;
-
   // Fetch conversation history from server on mount/reconnect
   useEffect(() => {
     if (!cacheKey || historyLoaded) return;
@@ -460,7 +550,13 @@ export function useSkuldChat(
       })();
 
     if (!resolvedHistoryUrl) {
-      // Cannot derive HTTP URL — schedule fallback to sessionStorage
+      // Cannot derive HTTP URL — optionally fall back to sessionStorage
+      if (!hydrateFromCache) {
+        const timer = setTimeout(() => {
+          setHistoryLoadedForKey(cacheKey);
+        }, 0);
+        return () => clearTimeout(timer);
+      }
       const timer = setTimeout(() => {
         const cached = getMessages(cacheKey);
         if (cached.length) setMessages(cached);
@@ -485,15 +581,19 @@ export function useSkuldChat(
         const isActive = data.is_active === true;
         const lastActivity = data.last_activity ?? '';
         setMessages(prev => {
-          // Server history is authoritative. Only keep local messages
-          // that were added AFTER the last server message (i.e. messages
-          // the user typed that haven't been recorded server-side yet).
-          const lastServerTime =
-            serverMsgs.length > 0 ? serverMsgs[serverMsgs.length - 1].createdAt.getTime() : 0;
-          const localOnly = prev.filter(
-            m => m.role === 'user' && m.createdAt.getTime() > lastServerTime
-          );
-          const merged = [...serverMsgs, ...localOnly];
+          // For active sessions, keep user messages typed after the last
+          // server turn so reconnects do not drop in-flight prompts.
+          // For stopped sessions, the saved transcript is authoritative and
+          // must not be polluted by cached local echoes from earlier views.
+          const merged = [...serverMsgs];
+          if (isActive || Boolean(url)) {
+            const lastServerTime =
+              serverMsgs.length > 0 ? serverMsgs[serverMsgs.length - 1].createdAt.getTime() : 0;
+            const localOnly = prev.filter(
+              m => m.role === 'user' && m.createdAt.getTime() > lastServerTime
+            );
+            merged.push(...localOnly);
+          }
           // If session is actively working, add a placeholder running message
           if (isActive && lastActivity) {
             merged.push({
@@ -511,28 +611,30 @@ export function useSkuldChat(
       })
       .catch(() => {
         if (cancelled) return;
-        // Fallback to sessionStorage cache
-        const cached = getMessages(cacheKey);
-        if (cached.length) setMessages(cached);
+        // Optional fallback to sessionStorage cache
+        if (hydrateFromCache) {
+          const cached = getMessages(cacheKey);
+          if (cached.length) setMessages(cached);
+        }
         setHistoryLoadedForKey(cacheKey);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [cacheKey, getMessages, historyEndpoint, historyLoaded, url]);
+  }, [cacheKey, getMessages, historyEndpoint, historyLoaded, hydrateFromCache, url]);
 
   // Persist messages to Zustand sessionStorage store on every change
   useEffect(() => {
-    if (!cacheKey) return;
+    if (!cacheKey || !persistCache) return;
     persistMessages(cacheKey, messages);
-  }, [cacheKey, messages, persistMessages]);
+  }, [cacheKey, messages, persistCache, persistMessages]);
 
   // Persist mesh events alongside messages
   useEffect(() => {
-    if (!cacheKey) return;
+    if (!cacheKey || !persistCache) return;
     persistMeshEvents(cacheKey, meshEvents);
-  }, [cacheKey, meshEvents, persistMeshEvents]);
+  }, [cacheKey, meshEvents, persistCache, persistMeshEvents]);
 
   // Streaming state refs (not in React state to avoid render churn)
   const streamingIdRef = useRef<string | null>(null);
@@ -544,6 +646,7 @@ export function useSkuldChat(
   const streamingToolJsonRef = useRef('');
   const streamingToolNameRef = useRef('');
   const streamingToolIdRef = useRef('');
+  const streamingAssistantMessageIdRef = useRef<string | null>(null);
 
   const resetStreamingRefs = useCallback(() => {
     streamingIdRef.current = null;
@@ -555,6 +658,7 @@ export function useSkuldChat(
     streamingToolJsonRef.current = '';
     streamingToolNameRef.current = '';
     streamingToolIdRef.current = '';
+    streamingAssistantMessageIdRef.current = null;
   }, []);
 
   const handleOpen = useCallback(() => {
@@ -613,7 +717,51 @@ export function useSkuldChat(
 
         // ── assistant: start of a new assistant turn ──────────────
         if (eventType === 'assistant') {
-          // Finalize any previous in-flight message before starting a new one
+          const assistantParts = assistantBlocksToParts(event.message?.content);
+          const initialContent =
+            event.message?.content
+              ?.filter(c => c.type === 'text' && c.text)
+              .map(c => c.text)
+              .join('') ?? '';
+          const assistantMessageId = event.message?.id ?? null;
+          let finalizePrevious: {
+            id: string;
+            text: string;
+            parts?: SkuldChatMessagePart[];
+            metadata: ChatMessageMeta;
+          } | null = null;
+
+          if (
+            streamingIdRef.current &&
+            assistantMessageId &&
+            streamingAssistantMessageIdRef.current === assistantMessageId
+          ) {
+            streamingTextRef.current = initialContent || streamingTextRef.current;
+            streamingModelRef.current = event.message?.model ?? streamingModelRef.current;
+            streamingInputTokensRef.current =
+              event.message?.usage?.input_tokens ?? streamingInputTokensRef.current;
+            streamingOutputTokensRef.current =
+              event.message?.usage?.output_tokens ?? streamingOutputTokensRef.current;
+            if (assistantParts.length > 0) {
+              streamingPartsRef.current = assistantParts;
+            }
+            const id = streamingIdRef.current;
+            const currentParts =
+              streamingPartsRef.current.length > 0 ? [...streamingPartsRef.current] : undefined;
+            setMessages(prev =>
+              prev.map(m =>
+                m.id === id
+                  ? {
+                      ...m,
+                      content: streamingTextRef.current,
+                      parts: currentParts,
+                    }
+                  : m
+              )
+            );
+            continue;
+          }
+
           if (streamingIdRef.current) {
             const prevId = streamingIdRef.current;
             const prevText = streamingTextRef.current;
@@ -630,54 +778,59 @@ export function useSkuldChat(
                   }
                 : undefined,
             };
-            if (prevText.trim()) {
-              // Has content — finalize as complete message
-              setMessages(prev =>
-                prev.map(m =>
-                  m.id === prevId
-                    ? {
-                        ...m,
-                        content: prevText,
-                        parts: prevParts,
-                        status: 'complete' as const,
-                        metadata: prevMeta,
-                      }
-                    : m
-                )
-              );
-            } else {
-              // Empty content (only thinking/tool calls) — remove to avoid clutter
-              setMessages(prev => prev.filter(m => m.id !== prevId));
-            }
+            finalizePrevious = prevText.trim()
+              ? {
+                  id: prevId,
+                  text: prevText,
+                  parts: prevParts,
+                  metadata: prevMeta,
+                }
+              : {
+                  id: prevId,
+                  text: '',
+                  metadata: prevMeta,
+                };
             resetStreamingRefs();
           }
-
-          // Extract any initial text content from the assistant event's message
-          const initialContent =
-            event.message?.content
-              ?.filter(c => c.type === 'text' && c.text)
-              .map(c => c.text)
-              .join('') ?? '';
 
           streamingTextRef.current = initialContent;
           streamingModelRef.current = event.message?.model ?? '';
           streamingInputTokensRef.current = event.message?.usage?.input_tokens ?? 0;
           streamingOutputTokensRef.current = event.message?.usage?.output_tokens ?? 0;
+          streamingPartsRef.current = assistantParts;
+          streamingAssistantMessageIdRef.current = assistantMessageId;
 
           const id = generateId();
           streamingIdRef.current = id;
           setIsRunning(true);
-          setMessages(prev => [
-            // Remove any activity indicator placeholder
-            ...prev.filter(m => m.id !== 'activity-indicator'),
-            {
+          setMessages(prev => {
+            let next = prev.filter(m => m.id !== 'activity-indicator');
+            if (finalizePrevious) {
+              if (finalizePrevious.text) {
+                next = next.map(m =>
+                  m.id === finalizePrevious!.id
+                    ? {
+                        ...m,
+                        content: finalizePrevious!.text,
+                        parts: finalizePrevious!.parts,
+                        status: 'complete' as const,
+                        metadata: finalizePrevious!.metadata,
+                      }
+                    : m
+                );
+              } else {
+                next = next.filter(m => m.id !== finalizePrevious!.id);
+              }
+            }
+            next.push({
               id,
               role: 'assistant',
               content: initialContent,
               createdAt: new Date(),
               status: 'running',
-            },
-          ]);
+            });
+            return next;
+          });
           continue;
         }
 
@@ -970,6 +1123,18 @@ export function useSkuldChat(
           continue;
         }
 
+        // ── conversation_history: reconcile after reconnect/startup ──
+        if (eventType === 'conversation_history') {
+          if (!reconcileConversationHistory) {
+            continue;
+          }
+          const turns = Array.isArray((event as unknown as { turns?: unknown[] }).turns)
+            ? ((event as unknown as { turns: ConversationTurn[] }).turns ?? [])
+            : [];
+          setMessages(prev => mergeServerTurnsWithLocal(turns, prev));
+          continue;
+        }
+
         // ── user_confirmed: broker echo confirming message reached session ──
         if (eventType === 'user_confirmed') {
           // The broker confirmed the message was sent to the CLI.
@@ -1026,6 +1191,7 @@ export function useSkuldChat(
               content,
               createdAt: new Date(),
               status: 'complete',
+              visibility: 'internal',
               metadata: { messageType: 'system', systemSubtype: subtype || 'info' },
             },
           ]);
@@ -1400,7 +1566,7 @@ export function useSkuldChat(
         // ── message_start, message_stop — silently consumed ──────
       } // end for (const event of events)
     },
-    [parseEvent, resetStreamingRefs]
+    [parseEvent, reconcileConversationHistory, resetStreamingRefs]
   );
 
   const handleClose = useCallback(() => {
@@ -1445,6 +1611,7 @@ export function useSkuldChat(
     onMessage: handleMessage,
     onClose: handleClose,
     onError: handleError,
+    queueWhenDisconnected: queueOutgoingWhileDisconnected,
   });
 
   const sendMessage = useCallback(

--- a/web/src/modules/volundr/pages/Volundr/VolundrPopout.tsx
+++ b/web/src/modules/volundr/pages/Volundr/VolundrPopout.tsx
@@ -262,6 +262,7 @@ export function VolundrPopout() {
             <SessionStartingIndicator className={styles.fullPanel} />
           ) : conversationEndpoint ? (
             <SessionChat
+              key={conversationEndpoint ?? session.id}
               url={chatWsUrl}
               historyEndpoint={conversationEndpoint}
               className={styles.fullPanel}

--- a/web/src/modules/volundr/pages/Volundr/index.tsx
+++ b/web/src/modules/volundr/pages/Volundr/index.tsx
@@ -1239,6 +1239,7 @@ export function VolundrPage() {
                 <SessionStartingIndicator className={styles.tabPanel} />
               ) : conversationEndpoint ? (
                 <SessionChat
+                  key={conversationEndpoint ?? effectiveSelectedSession.id}
                   url={chatWsUrl}
                   historyEndpoint={conversationEndpoint}
                   className={styles.tabPanel}


### PR DESCRIPTION
## Summary
- backport steerable Codex and Claude sessions into the old Volundr UI
- switch old Claude defaults to the Python SDK transport and carry steer/redirect support through Skuld and Ravn
- restore old stopped-session transcript replay, internal-message filtering, summary rendering, and live chat state handling

## Validation
- uv run pytest tests/test_skuld/test_broker.py tests/test_skuld/test_codex_ws_transport.py tests/test_domain/test_forge_service.py tests/test_volundr/test_session_definition_contributor.py tests/test_charts/test_volundr_chart.py -q
- cd web && npm run test -- --run src/modules/shared/hooks/useSkuldChat.test.ts src/modules/shared/hooks/useRoomState.test.ts src/modules/shared/components/SessionChat/MarkdownContent.test.tsx src/hooks/useWebSocket.test.ts src/modules/volundr/pages/Volundr/Volundr.test.tsx
- make build-web
- ./stop-dev && ./start-dev --ui old