### PR TITLE
Fix release and CI regressions on main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -217,9 +217,30 @@ jobs:
           path: sbom-${{ matrix.container }}.spdx.json
 
       - name: Install Grype
+        env:
+          GRYPE_VERSION: "0.87.0"
         run: |
-          GRYPE_VERSION="0.87.0"
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/247f5d72abf2131aa37f3164a98495c121b29029/install.sh | sh -s -- -b /usr/local/bin "v${GRYPE_VERSION}"
+          set -euo pipefail
+
+          install_grype() {
+            curl --retry 5 --retry-all-errors --retry-delay 2 -sSfL \
+              https://raw.githubusercontent.com/anchore/grype/247f5d72abf2131aa37f3164a98495c121b29029/install.sh \
+              | sh -s -- -b /usr/local/bin "v${GRYPE_VERSION}"
+          }
+
+          for attempt in 1 2 3; do
+            if install_grype; then
+              grype version
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+
+            sleep $((attempt * 5))
+          done
+
           grype version
 
       - name: Scan container with Grype
@@ -229,9 +250,19 @@ jobs:
             --fail-on critical \
             -o sarif > "grype-${{ matrix.container }}.sarif"
 
+      - name: Detect Grype results
+        id: sarif
+        if: always()
+        run: |
+          if [ -f "grype-${{ matrix.container }}.sarif" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload Grype results
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-        if: always()
+        if: always() && steps.sarif.outputs.present == 'true'
         with:
           sarif_file: grype-${{ matrix.container }}.sarif
           category: grype-${{ matrix.container }}
@@ -364,8 +395,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
-          cache: pnpm
-          cache-dependency-path: web-next/pnpm-lock.yaml
 
       - name: Install dependencies
         run: uv sync --python 3.12 --extra cli --extra dev

--- a/.github/workflows/reusable-container-build.yaml
+++ b/.github/workflows/reusable-container-build.yaml
@@ -41,8 +41,6 @@ on:
         type: string
         default: ghcr.io
 
-permissions: read-all
-
 jobs:
   build:
     name: "Build ${{ matrix.container }} (${{ matrix.platform }})"

--- a/.github/workflows/reusable-container-scan.yaml
+++ b/.github/workflows/reusable-container-scan.yaml
@@ -21,8 +21,6 @@ on:
         type: string
         default: "0.87.0"
 
-permissions: read-all
-
 jobs:
   scan:
     name: "Scan: ${{ matrix.container }}"
@@ -50,8 +48,30 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Grype
+        env:
+          GRYPE_VERSION: ${{ inputs.grype-version }}
         run: |
-          curl -sSfL https://raw.githubusercontent.com/anchore/grype/247f5d72abf2131aa37f3164a98495c121b29029/install.sh | sh -s -- -b /usr/local/bin "v${{ inputs.grype-version }}"
+          set -euo pipefail
+
+          install_grype() {
+            curl --retry 5 --retry-all-errors --retry-delay 2 -sSfL \
+              https://raw.githubusercontent.com/anchore/grype/247f5d72abf2131aa37f3164a98495c121b29029/install.sh \
+              | sh -s -- -b /usr/local/bin "v${GRYPE_VERSION}"
+          }
+
+          for attempt in 1 2 3; do
+            if install_grype; then
+              grype version
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+
+            sleep $((attempt * 5))
+          done
+
           grype version
 
       - name: Scan container with Grype
@@ -61,9 +81,19 @@ jobs:
             --fail-on critical \
             -o sarif > "grype-${{ matrix.container }}.sarif"
 
+      - name: Detect Grype results
+        id: sarif
+        if: always()
+        run: |
+          if [ -f "grype-${{ matrix.container }}.sarif" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload Grype results
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
-        if: always()
+        if: always() && steps.sarif.outputs.present == 'true'
         with:
           sarif_file: grype-${{ matrix.container }}.sarif
           category: grype-${{ matrix.container }}

--- a/src/bifrost/adapters/events/sleipnir.py
+++ b/src/bifrost/adapters/events/sleipnir.py
@@ -13,10 +13,10 @@ when the broker is unreachable.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import json
 import logging
+from contextlib import suppress
 from dataclasses import asdict
 
 from bifrost.ports.events import (

--- a/src/cli/commands/platform.py
+++ b/src/cli/commands/platform.py
@@ -6,12 +6,12 @@ automatically — no code changes needed here.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import inspect
 import json
 import os
+from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 

--- a/src/cli/services/preflight.py
+++ b/src/cli/services/preflight.py
@@ -6,13 +6,13 @@ the entire startup.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import logging
 import os
 import shutil
 import socket
 import subprocess
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING

--- a/src/cli/tui/app.py
+++ b/src/cli/tui/app.py
@@ -4,8 +4,8 @@ Uses the zinc theme, 4-mode keybinding system, and widget library.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult

--- a/src/cli/tui/widgets/metric_card.py
+++ b/src/cli/tui/widgets/metric_card.py
@@ -1,6 +1,7 @@
 """MetricCard widget — bordered box with icon, value, and label."""
 
 from __future__ import annotations
+
 from contextlib import suppress
 
 from textual.app import ComposeResult

--- a/src/cli/tui/widgets/modal.py
+++ b/src/cli/tui/widgets/modal.py
@@ -1,6 +1,7 @@
 """Modal widget — generic centered dialog with title and content."""
 
 from __future__ import annotations
+
 from contextlib import suppress
 
 from textual.app import ComposeResult

--- a/src/niuu/adapters/embedded_postgres.py
+++ b/src/niuu/adapters/embedded_postgres.py
@@ -11,7 +11,6 @@ Binary search order:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import hashlib
@@ -21,6 +20,7 @@ import re
 import socket
 import subprocess
 import tempfile
+from contextlib import suppress
 from pathlib import Path
 
 from niuu.ports.embedded_database import ConnectionInfo, EmbeddedDatabasePort

--- a/src/niuu/app.py
+++ b/src/niuu/app.py
@@ -1,7 +1,6 @@
 """Niuu composition root for shared HTTP hosting and mount selection."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import inspect
@@ -9,7 +8,7 @@ import json
 import logging
 import os
 from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/ravn/adapters/channels/_rabbitmq_base.py
+++ b/src/ravn/adapters/channels/_rabbitmq_base.py
@@ -16,11 +16,11 @@ Usage
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 import os
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/src/ravn/adapters/channels/gateway.py
+++ b/src/ravn/adapters/channels/gateway.py
@@ -15,11 +15,11 @@ Usage::
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/src/ravn/adapters/channels/gateway_discord.py
+++ b/src/ravn/adapters/channels/gateway_discord.py
@@ -14,12 +14,12 @@ Design principles:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import logging
 import os
+from contextlib import suppress
 from typing import Any
 
 import httpx

--- a/src/ravn/adapters/channels/gateway_matrix.py
+++ b/src/ravn/adapters/channels/gateway_matrix.py
@@ -11,12 +11,12 @@ Design principles:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 import os
 import uuid
+from contextlib import suppress
 from typing import Any
 from urllib.parse import quote
 

--- a/src/ravn/adapters/channels/gateway_slack.py
+++ b/src/ravn/adapters/channels/gateway_slack.py
@@ -15,12 +15,12 @@ polling when not set.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 import os
 import time
+from contextlib import suppress
 from typing import Any
 
 import httpx

--- a/src/ravn/adapters/channels/gateway_telegram.py
+++ b/src/ravn/adapters/channels/gateway_telegram.py
@@ -10,11 +10,11 @@ Design principles:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 import os
+from contextlib import suppress
 from typing import Any
 
 import httpx

--- a/src/ravn/adapters/channels/gateway_whatsapp.py
+++ b/src/ravn/adapters/channels/gateway_whatsapp.py
@@ -12,7 +12,6 @@ Design principles:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import hashlib
@@ -20,6 +19,7 @@ import hmac
 import json
 import logging
 import os
+from contextlib import suppress
 from typing import Any
 
 import httpx

--- a/src/ravn/adapters/checkpoint/disk.py
+++ b/src/ravn/adapters/checkpoint/disk.py
@@ -15,13 +15,13 @@ Old snapshots are pruned when ``max_snapshots_per_task`` is exceeded.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import gzip
 import json
 import logging
 import os
 import tempfile
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 

--- a/src/ravn/adapters/checkpoint/sleipnir_trigger.py
+++ b/src/ravn/adapters/checkpoint/sleipnir_trigger.py
@@ -28,12 +28,12 @@ registers/unregisters entries as agents start and stop.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 
 logger = logging.getLogger(__name__)
 

--- a/src/ravn/adapters/deployment.py
+++ b/src/ravn/adapters/deployment.py
@@ -1,12 +1,12 @@
 """Deployment adapters for long-lived Ravn wardens."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import os
 import subprocess
 import threading
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 

--- a/src/ravn/adapters/discovery/composite.py
+++ b/src/ravn/adapters/discovery/composite.py
@@ -10,10 +10,10 @@ Typical deployments:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 
 from ravn.domain.models import RavnCandidate, RavnIdentity, RavnPeer
 from ravn.ports.discovery import PeerCallback

--- a/src/ravn/adapters/discovery/k8s.py
+++ b/src/ravn/adapters/discovery/k8s.py
@@ -13,10 +13,10 @@ for subsequent Sleipnir communication — no handshake socket is opened.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 

--- a/src/ravn/adapters/discovery/mdns.py
+++ b/src/ravn/adapters/discovery/mdns.py
@@ -30,7 +30,6 @@ Peers are evicted when ``last_heartbeat`` is older than ``peer_ttl_s`` (default 
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import dataclasses
@@ -40,6 +39,7 @@ import json
 import logging
 import secrets
 import socket
+from contextlib import suppress
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 

--- a/src/ravn/adapters/discovery/sleipnir.py
+++ b/src/ravn/adapters/discovery/sleipnir.py
@@ -24,12 +24,12 @@ SPIFFE JWT-SVID validation is used for trust — no separate handshake socket.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import logging
 import os
+from contextlib import suppress
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 

--- a/src/ravn/adapters/discovery/static.py
+++ b/src/ravn/adapters/discovery/static.py
@@ -28,10 +28,10 @@ the file and updates the peer table (join/leave callbacks fire as needed).
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any

--- a/src/ravn/adapters/mcp/sse_transport.py
+++ b/src/ravn/adapters/mcp/sse_transport.py
@@ -8,11 +8,11 @@ HTTPTransport — simpler request/response: POST JSON-RPC, receive JSON reply.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import logging
+from contextlib import suppress
 from typing import Any
 
 from ravn.adapters.mcp.transport import MCPTransport, MCPTransportError

--- a/src/ravn/adapters/permission/enforcer.py
+++ b/src/ravn/adapters/permission/enforcer.py
@@ -25,7 +25,6 @@ Rule evaluation order
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import fnmatch
 import logging
@@ -33,6 +32,7 @@ import re
 import shlex
 import time
 from collections import deque
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 

--- a/src/ravn/adapters/tools/cascade_tools.py
+++ b/src/ravn/adapters/tools/cascade_tools.py
@@ -11,13 +11,13 @@ All routing logic (local vs mesh vs spawn) lives in ``task_create``.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import logging
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 

--- a/src/ravn/adapters/tools/terminal.py
+++ b/src/ravn/adapters/tools/terminal.py
@@ -12,13 +12,13 @@ itself performs no safety checks.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 import shlex
 import uuid
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
 
 from ravn.domain.models import ToolResult

--- a/src/ravn/adapters/triggers/cron.py
+++ b/src/ravn/adapters/triggers/cron.py
@@ -17,7 +17,6 @@ running.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import fcntl
@@ -28,6 +27,7 @@ import re
 import tempfile
 import time
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1,7 +1,6 @@
 """Ravn CLI entry point."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import importlib
@@ -12,6 +11,7 @@ import signal
 import sys
 import uuid
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 

--- a/src/ravn/cli/flock.py
+++ b/src/ravn/cli/flock.py
@@ -22,7 +22,6 @@ State files
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
@@ -32,6 +31,7 @@ import socket
 import subprocess
 import sys
 import time
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -25,9 +25,9 @@ without modifying the global ravn.yaml.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import os
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal

--- a/src/ravn/context/evolution.py
+++ b/src/ravn/context/evolution.py
@@ -32,11 +32,11 @@ Usage::
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import json
 import logging
 from collections import defaultdict
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -11,7 +11,6 @@ daemon instances.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import contextvars
@@ -19,6 +18,7 @@ import json
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path

--- a/src/ravn/prompt_builder.py
+++ b/src/ravn/prompt_builder.py
@@ -19,12 +19,12 @@ Two-layer cache
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import hashlib
 import json
 import logging
 from collections import OrderedDict
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/ravn/tui/app.py
+++ b/src/ravn/tui/app.py
@@ -1,10 +1,10 @@
 """RavnTUI — main Textual application for the Ravn terminal operator interface."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 

--- a/src/ravn/tui/widgets/bottom_bar.py
+++ b/src/ravn/tui/widgets/bottom_bar.py
@@ -1,6 +1,7 @@
 """BottomBar — contextual keybinding hints with kbd-style key boxes."""
 
 from __future__ import annotations
+
 from contextlib import suppress
 
 from textual.app import ComposeResult

--- a/src/ravn/tui/widgets/broadcast_overlay.py
+++ b/src/ravn/tui/widgets/broadcast_overlay.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+import textual.screen as textual_screen
 from textual.app import ComposeResult
 from textual.containers import Container
-import textual.screen as textual_screen
 from textual.widgets import Input, RichLog, Static
 
 ModalScreen = textual_screen.ModalScreen

--- a/src/ravn/tui/widgets/command_palette.py
+++ b/src/ravn/tui/widgets/command_palette.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+import textual.screen as textual_screen
 from textual.app import ComposeResult
 from textual.containers import Container
-import textual.screen as textual_screen
 from textual.widgets import Input, RichLog, Static
 
 ModalScreen = textual_screen.ModalScreen

--- a/src/ravn/tui/widgets/pane.py
+++ b/src/ravn/tui/widgets/pane.py
@@ -1,8 +1,8 @@
 """PaneWidget — leaf node of the split tree with a unified pane header bar."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from textual.app import ComposeResult

--- a/src/ravn/tui/widgets/status_bar.py
+++ b/src/ravn/tui/widgets/status_bar.py
@@ -1,8 +1,8 @@
 """StatusBar — top bar: ᚱ RAVN · flokk tag · active ravn · clock."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from datetime import datetime
 from typing import Any
 

--- a/src/ravn/tui/widgets/tab_bar.py
+++ b/src/ravn/tui/widgets/tab_bar.py
@@ -1,6 +1,7 @@
 """TabBar — layout preset tab switcher between StatusBar and the split container."""
 
 from __future__ import annotations
+
 from contextlib import suppress
 
 from textual.app import ComposeResult

--- a/src/ravn/tui/widgets/views/chat.py
+++ b/src/ravn/tui/widgets/views/chat.py
@@ -7,11 +7,11 @@ chat bubble to the RichLog.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import re
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from textual.app import ComposeResult

--- a/src/ravn/tui/widgets/views/checkpoints.py
+++ b/src/ravn/tui/widgets/views/checkpoints.py
@@ -1,9 +1,9 @@
 """CheckpointsView — checkpoint list and resume."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
+from contextlib import suppress
 from typing import Any
 
 from textual.app import ComposeResult

--- a/src/ravn/tui/widgets/views/cron.py
+++ b/src/ravn/tui/widgets/views/cron.py
@@ -1,9 +1,9 @@
 """CronView — scheduled task manager."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
+from contextlib import suppress
 from typing import Any
 
 from textual.app import ComposeResult

--- a/src/ravn/tui/widgets/views/events.py
+++ b/src/ravn/tui/widgets/views/events.py
@@ -1,8 +1,8 @@
 """EventStreamView — live SSE event stream with colour-coded type badges."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from datetime import datetime
 from typing import Any
 

--- a/src/ravn/tui/widgets/views/mimir.py
+++ b/src/ravn/tui/widgets/views/mimir.py
@@ -1,9 +1,9 @@
 """MimirView — navigable wiki browser with search, page content, and instance switching."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
+from contextlib import suppress
 from typing import Any
 
 from textual.app import ComposeResult

--- a/src/ravn/warden/__init__.py
+++ b/src/ravn/warden/__init__.py
@@ -13,7 +13,6 @@ from ravn.warden.models import (
     WardenSpec,
     WardenSupervisor,
 )
-from ravn.warden.store import WardenStore
 
 
 def resolve_deployment_adapter(deployment: str) -> str:
@@ -36,6 +35,8 @@ def build_warden_store(root=None):
 
 def __getattr__(name: str):
     if name == "WardenStore":
+        from ravn.warden.store import WardenStore
+
         return WardenStore
     msg = f"module {__name__!r} has no attribute {name!r}"
     raise AttributeError(msg)

--- a/src/ravn/warden/store.py
+++ b/src/ravn/warden/store.py
@@ -1,12 +1,12 @@
 """Filesystem-backed persistence for Ravn wardens."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import os
 import re
 import zlib
 from collections.abc import Callable
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -14,9 +14,9 @@ Environment variable override format:
   SESSION_ID, MODEL, HOST, PORT, VOLUNDR_API_URL, SERVICE_USER_ID, WORKSPACE_DIR
 """
 
-from contextlib import suppress
 import json
 import os
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 

--- a/src/skuld/transports/opencode.py
+++ b/src/skuld/transports/opencode.py
@@ -9,11 +9,11 @@ deltas, plus ``question.asked`` for permission requests and ``session.idle``
 for turn completion.
 """
 
-from contextlib import suppress
 import asyncio
 import json
 import logging
 import os
+from contextlib import suppress
 
 import httpx
 

--- a/src/skuld/transports/persistent_subprocess.py
+++ b/src/skuld/transports/persistent_subprocess.py
@@ -23,12 +23,12 @@ Limitations:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import logging
 import os
+from contextlib import suppress
 from typing import Any
 
 from niuu.adapters.cli.runtime import (

--- a/src/sleipnir/adapters/_subscriber_support.py
+++ b/src/sleipnir/adapters/_subscriber_support.py
@@ -6,11 +6,11 @@ and event dispatch logic without duplicating code.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 from collections.abc import Callable
+from contextlib import suppress
 
 from sleipnir.domain.events import SleipnirEvent, match_event_type
 from sleipnir.ports.events import EventHandler, Subscription

--- a/src/sleipnir/adapters/audit_subscriber.py
+++ b/src/sleipnir/adapters/audit_subscriber.py
@@ -8,10 +8,10 @@ has elapsed.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 from dataclasses import dataclass, field
 
 from sleipnir.domain.events import SleipnirEvent

--- a/src/sleipnir/adapters/cli_command.py
+++ b/src/sleipnir/adapters/cli_command.py
@@ -43,12 +43,12 @@ Configuration example
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import logging
 import os
+from contextlib import suppress
 
 from sleipnir.adapters._subscriber_support import (
     DEFAULT_RING_BUFFER_DEPTH,

--- a/src/sleipnir/adapters/in_process.py
+++ b/src/sleipnir/adapters/in_process.py
@@ -8,10 +8,10 @@ Overflow evicts the oldest event with a warning log (ring buffer semantics).
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 
 from sleipnir.adapters._subscriber_support import (
     DEFAULT_RING_BUFFER_DEPTH,

--- a/src/sleipnir/adapters/nats_transport.py
+++ b/src/sleipnir/adapters/nats_transport.py
@@ -62,11 +62,11 @@ Configuration example
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 from collections import deque
+from contextlib import suppress
 from datetime import datetime
 from typing import Any
 

--- a/src/sleipnir/adapters/nng_transport.py
+++ b/src/sleipnir/adapters/nng_transport.py
@@ -46,10 +46,10 @@ dials every live publisher socket it finds.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 
 try:
     import pynng

--- a/src/sleipnir/adapters/rabbitmq.py
+++ b/src/sleipnir/adapters/rabbitmq.py
@@ -50,10 +50,10 @@ Configuration example
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 
 try:
     import aio_pika

--- a/src/sleipnir/adapters/redis_streams.py
+++ b/src/sleipnir/adapters/redis_streams.py
@@ -20,12 +20,12 @@ Example config::
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 
 from sleipnir.adapters._subscriber_support import (
     _BaseSubscription,

--- a/src/sleipnir/adapters/webhook.py
+++ b/src/sleipnir/adapters/webhook.py
@@ -46,10 +46,10 @@ See ``docs/site/ravn/operations/sleipnir-transports.md`` for the full ladder.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 
 try:
     import httpx

--- a/src/ting/adapters/sleipnir_event_bridge.py
+++ b/src/ting/adapters/sleipnir_event_bridge.py
@@ -22,10 +22,10 @@ Event mapping
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 
 from sleipnir.domain.events import SleipnirEvent
 from sleipnir.domain.registry import (

--- a/src/ting/api/sagas.py
+++ b/src/ting/api/sagas.py
@@ -7,9 +7,9 @@ milestones, issues) is fetched live from the tracker at read time.
 from __future__ import annotations
 
 import logging
-from inspect import isawaitable
 from dataclasses import replace
 from datetime import UTC, datetime
+from inspect import isawaitable
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status

--- a/src/ting/api/sessions.py
+++ b/src/ting/api/sessions.py
@@ -12,8 +12,8 @@ approval flows back under Forge.
 from __future__ import annotations
 
 import asyncio
-from inspect import isawaitable
 import logging
+from inspect import isawaitable
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel

--- a/src/ting/domain/condition_evaluator.py
+++ b/src/ting/domain/condition_evaluator.py
@@ -26,9 +26,9 @@ Usage::
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import re
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/ting/domain/services/notification.py
+++ b/src/ting/domain/services/notification.py
@@ -6,11 +6,11 @@ user-facing notifications and delivers them through configured channels
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
 import os
+from contextlib import suppress
 from typing import Any
 
 from ting.ports.channel_resolver import ChannelResolverPort

--- a/src/ting/domain/services/review_engine.py
+++ b/src/ting/domain/services/review_engine.py
@@ -19,10 +19,10 @@ The engine then decides: auto-approve, auto-retry, or escalate to human review.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from uuid import UUID, uuid4

--- a/src/ting/domain/services/reviewer_session.py
+++ b/src/ting/domain/services/reviewer_session.py
@@ -9,10 +9,10 @@ LLM-powered review that understands code context, architecture, and quality.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import json
 import logging
+from contextlib import suppress
 from dataclasses import dataclass
 
 from ting.config import ReviewConfig

--- a/src/ting/domain/services/workflow_campaign_projector.py
+++ b/src/ting/domain/services/workflow_campaign_projector.py
@@ -1,10 +1,10 @@
 """Background projector that keeps workflow campaigns in sync with Volundr."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import logging
+from contextlib import suppress
 from datetime import UTC, datetime
 
 from ting.domain.models import WorkflowCampaign, WorkflowCampaignStatus

--- a/src/ting/domain/validation.py
+++ b/src/ting/domain/validation.py
@@ -5,10 +5,10 @@ against the SagaStructure schema and returns typed domain objects.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import json
 import re
+from contextlib import suppress
 
 from ting.domain.models import PhaseSpec, RunSpec, SagaStructure
 

--- a/src/ting/tui/pages/dispatch.py
+++ b/src/ting/tui/pages/dispatch.py
@@ -1,8 +1,8 @@
 """Dispatch TUI page — queue view with bulk dispatch and activity log."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from typing import TYPE_CHECKING, Any
 
 from textual.app import ComposeResult

--- a/src/volundr/adapters/outbound/local_process.py
+++ b/src/volundr/adapters/outbound/local_process.py
@@ -16,7 +16,6 @@ Constructor accepts plain kwargs (dynamic adapter pattern):
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
@@ -28,6 +27,7 @@ import signal
 import socket
 import subprocess
 import sys
+from contextlib import suppress
 from dataclasses import asdict, dataclass
 from enum import StrEnum
 from pathlib import Path

--- a/src/volundr/domain/__init__.py
+++ b/src/volundr/domain/__init__.py
@@ -2,7 +2,6 @@
 
 from volundr.domain.models import Session, SessionStatus
 from volundr.domain.ports import PodManager, SessionRepository
-from volundr.domain.services import SessionService
 
 __all__ = [
     "Session",
@@ -16,5 +15,7 @@ __all__ = [
 def __getattr__(name: str):
     """Lazily import heavyweight service exports to avoid config import cycles."""
     if name == "SessionService":
+        from volundr.domain.services import SessionService
+
         return SessionService
     raise AttributeError(name)

--- a/src/volundr/domain/services/chronicle.py
+++ b/src/volundr/domain/services/chronicle.py
@@ -1,9 +1,9 @@
 """Domain service for session chronicles."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import logging
+from contextlib import suppress
 from datetime import UTC, datetime
 from uuid import UUID
 
@@ -48,8 +48,8 @@ def _detect_git_info(path: str) -> dict[str, str]:
     Uses GitPython to inspect the repo. Returns empty dict if not a git repo.
     """
     result: dict[str, str] = {}
-    with suppress(InvalidGitRepositoryError, Exception):
-        from git import InvalidGitRepositoryError, Repo
+    with suppress(Exception):
+        from git import Repo
 
         repo = Repo(path, search_parent_directories=True)
 

--- a/src/volundr/tui/admin.py
+++ b/src/volundr/tui/admin.py
@@ -1,8 +1,8 @@
 """Admin page — user/tenant tables and stats dashboard with search."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/volundr/tui/chat.py
+++ b/src/volundr/tui/chat.py
@@ -1,8 +1,8 @@
 """Chat page — WebSocket streaming messages with markdown and mention menus."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/volundr/tui/chronicles.py
+++ b/src/volundr/tui/chronicles.py
@@ -1,8 +1,8 @@
 """Chronicles page — timeline events with filter tabs and search."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/volundr/tui/diffs.py
+++ b/src/volundr/tui/diffs.py
@@ -1,8 +1,8 @@
 """Diffs page — split view with file tree (left) and diff viewer (right)."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/volundr/tui/sessions.py
+++ b/src/volundr/tui/sessions.py
@@ -1,8 +1,8 @@
 """Sessions page — DataTable with status badges, filters, search, and actions."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import Any
 

--- a/src/volundr/tui/settings.py
+++ b/src/volundr/tui/settings.py
@@ -1,8 +1,8 @@
 """Settings page — tabbed configuration for connection, profile, integrations, appearance."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/src/volundr/tui/terminal.py
+++ b/src/volundr/tui/terminal.py
@@ -1,8 +1,8 @@
 """Terminal page — PTY over WebSocket with multi-tab, scrollback, Insert/Normal modes."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
 

--- a/tests/integration/helpers/kind_harness.py
+++ b/tests/integration/helpers/kind_harness.py
@@ -41,7 +41,6 @@ Usage example::
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import json
 import logging
@@ -52,6 +51,7 @@ import tempfile
 import time
 import urllib.error
 import urllib.request
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 

--- a/tests/ravn/unit/test_budget.py
+++ b/tests/ravn/unit/test_budget.py
@@ -1,10 +1,10 @@
 """Tests for DailyBudgetTracker and DriveLoop budget integration (NIU-570)."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import time
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -1,11 +1,11 @@
 """Tests for DriveLoop, SilentChannel, triggers, and initiative prompt."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
 import time
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/ravn/unit/test_mimir_threads.py
+++ b/tests/ravn/unit/test_mimir_threads.py
@@ -26,8 +26,8 @@ Tests cover:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_bifrost/test_streaming.py
+++ b/tests/test_bifrost/test_streaming.py
@@ -1,10 +1,10 @@
 """Tests for the streaming translation layer."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import json
 from collections.abc import AsyncIterator
+from contextlib import suppress
 
 import pytest
 

--- a/tests/test_cli/test_tui_pages.py
+++ b/tests/test_cli/test_tui_pages.py
@@ -253,7 +253,6 @@ class TestSessionsPage:
     async def test_sessions_action_messages(self) -> None:
         sessions = _sample_sessions()
         app = PageTestApp(SessionsPage, sessions=sessions)
-        messages: list[SessionsPage.SessionAction] = []
         async with app.run_test() as pilot:
             await pilot.pause()
             page = app.query_one(SessionsPage)

--- a/tests/test_ravn/test_cron_tools.py
+++ b/tests/test_ravn/test_cron_tools.py
@@ -1,10 +1,10 @@
 """Tests for NIU-437 cron scheduling: CronJobStore, cron tools, CronTrigger."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import stat
+from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, patch

--- a/tests/test_ravn/test_gateway_discord.py
+++ b/tests/test_ravn/test_gateway_discord.py
@@ -1,10 +1,10 @@
 """Tests for the Discord gateway adapter."""
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import json
+from contextlib import suppress
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_ravn/test_persona_slash_command.py
+++ b/tests/test_ravn/test_persona_slash_command.py
@@ -9,6 +9,7 @@ import pytest
 from ravn.adapters.slash_commands import PersonaCommand, SlashCommandContext, default_registry
 from ravn.domain.models import Session
 
+
 def _ctx() -> SlashCommandContext:
     return SlashCommandContext(session=Session())
 

--- a/tests/test_ravn/test_ting_queue_trigger.py
+++ b/tests/test_ravn/test_ting_queue_trigger.py
@@ -9,10 +9,10 @@ Covers:
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import importlib
+from contextlib import suppress
 from unittest.mock import AsyncMock, patch
 
 import httpx

--- a/tests/test_sleipnir/test_nng_transport.py
+++ b/tests/test_sleipnir/test_nng_transport.py
@@ -11,12 +11,12 @@ to ensure isolation even when tests run in parallel.
 """
 
 from __future__ import annotations
-from contextlib import suppress
 
 import asyncio
 import sys
 import textwrap
 import time
+from contextlib import suppress
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_ting/test_runs_api.py
+++ b/tests/test_ting/test_runs_api.py
@@ -1,8 +1,8 @@
 """Tests for run review REST API endpoints."""
 
 from __future__ import annotations
-from contextlib import suppress
 
+from contextlib import suppress
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from uuid import UUID, uuid4

--- a/web-next/.prettierignore
+++ b/web-next/.prettierignore
@@ -6,3 +6,4 @@ playwright-report
 test-results
 pnpm-lock.yaml
 *.tsbuildinfo
+packages/*/CHANGELOG.md


### PR DESCRIPTION
## Summary
- fix the release workflow regressions blocking main releases
- harden container scan workflow retries and SARIF upload handling
- break the ravn and volundr import cycles that were failing dev CI and helm smoke tests
- ignore generated package changelogs in web-next prettier checks

## Validation
- uv run pytest
- PR #761 against dev is fully green