### PR TITLE
[codex] Emit Mimir dream completion events in runner

### DIFF
--- a/ravn.example.yaml
+++ b/ravn.example.yaml
@@ -110,7 +110,7 @@ recap:
 #   3. Audit and update compiled truth pages
 #   4. Run mimir_lint --fix for auto-fixable issues
 #   5. Add missing cross-reference links
-#   6. Write log entry and emit mimir.dream.completed event
+#   6. Write log entry; runner emits mimir.dream.completed event
 #
 # Idempotent: running twice in a row produces no additional changes.
 # ---------------------------------------------------------------------------

--- a/src/ravn/adapters/triggers/dream_cycle.py
+++ b/src/ravn/adapters/triggers/dream_cycle.py
@@ -9,7 +9,7 @@ to run an end-to-end knowledge-base maintenance pass:
 4. Auto-fix safe lint issues via ``mimir_lint --fix``.
 5. Cross-reference pages that mention the same entities without links.
 6. Write a dream cycle log entry to ``wiki/log.md``.
-7. Emit a ``mimir.dream.completed`` Sleipnir event with summary counts.
+7. Return summary counts; the drive loop emits ``mimir.dream.completed``.
 
 State is persisted to ``<state_dir>/dream_cycle_state.json`` so the
 ``last_dream_at`` timestamp survives daemon restarts.  Running the dream
@@ -162,12 +162,13 @@ class DreamCycleTrigger(TriggerPort):
             f"Search for pages that mention the same entities as the updated pages but "
             f"lack wikilinks to them.  Add the missing links via `mimir_write`.\n"
             f"\n"
-            f"**Step 7 — Log and emit**\n"
+            f"**Step 7 — Log and finish**\n"
             f"Append a dream cycle summary entry to `wiki/log.md` with: timestamp, "
             f"`ravn={warden_id}`, pages_updated count, entities_created count, "
             f"lint_fixes count.\n"
-            f"Then call `sleipnir_publish` to emit a `mimir.dream.completed` event "
-            f"with those three counts.\n"
+            f"Do not call `sleipnir_publish`; the runner emits `mimir.dream.completed` "
+            f"automatically from your final outcome. Include `pages_updated`, "
+            f"`entities_created`, and `lint_fixes` as integer fields in the outcome block.\n"
             f"\n"
             f"Stay within the token budget.  If budget is running low before all steps "
             f"are done, skip Step 6, complete Steps 7, and note which steps were skipped.\n"

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -2376,6 +2376,7 @@ async def _run_daemon(
     # NIU-598: shared in-process bus for post-session reflection (daemon mode).
     # Captured by _agent_factory so each agent created by the daemon publishes to it.
     daemon_bus: Any | None = None
+    sleipnir_catalog_publisher: Any | None = None
     if settings.reflection.enabled:
         from sleipnir.adapters.in_process import InProcessBus
 
@@ -2571,6 +2572,28 @@ async def _run_daemon(
     if settings.initiative.enabled or task_dispatch:
         if settings.sleipnir.enabled:
             event_publisher = RabbitMQEventPublisher(settings.sleipnir)
+            amqp_url = os.environ.get(settings.sleipnir.amqp_url_env, "").strip()
+            if amqp_url:
+                try:
+                    from sleipnir.adapters.rabbitmq import RabbitMQPublisher
+
+                    sleipnir_catalog_publisher = RabbitMQPublisher(
+                        url=amqp_url,
+                        exchange_name=settings.sleipnir.exchange,
+                    )
+                    await sleipnir_catalog_publisher.start()
+                except Exception as exc:
+                    logger.warning(
+                        "sleipnir: catalog publisher unavailable; "
+                        "mimir.dream.completed emission will be skipped: %s",
+                        exc,
+                    )
+                    sleipnir_catalog_publisher = None
+            else:
+                logger.warning(
+                    "sleipnir: %s is not set; catalog events will not be published",
+                    settings.sleipnir.amqp_url_env,
+                )
 
         drive_loop = DriveLoop(
             agent_factory=_agent_factory,
@@ -2579,6 +2602,7 @@ async def _run_daemon(
             event_publisher=event_publisher,
             resume=resume,
             mimir=daemon_mimir,
+            sleipnir_publisher=sleipnir_catalog_publisher or daemon_bus,
         )
         _cron_jobs = _wire_triggers(drive_loop, settings.initiative)
         cron_tools[:] = _wire_cron(drive_loop, _cron_jobs, settings.initiative)
@@ -2704,6 +2728,8 @@ async def _run_daemon(
                 pass
         if daemon_reflection_svc is not None:
             await daemon_reflection_svc.stop()
+        if sleipnir_catalog_publisher is not None:
+            await sleipnir_catalog_publisher.stop()
         return
 
     try:
@@ -2728,6 +2754,8 @@ async def _run_daemon(
                 pass
         if daemon_reflection_svc is not None:
             await daemon_reflection_svc.stop()
+        if sleipnir_catalog_publisher is not None:
+            await sleipnir_catalog_publisher.stop()
 
 
 def _wire_triggers(drive_loop: Any, initiative: InitiativeConfig) -> list[Any]:

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -2101,7 +2101,7 @@ class DreamCycleTriggerConfig(BaseModel):
     3. Update compiled truth pages where evidence has changed.
     4. Run ``mimir_lint --fix`` to auto-fix safe issues.
     5. Cross-reference pages that mention the same entities without links.
-    6. Emit a ``mimir.dream.completed`` Sleipnir event with summary counts.
+    6. Return summary counts; the drive loop emits ``mimir.dream.completed``.
 
     Disabled by default — enable via ``dream_cycle.enabled: true`` in ravn.yaml.
     """

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -48,11 +48,17 @@ if TYPE_CHECKING:
     from ravn.ports.mesh import MeshPort
 
 try:
-    from sleipnir.domain.catalog import ravn_task_completed as _sleipnir_task_completed
+    from sleipnir.domain.catalog import (
+        mimir_dream_completed as _sleipnir_mimir_dream_completed,
+    )
+    from sleipnir.domain.catalog import (
+        ravn_task_completed as _sleipnir_task_completed,
+    )
     from sleipnir.ports.events import SleipnirPublisher as _SleipnirPublisher
 except ImportError:
     _SleipnirPublisher = None  # type: ignore[assignment,misc]
     _sleipnir_task_completed = None  # type: ignore[assignment]
+    _sleipnir_mimir_dream_completed = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +74,8 @@ _SUCCESS_VERDICT_PREFERENCE = (
     "clean",
 )
 _MIMIR_PAGE_WRITTEN_OUTCOME = "mimir.page.written"
+_DREAM_CYCLE_TRIGGER = "dream_cycle:cron"
+_DREAM_COUNT_FIELDS = ("pages_updated", "entities_created", "lint_fixes")
 
 
 def _default_success_verdict(produces: object) -> str:
@@ -196,6 +204,51 @@ def _parse_outcome_for_persona(
                 exc_info=True,
             )
     return parse_outcome_block(response_text)
+
+
+def _coerce_nonnegative_int(value: object) -> int | None:
+    """Return *value* as a non-negative integer, or None when it cannot be parsed."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value >= 0 else None
+    if isinstance(value, float) and value.is_integer():
+        parsed = int(value)
+        return parsed if parsed >= 0 else None
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _extract_mimir_dream_counts(
+    response_text: str,
+    persona_config: PersonaConfig | None,
+) -> dict[str, int]:
+    """Extract dream-cycle summary counts from a final outcome response."""
+    counts: dict[str, int] = {}
+    parsed = _parse_outcome_for_persona(response_text, persona_config) if response_text else None
+    fields = dict(getattr(parsed, "fields", {}) or {}) if parsed is not None else {}
+
+    for field in _DREAM_COUNT_FIELDS:
+        value = _coerce_nonnegative_int(fields.get(field))
+        if value is not None:
+            counts[field] = value
+
+    # Backward-compatible fallback for older warden prompts that only mention
+    # counts in the summary/log prose, e.g. ``pages_updated=0``.
+    for field in _DREAM_COUNT_FIELDS:
+        if field in counts:
+            continue
+        spaced = field.replace("_", r"[\s_-]")
+        match = re.search(rf"\b(?:{field}|{spaced})\b\s*[:=]\s*(\d+)", response_text)
+        counts[field] = int(match.group(1)) if match else 0
+
+    return counts
 
 
 # Type alias for the mesh RPC handler callable
@@ -1198,6 +1251,7 @@ class DriveLoop:
         )
 
         success = False
+        response_text = ""
         token = self._current_task_var.set(task)
         self._active_task_contexts[task.task_id] = task
         self._active_agents[task.task_id] = agent
@@ -1208,7 +1262,9 @@ class DriveLoop:
                 self._record_task_cost(task, turn_result)
                 await self._maybe_publish_budget_warning(task)
                 self._save_task_output(task, capture_channel or channel)
-                response_text = capture_channel.response_text if capture_channel else ""
+                response_text = (
+                    capture_channel.response_text if capture_channel else turn_result.response
+                )
                 if response_text:
                     logger.info(
                         "drive_loop: task %s output: %s",
@@ -1261,8 +1317,11 @@ class DriveLoop:
                     await emit_fn(outcome)
                 except Exception:
                     logger.warning("emit_session_ended failed; continuing", exc_info=True)
-            response_text = capture_channel.response_text if capture_channel else ""
+            if capture_channel is not None:
+                response_text = capture_channel.response_text
             await self._emit_sleipnir_task_completed(task, outcome, response_text=response_text)
+            if success:
+                await self._emit_sleipnir_mimir_dream_completed(task, response_text=response_text)
 
             # Publish outcome event to mesh for other agents to consume
             await self._emit_mesh_outcome_event(task, response_text, success)
@@ -1355,6 +1414,41 @@ class DriveLoop:
             await self._sleipnir_publisher.publish(event)
         except Exception:
             logger.warning("Failed to emit ravn.task.completed; continuing.", exc_info=True)
+
+    async def _emit_sleipnir_mimir_dream_completed(
+        self,
+        task: AgentTask,
+        *,
+        response_text: str,
+    ) -> None:
+        """Publish mimir.dream.completed for dream-cycle tasks.
+
+        Dream completion is orchestration bookkeeping, so the drive loop emits
+        it deterministically from the final outcome instead of requiring the
+        Mímir warden persona to call an extra publish tool.
+        """
+        if task.triggered_by != _DREAM_CYCLE_TRIGGER:
+            return
+        if self._sleipnir_publisher is None or _sleipnir_mimir_dream_completed is None:
+            return
+
+        try:
+            counts = _extract_mimir_dream_counts(response_text, self._persona_config)
+            event = _sleipnir_mimir_dream_completed(
+                pages_updated=counts["pages_updated"],
+                entities_created=counts["entities_created"],
+                lint_fixes=counts["lint_fixes"],
+                source=self._source_id,
+                correlation_id=task.session_id or task.task_id,
+            )
+            event.payload["task_id"] = task.task_id
+            if task.persona:
+                event.payload["persona"] = task.persona
+            if task.session_id:
+                event.payload["session_id"] = task.session_id
+            await self._sleipnir_publisher.publish(event)
+        except Exception:
+            logger.warning("Failed to emit mimir.dream.completed; continuing.", exc_info=True)
 
     async def emit_tool_outcome_event(
         self,

--- a/src/ravn/personas/_archived/mimir-curator.yaml
+++ b/src/ravn/personas/_archived/mimir-curator.yaml
@@ -65,7 +65,7 @@ system_prompt_template: |
 
   **Step 6 — Cross-reference**: Find pages mentioning the same entities as updated pages but lacking wikilinks; add missing links via `mimir_write`.
 
-  **Step 7 — Log and emit**: Append a summary entry to `wiki/log.md` with timestamp, pages_updated, entities_created, and lint_fixes.  Then call `sleipnir_publish` to emit a `mimir.dream.completed` event with those counts.
+  **Step 7 — Log and finish**: Append a summary entry to `wiki/log.md` with timestamp, pages_updated, entities_created, and lint_fixes. Include those counts in the final outcome; the runner emits `mimir.dream.completed` automatically.
 
   Idempotency: all writes must be conditional — only write a page if its content would actually change.  Running the dream cycle twice must produce no additional changes on the second run.
 

--- a/src/ravn/personas/mimir-warden.yaml
+++ b/src/ravn/personas/mimir-warden.yaml
@@ -49,7 +49,7 @@ system_prompt_template: |
   5. Run `mimir_lint` with safe auto-fix enabled.
   6. Add missing cross-links between related pages.
   7. Append a concise summary entry to `wiki/log.md`.
-  8. Publish a `mimir.dream.completed` event with counts via `sleipnir_publish`.
+  8. Leave `mimir.dream.completed` publishing to the runner; include counts in the final outcome.
 
   If time or budget is tight, prefer completing the audit, page updates, and final summary over broad
   cross-link cleanup.
@@ -105,6 +105,9 @@ system_prompt_template: |
     [One-line summary of what knowledge work was completed]
   pages_written:
     - [wiki/page/path.md]
+  pages_updated: 0
+  entities_created: 0
+  lint_fixes: 0
   ---end---
 
 allowed_tools:
@@ -116,7 +119,6 @@ allowed_tools:
     mimir_ingest,
     mimir_write,
     mimir_lint,
-    sleipnir_publish,
     web_search,
     web_fetch,
   ]
@@ -146,6 +148,18 @@ produces:
     pages_written:
       type: array
       description: wiki page paths written or updated during this turn
+      required: false
+    pages_updated:
+      type: number
+      description: number of compiled truth pages updated during a dream cycle
+      required: false
+    entities_created:
+      type: number
+      description: number of new entities created during a dream cycle
+      required: false
+    lint_fixes:
+      type: number
+      description: number of safe lint fixes applied during a dream cycle
       required: false
 
 fan_in:

--- a/tests/ravn/unit/test_dream_cycle_trigger.py
+++ b/tests/ravn/unit/test_dream_cycle_trigger.py
@@ -239,6 +239,10 @@ class TestDreamCycleTriggerTaskContent:
         context = enqueued[0].initiative_context
         for step_num in range(1, 8):
             assert f"Step {step_num}" in context
+        assert "Do not call `sleipnir_publish`" in context
+        assert "pages_updated" in context
+        assert "entities_created" in context
+        assert "lint_fixes" in context
 
     @pytest.mark.asyncio
     async def test_last_dream_at_updated_after_enqueue(self) -> None:

--- a/tests/test_ravn/test_drive_loop_outcome_contract.py
+++ b/tests/test_ravn/test_drive_loop_outcome_contract.py
@@ -12,11 +12,13 @@ from niuu.domain.outcome import OutcomeField
 from ravn.domain.events import RavnEventType
 from ravn.drive_loop import (
     _default_success_verdict,
+    _extract_mimir_dream_counts,
     _infer_tool_written_verdict,
     _known_verdict_tokens,
     _normalize_outcome_verdict,
     _parse_outcome_for_persona,
 )
+from sleipnir.domain import registry
 from tests.test_ravn.conftest import _make_agent_task, _make_drive_loop
 
 
@@ -826,6 +828,81 @@ summary: post-mortem source captured
         assert payload["structured_outcome"]["verdict"] == "pass"
         assert payload["summary"] == "shipped"
         assert payload["files_changed"] == 2
+
+    def test_extract_mimir_dream_counts_prefers_outcome_fields_and_falls_back_to_prose(
+        self,
+    ) -> None:
+        persona = SimpleNamespace(
+            produces=SimpleNamespace(
+                schema={
+                    "pages_updated": OutcomeField(type="number", description="pages"),
+                    "entities_created": OutcomeField(type="number", description="entities"),
+                    "lint_fixes": OutcomeField(type="number", description="lint"),
+                }
+            )
+        )
+
+        counts = _extract_mimir_dream_counts(
+            (
+                "---outcome---\n"
+                "pages_updated: 3\n"
+                "entities_created: 2\n"
+                "lint_fixes: 1\n"
+                "---end---"
+            ),
+            persona,
+        )
+        assert counts == {"pages_updated": 3, "entities_created": 2, "lint_fixes": 1}
+
+        assert _extract_mimir_dream_counts(
+            "maintenance ran; pages_updated=4, entities_created=0, lint_fixes=2",
+            None,
+        ) == {"pages_updated": 4, "entities_created": 0, "lint_fixes": 2}
+
+    @pytest.mark.asyncio
+    async def test_emit_sleipnir_mimir_dream_completed_for_dream_cycle_task(self) -> None:
+        dl = _make_drive_loop()
+        dl._source_id = "drive_loop"
+        published = []
+        dl._sleipnir_publisher = SimpleNamespace(publish=AsyncMock(side_effect=published.append))
+
+        task = _make_agent_task(task_id="task-dream")
+        task.triggered_by = "dream_cycle:cron"
+        task.persona = "mimir-warden"
+        task.session_id = "sess-dream"
+
+        await dl._emit_sleipnir_mimir_dream_completed(
+            task,
+            response_text=(
+                "---outcome---\n"
+                "verdict: complete\n"
+                "pages_updated: 5\n"
+                "entities_created: 2\n"
+                "lint_fixes: 1\n"
+                "---end---"
+            ),
+        )
+
+        assert published
+        event = published[0]
+        assert event.event_type == registry.MIMIR_DREAM_COMPLETED
+        assert event.correlation_id == "sess-dream"
+        assert event.payload["pages_updated"] == 5
+        assert event.payload["entities_created"] == 2
+        assert event.payload["lint_fixes"] == 1
+        assert event.payload["task_id"] == "task-dream"
+        assert event.payload["persona"] == "mimir-warden"
+
+    @pytest.mark.asyncio
+    async def test_emit_sleipnir_mimir_dream_completed_ignores_non_dream_task(self) -> None:
+        dl = _make_drive_loop()
+        dl._sleipnir_publisher = SimpleNamespace(publish=AsyncMock())
+        task = _make_agent_task(task_id="task-normal")
+        task.triggered_by = "thread:inbox"
+
+        await dl._emit_sleipnir_mimir_dream_completed(task, response_text="pages_updated=1")
+
+        dl._sleipnir_publisher.publish.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_emit_tool_outcome_event_publishes_and_tolerates_skuld_failure(self) -> None:


### PR DESCRIPTION
## Summary

- Move `mimir.dream.completed` emission out of the Mímir warden prompt and into `DriveLoop` orchestration.
- Extract dream-cycle counts from the final outcome block, with fallback parsing for older `pages_updated=0` style summaries.
- Wire the daemon to use a Sleipnir catalog publisher when Sleipnir/RabbitMQ is configured.
- Update the dream-cycle trigger/persona docs so the agent no longer tries to call the nonexistent `sleipnir_publish` tool.

## Root cause

The dream-cycle task instructed the warden persona to call `sleipnir_publish`, but no such model-callable tool exists. The event factory and publisher ports exist, so completion publishing belongs in orchestration rather than in the agent tool surface.

## Validation

- `uv run ruff check src/ravn/drive_loop.py src/ravn/cli/commands.py src/ravn/adapters/triggers/dream_cycle.py tests/ravn/unit/test_dream_cycle_trigger.py tests/test_ravn/test_drive_loop_outcome_contract.py`
- `uv run pytest tests/ravn/unit/test_dream_cycle_trigger.py tests/test_ravn/test_drive_loop_outcome_contract.py tests/ravn/unit/test_reflection_wiring.py -q`
