### PR TITLE
feat: import and resume external Claude/Codex sessions

### DIFF
--- a/charts/volundr/templates/migrations-configmap.yaml
+++ b/charts/volundr/templates/migrations-configmap.yaml
@@ -1179,4 +1179,21 @@ data:
     ALTER TABLE volundr_launch_specs DROP COLUMN IF EXISTS session_definition;
 
     ALTER TABLE volundr_launch_specs RENAME TO volundr_presets;
+
+  000045_session_origin.up.sql: |
+    -- Track where a session originated (volundr, claude, codex) and the native
+    -- CLI session/thread id for sessions imported from an external harness.
+
+    ALTER TABLE sessions ADD COLUMN IF NOT EXISTS origin VARCHAR(50) NOT NULL DEFAULT 'volundr';
+    ALTER TABLE sessions ADD COLUMN IF NOT EXISTS external_session_id VARCHAR(255);
+
+    CREATE INDEX IF NOT EXISTS idx_sessions_external_session_id
+        ON sessions (external_session_id)
+        WHERE external_session_id IS NOT NULL;
+
+  000045_session_origin.down.sql: |
+    DROP INDEX IF EXISTS idx_sessions_external_session_id;
+
+    ALTER TABLE sessions DROP COLUMN IF EXISTS external_session_id;
+    ALTER TABLE sessions DROP COLUMN IF EXISTS origin;
 {{- end }}

--- a/docs/openclaw-session-orchestrator-guide.md
+++ b/docs/openclaw-session-orchestrator-guide.md
@@ -105,6 +105,8 @@ When you fetch or receive session state, these fields are the most important:
 - `activity_state`
 - `activity_metadata`
 - `workload_type`
+- `origin` — where the session came from: `volundr` (created through the API), `claude`, or `codex` (imported from an external CLI store)
+- `external_session_id` — the native CLI session/thread id for imported sessions; `null` otherwise
 
 You should cache the latest session object keyed by `session_id`.
 
@@ -119,6 +121,7 @@ Preferred control-plane endpoints:
 | `POST` | `/api/v1/forge/sessions` | Create and start a session |
 | `PUT` | `/api/v1/forge/sessions/{id}` | Update mutable fields |
 | `POST` | `/api/v1/forge/sessions/{id}/start` | Restart a stopped or failed session |
+| `POST` | `/api/v1/forge/sessions/{id}/resume` | Alias of `start`; for imported sessions this resumes the native CLI session |
 | `POST` | `/api/v1/forge/sessions/{id}/stop` | Stop a running session |
 | `PATCH` | `/api/v1/forge/sessions/{id}/archive` | Archive a session |
 | `PATCH` | `/api/v1/forge/sessions/{id}/restore` | Restore an archived session |
@@ -212,6 +215,44 @@ After creation:
 
 If you are deploying Volundr in mini mode or a self-hosted remote setup, these config behaviors matter:
 
+#### Running the stack locally (mini mode)
+
+The fastest way to a working control plane on a developer host:
+
+```bash
+./start-dev     # builds web assets, starts embedded PostgreSQL, boots the platform on :8080
+./stop-dev      # stops everything
+```
+
+`start-dev` wraps `uv run niuu platform up --host-profile full`. The platform
+CLI defaults to `mode: mini`, which means:
+
+- the embedded PostgreSQL starts automatically and migrations are applied
+- `LOCAL_MOUNTS__ENABLED=true` and `LOCAL_MOUNTS__MINI_MODE=true` are set
+- sessions run as local Skuld broker subprocesses on the host, not Kubernetes pods
+- external session discovery (next section) is enabled by default
+
+Probe capabilities before relying on host-only features:
+
+```http
+GET /api/v1/forge/feature-flags
+```
+
+```json
+{
+  "local_mounts_enabled": true,
+  "file_manager_enabled": true,
+  "mini_mode": true,
+  "local_mounts_allowed_prefixes": []
+}
+```
+
+`mini_mode: true` tells you the deployment runs on a host with direct access to
+local workspaces and CLI session stores. An empty
+`local_mounts_allowed_prefixes` means any host directory may be used as a
+session workspace; a non-empty list restricts workspaces (and external session
+imports) to those path prefixes.
+
 #### `session_definitions` overrides are partial now
 
 You can override only part of a built-in runtime definition. Volundr now deep-merges configured `session_definitions` over the built-ins instead of replacing the entire map.
@@ -276,7 +317,147 @@ Practical effect:
 - `definition: skuldCodex` with no `model` will not inject `claude-sonnet-4-6` into the Skuld session env.
 - definition defaults can provide the runtime-specific model when desired.
 
-## 7. Real-time session SSE
+## 7. Discover and import external CLI sessions
+
+Volundr can adopt coding sessions that were started outside the platform —
+directly with the Claude Code CLI or the Codex CLI on the same host. Discovery
+scans the harnesses' native stores (`~/.claude/projects`, `~/.codex/sessions`),
+and an imported session becomes a normal Volundr session that, when started,
+resumes the native conversation with full history (`claude --resume` for
+Claude, the `thread/resume` RPC for Codex).
+
+This is a host-local feature. It is enabled by default in mini mode and
+disabled in cluster deployments unless `external_sessions.enabled: true` is
+configured. If `GET /api/v1/forge/external-sessions` returns `503`, treat the
+feature as unavailable and do not retry.
+
+### List discoverable sessions
+
+```http
+GET /api/v1/forge/external-sessions
+GET /api/v1/forge/external-sessions?provider=claude-code
+GET /api/v1/forge/external-sessions?provider=codex
+```
+
+Each record:
+
+```json
+{
+  "provider": "claude-code",
+  "harness": "claude",
+  "external_id": "5554a0e2-e8db-4c32-b18d-007591620d1e",
+  "workspace_path": "/Users/dev/code/acme",
+  "title": "Fix the login bug",
+  "model": "claude-sonnet-4-6",
+  "created_at": "2026-06-10T12:53:22Z",
+  "updated_at": "2026-06-10T12:55:26Z",
+  "live": false,
+  "workspace_exists": true,
+  "workspace_allowed": true,
+  "imported_session_id": null,
+  "importable": true
+}
+```
+
+Field semantics for a controller:
+
+- `live` — the session shows recent activity in its store and is probably
+  running in a terminal right now. You can still import it; resuming while the
+  human is mid-conversation is rude, so prefer dead sessions unless told
+  otherwise.
+- `importable` — derived flag: the workspace still exists on disk, passes the
+  mount prefix policy, and the session has not been imported yet. Gate your
+  import action on this.
+- `imported_session_id` — set when a Volundr session already wraps this
+  external session; use that id with the normal lifecycle API instead of
+  importing again.
+- `workspace_allowed` — `false` when the session's working directory falls
+  outside `local_mounts.allowed_prefixes`. Imports of such sessions are
+  rejected.
+
+Results are sorted newest-first and capped per provider (default 200, see the
+`max_sessions` adapter kwarg). Listing is read-only and cheap to poll.
+
+### Import a session
+
+```http
+POST /api/v1/forge/sessions/import
+```
+
+```json
+{
+  "provider": "claude-code",
+  "external_id": "5554a0e2-e8db-4c32-b18d-007591620d1e",
+  "name": "adopted-login-fix"
+}
+```
+
+`name` is optional; a `<harness>-import-<prefix>` name is derived when omitted.
+
+The `201` response is a regular session object with `origin` set to the
+harness (`claude` or `codex`), `external_session_id` recorded, and a
+`local_mount` source pointing at the session's original working directory. The
+session is created in a non-running state — importing never launches anything.
+
+Error contract:
+
+| Status | Meaning | Controller action |
+|---|---|---|
+| `404` | Unknown provider or external id | Re-list and reconcile |
+| `409` | Already imported | Extract the existing session id from the listing's `imported_session_id` |
+| `403` | Workspace outside allowed mount prefixes | Do not retry; surface to operator |
+| `422` | Workspace directory no longer exists | Do not retry; the session is dead on disk |
+| `503` | Discovery not enabled on this deployment | Stop using the feature |
+
+### Resume an imported session
+
+Start the imported session like any other:
+
+```http
+POST /api/v1/forge/sessions/{id}/resume
+```
+
+(`/resume` and `/start` are aliases.) For sessions with an
+`external_session_id`, Volundr pins a resume-capable transport and hands the
+native session id to the broker, so the CLI reattaches to the original
+conversation — prior context, decisions, and file state knowledge included.
+From that point the session behaves like any Volundr session: SSE updates,
+live chat over `chat_endpoint`, stop/archive lifecycle, chronicles.
+
+Recommended controller flow:
+
+1. `GET /external-sessions`, filter `importable == true` (and usually `live == false`)
+2. `POST /sessions/import` with provider + external id
+3. `POST /sessions/{id}/resume`, then wait for `status=running` via SSE
+4. Interact over the normal chat transport; the resumed agent already has the
+   conversation history, so you can ask "where did you leave off?" instead of
+   re-briefing from scratch
+
+### Configuration reference
+
+Defaults need nothing. To override:
+
+```yaml
+external_sessions:
+  enabled: true            # default null = follow local_mounts.mini_mode
+  providers:
+    - adapter: "volundr.adapters.outbound.external_sessions.ClaudeCodeSessionProvider"
+      kwargs:
+        projects_dir: "~/.claude/projects"
+        live_threshold_seconds: 120
+        max_sessions: 200
+    - adapter: "volundr.adapters.outbound.external_sessions.CodexSessionProvider"
+      kwargs:
+        sessions_dir: "~/.codex/sessions"
+
+local_mounts:
+  allowed_prefixes: []     # non-empty restricts workspaces and imports
+```
+
+Environment variable equivalents use nested `__` delimiters, for example
+`EXTERNAL_SESSIONS__ENABLED=true`.
+
+## 8. Real-time session SSE
 
 Subscribe here:
 
@@ -368,7 +549,7 @@ Recommended timeout strategy:
 - if the stream goes silent beyond your liveness threshold, reconnect
 - after reconnect, refresh all sessions you still care about
 
-## 8. Live chat transport
+## 9. Live chat transport
 
 The live agent stream does not come from the Volundr API server. It comes from the session broker reachable at `chat_endpoint`.
 
@@ -399,7 +580,7 @@ Use the HTTP proxy endpoints when you only need:
 - conversation history after the fact
 - compatibility with simpler HTTP-only workers
 
-## 9. WebSocket protocol for the live session
+## 10. WebSocket protocol for the live session
 
 Connect to:
 
@@ -551,7 +732,7 @@ If you want richer internal event visibility on the WebSocket, you can send:
 
 This is optional for controllers, but useful for debugging or agent analytics.
 
-## 10. Simpler HTTP-only interaction mode
+## 11. Simpler HTTP-only interaction mode
 
 If your controller does not want to maintain a direct WebSocket, you can still drive a session through HTTP.
 
@@ -629,7 +810,7 @@ GET /api/v1/forge/sessions/{session_id}/archive
 
 Useful for post-run harvesters.
 
-## 11. Broker-side HTTP endpoints derived from `chat_endpoint`
+## 12. Broker-side HTTP endpoints derived from `chat_endpoint`
 
 If you have a live `chat_endpoint`, you can derive the live broker base URL:
 
@@ -655,7 +836,7 @@ Useful live-broker endpoints:
 
 Use the broker endpoints only when the session is running.
 
-## 12. Event-history API
+## 13. Event-history API
 
 Use the event repository when you want durable evidence instead of transient SSE.
 
@@ -719,7 +900,7 @@ Use these events to answer questions like:
 - Did it call a git or shell tool?
 - How much token budget did it burn?
 
-## 13. PR, diff, and git inspection
+## 14. PR, diff, and git inspection
 
 ### PR status
 
@@ -759,7 +940,7 @@ Useful endpoints:
 
 Use diff endpoints when you want fast post-run inspection without reading the entire transcript.
 
-## 14. Chronicles and timeline
+## 15. Chronicles and timeline
 
 Chronicles are the durable narrative summary of a session.
 
@@ -808,7 +989,7 @@ Use timeline data for:
 - building agent scorecards
 - classifying sessions as coding, review, research, or failure-heavy
 
-## 15. How to decide whether a session has finished its work
+## 16. How to decide whether a session has finished its work
 
 This is the most important section.
 
@@ -950,7 +1131,7 @@ async def evaluate_completion(api, session_id, latest_activity):
     return {"state": "running", "confidence": 0.0}
 ```
 
-## 16. Special case: flock or workflow sessions
+## 17. Special case: flock or workflow sessions
 
 Be careful with:
 
@@ -966,7 +1147,7 @@ Use a stricter rule:
 
 If you are binding OpenClaw to this system, model flock sessions separately from ordinary coding sessions.
 
-## 17. Recommended controller state machine
+## 18. Recommended controller state machine
 
 Use this state machine in your orchestrator:
 
@@ -992,7 +1173,7 @@ Meaning:
 - `FAILED`: terminal runtime or outcome failure
 - `ABANDONED`: operator stopped it or evidence is too weak
 
-## 18. Recommended runtime loop
+## 19. Recommended runtime loop
 
 A robust loop looks like this:
 
@@ -1009,7 +1190,7 @@ A robust loop looks like this:
 11. If complete, fetch chronicle, transcript, events, diff, and PR status.
 12. Stop or archive the session if your operating policy requires it.
 
-## 19. Recovery rules
+## 20. Recovery rules
 
 ### SSE disconnect
 
@@ -1040,7 +1221,7 @@ Interpret this as:
 
 Do not try to chat until `chat_endpoint` is present.
 
-## 20. What to persist in OpenClaw
+## 21. What to persist in OpenClaw
 
 For each tracked session, persist:
 
@@ -1057,7 +1238,7 @@ For each tracked session, persist:
 
 This allows crash recovery without depending on SSE durability.
 
-## 21. Minimum viable implementation
+## 22. Minimum viable implementation
 
 If you want the smallest useful controller:
 
@@ -1074,7 +1255,7 @@ If you want the smallest useful controller:
 
 That is enough to implement a basic Tyr-like controller loop.
 
-## 22. Recommended full implementation
+## 23. Recommended full implementation
 
 For production behavior, support all of:
 
@@ -1090,7 +1271,7 @@ For production behavior, support all of:
 - reconnection and rehydration logic
 - confidence-based completion
 
-## 23. Final guidance for an AI orchestrator
+## 24. Final guidance for an AI orchestrator
 
 If you are the controller:
 

--- a/migrations/000045_session_origin.down.sql
+++ b/migrations/000045_session_origin.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_sessions_external_session_id;
+
+ALTER TABLE sessions DROP COLUMN IF EXISTS external_session_id;
+ALTER TABLE sessions DROP COLUMN IF EXISTS origin;

--- a/migrations/000045_session_origin.up.sql
+++ b/migrations/000045_session_origin.up.sql
@@ -1,0 +1,9 @@
+-- Track where a session originated (volundr, claude, codex) and the native
+-- CLI session/thread id for sessions imported from an external harness.
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS origin VARCHAR(50) NOT NULL DEFAULT 'volundr';
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS external_session_id VARCHAR(255);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_external_session_id
+    ON sessions (external_session_id)
+    WHERE external_session_id IS NOT NULL;

--- a/scripts/extract_openapi.py
+++ b/scripts/extract_openapi.py
@@ -135,7 +135,9 @@ def build_openapi_app() -> FastAPI:
 
     mock = MagicMock()
 
-    app.include_router(create_router(mock, mock, mock, mock, mock, mock, mock))
+    app.include_router(
+        create_router(mock, mock, mock, mock, mock, mock, mock, external_session_service=mock)
+    )
     app.include_router(create_launch_specs_router(mock, mock))
     app.include_router(create_resources_router(mock))
     app.include_router(create_secrets_router(mock, mock))

--- a/src/mimir/mcp.py
+++ b/src/mimir/mcp.py
@@ -53,6 +53,7 @@ def _sanitize_log(value: object) -> str:
     """Sanitize a value for safe log output (prevent log injection)."""
     return str(value).replace("\n", "\\n").replace("\r", "\\r")
 
+
 # MCP protocol version negotiated during initialize
 _PROTOCOL_VERSION = "2024-11-05"
 

--- a/src/mimir/router.py
+++ b/src/mimir/router.py
@@ -97,12 +97,15 @@ class PageResponse(BaseModel):
     updated_by: str = "mimir"
     size: int = 0
     related: list[str] = []
-    zones: list[
-        KeyFactsZoneResponse
-        | RelationshipsZoneResponse
-        | AssessmentZoneResponse
-        | TimelineZoneResponse
-    ] | None = None
+    zones: (
+        list[
+            KeyFactsZoneResponse
+            | RelationshipsZoneResponse
+            | AssessmentZoneResponse
+            | TimelineZoneResponse
+        ]
+        | None
+    ) = None
 
 
 class KeyFactsZoneResponse(BaseModel):
@@ -836,12 +839,15 @@ def _extract_relationships(compiled_truth: str) -> list[RelationshipZoneItemResp
 
 def _decorate_page_zones(
     parsed: CompiledTruthPage,
-) -> list[
-    KeyFactsZoneResponse
-    | RelationshipsZoneResponse
-    | AssessmentZoneResponse
-    | TimelineZoneResponse
-] | None:
+) -> (
+    list[
+        KeyFactsZoneResponse
+        | RelationshipsZoneResponse
+        | AssessmentZoneResponse
+        | TimelineZoneResponse
+    ]
+    | None
+):
     zones: list[
         KeyFactsZoneResponse
         | RelationshipsZoneResponse
@@ -1084,10 +1090,7 @@ class MimirRouter:
                     for mount in mounts
                 ]
 
-            return [
-                _registry_to_response(entry)
-                for entry in self._registry_store.list_entries()
-            ]
+            return [_registry_to_response(entry) for entry in self._registry_store.list_entries()]
 
         @router.post("/registry/mounts", response_model=RegistryMountResponse)
         async def create_registry_mount(

--- a/src/niuu/adapters/inbound/rest_volundr.py
+++ b/src/niuu/adapters/inbound/rest_volundr.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 import httpx
@@ -81,6 +82,10 @@ def _normalize_timestamp(value: Any) -> float:
         return 0.0
     try:
         return float(value)
+    except ValueError:
+        pass
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
     except ValueError:
         return 0.0
 
@@ -546,6 +551,155 @@ def create_volundr_router(
             if isinstance(payload, list):
                 archived.extend(str(item) for item in payload)
         return archived
+
+    @router.get("/feature-flags")
+    async def get_feature_flags(
+        request: Request,
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        instance = await _resolve_target_instance(service, principal, None)
+        response = await _request_remote(
+            instance,
+            request,
+            method="GET",
+            path="/feature-flags",
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    @router.get("/external-sessions")
+    async def list_external_sessions(
+        request: Request,
+        principal: Principal = Depends(extract_principal),
+    ) -> list[dict[str, Any]]:
+        """Aggregate discoverable external CLI sessions across instances.
+
+        Returns 503 only when every visible instance reports discovery as
+        unavailable, so the UI can hide the import affordance.
+        """
+        instances = await _visible_instances(service, principal)
+        params = _query_params(request)
+        results = await asyncio.gather(
+            *[
+                _request_remote(
+                    instance,
+                    request,
+                    method="GET",
+                    path="/external-sessions",
+                    params=params,
+                    embedded_app=embedded_forge_app,
+                )
+                for instance in instances
+            ],
+            return_exceptions=True,
+        )
+
+        merged: list[dict[str, Any]] = []
+        succeeded = False
+        for instance, result in zip(instances, results, strict=False):
+            if isinstance(result, Exception):
+                continue
+            if result.status_code >= 400:
+                continue
+            payload = result.json()
+            if not isinstance(payload, list):
+                continue
+            succeeded = True
+            merged.extend(
+                _with_instance(item, instance) for item in payload if isinstance(item, dict)
+            )
+
+        if not succeeded:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="External session discovery not available",
+            )
+
+        merged.sort(
+            key=lambda item: _normalize_timestamp(item.get("updated_at") or item.get("updatedAt")),
+            reverse=True,
+        )
+        return merged
+
+    @router.post("/sessions/import", status_code=status.HTTP_201_CREATED)
+    async def import_external_session(
+        request: Request,
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        requested_instance_id = body.get("instance_id") or body.get("instanceId")
+        target_tags = body.get("target_tags") or body.get("targetTags")
+        target_match = body.get("target_match") or body.get("targetMatch") or "all"
+        instance = await _resolve_target_instance(
+            service,
+            principal,
+            str(requested_instance_id) if requested_instance_id else None,
+            tags=list(target_tags) if target_tags else None,
+            match=str(target_match),
+        )
+        response = await _request_remote(
+            instance,
+            request,
+            method="POST",
+            path="/sessions/import",
+            json_body=_strip_instance_hints(body),
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Unexpected response from target Volundr instance",
+            )
+        return _with_instance(payload, instance)
+
+    async def _start_session_on_owner(
+        request: Request,
+        session_id: str,
+        principal: Principal,
+        path_suffix: str,
+    ) -> dict[str, Any]:
+        instance, _ = await _find_session_owner(
+            service,
+            principal,
+            request,
+            session_id,
+            embedded_app=embedded_forge_app,
+        )
+        try:
+            json_body = await request.json()
+        except Exception:
+            json_body = None
+        response = await _request_remote(
+            instance,
+            request,
+            method="POST",
+            path=f"/sessions/{session_id}/{path_suffix}",
+            json_body=json_body if isinstance(json_body, dict) else None,
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return _with_instance(payload, instance) if isinstance(payload, dict) else {}
+
+    @router.post("/sessions/{session_id}/start")
+    async def start_session(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        return await _start_session_on_owner(request, session_id, principal, "start")
+
+    @router.post("/sessions/{session_id}/resume")
+    async def resume_session(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        return await _start_session_on_owner(request, session_id, principal, "resume")
 
     @router.post("/sessions/{session_id}/stop")
     async def stop_session(

--- a/src/niuu/adapters/openbao_credential_store.py
+++ b/src/niuu/adapters/openbao_credential_store.py
@@ -89,9 +89,7 @@ class OpenBaoCredentialStore(CredentialStorePort):
             return ""
 
         if self._auth_method != "approle":
-            raise RuntimeError(
-                "OpenBao credential store requires a token or approle credentials"
-            )
+            raise RuntimeError("OpenBao credential store requires a token or approle credentials")
         if not self._role_id or not self._secret_id:
             raise RuntimeError("AppRole auth requires role_id and secret_id")
 
@@ -129,9 +127,7 @@ class OpenBaoCredentialStore(CredentialStorePort):
         return str(PurePosixPath(self._mount_path, "data", f"{owner_type}s", owner_id, name))
 
     def _metadata_path(self, owner_type: str, owner_id: str, name: str) -> str:
-        return str(
-            PurePosixPath(self._mount_path, "metadata", f"{owner_type}s", owner_id, name)
-        )
+        return str(PurePosixPath(self._mount_path, "metadata", f"{owner_type}s", owner_id, name))
 
     def _list_path(self, owner_type: str, owner_id: str) -> str:
         return str(PurePosixPath(self._mount_path, "metadata", f"{owner_type}s", owner_id))
@@ -188,9 +184,7 @@ class OpenBaoCredentialStore(CredentialStorePort):
             json={"data": payload},
         )
         if response.status_code >= 400:
-            raise RuntimeError(
-                f"OpenBao store error ({response.status_code}): {response.text}"
-            )
+            raise RuntimeError(f"OpenBao store error ({response.status_code}): {response.text}")
 
         return StoredCredential(
             id=cred_id,

--- a/src/niuu/app.py
+++ b/src/niuu/app.py
@@ -138,9 +138,7 @@ def _create_plugin_api_app_with_context(plugin: Service, **context: Any) -> Any:
     )
     if accepts_kwargs:
         return factory(**context)
-    accepted_context = {
-        key: value for key, value in context.items() if key in signature.parameters
-    }
+    accepted_context = {key: value for key, value in context.items() if key in signature.parameters}
     return factory(**accepted_context)
 
 

--- a/src/ravn/adapters/environment_signals.py
+++ b/src/ravn/adapters/environment_signals.py
@@ -180,8 +180,7 @@ class KubernetesSignalAdapter(_IterableSignalAdapter):
             signals = [
                 signal
                 for signal in signals
-                if _text(signal.normalized_payload.get("reason")).lower()
-                in self._include_reasons
+                if _text(signal.normalized_payload.get("reason")).lower() in self._include_reasons
             ]
         if self._exclude_reasons:
             signals = [

--- a/src/ravn/adapters/executors/cli.py
+++ b/src/ravn/adapters/executors/cli.py
@@ -31,8 +31,7 @@ class _TransportBinding:
 def _delegates_permission_config_to_cli(cls: type[CLITransport]) -> bool:
     """Return true for transports whose native CLI profile owns permissions."""
     return (
-        cls.__module__ == "skuld.transports.codex_ws"
-        and cls.__name__ == "CodexWebSocketTransport"
+        cls.__module__ == "skuld.transports.codex_ws" and cls.__name__ == "CodexWebSocketTransport"
     )
 
 

--- a/src/ravn/adapters/triggers/valkyrie_cycle.py
+++ b/src/ravn/adapters/triggers/valkyrie_cycle.py
@@ -70,9 +70,7 @@ class ValkyrieCycleStatus:
             "last_dream_completed_at": (
                 self.last_dream_completed_at.isoformat() if self.last_dream_completed_at else ""
             ),
-            "next_dream_after": self.next_dream_after.isoformat()
-            if self.next_dream_after
-            else "",
+            "next_dream_after": self.next_dream_after.isoformat() if self.next_dream_after else "",
             "last_error": self.last_error,
             "proposals_created": self.proposals_created,
             "proposals_applied": self.proposals_applied,
@@ -165,9 +163,7 @@ class ValkyrieCycleScheduler:
             saved = await evaluate_and_store_proposals(proposals, store=self._store)
             applied = await self._apply_allowed(saved)
             deferred = [
-                proposal
-                for proposal in saved
-                if proposal.status != ProposalStatus.APPLIED.value
+                proposal for proposal in saved if proposal.status != ProposalStatus.APPLIED.value
             ]
             completed_at = self._clock()
             result.completed_at = completed_at

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -3833,9 +3833,7 @@ def _resolve_transport_kwargs(
             "user": os.environ.get(nats_cfg.user_env, nats_cfg.user)
             if nats_cfg.user_env
             else nats_cfg.user,
-            "password": os.environ.get(nats_cfg.password_env, "")
-            if nats_cfg.password_env
-            else "",
+            "password": os.environ.get(nats_cfg.password_env, "") if nats_cfg.password_env else "",
             "token": os.environ.get(nats_cfg.token_env, "") if nats_cfg.token_env else "",
             "nkeys_seed_file": nats_cfg.nkeys_seed_file,
             "nkeys_seed": os.environ.get(nats_cfg.nkeys_seed_env, "")

--- a/src/ravn/demo/__init__.py
+++ b/src/ravn/demo/__init__.py
@@ -1,2 +1,1 @@
 """Demo fixtures for Ravn and resident Valkyrie workflows."""
-

--- a/src/ravn/domain/environment.py
+++ b/src/ravn/domain/environment.py
@@ -259,9 +259,7 @@ class Environment(BaseModel):
     @property
     def mimir_mount_names(self) -> list[str]:
         """Flattened Mimir mount list for Warden/Ravn runtime config."""
-        return _dedupe(
-            mount for scope in self.learning_scopes for mount in scope.mimir_mounts
-        )
+        return _dedupe(mount for scope in self.learning_scopes for mount in scope.mimir_mounts)
 
     def signal_subjects(self) -> list[str]:
         """NATS subjects resident Valkyries should subscribe to for signals."""

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -1130,9 +1130,7 @@ class DriveLoop:
                 name=f"initiative:{task.task_id}",
             )
             self._active_tasks[task.task_id] = asyncio_task
-            asyncio_task.add_done_callback(
-                lambda _t, tid=task.task_id: self._on_task_done(tid, _t)
-            )
+            asyncio_task.add_done_callback(lambda _t, tid=task.task_id: self._on_task_done(tid, _t))
             self._queue.task_done()
 
     def _on_task_done(self, task_id: str, finished_task: asyncio.Task[Any]) -> None:

--- a/src/ravn/environment_signal_runtime.py
+++ b/src/ravn/environment_signal_runtime.py
@@ -79,8 +79,7 @@ def build_runtime_environment(settings: Settings) -> Environment:
             for source in cfg.signal_sources
         ],
         flock_memberships=[
-            FlockMembership(flock_id=flock_id, role="resident")
-            for flock_id in cfg.flocks
+            FlockMembership(flock_id=flock_id, role="resident") for flock_id in cfg.flocks
         ],
     )
 
@@ -225,8 +224,7 @@ class EnvironmentSignalRuntime:
         obj = signal.object_ref or {}
         if obj.get("kind") and obj.get("name"):
             title = (
-                f"{obj['kind']} {obj.get('namespace', 'default')}/{obj['name']}: "
-                f"{signal.severity}"
+                f"{obj['kind']} {obj.get('namespace', 'default')}/{obj['name']}: {signal.severity}"
             )
         context = (
             "A resident Valkyrie received an environment signal.\n\n"

--- a/src/ravn/feedback/recorder.py
+++ b/src/ravn/feedback/recorder.py
@@ -99,18 +99,16 @@ class EnvironmentFeedbackRecorder:
         effective_until = _text(delivery_effect.get("effective_until"))
         user_id = _text(payload.get("user_id"))
 
-        self._delivery_state[(environment_id, target_event_id, surface_id)] = (
-            DeliveryFeedbackState(
-                environment_id=environment_id,
-                target_event_id=target_event_id,
-                feedback_type=feedback_type,
-                delivery_state=state,
-                surface_id=surface_id,
-                user_id=user_id,
-                effective_until=effective_until,
-                source_feedback_id=event.event_id,
-                updated_at=datetime.now(UTC),
-            )
+        self._delivery_state[(environment_id, target_event_id, surface_id)] = DeliveryFeedbackState(
+            environment_id=environment_id,
+            target_event_id=target_event_id,
+            feedback_type=feedback_type,
+            delivery_state=state,
+            surface_id=surface_id,
+            user_id=user_id,
+            effective_until=effective_until,
+            source_feedback_id=event.event_id,
+            updated_at=datetime.now(UTC),
         )
 
         if self._publisher is not None:
@@ -194,8 +192,7 @@ def feedback_event_to_episode(event: SleipnirEvent) -> Episode:
         f"in {environment_id}: {notes or rating}"
     )
     task_description = (
-        f"Capture resident Valkyrie feedback for {environment_id} "
-        f"targeting {target_event_id}"
+        f"Capture resident Valkyrie feedback for {environment_id} targeting {target_event_id}"
     )
     return Episode(
         episode_id=f"feedback:{event.event_id}",

--- a/src/ravn/odin/court.py
+++ b/src/ravn/odin/court.py
@@ -78,9 +78,7 @@ class InMemoryCourtAuditSink:
     def records(self) -> list[CourtDecisionRecord]:
         return list(self._records)
 
-    def find(
-        self, *, environment_id: str, root_correlation_id: str
-    ) -> CourtDecisionRecord | None:
+    def find(self, *, environment_id: str, root_correlation_id: str) -> CourtDecisionRecord | None:
         for record in reversed(self._records):
             if (
                 record.environment_id == environment_id

--- a/src/ravn/skills/management.py
+++ b/src/ravn/skills/management.py
@@ -112,14 +112,10 @@ class SkillManagementRegistry:
             name=skill.name,
             description=description if description is not None else skill.description,
             content=(
-                _ensure_skill_header(skill.name, content)
-                if content is not None
-                else skill.content
+                _ensure_skill_header(skill.name, content) if content is not None else skill.content
             ),
             requires_tools=(
-                _tools_from_content(content)
-                if content is not None
-                else skill.requires_tools
+                _tools_from_content(content) if content is not None else skill.requires_tools
             ),
             fallback_for_tools=skill.fallback_for_tools,
             source_episodes=skill.source_episodes,
@@ -310,9 +306,7 @@ class SkillManagementRegistry:
         except (OSError, json.JSONDecodeError):
             return
         self._metadata = {
-            key: SkillLifecycle(**value)
-            for key, value in data.items()
-            if isinstance(value, dict)
+            key: SkillLifecycle(**value) for key, value in data.items() if isinstance(value, dict)
         }
 
     def _save(self) -> None:

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -183,9 +183,7 @@ def _normalize_browser_message_content(content: object) -> str:
             f"{count} {label}" if count != 1 else f"1 {label}"
             for label, count in sorted(counts.items())
         )
-        lines.append(
-            f"[User attached {attachment_summary}. This transport forwards text only.]"
-        )
+        lines.append(f"[User attached {attachment_summary}. This transport forwards text only.]")
     return "\n\n".join(lines).strip()
 
 
@@ -206,6 +204,8 @@ _GIT_COMMIT_PREFIXES = ("git commit", "git -c ", "git -C ")
 
 # Matches git commit output like: [main e4f7a21] fix: some message
 _GIT_COMMIT_OUTPUT_RE = re.compile(r"\[[\w/-]+\s+([a-f0-9]{7,})\]\s+(.+)")
+
+
 def _is_git_commit(cmd: str) -> bool:
     """Return True if a Bash command is a git commit invocation."""
     stripped = cmd.lstrip()
@@ -697,9 +697,12 @@ def _workflow_gate_nodes(graph: dict[str, Any] | None) -> list[WorkflowGateNode]
                 else "gate.changes_requested",
             ),
         )
-        pending_behavior = str(
-            node.get("pendingBehavior") or node.get("pending_behavior") or "help_needed"
-        ).strip() or "help_needed"
+        pending_behavior = (
+            str(
+                node.get("pendingBehavior") or node.get("pending_behavior") or "help_needed"
+            ).strip()
+            or "help_needed"
+        )
         mode = str(node.get("mode") or "human_approval").strip() or "human_approval"
         instructions = str(node.get("instructions") or "").strip()
 
@@ -1348,9 +1351,7 @@ class Broker:
 
         deadline = time.monotonic() + max(0.0, timeout_s)
         missing = {
-            peer_id
-            for peer_id in required_peers
-            if not self._room_bridge.is_connected(peer_id)
+            peer_id for peer_id in required_peers if not self._room_bridge.is_connected(peer_id)
         }
         if missing:
             logger.info(
@@ -1363,9 +1364,7 @@ class Broker:
         while missing and time.monotonic() < deadline:
             await asyncio.sleep(poll_interval_s)
             missing = {
-                peer_id
-                for peer_id in required_peers
-                if not self._room_bridge.is_connected(peer_id)
+                peer_id for peer_id in required_peers if not self._room_bridge.is_connected(peer_id)
             }
 
         if missing:
@@ -1405,9 +1404,7 @@ class Broker:
             wait_timeout_s,
         )
         if not consumers_ready:
-            raise RuntimeError(
-                f"workflow trigger consumers for {cfg.event_type} did not connect"
-            )
+            raise RuntimeError(f"workflow trigger consumers for {cfg.event_type} did not connect")
 
         delay_s = max(0.0, float(cfg.startup_delay_s or 0.0))
         if delay_s and not self._workflow_trigger_consumer_peer_ids(cfg.event_type):
@@ -1495,6 +1492,7 @@ class Broker:
                 "" if self._has_workflow_trigger() else self._settings.session.initial_prompt
             ),
             "mcp_servers": self._settings.mcp_servers,
+            "resume_session_id": self._settings.session.resume_session_id,
         }
 
     def _create_transport(self) -> CLITransport:
@@ -1616,9 +1614,7 @@ class Broker:
         if self._settings.mesh.enabled:
             await self._start_mesh_adapter()
             if self._has_workflow_trigger():
-                self._workflow_trigger_task = asyncio.create_task(
-                    self._run_workflow_trigger_task()
-                )
+                self._workflow_trigger_task = asyncio.create_task(self._run_workflow_trigger_task())
         elif self._has_workflow_trigger():
             logger.warning("Workflow trigger configured but mesh is disabled — skipping dispatch")
 
@@ -2093,10 +2089,7 @@ class Broker:
             or f"{state.label} is waiting for human approval before the workflow can continue.",
             "reason": "needs_human_approval",
             "recommendation": state.condition
-            or (
-                "Review the pending gate and decide whether to approve "
-                "or request changes."
-            ),
+            or ("Review the pending gate and decide whether to approve or request changes."),
             "context": {
                 "gate_id": state.id,
                 "gate_label": state.label,
@@ -2810,8 +2803,8 @@ class Broker:
         if event_type == "control_request":
             self._track_pending_permission_request(data)
 
-        tool_result_only_user_event = (
-            event_type == "user" and self._is_tool_result_only_user_event(data)
+        tool_result_only_user_event = event_type == "user" and self._is_tool_result_only_user_event(
+            data
         )
         suppress_channel_broadcast = (
             event_type in {"user", "assistant", "content_block_delta", "result"}
@@ -4092,9 +4085,7 @@ class Broker:
     ) -> tuple[uuid.UUID | None, str]:
         """Pop a pending assistant tool span by id, falling back to FIFO order."""
         tool_key = (
-            tool_use_id
-            if tool_use_id and tool_use_id in self._trace_assistant_tool_spans
-            else ""
+            tool_use_id if tool_use_id and tool_use_id in self._trace_assistant_tool_spans else ""
         )
         if not tool_key and self._trace_assistant_tool_order:
             tool_key = self._trace_assistant_tool_order[0]

--- a/src/skuld/channels.py
+++ b/src/skuld/channels.py
@@ -42,6 +42,7 @@ def _is_expected_ws_disconnect(exc: Exception) -> bool:
         )
     return False
 
+
 try:
     from telegram import Bot, InlineKeyboardButton, InlineKeyboardMarkup
     from telegram.ext import (

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -195,6 +195,13 @@ class SkuldSessionConfig(BaseModel):
     initial_prompt: str = Field(default="")
     saga_id: str | None = Field(default=None)
     run_id: str | None = Field(default=None)
+    resume_session_id: str = Field(
+        default="",
+        description=(
+            "Native CLI session/thread id to resume on first start. Set by "
+            "Volundr for sessions imported from an external harness."
+        ),
+    )
 
 
 class ArchiveStoreConfig(BaseModel):

--- a/src/skuld/room_bridge.py
+++ b/src/skuld/room_bridge.py
@@ -291,17 +291,13 @@ class RoomBridge:
         requested_capabilities = tuple(capabilities or role_capabilities)
         disallowed = sorted(set(requested_capabilities) - set(role_capabilities))
         if disallowed:
-            raise PermissionError(
-                f"Role {role} cannot claim capabilities: {', '.join(disallowed)}"
-            )
+            raise PermissionError(f"Role {role} cannot claim capabilities: {', '.join(disallowed)}")
 
         room_membership = tuple(room_id for room_id in [room_id] if room_id)
         if participant_id in self._participants:
             old = self._participants[participant_id]
             color = old.color
-            existing_rooms = tuple(
-                dict.fromkeys([*old.room_ids, *room_membership])
-            )
+            existing_rooms = tuple(dict.fromkeys([*old.room_ids, *room_membership]))
         else:
             color = next(self._color_cycle)
             existing_rooms = room_membership
@@ -356,9 +352,7 @@ class RoomBridge:
         if meta is None:
             raise LookupError(f"Unknown room participant: {participant_id}")
         if capability not in meta.capabilities:
-            raise PermissionError(
-                f"Participant {participant_id} lacks capability: {capability}"
-            )
+            raise PermissionError(f"Participant {participant_id} lacks capability: {capability}")
 
     # ------------------------------------------------------------------
     # Environment huddles and replay

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -138,6 +138,7 @@ class CodexWebSocketTransport(CLITransport):
         initial_prompt: str = "",
         codex_port: int = 0,
         mcp_servers: list[dict] | None = None,
+        resume_session_id: str = "",
         **_kwargs: object,
     ) -> None:
         super().__init__()
@@ -151,6 +152,7 @@ class CodexWebSocketTransport(CLITransport):
         self._codex_port = codex_port or _pick_free_port()
         self._mcp_servers = list(mcp_servers or [])
         self._mcp_overrides = build_codex_mcp_overrides(self._mcp_servers)
+        self._resume_session_id = resume_session_id
         self._env = dict(os.environ)
 
         self._process: asyncio.subprocess.Process | None = None
@@ -408,27 +410,43 @@ class CodexWebSocketTransport(CLITransport):
 
         await self._send_notification("initialized")
 
-        thread_params: dict = {
-            "experimentalRawEvents": False,
-            "persistExtendedHistory": True,
-            "cwd": self.workspace_dir,
-        }
-        if self._model:
-            thread_params["model"] = self._model
-        thread_params.update(self._permission_thread_params())
-        if self._system_prompt:
-            # baseInstructions = role/persona ("you are a service developer…")
-            # developerInstructions = per-session task instructions
-            # Skuld provides a single system_prompt that combines both,
-            # so we set it as baseInstructions (persistent identity).
-            thread_params["baseInstructions"] = self._system_prompt
+        if self._resume_session_id:
+            # Imported/external session — reattach to the existing thread
+            # instead of starting a fresh one.
+            resume_params: dict = {
+                "threadId": self._resume_session_id,
+                "persistExtendedHistory": True,
+            }
+            if self._model:
+                resume_params["model"] = self._model
+            resume_params.update(self._permission_thread_params())
 
-        result = await self._send_rpc("thread/start", thread_params)
-        # The response triggers a thread/started notification with the thread info.
-        # But the RPC response itself may contain the thread_id.
-        thread = result.get("thread", {})
-        self._thread_id = thread.get("id") or result.get("threadId")
-        logger.info("Codex thread started: %s", self._thread_id)
+            result = await self._send_rpc("thread/resume", resume_params)
+            thread = result.get("thread", {})
+            self._thread_id = thread.get("id") or self._resume_session_id
+            logger.info("Codex thread resumed: %s", self._thread_id)
+        else:
+            thread_params: dict = {
+                "experimentalRawEvents": False,
+                "persistExtendedHistory": True,
+                "cwd": self.workspace_dir,
+            }
+            if self._model:
+                thread_params["model"] = self._model
+            thread_params.update(self._permission_thread_params())
+            if self._system_prompt:
+                # baseInstructions = role/persona ("you are a service developer…")
+                # developerInstructions = per-session task instructions
+                # Skuld provides a single system_prompt that combines both,
+                # so we set it as baseInstructions (persistent identity).
+                thread_params["baseInstructions"] = self._system_prompt
+
+            result = await self._send_rpc("thread/start", thread_params)
+            # The response triggers a thread/started notification with the thread info.
+            # But the RPC response itself may contain the thread_id.
+            thread = result.get("thread", {})
+            self._thread_id = thread.get("id") or result.get("threadId")
+            logger.info("Codex thread started: %s", self._thread_id)
 
         # Emit a synthetic init event so the broker knows we're ready.
         await self._emit(
@@ -670,8 +688,7 @@ class CodexWebSocketTransport(CLITransport):
                 payload.get("call_id"),
             )
             task_name = (
-                "codex-response-function-"
-                f"{payload.get('call_id') or payload.get('name') or 'call'}"
+                f"codex-response-function-{payload.get('call_id') or payload.get('name') or 'call'}"
             )
             task = asyncio.create_task(
                 self._handle_raw_function_call_item(payload),
@@ -892,8 +909,7 @@ class CodexWebSocketTransport(CLITransport):
         env = args.get("env")
         if isinstance(env, dict):
             exec_params["env"] = {
-                str(key): (str(value) if value is not None else None)
-                for key, value in env.items()
+                str(key): (str(value) if value is not None else None) for key, value in env.items()
             }
 
         result = await self._send_rpc("command/exec", exec_params)

--- a/src/skuld/transports/persistent_subprocess.py
+++ b/src/skuld/transports/persistent_subprocess.py
@@ -66,6 +66,7 @@ class PersistentSubprocessTransport(CLITransport):
         system_prompt: str = "",
         initial_prompt: str = "",
         mcp_servers: list[dict] | None = None,
+        resume_session_id: str = "",
     ) -> None:
         super().__init__()
         self.workspace_dir = workspace_dir
@@ -84,7 +85,9 @@ class PersistentSubprocessTransport(CLITransport):
         # Set when the current turn's ``result`` event arrives. ``None``
         # when no turn is awaiting completion.
         self._turn_done: asyncio.Event | None = None
-        self._session_id: str | None = None
+        # Seeding the session id makes the FIRST spawn pass ``--resume``,
+        # which reattaches to an imported/external Claude session.
+        self._session_id: str | None = resume_session_id or None
         self._last_result: dict | None = None
 
     # ------------------------------------------------------------------
@@ -186,8 +189,9 @@ class PersistentSubprocessTransport(CLITransport):
             cmd.extend(["--model", self._model])
         if self._skip_permissions:
             cmd.extend(["--permission-mode", _DEFAULT_PERMISSION_MODE])
-        # ``--resume`` only applies when re-spawning after a crash; the
-        # first spawn has no session yet. Claude assigns one in its first
+        # ``--resume`` applies when re-spawning after a crash or when a
+        # resume id was seeded for an imported session. Otherwise the first
+        # spawn has no session yet — Claude assigns one in its first
         # ``system`` event, which we capture in the stdout reader.
         if self._session_id:
             cmd.extend(["--resume", self._session_id])

--- a/src/skuld/transports/tool_shims.py
+++ b/src/skuld/transports/tool_shims.py
@@ -42,7 +42,7 @@ def _extract_platform_config() -> tuple[str, float, str]:
         payload = yaml.safe_load(Path(config_path).read_text(encoding="utf-8")) or {}
     except Exception:
         return base_url, timeout, pat_token
-    platform = ((payload.get("gateway") or {}).get("platform") or {})
+    platform = (payload.get("gateway") or {}).get("platform") or {}
     if isinstance(platform.get("base_url"), str) and platform["base_url"].strip():
         base_url = platform["base_url"].strip()
     if isinstance(platform.get("timeout"), (int, float)):
@@ -156,9 +156,7 @@ def ensure_codex_tool_shims(
         _tracker_issue_script(platform_base_url, platform_timeout, platform_pat),
         encoding="utf-8",
     )
-    tracker_target.chmod(
-        tracker_target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
-    )
+    tracker_target.chmod(tracker_target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     commands: dict[str, tuple[str, str]] = {}
     if mount is not None:

--- a/src/sleipnir/adapters/nats_transport.py
+++ b/src/sleipnir/adapters/nats_transport.py
@@ -124,12 +124,7 @@ def _build_tls_context(
     tls_insecure_skip_verify: bool = False,
 ) -> ssl.SSLContext | None:
     """Build an SSL context for NATS TLS, or return None when TLS files are unset."""
-    if (
-        not tls_ca_file
-        and not tls_cert_file
-        and not tls_key_file
-        and not tls_insecure_skip_verify
-    ):
+    if not tls_ca_file and not tls_cert_file and not tls_key_file and not tls_insecure_skip_verify:
         return None
     context = ssl.create_default_context(cafile=tls_ca_file or None)
     if tls_insecure_skip_verify:
@@ -184,6 +179,7 @@ def _connect_options(
     elif nkeys_seed:
         options["nkeys_seed_str"] = nkeys_seed
     return options
+
 
 #: Maximum number of event IDs held in the deduplication cache.
 DEFAULT_DEDUP_CACHE_SIZE = 10_000

--- a/src/sleipnir/domain/registry.py
+++ b/src/sleipnir/domain/registry.py
@@ -466,6 +466,28 @@ LEARNING_PROMOTED: str = "learning.promoted"
 LEARNING_ADOPTION_RECORDED: str = "learning.adoption.recorded"
 
 # ---------------------------------------------------------------------------
+# flock — membership, learning exchange, canary, and adoption events
+# ---------------------------------------------------------------------------
+
+#: A peer proposed a learning to its flock.
+FLOCK_LEARNING_PROPOSED: str = "flock.learning.proposed"
+
+#: A canary trial started for a proposed flock learning.
+FLOCK_LEARNING_CANARY_STARTED: str = "flock.learning.canary_started"
+
+#: A flock learning was adopted after its canary trial.
+FLOCK_LEARNING_ADOPTED: str = "flock.learning.adopted"
+
+#: A flock learning was rejected.
+FLOCK_LEARNING_REJECTED: str = "flock.learning.rejected"
+
+#: A flock learning was activated on a peer.
+FLOCK_LEARNING_ACTIVATED: str = "flock.learning.activated"
+
+#: A flock learning was rolled back after adoption.
+FLOCK_LEARNING_ROLLED_BACK: str = "flock.learning.rolled_back"
+
+# ---------------------------------------------------------------------------
 # participant — humans, agents, tools, and surfaces in an Environment
 # ---------------------------------------------------------------------------
 

--- a/src/ting/adapters/postgres_workflow_campaigns.py
+++ b/src/ting/adapters/postgres_workflow_campaigns.py
@@ -154,18 +154,14 @@ class PostgresWorkflowCampaignRepository(WorkflowCampaignRepository):
         raw_snapshot = row.get("workflow_snapshot") or {}
         raw_stage_state = row.get("stage_state") or []
         raw_metadata = row.get("metadata") or {}
-        snapshot = (
-            json.loads(raw_snapshot) if isinstance(raw_snapshot, str) else dict(raw_snapshot)
-        )
+        snapshot = json.loads(raw_snapshot) if isinstance(raw_snapshot, str) else dict(raw_snapshot)
         stage_state_data = (
             json.loads(raw_stage_state)
             if isinstance(raw_stage_state, str)
             else list(raw_stage_state)
         )
         metadata = json.loads(raw_metadata) if isinstance(raw_metadata, str) else dict(raw_metadata)
-        status = WorkflowCampaignStatus(
-            row.get("status") or WorkflowCampaignStatus.PENDING.value
-        )
+        status = WorkflowCampaignStatus(row.get("status") or WorkflowCampaignStatus.PENDING.value)
         stage_state = [
             _stage_from_json(item) for item in stage_state_data if isinstance(item, dict)
         ]
@@ -211,9 +207,7 @@ def _stage_from_json(raw: dict[str, object]) -> CampaignStageState:
         status=str(raw.get("status") or "pending"),
         started_at=datetime.fromisoformat(str(started_at)) if isinstance(started_at, str) else None,
         completed_at=(
-            datetime.fromisoformat(str(completed_at))
-            if isinstance(completed_at, str)
-            else None
+            datetime.fromisoformat(str(completed_at)) if isinstance(completed_at, str) else None
         ),
         reason=str(raw.get("reason")) if raw.get("reason") is not None else None,
     )

--- a/src/ting/api/workflows.py
+++ b/src/ting/api/workflows.py
@@ -341,11 +341,7 @@ async def launch_workflow_execution(
                 "workflow": workflow_snapshot,
                 **({"mimir": workflow_mimir} if workflow_mimir else {}),
                 **(
-                    {
-                        "sleipnir_publish_urls": list(
-                            settings.dispatch.flock.sleipnir_publish_urls
-                        )
-                    }
+                    {"sleipnir_publish_urls": list(settings.dispatch.flock.sleipnir_publish_urls)}
                     if settings.dispatch.flock.sleipnir_publish_urls
                     else {}
                 ),

--- a/src/ting/config.py
+++ b/src/ting/config.py
@@ -1069,9 +1069,7 @@ class Settings(BaseSettings):
     dispatch: DispatchConfig = Field(default_factory=DispatchConfig)
     planner: PlannerConfig = Field(default_factory=PlannerConfig)
     credential_store: CredentialStoreConfig = Field(default_factory=CredentialStoreConfig)
-    shared_integrations: SharedIntegrationsConfig = Field(
-        default_factory=SharedIntegrationsConfig
-    )
+    shared_integrations: SharedIntegrationsConfig = Field(default_factory=SharedIntegrationsConfig)
     pat: PATConfig = Field(default_factory=PATConfig)
     auth: AuthConfig = Field(default_factory=AuthConfig)
     cerbos: CerbosConfig = Field(default_factory=CerbosConfig)

--- a/src/ting/domain/services/dispatch_service.py
+++ b/src/ting/domain/services/dispatch_service.py
@@ -906,12 +906,15 @@ class DispatchService:
                 logger.info("Auto-continue skipped for owner %s: no Volundr adapter", owner_id[:8])
                 return []
 
-            state, active_sessions, running_runs, available_slots = (
-                await self._dispatch_capacity_snapshot(
-                    owner_id,
-                    volundr=volundr,
-                    trackers=adapters,
-                )
+            (
+                state,
+                active_sessions,
+                running_runs,
+                available_slots,
+            ) = await self._dispatch_capacity_snapshot(
+                owner_id,
+                volundr=volundr,
+                trackers=adapters,
             )
             if available_slots <= 0:
                 logger.info(
@@ -1126,12 +1129,15 @@ class DispatchService:
             owner_id,
         )
         trackers = await self._tracker_factory.for_owner(owner_id)
-        state, active_sessions, running_runs, available_slots = (
-            await self._dispatch_capacity_snapshot(
-                owner_id,
-                volundr=volundr,
-                trackers=trackers,
-            )
+        (
+            state,
+            active_sessions,
+            running_runs,
+            available_slots,
+        ) = await self._dispatch_capacity_snapshot(
+            owner_id,
+            volundr=volundr,
+            trackers=trackers,
         )
         if available_slots < len(runs):
             logger.info(
@@ -1448,9 +1454,7 @@ class DispatchService:
                 configured_models=self._config.configured_models,
             ):
                 workflow_definition = None
-            workflow_definition = (
-                workflow_definition or _DEFAULT_WORKFLOW_SESSION_DEFINITION
-            )
+            workflow_definition = workflow_definition or _DEFAULT_WORKFLOW_SESSION_DEFINITION
             (
                 resolved_effective_model,
                 resolved_session_definition,

--- a/src/ting/plugin.py
+++ b/src/ting/plugin.py
@@ -115,8 +115,7 @@ class TingPlugin(ServicePlugin):
                 name="ting-channel-api",
                 prefixes=("/api/v1/ting/telegram",),
                 description=(
-                    "Ting operator-channel routes for Telegram setup and "
-                    "webhook ingress."
+                    "Ting operator-channel routes for Telegram setup and webhook ingress."
                 ),
             ),
             APIRouteDomain(

--- a/src/ting/ports/tracker.py
+++ b/src/ting/ports/tracker.py
@@ -41,9 +41,7 @@ class TrackerPort(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def create_run(
-        self, run: Run, *, project_id: str = "", milestone_id: str = ""
-    ) -> str:
+    async def create_run(self, run: Run, *, project_id: str = "", milestone_id: str = "") -> str:
         raise NotImplementedError
 
     async def attach_document(self, project_id: str, title: str, content: str) -> str:
@@ -177,9 +175,7 @@ class TrackerPort(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    async def update_phase_status(
-        self, phase_tracker_id: str, status: PhaseStatus
-    ) -> Phase | None:
+    async def update_phase_status(self, phase_tracker_id: str, status: PhaseStatus) -> Phase | None:
         raise NotImplementedError
 
     # -- Cross-entity navigation --

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -22,6 +22,7 @@ from volundr.domain.models import (
     Chronicle,
     ChronicleStatus,
     CleanupTarget,
+    ExternalSessionRecord,
     GitProviderType,
     GitSource,
     LocalMountSource,
@@ -44,6 +45,11 @@ from volundr.domain.ports import (
 from volundr.domain.services import (
     ChronicleNotFoundError,
     ChronicleService,
+    ExternalSessionAlreadyImportedError,
+    ExternalSessionNotFoundError,
+    ExternalSessionProviderNotFoundError,
+    ExternalSessionService,
+    ExternalSessionWorkspaceError,
     ForgeService,
     ProviderInfo,
     RepoService,
@@ -407,6 +413,71 @@ class SessionStart(BaseModel):
     }
 
 
+class SessionImportRequest(BaseModel):
+    """Request model for importing an external CLI session."""
+
+    provider: str = Field(
+        min_length=1,
+        max_length=100,
+        description="External session provider key (e.g. 'claude-code', 'codex')",
+    )
+    external_id: str = Field(
+        min_length=1,
+        max_length=255,
+        description="Native session/thread identifier to import",
+    )
+    name: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Optional session name; derived from the harness when omitted",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "provider": "claude-code",
+                "external_id": "2e877b9f-4b8a-4d46-8f00-03f6163addd5",
+                "name": "imported-debug-session",
+            },
+        },
+    }
+
+
+class ExternalSessionResponse(BaseModel):
+    """Response model for a discoverable external CLI session."""
+
+    provider: str = Field(description="Provider key that discovered the session")
+    harness: str = Field(description="CLI harness owning the session (claude, codex)")
+    external_id: str = Field(description="Native session/thread identifier")
+    workspace_path: str = Field(description="Working directory the session ran in")
+    title: str = Field(description="Short human-readable summary")
+    model: str = Field(description="Model the session used, when known")
+    created_at: str | None = Field(description="ISO 8601 start timestamp, when known")
+    updated_at: str | None = Field(description="ISO 8601 last-activity timestamp")
+    live: bool = Field(description="Whether the session appears to be actively running")
+    workspace_exists: bool = Field(description="Whether the workspace still exists on disk")
+    imported_session_id: UUID | None = Field(
+        description="Volundr session id when already imported",
+    )
+
+    @classmethod
+    def from_record(cls, record: ExternalSessionRecord) -> "ExternalSessionResponse":
+        """Create response from domain model."""
+        return cls(
+            provider=record.provider,
+            harness=record.harness,
+            external_id=record.external_id,
+            workspace_path=record.workspace_path,
+            title=record.title,
+            model=record.model,
+            created_at=record.created_at.isoformat() if record.created_at else None,
+            updated_at=record.updated_at.isoformat() if record.updated_at else None,
+            live=record.live,
+            workspace_exists=record.workspace_exists,
+            imported_session_id=record.imported_session_id,
+        )
+
+
 class DeleteSessionBody(BaseModel):
     """Optional request body for session deletion with cleanup targets."""
 
@@ -484,6 +555,14 @@ class SessionResponse(BaseModel):
         default="session",
         description="Workload type used to launch the session",
     )
+    origin: str = Field(
+        default="volundr",
+        description="Where the session originated (volundr, claude, codex)",
+    )
+    external_session_id: str | None = Field(
+        default=None,
+        description="Native CLI session id for imported sessions",
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -541,6 +620,8 @@ class SessionResponse(BaseModel):
             activity_state=(session.activity_state.value if session.activity_state else None),
             activity_metadata=session.activity_metadata,
             workload_type=session.workload_type,
+            origin=session.origin,
+            external_session_id=session.external_session_id,
         )
 
 
@@ -997,6 +1078,7 @@ def create_router(
     chronicle_service: ChronicleService | None = None,
     archive_service=None,
     *,
+    external_session_service: ExternalSessionService | None = None,
     prefix: str = "/api/v1/forge",
 ) -> APIRouter:
     """Create FastAPI router with session, stats, token, repo, and SSE endpoints."""
@@ -1197,6 +1279,92 @@ def create_router(
         archived_ids = await forge.archive_stopped_sessions()
         return [str(uid) for uid in archived_ids]
 
+    @router.get(
+        "/external-sessions",
+        response_model=list[ExternalSessionResponse],
+        responses={
+            404: {"model": ErrorResponse},
+            503: {"model": ErrorResponse},
+        },
+        tags=["Sessions"],
+    )
+    async def list_external_sessions(
+        provider: str | None = Query(
+            default=None,
+            description="Restrict discovery to a single provider key",
+        ),
+    ) -> list[ExternalSessionResponse]:
+        """List CLI sessions discoverable on the host (Claude Code, Codex).
+
+        Sessions already imported into Volundr carry their Volundr session
+        id in ``imported_session_id``. Live sessions are flagged via a
+        recent-activity heuristic on the harness's session store.
+        """
+        if external_session_service is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="External session discovery not available",
+            )
+        try:
+            records = await external_session_service.list_external_sessions(provider=provider)
+        except ExternalSessionProviderNotFoundError as e:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=str(e),
+            )
+        return [ExternalSessionResponse.from_record(record) for record in records]
+
+    @router.post(
+        "/sessions/import",
+        response_model=SessionResponse,
+        status_code=status.HTTP_201_CREATED,
+        responses={
+            404: {"model": ErrorResponse},
+            409: {"model": ErrorResponse},
+            422: {"model": ErrorResponse},
+            503: {"model": ErrorResponse},
+        },
+        tags=["Sessions"],
+    )
+    async def import_external_session(
+        request: Request,
+        data: SessionImportRequest,
+    ) -> SessionResponse:
+        """Import an external CLI session as a stopped Volundr session.
+
+        The imported session keeps pointing at its original working
+        directory and resumes the native CLI session when started.
+        """
+        if external_session_service is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="External session discovery not available",
+            )
+        principal = await _optional_principal(request)
+        try:
+            session = await external_session_service.import_session(
+                provider=data.provider,
+                external_id=data.external_id,
+                name=data.name,
+                principal=principal,
+            )
+        except (ExternalSessionProviderNotFoundError, ExternalSessionNotFoundError) as e:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=str(e),
+            )
+        except ExternalSessionAlreadyImportedError as e:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(e),
+            )
+        except ExternalSessionWorkspaceError as e:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=str(e),
+            )
+        return SessionResponse.from_session(session)
+
     @router.post(
         "/sessions",
         response_model=SessionResponse,
@@ -1377,6 +1545,15 @@ def create_router(
         },
         tags=["Sessions"],
     )
+    @router.post(
+        "/sessions/{session_id}/resume",
+        response_model=SessionResponse,
+        responses={
+            404: {"model": ErrorResponse},
+            409: {"model": ErrorResponse},
+        },
+        tags=["Sessions"],
+    )
     async def start_session(
         request: Request,
         session_id: UUID = Path(description="Unique session identifier"),
@@ -1386,6 +1563,8 @@ def create_router(
 
         Used to relaunch a stopped or failed session. An optional
         launch_spec in the body overrides the default launch spec.
+        ``/resume`` is an alias for ``/start``; imported sessions resume
+        their native CLI session via the recorded external session id.
         """
         launch_spec = data.launch_spec if data else None
         principal = await _optional_principal(request)

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -463,6 +463,12 @@ class ExternalSessionResponse(BaseModel):
     imported_session_id: UUID | None = Field(
         description="Volundr session id when already imported",
     )
+    importable: bool = Field(
+        description=(
+            "Whether the session can be imported right now (workspace present, "
+            "allowed by policy, and not already imported)"
+        ),
+    )
 
     @classmethod
     def from_record(cls, record: ExternalSessionRecord) -> "ExternalSessionResponse":
@@ -480,6 +486,11 @@ class ExternalSessionResponse(BaseModel):
             workspace_exists=record.workspace_exists,
             workspace_allowed=record.workspace_allowed,
             imported_session_id=record.imported_session_id,
+            importable=(
+                record.workspace_exists
+                and record.workspace_allowed
+                and record.imported_session_id is None
+            ),
         )
 
 

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -47,6 +47,7 @@ from volundr.domain.services import (
     ChronicleService,
     ExternalSessionAlreadyImportedError,
     ExternalSessionNotFoundError,
+    ExternalSessionPathNotAllowedError,
     ExternalSessionProviderNotFoundError,
     ExternalSessionService,
     ExternalSessionWorkspaceError,
@@ -456,6 +457,9 @@ class ExternalSessionResponse(BaseModel):
     updated_at: str | None = Field(description="ISO 8601 last-activity timestamp")
     live: bool = Field(description="Whether the session appears to be actively running")
     workspace_exists: bool = Field(description="Whether the workspace still exists on disk")
+    workspace_allowed: bool = Field(
+        description="Whether the workspace passes the allowed mount prefix policy",
+    )
     imported_session_id: UUID | None = Field(
         description="Volundr session id when already imported",
     )
@@ -474,6 +478,7 @@ class ExternalSessionResponse(BaseModel):
             updated_at=record.updated_at.isoformat() if record.updated_at else None,
             live=record.live,
             workspace_exists=record.workspace_exists,
+            workspace_allowed=record.workspace_allowed,
             imported_session_id=record.imported_session_id,
         )
 
@@ -1141,6 +1146,7 @@ def create_router(
             "local_mounts_enabled": settings.local_mounts.enabled,
             "file_manager_enabled": admin.get("storage", {}).get("file_manager_enabled", True),
             "mini_mode": settings.local_mounts.mini_mode,
+            "local_mounts_allowed_prefixes": settings.local_mounts.allowed_prefixes,
         }
 
     @router.get("/repos/branches", response_model=list[str], tags=["Repositories"])
@@ -1356,6 +1362,11 @@ def create_router(
         except ExternalSessionAlreadyImportedError as e:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
+                detail=str(e),
+            )
+        except ExternalSessionPathNotAllowedError as e:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
                 detail=str(e),
             )
         except ExternalSessionWorkspaceError as e:

--- a/src/volundr/adapters/inbound/rest_trace.py
+++ b/src/volundr/adapters/inbound/rest_trace.py
@@ -139,8 +139,10 @@ def _trace_bounds(spans: list[SessionSpan]) -> tuple[datetime | None, datetime |
     root = next((span for span in spans if span.kind == "session.lifecycle"), None)
     started_at = root.started_at if root is not None else min(span.started_at for span in spans)
     ended_candidates = [span.ended_at for span in spans if span.ended_at is not None]
-    ended_at = root.ended_at if root is not None and root.ended_at is not None else (
-        max(ended_candidates) if ended_candidates else None
+    ended_at = (
+        root.ended_at
+        if root is not None and root.ended_at is not None
+        else (max(ended_candidates) if ended_candidates else None)
     )
     duration_ms = None
     if root is not None and root.duration_ms is not None:
@@ -163,13 +165,13 @@ def _build_summary(spans: list[SessionSpan]) -> SessionTraceSummaryResponse:
             spans, lambda span: span.kind == "session.provisioning"
         ),
         setup_duration_ms=_sum_durations(spans, lambda span: span.kind == "session.setup"),
-        workflow_duration_ms=_sum_durations(
-            spans, lambda span: span.kind == "session.workflow"
-        ),
+        workflow_duration_ms=_sum_durations(spans, lambda span: span.kind == "session.workflow"),
         publish_duration_ms=_sum_durations(
             spans,
-            lambda span: span.kind == "session.publish"
-            or (span.kind == "session.workflow" and "publish" in span.name.lower()),
+            lambda span: (
+                span.kind == "session.publish"
+                or (span.kind == "session.workflow" and "publish" in span.name.lower())
+            ),
         ),
         cleanup_duration_ms=_sum_durations(spans, lambda span: span.kind == "session.cleanup"),
         active_execution_duration_ms=_sum_durations(

--- a/src/volundr/adapters/outbound/contributors/local_mount.py
+++ b/src/volundr/adapters/outbound/contributors/local_mount.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import logging
-import os
-from pathlib import PurePosixPath
 
 from volundr.domain.models import LocalMountSource, PodSpecAdditions, Session
+from volundr.domain.mount_policy import ensure_host_path_allowed
 from volundr.domain.ports import SessionContext, SessionContribution, SessionContributor
 
 logger = logging.getLogger(__name__)
@@ -83,21 +82,8 @@ class LocalMountContributor(SessionContributor):
         Raises:
             ValueError: If the path is not allowed.
         """
-        resolved = str(PurePosixPath(os.path.normpath(host_path)))
-
-        if resolved == "/":
-            if not self._allow_root_mount:
-                raise ValueError("Mounting root filesystem (/) requires allow_root_mount=true")
-            return
-
-        if not self._allowed_prefixes:
-            return
-
-        for prefix in self._allowed_prefixes:
-            normalized_prefix = str(PurePosixPath(os.path.normpath(prefix)))
-            if resolved == normalized_prefix or resolved.startswith(normalized_prefix + "/"):
-                return
-
-        raise ValueError(
-            f"Host path '{host_path}' is not under any allowed prefix: {self._allowed_prefixes}"
+        ensure_host_path_allowed(
+            host_path,
+            self._allowed_prefixes,
+            allow_root_mount=self._allow_root_mount,
         )

--- a/src/volundr/adapters/outbound/external_sessions/__init__.py
+++ b/src/volundr/adapters/outbound/external_sessions/__init__.py
@@ -1,0 +1,15 @@
+"""External session provider adapters.
+
+Each adapter implements the ExternalSessionProvider port for one CLI
+harness's on-disk session store (Claude Code, Codex, ...).
+"""
+
+from volundr.adapters.outbound.external_sessions.claude_code import (
+    ClaudeCodeSessionProvider,
+)
+from volundr.adapters.outbound.external_sessions.codex import CodexSessionProvider
+
+__all__ = [
+    "ClaudeCodeSessionProvider",
+    "CodexSessionProvider",
+]

--- a/src/volundr/adapters/outbound/external_sessions/claude_code.py
+++ b/src/volundr/adapters/outbound/external_sessions/claude_code.py
@@ -1,0 +1,181 @@
+"""Claude Code session provider — scans ~/.claude/projects for sessions.
+
+Claude Code stores one JSONL transcript per session under
+``~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl``. Each record
+carries the session id, working directory, and timestamps, so sessions
+can be discovered and later resumed with ``claude --resume <id>``.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import UUID
+
+from volundr.domain.models import ExternalSessionRecord
+from volundr.domain.ports import ExternalSessionProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROJECTS_DIR = "~/.claude/projects"
+DEFAULT_LIVE_THRESHOLD_SECONDS = 120
+DEFAULT_HEAD_LINES = 50
+DEFAULT_MAX_SESSIONS = 200
+TITLE_MAX_CHARS = 120
+
+
+def _parse_timestamp(raw: object) -> datetime | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _message_text(message: object) -> str:
+    """Extract plain text from a Claude message payload."""
+    if not isinstance(message, dict):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    return text
+    return ""
+
+
+def _clean_title(text: str) -> str:
+    title = " ".join(text.split())
+    if len(title) > TITLE_MAX_CHARS:
+        return title[: TITLE_MAX_CHARS - 1] + "…"
+    return title
+
+
+class ClaudeCodeSessionProvider(ExternalSessionProvider):
+    """Discovers Claude Code sessions on the local host."""
+
+    def __init__(
+        self,
+        *,
+        projects_dir: str = DEFAULT_PROJECTS_DIR,
+        live_threshold_seconds: int = DEFAULT_LIVE_THRESHOLD_SECONDS,
+        head_lines: int = DEFAULT_HEAD_LINES,
+        max_sessions: int = DEFAULT_MAX_SESSIONS,
+        **_extra: object,
+    ):
+        self._projects_dir = Path(str(projects_dir)).expanduser()
+        self._live_threshold_seconds = int(live_threshold_seconds)
+        self._head_lines = int(head_lines)
+        self._max_sessions = int(max_sessions)
+
+    @property
+    def name(self) -> str:
+        return "claude-code"
+
+    @property
+    def harness(self) -> str:
+        return "claude"
+
+    async def list_sessions(self) -> list[ExternalSessionRecord]:
+        return await asyncio.to_thread(self._scan)
+
+    async def get_session(self, external_id: str) -> ExternalSessionRecord | None:
+        return await asyncio.to_thread(self._find_one, external_id)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _scan(self) -> list[ExternalSessionRecord]:
+        candidates = self._session_files()
+        candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+        records: list[ExternalSessionRecord] = []
+        for path in candidates[: self._max_sessions]:
+            record = self._parse_session_file(path)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def _find_one(self, external_id: str) -> ExternalSessionRecord | None:
+        try:
+            UUID(external_id)
+        except ValueError:
+            return None
+        for path in self._session_files():
+            if path.stem == external_id:
+                return self._parse_session_file(path)
+        return None
+
+    def _session_files(self) -> list[Path]:
+        if not self._projects_dir.is_dir():
+            return []
+        files: list[Path] = []
+        for project_dir in self._projects_dir.iterdir():
+            if not project_dir.is_dir():
+                continue
+            for path in project_dir.glob("*.jsonl"):
+                try:
+                    UUID(path.stem)
+                except ValueError:
+                    continue
+                files.append(path)
+        return files
+
+    def _parse_session_file(self, path: Path) -> ExternalSessionRecord | None:
+        cwd = ""
+        title = ""
+        model = ""
+        created_at: datetime | None = None
+
+        try:
+            with path.open(encoding="utf-8") as handle:
+                for index, line in enumerate(handle):
+                    if index >= self._head_lines:
+                        break
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    if record.get("isSidechain"):
+                        continue
+                    if not cwd and isinstance(record.get("cwd"), str):
+                        cwd = record["cwd"]
+                    if created_at is None:
+                        created_at = _parse_timestamp(record.get("timestamp"))
+                    if not title and record.get("type") == "user":
+                        title = _clean_title(_message_text(record.get("message")))
+                    if not model and record.get("type") == "assistant":
+                        message = record.get("message")
+                        if isinstance(message, dict) and isinstance(message.get("model"), str):
+                            model = message["model"]
+                    if cwd and title and model and created_at is not None:
+                        break
+        except OSError:
+            logger.warning("Failed to read Claude session file %s", path, exc_info=True)
+            return None
+
+        stat = path.stat()
+        updated_at = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+        age_seconds = (datetime.now(UTC) - updated_at).total_seconds()
+
+        return ExternalSessionRecord(
+            provider=self.name,
+            harness=self.harness,
+            external_id=path.stem,
+            workspace_path=cwd,
+            title=title,
+            model=model,
+            created_at=created_at,
+            updated_at=updated_at,
+            live=age_seconds <= self._live_threshold_seconds,
+            workspace_exists=bool(cwd) and Path(cwd).is_dir(),
+        )

--- a/src/volundr/adapters/outbound/external_sessions/codex.py
+++ b/src/volundr/adapters/outbound/external_sessions/codex.py
@@ -1,0 +1,171 @@
+"""Codex session provider — scans ~/.codex/sessions for rollout files.
+
+Codex stores one JSONL rollout per session under
+``~/.codex/sessions/YYYY/MM/DD/rollout-<timestamp>-<thread-id>.jsonl``.
+The first line is a ``session_meta`` record with the thread id and
+working directory, so sessions can be discovered and later resumed via
+the ``thread/resume`` app-server RPC.
+"""
+
+import asyncio
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from volundr.domain.models import ExternalSessionRecord
+from volundr.domain.ports import ExternalSessionProvider
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SESSIONS_DIR = "~/.codex/sessions"
+DEFAULT_LIVE_THRESHOLD_SECONDS = 120
+DEFAULT_HEAD_LINES = 50
+DEFAULT_MAX_SESSIONS = 200
+TITLE_MAX_CHARS = 120
+
+
+def _parse_timestamp(raw: object) -> datetime | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _clean_title(text: str) -> str:
+    title = " ".join(text.split())
+    if len(title) > TITLE_MAX_CHARS:
+        return title[: TITLE_MAX_CHARS - 1] + "…"
+    return title
+
+
+class CodexSessionProvider(ExternalSessionProvider):
+    """Discovers Codex sessions on the local host."""
+
+    def __init__(
+        self,
+        *,
+        sessions_dir: str = DEFAULT_SESSIONS_DIR,
+        live_threshold_seconds: int = DEFAULT_LIVE_THRESHOLD_SECONDS,
+        head_lines: int = DEFAULT_HEAD_LINES,
+        max_sessions: int = DEFAULT_MAX_SESSIONS,
+        **_extra: object,
+    ):
+        self._sessions_dir = Path(str(sessions_dir)).expanduser()
+        self._live_threshold_seconds = int(live_threshold_seconds)
+        self._head_lines = int(head_lines)
+        self._max_sessions = int(max_sessions)
+
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    @property
+    def harness(self) -> str:
+        return "codex"
+
+    async def list_sessions(self) -> list[ExternalSessionRecord]:
+        return await asyncio.to_thread(self._scan)
+
+    async def get_session(self, external_id: str) -> ExternalSessionRecord | None:
+        return await asyncio.to_thread(self._find_one, external_id)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _scan(self) -> list[ExternalSessionRecord]:
+        candidates = self._rollout_files()
+        candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+        records: list[ExternalSessionRecord] = []
+        for path in candidates[: self._max_sessions]:
+            record = self._parse_rollout_file(path)
+            if record is not None:
+                records.append(record)
+        return records
+
+    def _find_one(self, external_id: str) -> ExternalSessionRecord | None:
+        if not external_id:
+            return None
+        for path in self._rollout_files():
+            if path.stem.endswith(external_id):
+                record = self._parse_rollout_file(path)
+                if record is not None and record.external_id == external_id:
+                    return record
+        return None
+
+    def _rollout_files(self) -> list[Path]:
+        if not self._sessions_dir.is_dir():
+            return []
+        return [path for path in self._sessions_dir.rglob("rollout-*.jsonl") if path.is_file()]
+
+    def _parse_rollout_file(self, path: Path) -> ExternalSessionRecord | None:
+        external_id = ""
+        cwd = ""
+        title = ""
+        model = ""
+        created_at: datetime | None = None
+
+        try:
+            with path.open(encoding="utf-8") as handle:
+                for index, line in enumerate(handle):
+                    if index >= self._head_lines:
+                        break
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    payload = record.get("payload")
+                    if not isinstance(payload, dict):
+                        continue
+
+                    record_type = record.get("type")
+                    if record_type == "session_meta":
+                        external_id = str(payload.get("id") or "")
+                        cwd = str(payload.get("cwd") or "")
+                        created_at = _parse_timestamp(payload.get("timestamp"))
+                        continue
+                    if record_type == "turn_context" and not model:
+                        raw_model = payload.get("model")
+                        if isinstance(raw_model, str):
+                            model = raw_model
+                        continue
+                    if (
+                        record_type == "event_msg"
+                        and not title
+                        and payload.get("type") == "user_message"
+                        and isinstance(payload.get("message"), str)
+                    ):
+                        title = _clean_title(payload["message"])
+
+                    if external_id and cwd and title and model:
+                        break
+        except OSError:
+            logger.warning("Failed to read Codex rollout file %s", path, exc_info=True)
+            return None
+
+        if not external_id:
+            logger.warning("Codex rollout file %s has no session_meta record", path)
+            return None
+
+        stat = path.stat()
+        updated_at = datetime.fromtimestamp(stat.st_mtime, tz=UTC)
+        age_seconds = (datetime.now(UTC) - updated_at).total_seconds()
+
+        return ExternalSessionRecord(
+            provider=self.name,
+            harness=self.harness,
+            external_id=external_id,
+            workspace_path=cwd,
+            title=title,
+            model=model,
+            created_at=created_at,
+            updated_at=updated_at,
+            live=age_seconds <= self._live_threshold_seconds,
+            workspace_exists=bool(cwd) and Path(cwd).is_dir(),
+        )

--- a/src/volundr/adapters/outbound/local_process.py
+++ b/src/volundr/adapters/outbound/local_process.py
@@ -652,6 +652,10 @@ class LocalProcessPodManager(PodManager):
             workspace = Path(session.source.local_path)
             if not workspace.is_dir():
                 raise RuntimeError(f"local path {workspace!r} is not a directory")
+            if not self._is_allowed_mount(workspace):
+                raise RuntimeError(
+                    f"local path {workspace!r} is not under any allowed mount prefix"
+                )
             self._write_claude_md(workspace, spec)
             return workspace
         if isinstance(session.source, GitSource) and session.source.repo:

--- a/src/volundr/adapters/outbound/local_process.py
+++ b/src/volundr/adapters/outbound/local_process.py
@@ -437,9 +437,7 @@ class LocalProcessPodManager(PodManager):
         self._state_file = Path(str(state_file)).expanduser()
         if isinstance(allowed_mount_prefixes, str):
             allowed_mount_prefixes = [
-                prefix.strip()
-                for prefix in allowed_mount_prefixes.split(",")
-                if prefix.strip()
+                prefix.strip() for prefix in allowed_mount_prefixes.split(",") if prefix.strip()
             ]
         self._allowed_mount_prefixes = allowed_mount_prefixes or DEFAULT_ALLOWED_MOUNT_PREFIXES
 
@@ -494,9 +492,7 @@ class LocalProcessPodManager(PodManager):
                 if container.get("name", "").startswith("ravn-")
             )
             if persona_count > 0:
-                flock_plan = self._flock_port_plan(
-                    self._pick_flock_base_port(persona_count)
-                )
+                flock_plan = self._flock_port_plan(self._pick_flock_base_port(persona_count))
 
         info = ProcessInfo(
             session_id=session_id,
@@ -662,9 +658,7 @@ class LocalProcessPodManager(PodManager):
             local_workspace = _local_workspace_from_repo(session.source.repo)
             if local_workspace is not None:
                 if not local_workspace.is_dir():
-                    raise RuntimeError(
-                        f"local repo path {local_workspace!r} is not a directory"
-                    )
+                    raise RuntimeError(f"local repo path {local_workspace!r} is not a directory")
                 workspace = local_workspace.resolve()
                 self._write_claude_md(workspace, spec)
                 return workspace
@@ -1440,6 +1434,10 @@ class LocalProcessPodManager(PodManager):
             transport_adapter = broker.get("transportAdapter")
             if transport_adapter:
                 env["SKULD__TRANSPORT_ADAPTER"] = str(transport_adapter)
+
+            resume_session_id = broker.get("resumeSessionId")
+            if resume_session_id:
+                env["SKULD__SESSION__RESUME_SESSION_ID"] = str(resume_session_id)
 
             if "skipPermissions" in broker:
                 env["SKULD__SKIP_PERMISSIONS"] = str(bool(broker["skipPermissions"])).lower()

--- a/src/volundr/adapters/outbound/openbao_secret_injection.py
+++ b/src/volundr/adapters/outbound/openbao_secret_injection.py
@@ -283,7 +283,7 @@ class OpenBaoAgentInjectionAdapter(SecretInjectionPort):
                 env_lines.extend(
                     [
                         f'{{{{ with secret "{secret_path}" }}}}',
-                        f'export {env_var}=\'{{{{ index .Data.data "{field_name}" }}}}\'',
+                        f"export {env_var}='{{{{ index .Data.data \"{field_name}\" }}}}'",
                         "{{ end }}",
                     ]
                 )

--- a/src/volundr/adapters/outbound/postgres.py
+++ b/src/volundr/adapters/outbound/postgres.py
@@ -25,9 +25,11 @@ class PostgresSessionRepository(SessionRepository):
                 (id, name, model, source, status, chat_endpoint, code_endpoint,
                  created_at, updated_at, last_active, message_count, tokens_used,
                  pod_name, error, tracker_issue_id, issue_tracker_url,
-                 launch_spec_id, archived_at, owner_id, tenant_id, workload_type)
+                 launch_spec_id, archived_at, owner_id, tenant_id, workload_type,
+                 origin, external_session_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
-                    $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+                    $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21,
+                    $22, $23)
             """,
             session.id,
             session.name,
@@ -50,6 +52,8 @@ class PostgresSessionRepository(SessionRepository):
             session.owner_id,
             session.tenant_id,
             session.workload_type,
+            session.origin,
+            session.external_session_id,
         )
         return session
 
@@ -118,7 +122,8 @@ class PostgresSessionRepository(SessionRepository):
                 last_active = $9, message_count = $10, tokens_used = $11,
                 pod_name = $12, error = $13, tracker_issue_id = $14,
                 issue_tracker_url = $15, launch_spec_id = $16, archived_at = $17,
-                owner_id = $18, tenant_id = $19, workload_type = $20
+                owner_id = $18, tenant_id = $19, workload_type = $20,
+                origin = $21, external_session_id = $22
             WHERE id = $1
             """,
             session.id,
@@ -141,6 +146,8 @@ class PostgresSessionRepository(SessionRepository):
             session.owner_id,
             session.tenant_id,
             session.workload_type,
+            session.origin,
+            session.external_session_id,
         )
         return session
 
@@ -192,6 +199,8 @@ class PostgresSessionRepository(SessionRepository):
             owner_id=row.get("owner_id"),
             tenant_id=row.get("tenant_id"),
             workload_type=row.get("workload_type") or "session",
+            origin=row.get("origin") or "volundr",
+            external_session_id=row.get("external_session_id"),
         )
 
     @staticmethod

--- a/src/volundr/adapters/outbound/postgres_launch_specs.py
+++ b/src/volundr/adapters/outbound/postgres_launch_specs.py
@@ -61,15 +61,11 @@ class PostgresLaunchSpecRepository(LaunchSpecRepository):
         return spec
 
     async def get(self, spec_id: UUID) -> LaunchSpec | None:
-        row = await self._pool.fetchrow(
-            "SELECT * FROM volundr_launch_specs WHERE id = $1", spec_id
-        )
+        row = await self._pool.fetchrow("SELECT * FROM volundr_launch_specs WHERE id = $1", spec_id)
         return self._row_to_spec(row) if row is not None else None
 
     async def get_by_name(self, name: str) -> LaunchSpec | None:
-        row = await self._pool.fetchrow(
-            "SELECT * FROM volundr_launch_specs WHERE name = $1", name
-        )
+        row = await self._pool.fetchrow("SELECT * FROM volundr_launch_specs WHERE name = $1", name)
         return self._row_to_spec(row) if row is not None else None
 
     async def list(
@@ -133,9 +129,7 @@ class PostgresLaunchSpecRepository(LaunchSpecRepository):
         return spec
 
     async def delete(self, spec_id: UUID) -> bool:
-        result = await self._pool.execute(
-            "DELETE FROM volundr_launch_specs WHERE id = $1", spec_id
-        )
+        result = await self._pool.execute("DELETE FROM volundr_launch_specs WHERE id = $1", spec_id)
         return result == "DELETE 1"
 
     async def clear_default(self, cli_tool: str) -> None:

--- a/src/volundr/adapters/outbound/skuld_room.py
+++ b/src/volundr/adapters/outbound/skuld_room.py
@@ -80,7 +80,7 @@ class SkuldRoomAdapter(SessionRoomPort, SessionCommunicationPort):
                     participant_type=str(participant.get("participant_type") or "ravn"),
                     status=str(participant.get("status") or "idle"),
                 )
-        )
+            )
         return [participant for participant in result if participant.peer_id]
 
     async def list_communication_targets(

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -89,6 +89,58 @@ class LocalMountsConfig(BaseModel):
     )
 
 
+class ExternalSessionProviderConfig(BaseModel):
+    """Configuration for a single external session provider.
+
+    The ``adapter`` key is a fully-qualified class path. All other
+    fields are forwarded as **kwargs to the adapter constructor.
+
+    Example YAML::
+
+        external_sessions:
+          enabled: true
+          providers:
+            - adapter: "volundr.adapters.outbound.external_sessions.ClaudeCodeSessionProvider"
+              projects_dir: "~/.claude/projects"
+            - adapter: "volundr.adapters.outbound.external_sessions.CodexSessionProvider"
+              sessions_dir: "~/.codex/sessions"
+    """
+
+    adapter: str
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+def _default_external_session_providers() -> list[ExternalSessionProviderConfig]:
+    """Built-in providers: Claude Code and Codex local stores."""
+    return [
+        ExternalSessionProviderConfig(
+            adapter="volundr.adapters.outbound.external_sessions.ClaudeCodeSessionProvider",
+        ),
+        ExternalSessionProviderConfig(
+            adapter="volundr.adapters.outbound.external_sessions.CodexSessionProvider",
+        ),
+    ]
+
+
+class ExternalSessionsConfig(BaseModel):
+    """Configuration for discovering and importing external CLI sessions.
+
+    When ``enabled`` is left unset, discovery follows ``local_mounts.mini_mode``
+    — host session stores are only reachable when Volundr runs on the host.
+    """
+
+    enabled: bool | None = Field(
+        default=None,
+        description=(
+            "Enable external session discovery. None (default) follows local_mounts.mini_mode."
+        ),
+    )
+    providers: list[ExternalSessionProviderConfig] = Field(
+        default_factory=_default_external_session_providers,
+        description="External session provider adapters (dynamic adapter pattern).",
+    )
+
+
 class ProvisioningConfig(BaseModel):
     """Configuration for the session provisioning readiness polling."""
 
@@ -1415,6 +1467,7 @@ class Settings(BaseSettings):
     )
     local_git: LocalGitConfig = Field(default_factory=LocalGitConfig)
     local_mounts: LocalMountsConfig = Field(default_factory=LocalMountsConfig)
+    external_sessions: ExternalSessionsConfig = Field(default_factory=ExternalSessionsConfig)
     telegram_ingress: TelegramIngressConfig = Field(default_factory=TelegramIngressConfig)
     session_contributors: list[SessionContributorConfig] = Field(default_factory=list)
     session_definitions: dict[str, SessionDefinitionConfig] = Field(

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -416,6 +416,16 @@ class Session(BaseModel):
         default="session",
         description="Workload type used to launch the session",
     )
+    origin: str = Field(
+        default="volundr",
+        max_length=50,
+        description="Where the session originated (volundr, claude, codex)",
+    )
+    external_session_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Native CLI session/thread id for imported sessions",
+    )
 
     model_config = {"frozen": False}
 
@@ -503,6 +513,52 @@ class Session(BaseModel):
                 "updated_at": now,
             }
         )
+
+
+class ExternalSessionRecord(BaseModel):
+    """A CLI session discovered outside Volundr (Claude Code, Codex, ...).
+
+    External sessions live in the harness's own on-disk store (e.g.
+    ``~/.claude/projects`` or ``~/.codex/sessions``). They can be imported
+    into Volundr, which creates a stopped Session that resumes the native
+    session when started.
+    """
+
+    provider: str = Field(description="Provider key that discovered the session")
+    harness: str = Field(description="CLI harness that owns the session (claude, codex)")
+    external_id: str = Field(description="Native session/thread identifier")
+    workspace_path: str = Field(
+        default="",
+        description="Working directory the session ran in",
+    )
+    title: str = Field(
+        default="",
+        description="Short human-readable summary (first prompt or similar)",
+    )
+    model: str = Field(
+        default="",
+        description="Model the session used, when known",
+    )
+    created_at: datetime | None = Field(
+        default=None,
+        description="When the session started, when known",
+    )
+    updated_at: datetime | None = Field(
+        default=None,
+        description="Last activity in the session store",
+    )
+    live: bool = Field(
+        default=False,
+        description="Whether the session appears to be actively running",
+    )
+    workspace_exists: bool = Field(
+        default=False,
+        description="Whether the workspace directory still exists on disk",
+    )
+    imported_session_id: UUID | None = Field(
+        default=None,
+        description="Volundr session id when this session was already imported",
+    )
 
 
 @dataclass(frozen=True)

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -555,6 +555,10 @@ class ExternalSessionRecord(BaseModel):
         default=False,
         description="Whether the workspace directory still exists on disk",
     )
+    workspace_allowed: bool = Field(
+        default=True,
+        description="Whether the workspace passes the allowed mount prefix policy",
+    )
     imported_session_id: UUID | None = Field(
         default=None,
         description="Volundr session id when this session was already imported",

--- a/src/volundr/domain/mount_policy.py
+++ b/src/volundr/domain/mount_policy.py
@@ -1,0 +1,51 @@
+"""Host path mount policy — shared prefix allowlist for local workspaces.
+
+One source of truth for deciding whether a host directory may be used as
+a session workspace or mount. Used by the local mount contributor, the
+local process pod manager, and external session import.
+
+Paths are resolved (symlinks followed) before matching, so an allowlist
+of ``/tmp`` also covers macOS's ``/private/tmp`` and symlinks inside an
+allowed directory cannot escape the policy.
+"""
+
+from pathlib import Path
+
+
+def is_host_path_allowed(
+    host_path: str,
+    allowed_prefixes: list[str],
+    *,
+    allow_root_mount: bool = False,
+) -> bool:
+    """Return whether *host_path* may be mounted under the prefix policy.
+
+    An empty *allowed_prefixes* list means every path is allowed (the
+    policy is opt-in), except the filesystem root which always requires
+    ``allow_root_mount``.
+    """
+    resolved = Path(host_path).resolve()
+
+    if str(resolved) == "/":
+        return allow_root_mount
+
+    if not allowed_prefixes:
+        return True
+
+    return any(resolved.is_relative_to(Path(prefix).resolve()) for prefix in allowed_prefixes)
+
+
+def ensure_host_path_allowed(
+    host_path: str,
+    allowed_prefixes: list[str],
+    *,
+    allow_root_mount: bool = False,
+) -> None:
+    """Raise ``ValueError`` when *host_path* violates the prefix policy."""
+    if is_host_path_allowed(host_path, allowed_prefixes, allow_root_mount=allow_root_mount):
+        return
+
+    if str(Path(host_path).resolve()) == "/":
+        raise ValueError("Mounting root filesystem (/) requires allow_root_mount=true")
+
+    raise ValueError(f"Host path '{host_path}' is not under any allowed prefix: {allowed_prefixes}")

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -27,6 +27,7 @@ from volundr.domain.models import (
     ClusterResourceInfo,
     CommunicationRoute,
     CredentialMapping,
+    ExternalSessionRecord,
     IntegrationConnection,
     LaunchSpec,
     MCPServerConfig,
@@ -115,6 +116,38 @@ class SessionRepository(ABC):
     @abstractmethod
     async def delete(self, session_id: UUID) -> bool:
         """Delete a session. Returns True if deleted, False if not found."""
+
+
+class ExternalSessionProvider(ABC):
+    """Port for discovering CLI sessions that live outside Volundr.
+
+    Implementations scan a harness's native session store (e.g. Claude
+    Code's ``~/.claude/projects`` or Codex's ``~/.codex/sessions``) so
+    stopped or live sessions can be listed and imported as Volundr
+    sessions.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Unique provider key (e.g. 'claude-code', 'codex')."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def harness(self) -> str:
+        """CLI harness the sessions belong to ('claude' or 'codex')."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def list_sessions(self) -> list[ExternalSessionRecord]:
+        """Discover sessions in the harness's store, newest first."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_session(self, external_id: str) -> ExternalSessionRecord | None:
+        """Look up a single session by its native identifier."""
+        raise NotImplementedError
 
 
 class CommunicationRouteRepository(ABC):

--- a/src/volundr/domain/services/__init__.py
+++ b/src/volundr/domain/services/__init__.py
@@ -7,6 +7,13 @@ Re-exports all public names for backward compatibility so that
 from __future__ import annotations
 
 from .chronicle import ChronicleNotFoundError, ChronicleService
+from .external_sessions import (
+    ExternalSessionAlreadyImportedError,
+    ExternalSessionNotFoundError,
+    ExternalSessionProviderNotFoundError,
+    ExternalSessionService,
+    ExternalSessionWorkspaceError,
+)
 from .feature import FeatureModule, FeatureService, UserFeaturePreference
 from .forge import ForgeService
 from .git_workflow import ConfidenceScorer, GitWorkflowService
@@ -34,6 +41,10 @@ from .workspace import WorkspaceService
 __all__ = [
     # Exceptions
     "ChronicleNotFoundError",
+    "ExternalSessionAlreadyImportedError",
+    "ExternalSessionNotFoundError",
+    "ExternalSessionProviderNotFoundError",
+    "ExternalSessionWorkspaceError",
     "LaunchSpecDuplicateNameError",
     "LaunchSpecNotFoundError",
     "PromptNotFoundError",
@@ -47,6 +58,7 @@ __all__ = [
     "TrackerIssueNotFoundError",
     "TrackerMappingNotFoundError",
     # Services
+    "ExternalSessionService",
     "FeatureService",
     "ForgeService",
     "ChronicleService",

--- a/src/volundr/domain/services/__init__.py
+++ b/src/volundr/domain/services/__init__.py
@@ -10,6 +10,7 @@ from .chronicle import ChronicleNotFoundError, ChronicleService
 from .external_sessions import (
     ExternalSessionAlreadyImportedError,
     ExternalSessionNotFoundError,
+    ExternalSessionPathNotAllowedError,
     ExternalSessionProviderNotFoundError,
     ExternalSessionService,
     ExternalSessionWorkspaceError,
@@ -43,6 +44,7 @@ __all__ = [
     "ChronicleNotFoundError",
     "ExternalSessionAlreadyImportedError",
     "ExternalSessionNotFoundError",
+    "ExternalSessionPathNotAllowedError",
     "ExternalSessionProviderNotFoundError",
     "ExternalSessionWorkspaceError",
     "LaunchSpecDuplicateNameError",

--- a/src/volundr/domain/services/external_sessions.py
+++ b/src/volundr/domain/services/external_sessions.py
@@ -1,0 +1,168 @@
+"""Service for discovering and importing external CLI sessions.
+
+External sessions are Claude Code or Codex sessions that live in the
+harness's own on-disk store. This service lists them across all
+configured providers and imports them as Volundr sessions, so they can
+be restarted (resumed) as regular Volundr-managed sessions.
+"""
+
+import logging
+from uuid import UUID
+
+from volundr.domain.models import (
+    ExternalSessionRecord,
+    LocalMountSource,
+    Principal,
+    Session,
+)
+from volundr.domain.ports import ExternalSessionProvider, SessionRepository
+from volundr.domain.services.session import SessionService
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalSessionProviderNotFoundError(Exception):
+    """Raised when no provider matches the requested name."""
+
+    def __init__(self, provider: str):
+        self.provider = provider
+        super().__init__(f"Unknown external session provider: {provider}")
+
+
+class ExternalSessionNotFoundError(Exception):
+    """Raised when an external session cannot be found in the provider's store."""
+
+    def __init__(self, provider: str, external_id: str):
+        self.provider = provider
+        self.external_id = external_id
+        super().__init__(f"External session not found: {provider}/{external_id}")
+
+
+class ExternalSessionAlreadyImportedError(Exception):
+    """Raised when the external session was already imported."""
+
+    def __init__(self, external_id: str, session_id: UUID):
+        self.external_id = external_id
+        self.session_id = session_id
+        super().__init__(f"External session {external_id} already imported as session {session_id}")
+
+
+class ExternalSessionWorkspaceError(Exception):
+    """Raised when the external session's workspace is unusable."""
+
+    def __init__(self, external_id: str, workspace_path: str):
+        self.external_id = external_id
+        self.workspace_path = workspace_path
+        super().__init__(
+            f"Workspace for external session {external_id} is not available: {workspace_path!r}"
+        )
+
+
+class ExternalSessionService:
+    """Lists external CLI sessions and imports them as Volundr sessions."""
+
+    def __init__(
+        self,
+        providers: list[ExternalSessionProvider],
+        repository: SessionRepository,
+        session_service: SessionService,
+    ):
+        self._providers = {provider.name: provider for provider in providers}
+        self._repository = repository
+        self._session_service = session_service
+
+    @property
+    def provider_names(self) -> list[str]:
+        return list(self._providers)
+
+    async def list_external_sessions(
+        self,
+        provider: str | None = None,
+    ) -> list[ExternalSessionRecord]:
+        """List discoverable sessions across providers, newest first.
+
+        Records that were already imported carry the Volundr session id
+        in ``imported_session_id``.
+        """
+        if provider is not None and provider not in self._providers:
+            raise ExternalSessionProviderNotFoundError(provider)
+
+        providers = (
+            [self._providers[provider]] if provider is not None else list(self._providers.values())
+        )
+
+        records: list[ExternalSessionRecord] = []
+        for prov in providers:
+            records.extend(await prov.list_sessions())
+
+        imported = await self._imported_index()
+        annotated = [
+            record.model_copy(update={"imported_session_id": imported.get(record.external_id)})
+            for record in records
+        ]
+        annotated.sort(
+            key=lambda r: r.updated_at.timestamp() if r.updated_at else 0.0,
+            reverse=True,
+        )
+        return annotated
+
+    async def import_session(
+        self,
+        provider: str,
+        external_id: str,
+        name: str | None = None,
+        principal: Principal | None = None,
+    ) -> Session:
+        """Import an external session as a stopped Volundr session.
+
+        The created session points at the original working directory via
+        a local mount, records its origin and native session id, and can
+        then be started like any other Volundr session — the start path
+        resumes the native CLI session.
+        """
+        prov = self._providers.get(provider)
+        if prov is None:
+            raise ExternalSessionProviderNotFoundError(provider)
+
+        record = await prov.get_session(external_id)
+        if record is None:
+            raise ExternalSessionNotFoundError(provider, external_id)
+
+        imported = await self._imported_index()
+        existing = imported.get(record.external_id)
+        if existing is not None:
+            raise ExternalSessionAlreadyImportedError(record.external_id, existing)
+
+        if not record.workspace_exists:
+            raise ExternalSessionWorkspaceError(record.external_id, record.workspace_path)
+
+        session_name = name or self._default_name(record)
+        session = await self._session_service.create_session(
+            name=session_name,
+            model=record.model,
+            source=LocalMountSource(local_path=record.workspace_path),
+            principal=principal,
+            origin=record.harness,
+            external_session_id=record.external_id,
+        )
+        logger.info(
+            "Imported external session %s/%s as Volundr session %s",
+            provider,
+            record.external_id,
+            session.id,
+        )
+        return session
+
+    async def _imported_index(self) -> dict[str, UUID]:
+        """Map external session id → Volundr session id for imported sessions."""
+        sessions = await self._repository.list()
+        return {
+            session.external_session_id: session.id
+            for session in sessions
+            if session.external_session_id
+        }
+
+    @staticmethod
+    def _default_name(record: ExternalSessionRecord) -> str:
+        suffix = record.external_id.split("-")[0] or record.external_id
+        return f"{record.harness}-import-{suffix}"

--- a/src/volundr/domain/services/external_sessions.py
+++ b/src/volundr/domain/services/external_sessions.py
@@ -15,6 +15,7 @@ from volundr.domain.models import (
     Principal,
     Session,
 )
+from volundr.domain.mount_policy import is_host_path_allowed
 from volundr.domain.ports import ExternalSessionProvider, SessionRepository
 from volundr.domain.services.session import SessionService
 
@@ -58,6 +59,18 @@ class ExternalSessionWorkspaceError(Exception):
         )
 
 
+class ExternalSessionPathNotAllowedError(Exception):
+    """Raised when the external session's workspace violates the mount prefix policy."""
+
+    def __init__(self, external_id: str, workspace_path: str):
+        self.external_id = external_id
+        self.workspace_path = workspace_path
+        super().__init__(
+            f"Workspace for external session {external_id} is outside the allowed "
+            f"mount prefixes: {workspace_path!r}"
+        )
+
+
 class ExternalSessionService:
     """Lists external CLI sessions and imports them as Volundr sessions."""
 
@@ -66,10 +79,14 @@ class ExternalSessionService:
         providers: list[ExternalSessionProvider],
         repository: SessionRepository,
         session_service: SessionService,
+        allowed_workspace_prefixes: list[str] | None = None,
+        allow_root_workspace: bool = False,
     ):
         self._providers = {provider.name: provider for provider in providers}
         self._repository = repository
         self._session_service = session_service
+        self._allowed_workspace_prefixes = allowed_workspace_prefixes or []
+        self._allow_root_workspace = allow_root_workspace
 
     @property
     def provider_names(self) -> list[str]:
@@ -97,7 +114,12 @@ class ExternalSessionService:
 
         imported = await self._imported_index()
         annotated = [
-            record.model_copy(update={"imported_session_id": imported.get(record.external_id)})
+            record.model_copy(
+                update={
+                    "imported_session_id": imported.get(record.external_id),
+                    "workspace_allowed": self._workspace_allowed(record),
+                }
+            )
             for record in records
         ]
         annotated.sort(
@@ -136,6 +158,9 @@ class ExternalSessionService:
         if not record.workspace_exists:
             raise ExternalSessionWorkspaceError(record.external_id, record.workspace_path)
 
+        if not self._workspace_allowed(record):
+            raise ExternalSessionPathNotAllowedError(record.external_id, record.workspace_path)
+
         session_name = name or self._default_name(record)
         session = await self._session_service.create_session(
             name=session_name,
@@ -152,6 +177,16 @@ class ExternalSessionService:
             session.id,
         )
         return session
+
+    def _workspace_allowed(self, record: ExternalSessionRecord) -> bool:
+        """Apply the allowed mount prefix policy to the record's workspace."""
+        if not record.workspace_path:
+            return False
+        return is_host_path_allowed(
+            record.workspace_path,
+            self._allowed_workspace_prefixes,
+            allow_root_mount=self._allow_root_workspace,
+        )
 
     async def _imported_index(self) -> dict[str, UUID]:
         """Map external session id → Volundr session id for imported sessions."""

--- a/src/volundr/domain/services/external_sessions.py
+++ b/src/volundr/domain/services/external_sessions.py
@@ -17,7 +17,7 @@ from volundr.domain.models import (
 )
 from volundr.domain.mount_policy import is_host_path_allowed
 from volundr.domain.ports import ExternalSessionProvider, SessionRepository
-from volundr.domain.services.session import SessionService
+from volundr.domain.services.session import SessionService, _sanitize_log
 
 logger = logging.getLogger(__name__)
 
@@ -172,8 +172,8 @@ class ExternalSessionService:
         )
         logger.info(
             "Imported external session %s/%s as Volundr session %s",
-            provider,
-            record.external_id,
+            _sanitize_log(provider),
+            _sanitize_log(record.external_id),
             session.id,
         )
         return session

--- a/src/volundr/domain/services/session.py
+++ b/src/volundr/domain/services/session.py
@@ -159,6 +159,8 @@ class SessionService:
         workspace_id: UUID | None = None,
         tracker_issue_id: str | None = None,
         issue_tracker_url: str | None = None,
+        origin: str = "volundr",
+        external_session_id: str | None = None,
     ) -> Session:
         """Create a new session.
 
@@ -172,6 +174,8 @@ class SessionService:
             launch_spec_id: Optional user launch spec id to associate with the session.
             principal: Authenticated identity. When provided, sets owner_id
                 and tenant_id on the session.
+            origin: Where the session originated (volundr, claude, codex).
+            external_session_id: Native CLI session id for imported sessions.
 
         Returns:
             Created session.
@@ -231,6 +235,8 @@ class SessionService:
             workspace_id=workspace_id,
             tracker_issue_id=tracker_issue_id,
             issue_tracker_url=issue_tracker_url,
+            origin=origin,
+            external_session_id=external_session_id,
         )
         created = await self._repository.create(session)
 
@@ -782,7 +788,32 @@ class SessionService:
             contributions.append(contribution)
 
         spec = SessionSpec.merge(contributions)
+        self._overlay_external_resume(session, spec)
         return await self._pod_manager.start(session, spec=spec)
+
+    @staticmethod
+    def _overlay_external_resume(session: Session, spec: SessionSpec) -> None:
+        """Force broker config to resume the native CLI session when imported.
+
+        Imported sessions carry the harness's own session/thread id. The
+        broker must use a resume-capable transport: Claude's default SDK
+        transport cannot resume, so imported Claude sessions are pinned to
+        the persistent subprocess transport (``claude --resume``); Codex
+        resumes through the WebSocket transport's ``thread/resume`` RPC.
+        """
+        if not session.external_session_id:
+            return
+
+        broker = spec.values.setdefault("broker", {})
+        broker["resumeSessionId"] = session.external_session_id
+        if session.origin == "claude":
+            broker["cliType"] = "claude"
+            broker["transportAdapter"] = (
+                "skuld.transports.persistent_subprocess.PersistentSubprocessTransport"
+            )
+        if session.origin == "codex":
+            broker["cliType"] = "codex-ws"
+            broker["transportAdapter"] = "skuld.transports.codex_ws.CodexWebSocketTransport"
 
     async def _run_cleanup(
         self,
@@ -1167,7 +1198,6 @@ def _communication_route_id(
 ) -> UUID:
     """Return a stable route UUID for a session communication target."""
     value = (
-        f"volundr:communication-route:{session_id}:{platform}:"
-        f"{conversation_id}:{thread_id or ''}"
+        f"volundr:communication-route:{session_id}:{platform}:{conversation_id}:{thread_id or ''}"
     )
     return uuid5(NAMESPACE_URL, value)

--- a/src/volundr/domain/services/telegram_ingress.py
+++ b/src/volundr/domain/services/telegram_ingress.py
@@ -93,9 +93,7 @@ class TelegramIngressService:
                 for binding in bindings:
                     if binding.bot_token in self._bot_tasks:
                         continue
-                    self._bot_tasks[binding.bot_token] = asyncio.create_task(
-                        self._run_bot(binding)
-                    )
+                    self._bot_tasks[binding.bot_token] = asyncio.create_task(self._run_bot(binding))
 
                 stale = [token for token in self._bot_tasks if token not in active_tokens]
                 for token in stale:

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -749,6 +749,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     external_session_providers,
                     repository,
                     session_service,
+                    allowed_workspace_prefixes=settings.local_mounts.allowed_prefixes,
+                    allow_root_workspace=settings.local_mounts.allow_root_mount,
                 )
 
             # Create and include routers

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -81,6 +81,7 @@ from volundr.catalog import build_catalog
 from volundr.domain.ports import SessionContributor
 from volundr.domain.services import (
     ChronicleService,
+    ExternalSessionService,
     GitWorkflowService,
     PromptService,
     RepoService,
@@ -226,6 +227,29 @@ def _create_archive_store(settings: Settings) -> "ArchiveStorePort":  # noqa: F8
     instance = cls(**kwargs)
     logger.info("Archive store: %s", as_cfg.adapter.rsplit(".", 1)[-1])
     return instance
+
+
+def _create_external_session_providers(
+    settings: Settings,
+) -> list["ExternalSessionProvider"]:  # noqa: F821
+    """Create external session provider adapters from dynamic config.
+
+    Disabled unless ``external_sessions.enabled`` is true, or unset while
+    running in mini/local mode — host session stores are only reachable
+    when Volundr runs on the host.
+    """
+    es_cfg = settings.external_sessions
+    enabled = es_cfg.enabled if es_cfg.enabled is not None else settings.local_mounts.mini_mode
+    if not enabled:
+        return []
+
+    providers = []
+    for provider_cfg in es_cfg.providers:
+        cls = import_class(provider_cfg.adapter)
+        instance = cls(**provider_cfg.kwargs)
+        providers.append(instance)
+        logger.info("External session provider: %s", provider_cfg.adapter.rsplit(".", 1)[-1])
+    return providers
 
 
 def _create_contributors(
@@ -717,6 +741,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 workflow_config=settings.git.workflow,
             )
 
+            # External session discovery (Claude Code / Codex on the host)
+            external_session_providers = _create_external_session_providers(settings)
+            external_session_service = None
+            if external_session_providers:
+                external_session_service = ExternalSessionService(
+                    external_session_providers,
+                    repository,
+                    session_service,
+                )
+
             # Create and include routers
             forge_router = create_router(
                 session_service,
@@ -727,6 +761,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 repo_service=repo_service,
                 chronicle_service=chronicle_service,
                 archive_service=archive_service,
+                external_session_service=external_session_service,
                 prefix="/api/v1/forge",
             )
             app.include_router(forge_router)

--- a/src/volundr/plugin.py
+++ b/src/volundr/plugin.py
@@ -86,8 +86,7 @@ class VolundrPlugin(ServicePlugin):
                     "/api/v1/volundr/prompts",
                 ),
                 description=(
-                    "Launch specs, session definitions, prompts, "
-                    "and resource catalog routes."
+                    "Launch specs, session definitions, prompts, and resource catalog routes."
                 ),
             ),
         )

--- a/tests/ravn/unit/test_task_dispatch.py
+++ b/tests/ravn/unit/test_task_dispatch.py
@@ -719,6 +719,7 @@ class TestConnectAndConsume:
     async def test_no_amqp_url_sleeps_and_returns(self) -> None:
         """_connect_and_consume returns early when AMQP URL is not set."""
         import os
+
         event_mod = sys.modules["ravn.adapters.channels.event"]
         ch = TaskDispatchChannel(_config())
         enqueued: list = []
@@ -737,6 +738,7 @@ class TestConnectAndConsume:
     async def test_messages_are_consumed(self) -> None:
         """_connect_and_consume delivers messages via _handle_message."""
         import os
+
         event_mod = sys.modules["ravn.adapters.channels.event"]
         loader = _fake_persona_loader(["autonomous-agent"])
         ch = TaskDispatchChannel(_config(reconnect_delay_s=0.0), persona_loader=loader)

--- a/tests/test_adapters/test_contributors/test_notification_channels.py
+++ b/tests/test_adapters/test_contributors/test_notification_channels.py
@@ -165,9 +165,7 @@ class TestNotificationChannelContributor:
         context = SessionContext(
             principal=principal,
             workload_type="ravn_flock",
-            integration_connections=(
-                _telegram_connection(config={"topic_per_session": False}),
-            ),
+            integration_connections=(_telegram_connection(config={"topic_per_session": False}),),
         )
 
         result = await contributor.contribute(session, context)
@@ -184,9 +182,7 @@ class TestNotificationChannelContributor:
         context = SessionContext(
             principal=principal,
             workload_type="ravn_flock",
-            integration_connections=(
-                _telegram_connection(config={"message_thread_id": 42}),
-            ),
+            integration_connections=(_telegram_connection(config={"message_thread_id": 42}),),
         )
 
         result = await contributor.contribute(session, context)

--- a/tests/test_adapters/test_contributors/test_ravn_flock.py
+++ b/tests/test_adapters/test_contributors/test_ravn_flock.py
@@ -284,11 +284,9 @@ class TestContributorOutput:
         assert env_names["SKULD__WORKFLOW_TRIGGER__NODE_ID"] == "trigger-1"
         assert env_names["SKULD__WORKFLOW__WORKFLOW_ID"] == "wf-1"
         assert env_names["SKULD__WORKFLOW__NAME"] == "Code"
-        assert "\"trigger-1\"" in env_names["SKULD__WORKFLOW__GRAPH"]
+        assert '"trigger-1"' in env_names["SKULD__WORKFLOW__GRAPH"]
 
-    async def test_skuld_generic_trigger_env_present_for_plain_coordinator_flock(
-        self, session
-    ):
+    async def test_skuld_generic_trigger_env_present_for_plain_coordinator_flock(self, session):
         template = LaunchSpec(
             name="plain-flock",
             workload_type="ravn_flock",
@@ -1490,9 +1488,7 @@ class TestPerPersonaLLMOverrides:
 
         reviewer_cfg = _extract_mounted_config(result.pod_spec, "reviewer")
         reviewer_parsed = yaml.safe_load(reviewer_cfg)
-        assert reviewer_parsed["persona_overrides"]["consumes_event_types"] == [
-            "review.requested"
-        ]
+        assert reviewer_parsed["persona_overrides"]["consumes_event_types"] == ["review.requested"]
 
     async def test_per_persona_max_concurrent_tasks(self, session):
         """max_concurrent_tasks from persona override replaces global value in initiative."""

--- a/tests/test_adapters/test_external_session_providers.py
+++ b/tests/test_adapters/test_external_session_providers.py
@@ -1,0 +1,260 @@
+"""Tests for the Claude Code and Codex external session providers."""
+
+import json
+from pathlib import Path
+
+from volundr.adapters.outbound.external_sessions import (
+    ClaudeCodeSessionProvider,
+    CodexSessionProvider,
+)
+
+CLAUDE_SESSION_ID = "2e877b9f-4b8a-4d46-8f00-03f6163addd5"
+CODEX_THREAD_ID = "019e88ee-074d-72a2-a81b-3fabef982d78"
+
+
+def _write_claude_session(
+    projects_dir: Path,
+    session_id: str,
+    workspace: Path,
+    *,
+    title: str = "Fix the login bug please",
+) -> Path:
+    project_dir = projects_dir / str(workspace).replace("/", "-")
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{session_id}.jsonl"
+    lines = [
+        {"type": "permission-mode", "permissionMode": "default", "sessionId": session_id},
+        {
+            "type": "user",
+            "sessionId": session_id,
+            "cwd": str(workspace),
+            "timestamp": "2026-06-01T10:00:00.000Z",
+            "message": {"role": "user", "content": title},
+        },
+        {
+            "type": "assistant",
+            "sessionId": session_id,
+            "cwd": str(workspace),
+            "timestamp": "2026-06-01T10:00:05.000Z",
+            "message": {"role": "assistant", "model": "claude-sonnet-4-6", "content": []},
+        },
+    ]
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return path
+
+
+def _write_codex_session(
+    sessions_dir: Path,
+    thread_id: str,
+    workspace: Path,
+    *,
+    title: str = "Refactor the billing module",
+) -> Path:
+    day_dir = sessions_dir / "2026" / "06" / "01"
+    day_dir.mkdir(parents=True, exist_ok=True)
+    path = day_dir / f"rollout-2026-06-01T10-00-00-{thread_id}.jsonl"
+    lines = [
+        {
+            "timestamp": "2026-06-01T10:00:00.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": thread_id,
+                "timestamp": "2026-06-01T10:00:00.000Z",
+                "cwd": str(workspace),
+                "model_provider": "openai",
+            },
+        },
+        {
+            "timestamp": "2026-06-01T10:00:01.000Z",
+            "type": "turn_context",
+            "payload": {"turn_id": "turn-1", "cwd": str(workspace), "model": "gpt-5-codex"},
+        },
+        {
+            "timestamp": "2026-06-01T10:00:02.000Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": title},
+        },
+    ]
+    path.write_text("\n".join(json.dumps(line) for line in lines) + "\n")
+    return path
+
+
+class TestClaudeCodeSessionProvider:
+    async def test_lists_sessions_with_metadata(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        projects_dir = tmp_path / "projects"
+        _write_claude_session(projects_dir, CLAUDE_SESSION_ID, workspace)
+
+        provider = ClaudeCodeSessionProvider(projects_dir=str(projects_dir))
+        records = await provider.list_sessions()
+
+        assert len(records) == 1
+        record = records[0]
+        assert record.provider == "claude-code"
+        assert record.harness == "claude"
+        assert record.external_id == CLAUDE_SESSION_ID
+        assert record.workspace_path == str(workspace)
+        assert record.title == "Fix the login bug please"
+        assert record.model == "claude-sonnet-4-6"
+        assert record.created_at is not None
+        assert record.updated_at is not None
+        assert record.workspace_exists is True
+        assert record.live is True
+
+    async def test_stale_session_is_not_live(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        projects_dir = tmp_path / "projects"
+        _write_claude_session(projects_dir, CLAUDE_SESSION_ID, workspace)
+
+        provider = ClaudeCodeSessionProvider(
+            projects_dir=str(projects_dir),
+            live_threshold_seconds=0,
+        )
+        records = await provider.list_sessions()
+
+        assert records[0].live is False
+
+    async def test_skips_non_uuid_files(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        projects_dir = tmp_path / "projects"
+        _write_claude_session(projects_dir, CLAUDE_SESSION_ID, workspace)
+        project_dir = next(projects_dir.iterdir())
+        (project_dir / "agent-helper.jsonl").write_text("{}\n")
+
+        provider = ClaudeCodeSessionProvider(projects_dir=str(projects_dir))
+        records = await provider.list_sessions()
+
+        assert [r.external_id for r in records] == [CLAUDE_SESSION_ID]
+
+    async def test_missing_projects_dir_returns_empty(self, tmp_path: Path) -> None:
+        provider = ClaudeCodeSessionProvider(projects_dir=str(tmp_path / "missing"))
+        assert await provider.list_sessions() == []
+
+    async def test_get_session_by_id(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        projects_dir = tmp_path / "projects"
+        _write_claude_session(projects_dir, CLAUDE_SESSION_ID, workspace)
+
+        provider = ClaudeCodeSessionProvider(projects_dir=str(projects_dir))
+        record = await provider.get_session(CLAUDE_SESSION_ID)
+
+        assert record is not None
+        assert record.external_id == CLAUDE_SESSION_ID
+
+    async def test_get_session_rejects_non_uuid(self, tmp_path: Path) -> None:
+        provider = ClaudeCodeSessionProvider(projects_dir=str(tmp_path))
+        assert await provider.get_session("not-a-uuid") is None
+
+    async def test_get_session_missing_returns_none(self, tmp_path: Path) -> None:
+        provider = ClaudeCodeSessionProvider(projects_dir=str(tmp_path))
+        assert await provider.get_session(CLAUDE_SESSION_ID) is None
+
+    async def test_missing_workspace_flagged(self, tmp_path: Path) -> None:
+        projects_dir = tmp_path / "projects"
+        _write_claude_session(projects_dir, CLAUDE_SESSION_ID, tmp_path / "gone")
+
+        provider = ClaudeCodeSessionProvider(projects_dir=str(projects_dir))
+        records = await provider.list_sessions()
+
+        assert records[0].workspace_exists is False
+
+    async def test_corrupt_lines_are_skipped(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        projects_dir = tmp_path / "projects"
+        path = _write_claude_session(projects_dir, CLAUDE_SESSION_ID, workspace)
+        path.write_text("not-json\n" + path.read_text())
+
+        provider = ClaudeCodeSessionProvider(projects_dir=str(projects_dir))
+        records = await provider.list_sessions()
+
+        assert records[0].workspace_path == str(workspace)
+
+    async def test_max_sessions_caps_results(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        projects_dir = tmp_path / "projects"
+        _write_claude_session(projects_dir, CLAUDE_SESSION_ID, workspace)
+        _write_claude_session(
+            projects_dir,
+            "11111111-2222-3333-4444-555555555555",
+            workspace,
+        )
+
+        provider = ClaudeCodeSessionProvider(projects_dir=str(projects_dir), max_sessions=1)
+        records = await provider.list_sessions()
+
+        assert len(records) == 1
+
+
+class TestCodexSessionProvider:
+    async def test_lists_sessions_with_metadata(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        sessions_dir = tmp_path / "sessions"
+        _write_codex_session(sessions_dir, CODEX_THREAD_ID, workspace)
+
+        provider = CodexSessionProvider(sessions_dir=str(sessions_dir))
+        records = await provider.list_sessions()
+
+        assert len(records) == 1
+        record = records[0]
+        assert record.provider == "codex"
+        assert record.harness == "codex"
+        assert record.external_id == CODEX_THREAD_ID
+        assert record.workspace_path == str(workspace)
+        assert record.title == "Refactor the billing module"
+        assert record.model == "gpt-5-codex"
+        assert record.created_at is not None
+        assert record.workspace_exists is True
+        assert record.live is True
+
+    async def test_stale_session_is_not_live(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        sessions_dir = tmp_path / "sessions"
+        _write_codex_session(sessions_dir, CODEX_THREAD_ID, workspace)
+
+        provider = CodexSessionProvider(
+            sessions_dir=str(sessions_dir),
+            live_threshold_seconds=0,
+        )
+        records = await provider.list_sessions()
+
+        assert records[0].live is False
+
+    async def test_missing_sessions_dir_returns_empty(self, tmp_path: Path) -> None:
+        provider = CodexSessionProvider(sessions_dir=str(tmp_path / "missing"))
+        assert await provider.list_sessions() == []
+
+    async def test_file_without_session_meta_is_skipped(self, tmp_path: Path) -> None:
+        sessions_dir = tmp_path / "sessions"
+        day_dir = sessions_dir / "2026" / "06" / "01"
+        day_dir.mkdir(parents=True)
+        (day_dir / "rollout-2026-06-01T10-00-00-deadbeef.jsonl").write_text(
+            json.dumps({"type": "event_msg", "payload": {"type": "task_started"}}) + "\n"
+        )
+
+        provider = CodexSessionProvider(sessions_dir=str(sessions_dir))
+        assert await provider.list_sessions() == []
+
+    async def test_get_session_by_id(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "repo"
+        workspace.mkdir()
+        sessions_dir = tmp_path / "sessions"
+        _write_codex_session(sessions_dir, CODEX_THREAD_ID, workspace)
+
+        provider = CodexSessionProvider(sessions_dir=str(sessions_dir))
+        record = await provider.get_session(CODEX_THREAD_ID)
+
+        assert record is not None
+        assert record.external_id == CODEX_THREAD_ID
+
+    async def test_get_session_missing_returns_none(self, tmp_path: Path) -> None:
+        provider = CodexSessionProvider(sessions_dir=str(tmp_path))
+        assert await provider.get_session("nope") is None
+        assert await provider.get_session("") is None

--- a/tests/test_adapters/test_local_process.py
+++ b/tests/test_adapters/test_local_process.py
@@ -255,6 +255,34 @@ class TestSkuldEnv:
         assert env["SKULD__TELEGRAM__TOPIC_MODE"] == "fixed_topic"
         assert env["SKULD__TELEGRAM__MESSAGE_THREAD_ID"] == "77"
 
+    def test_build_env_includes_resume_session_id(self) -> None:
+        """Imported sessions thread their native CLI session id to Skuld."""
+        spec = SessionSpec(
+            values={
+                "broker": {
+                    "cliType": "claude",
+                    "resumeSessionId": "2e877b9f-4b8a-4d46-8f00-03f6163addd5",
+                }
+            },
+            pod_spec=PodSpecAdditions(),
+        )
+
+        env = LocalProcessPodManager._build_env(spec, Path("/tmp/ws"))
+
+        assert env["SKULD__SESSION__RESUME_SESSION_ID"] == (
+            "2e877b9f-4b8a-4d46-8f00-03f6163addd5"
+        )
+
+    def test_build_env_omits_resume_session_id_when_absent(self) -> None:
+        spec = SessionSpec(
+            values={"broker": {"cliType": "claude"}},
+            pod_spec=PodSpecAdditions(),
+        )
+
+        env = LocalProcessPodManager._build_env(spec, Path("/tmp/ws"))
+
+        assert "SKULD__SESSION__RESUME_SESSION_ID" not in env
+
     def test_build_env_includes_localized_mcp_servers(self) -> None:
         spec = SessionSpec(
             values={

--- a/tests/test_adapters/test_local_process.py
+++ b/tests/test_adapters/test_local_process.py
@@ -269,9 +269,7 @@ class TestSkuldEnv:
 
         env = LocalProcessPodManager._build_env(spec, Path("/tmp/ws"))
 
-        assert env["SKULD__SESSION__RESUME_SESSION_ID"] == (
-            "2e877b9f-4b8a-4d46-8f00-03f6163addd5"
-        )
+        assert env["SKULD__SESSION__RESUME_SESSION_ID"] == ("2e877b9f-4b8a-4d46-8f00-03f6163addd5")
 
     def test_build_env_omits_resume_session_id_when_absent(self) -> None:
         spec = SessionSpec(
@@ -1184,9 +1182,7 @@ class TestProcessSpawning:
                     {"name": "MESH_HANDSHAKE_PORT", "value": "7580"},
                     {"name": "MESH_PEER_ID", "value": "skuld-test"},
                 ),
-                extra_containers=(
-                    {"name": "ravn-reviewer"},
-                ),
+                extra_containers=({"name": "ravn-reviewer"},),
             ),
         )
 
@@ -1245,12 +1241,8 @@ class TestProcessSpawning:
         spec = SessionSpec(
             values={},
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
-                extra_containers=(
-                    {"name": "ravn-reviewer"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
+                extra_containers=({"name": "ravn-reviewer"},),
             ),
         )
 
@@ -1305,9 +1297,7 @@ class TestProcessSpawning:
         spec = SessionSpec(
             values={},
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
                 extra_containers=(
                     {"name": "ravn-claude-mimir-researcher"},
                     {"name": "ravn-codex-mimir-researcher"},
@@ -1337,12 +1327,8 @@ class TestProcessSpawning:
             )
 
         persona_dir = workspace / ".ravn" / "personas"
-        claude_yaml = (persona_dir / "claude-mimir-researcher.yaml").read_text(
-            encoding="utf-8"
-        )
-        codex_yaml = (persona_dir / "codex-mimir-researcher.yaml").read_text(
-            encoding="utf-8"
-        )
+        claude_yaml = (persona_dir / "claude-mimir-researcher.yaml").read_text(encoding="utf-8")
+        codex_yaml = (persona_dir / "codex-mimir-researcher.yaml").read_text(encoding="utf-8")
         assert claude_yaml.startswith("name: claude-mimir-researcher")
         assert codex_yaml.startswith("name: codex-mimir-researcher")
         assert mock_run.call_args_list[0].kwargs["cwd"] == str(workspace)
@@ -1376,12 +1362,8 @@ class TestProcessSpawning:
                 }
             },
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
-                extra_containers=(
-                    {"name": "ravn-reviewer"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
+                extra_containers=({"name": "ravn-reviewer"},),
             ),
         )
 
@@ -1445,12 +1427,8 @@ class TestProcessSpawning:
                 }
             },
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
-                extra_containers=(
-                    {"name": "ravn-reviewer"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
+                extra_containers=({"name": "ravn-reviewer"},),
             ),
         )
 
@@ -1543,12 +1521,8 @@ class TestProcessSpawning:
                 },
             },
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
-                extra_containers=(
-                    {"name": "ravn-coder"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
+                extra_containers=({"name": "ravn-coder"},),
             ),
         )
 
@@ -1670,9 +1644,7 @@ class TestProcessSpawning:
                 },
             },
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
                 extra_containers=(
                     {"name": "ravn-coder"},
                     {"name": "ravn-reviewer"},
@@ -2343,9 +2315,7 @@ class TestLocalFlockMeshMode:
                     {"name": "MESH_HANDSHAKE_PORT", "value": "7580"},
                     {"name": "MESH_PEER_ID", "value": "skuld-test"},
                 ),
-                extra_containers=(
-                    {"name": "ravn-reviewer"},
-                ),
+                extra_containers=({"name": "ravn-reviewer"},),
             ),
         )
 
@@ -2403,12 +2373,8 @@ class TestLocalFlockMeshMode:
         spec = SessionSpec(
             values={},
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
-                extra_containers=(
-                    {"name": "ravn-reviewer"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
+                extra_containers=({"name": "ravn-reviewer"},),
             ),
         )
 
@@ -2471,12 +2437,8 @@ class TestLocalFlockMeshMode:
                 }
             },
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
-                extra_containers=(
-                    {"name": "ravn-reviewer"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
+                extra_containers=({"name": "ravn-reviewer"},),
             ),
         )
 
@@ -2533,12 +2495,8 @@ class TestLocalFlockMeshMode:
                 }
             },
             pod_spec=PodSpecAdditions(
-                env=(
-                    {"name": "MESH_PEER_ID", "value": "skuld-test"},
-                ),
-                extra_containers=(
-                    {"name": "ravn-reviewer"},
-                ),
+                env=({"name": "MESH_PEER_ID", "value": "skuld-test"},),
+                extra_containers=({"name": "ravn-reviewer"},),
             ),
         )
 

--- a/tests/test_adapters/test_local_process.py
+++ b/tests/test_adapters/test_local_process.py
@@ -538,6 +538,57 @@ class TestWorkspaceProvisioning:
         content = claude_md.read_text()
         assert "You are a helpful assistant." in content
 
+    async def test_local_mount_path_outside_allowed_prefixes_is_rejected(
+        self,
+        tmp_workspaces: Path,
+        tmp_state_file: Path,
+        default_spec: SessionSpec,
+        tmp_path: Path,
+    ) -> None:
+        """Mini-mode local_path workspaces obey the allowed mount prefix policy."""
+        allowed = tmp_path / "allowed"
+        outside = tmp_path / "outside"
+        allowed.mkdir()
+        outside.mkdir()
+        manager = LocalProcessPodManager(
+            workspaces_dir=str(tmp_workspaces),
+            state_file=str(tmp_state_file),
+            allowed_mount_prefixes=[str(allowed)],
+        )
+        session = Session(
+            id=uuid4(),
+            name="denied-local-mount",
+            source=LocalMountSource(local_path=str(outside)),
+        )
+
+        with pytest.raises(RuntimeError, match="allowed mount prefix"):
+            await manager._provision_workspace(session, default_spec)
+
+    async def test_local_mount_path_under_allowed_prefix_is_used(
+        self,
+        tmp_workspaces: Path,
+        tmp_state_file: Path,
+        default_spec: SessionSpec,
+        tmp_path: Path,
+    ) -> None:
+        allowed = tmp_path / "allowed"
+        workspace_dir = allowed / "project"
+        workspace_dir.mkdir(parents=True)
+        manager = LocalProcessPodManager(
+            workspaces_dir=str(tmp_workspaces),
+            state_file=str(tmp_state_file),
+            allowed_mount_prefixes=[str(allowed)],
+        )
+        session = Session(
+            id=uuid4(),
+            name="allowed-local-mount",
+            source=LocalMountSource(local_path=str(workspace_dir)),
+        )
+
+        workspace = await manager._provision_workspace(session, default_spec)
+
+        assert workspace == workspace_dir
+
     async def test_git_source_local_path_uses_directory_directly(
         self,
         manager: LocalProcessPodManager,

--- a/tests/test_adapters/test_openbao.py
+++ b/tests/test_adapters/test_openbao.py
@@ -126,7 +126,9 @@ class TestConfigureJwtAuth:
         respx.post(f"{BAO_URL}/v1/auth/jwt/config").respond(status_code=500, text="boom")
 
         with pytest.raises(OpenBaoApiError):
-            await client.configure_jwt_auth(OpenBaoJWTAuthConfig(oidc_discovery_url="https://issuer"))
+            await client.configure_jwt_auth(
+                OpenBaoJWTAuthConfig(oidc_discovery_url="https://issuer")
+            )
 
 
 class TestEnsurePolicy:

--- a/tests/test_adapters/test_openbao_secret_injection.py
+++ b/tests/test_adapters/test_openbao_secret_injection.py
@@ -84,8 +84,7 @@ class TestOpenBaoAgentInjectionAdapter:
         assert result.service_account == "openbao-session-session-123"
         assert result.annotations["vault.hashicorp.com/agent-inject"] == "true"
         assert (
-            result.annotations["vault.hashicorp.com/agent-configmap"]
-            == "openbao-agent-session-123"
+            result.annotations["vault.hashicorp.com/agent-configmap"] == "openbao-agent-session-123"
         )
         assert result.annotations["vault.hashicorp.com/agent-pre-populate-only"] == "true"
         assert result.annotations["vault.hashicorp.com/auth-type"] == "jwt"
@@ -205,7 +204,7 @@ class TestOpenBaoAgentInjectionAdapter:
         assert 'destination = "/run/secrets/env.sh"' in config_hcl
         assert 'destination = "/home/volundr/.git-credentials"' in config_hcl
         assert 'secret "volundr/data/users/alice/github"' in config_hcl
-        assert "{{ with secret \"volundr/data/users/alice/github\" }}" in config_hcl
+        assert '{{ with secret "volundr/data/users/alice/github" }}' in config_hcl
         assert "{{ end }}" in config_hcl
 
     def test_build_configmap_data_separates_env_exports_with_newlines(self, adapter):
@@ -229,7 +228,7 @@ class TestOpenBaoAgentInjectionAdapter:
         expected_linear = (
             "export LINEAR_API_KEY='{{ index .Data.data \"api_key\" }}'\n"
             "{{ end }}\n"
-            "{{ with secret \"volundr/data/users/alice/github\" }}"
+            '{{ with secret "volundr/data/users/alice/github" }}'
         )
         assert expected_linear in env_block
         assert "export GITHUB_TOKEN='{{ index .Data.data \"token\" }}'\n{{ end }}" in env_block
@@ -246,10 +245,7 @@ class TestOpenBaoAgentInjectionAdapter:
 
     def test_helper_paths_and_names(self, adapter):
         assert adapter._auth_mount_path() == "auth/jwt-valhalla"
-        assert (
-            adapter._credential_path("alice", "github")
-            == "volundr/data/users/alice/github"
-        )
+        assert adapter._credential_path("alice", "github") == "volundr/data/users/alice/github"
         assert adapter._sanitize_name("Session_ABC/123") == "session-abc-123"
         assert adapter._k8s_name("openbao/session", "A" * 80).startswith("openbao-session-")
 

--- a/tests/test_adapters/test_postgres.py
+++ b/tests/test_adapters/test_postgres.py
@@ -88,6 +88,7 @@ class TestPostgresSessionRepositoryCreate:
         result = await repository.create(sample_session)
         assert result == sample_session
 
+
 class TestPostgresSessionRepositoryGet:
     """Tests for get method."""
 
@@ -224,6 +225,7 @@ class TestPostgresSessionRepositoryUpdate:
         """Test that update returns the session."""
         result = await repository.update(sample_session)
         assert result == sample_session
+
 
 class TestPostgresSessionRepositoryDelete:
     """Tests for delete method."""

--- a/tests/test_adapters/test_rest.py
+++ b/tests/test_adapters/test_rest.py
@@ -968,6 +968,14 @@ class TestFeatureFlags:
         assert "local_mounts_enabled" in data
         assert isinstance(data["local_mounts_enabled"], bool)
 
+    def test_feature_flags_lists_allowed_mount_prefixes(self, client: TestClient):
+        """Exposes the configured mount prefix allowlist for UI/automation."""
+        response = client.get("/api/v1/forge/feature-flags")
+        assert response.status_code == 200
+        data = response.json()
+        assert "local_mounts_allowed_prefixes" in data
+        assert isinstance(data["local_mounts_allowed_prefixes"], list)
+
 
 class TestStatsResponse:
     """Tests for StatsResponse model."""

--- a/tests/test_adapters/test_rest_external_sessions.py
+++ b/tests/test_adapters/test_rest_external_sessions.py
@@ -169,6 +169,41 @@ class TestImportSession:
         response = client.post("/api/v1/forge/sessions/import", json=body)
         assert response.status_code == 409
 
+    def test_disallowed_workspace_returns_403(
+        self, repository, session_service, claude_record, tmp_path
+    ) -> None:
+        allowed_dir = tmp_path / "only-this"
+        allowed_dir.mkdir()
+        provider = FakeProvider("claude-code", "claude", [claude_record])
+        external_service = ExternalSessionService(
+            [provider],
+            repository,
+            session_service,
+            allowed_workspace_prefixes=[str(allowed_dir)],
+        )
+        app = FastAPI()
+        app.include_router(
+            create_router(
+                session_service=session_service,
+                external_session_service=external_service,
+            )
+        )
+        client = TestClient(app)
+
+        listing = client.get("/api/v1/forge/external-sessions").json()
+        assert listing[0]["workspace_allowed"] is False
+
+        response = client.post(
+            "/api/v1/forge/sessions/import",
+            json={"provider": "claude-code", "external_id": claude_record.external_id},
+        )
+        assert response.status_code == 403
+        assert "allowed" in response.json()["detail"]
+
+    def test_workspace_allowed_in_listing_by_default(self, client) -> None:
+        listing = client.get("/api/v1/forge/external-sessions").json()
+        assert listing[0]["workspace_allowed"] is True
+
     def test_missing_workspace_returns_422(self, repository, session_service, tmp_path) -> None:
         record = ExternalSessionRecord(
             provider="claude-code",

--- a/tests/test_adapters/test_rest_external_sessions.py
+++ b/tests/test_adapters/test_rest_external_sessions.py
@@ -1,0 +1,226 @@
+"""Tests for external session discovery/import REST endpoints and resume alias."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from volundr.adapters.inbound.rest import create_router
+from volundr.domain.models import (
+    ExternalSessionRecord,
+    LocalMountSource,
+    Session,
+    SessionStatus,
+)
+from volundr.domain.ports import ExternalSessionProvider
+from volundr.domain.services import ExternalSessionService, SessionService
+
+
+class FakeProvider(ExternalSessionProvider):
+    """In-memory external session provider for tests."""
+
+    def __init__(self, name: str, harness: str, records: list[ExternalSessionRecord]):
+        self._name = name
+        self._harness = harness
+        self._records = records
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def harness(self) -> str:
+        return self._harness
+
+    async def list_sessions(self) -> list[ExternalSessionRecord]:
+        return list(self._records)
+
+    async def get_session(self, external_id: str) -> ExternalSessionRecord | None:
+        for record in self._records:
+            if record.external_id == external_id:
+                return record
+        return None
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    path = tmp_path / "workspace"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def claude_record(workspace: Path) -> ExternalSessionRecord:
+    return ExternalSessionRecord(
+        provider="claude-code",
+        harness="claude",
+        external_id="2e877b9f-4b8a-4d46-8f00-03f6163addd5",
+        workspace_path=str(workspace),
+        title="Fix the login bug",
+        model="claude-sonnet-4-6",
+        created_at=datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+        updated_at=datetime(2026, 6, 1, 11, 0, tzinfo=UTC),
+        live=False,
+        workspace_exists=True,
+    )
+
+
+@pytest.fixture
+def session_service(repository, pod_manager) -> SessionService:
+    return SessionService(repository=repository, pod_manager=pod_manager)
+
+
+@pytest.fixture
+def app(repository, session_service, claude_record) -> FastAPI:
+    provider = FakeProvider("claude-code", "claude", [claude_record])
+    external_service = ExternalSessionService([provider], repository, session_service)
+
+    app = FastAPI()
+    router = create_router(
+        session_service=session_service,
+        external_session_service=external_service,
+    )
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+class TestListExternalSessions:
+    def test_lists_discoverable_sessions(self, client, claude_record) -> None:
+        response = client.get("/api/v1/forge/external-sessions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["provider"] == "claude-code"
+        assert data[0]["harness"] == "claude"
+        assert data[0]["external_id"] == claude_record.external_id
+        assert data[0]["title"] == "Fix the login bug"
+        assert data[0]["imported_session_id"] is None
+
+    def test_unknown_provider_returns_404(self, client) -> None:
+        response = client.get("/api/v1/forge/external-sessions", params={"provider": "nope"})
+        assert response.status_code == 404
+
+    def test_unavailable_without_service(self, session_service) -> None:
+        app = FastAPI()
+        app.include_router(create_router(session_service=session_service))
+        client = TestClient(app)
+
+        response = client.get("/api/v1/forge/external-sessions")
+        assert response.status_code == 503
+
+        response = client.post(
+            "/api/v1/forge/sessions/import",
+            json={"provider": "claude-code", "external_id": "x"},
+        )
+        assert response.status_code == 503
+
+
+class TestImportSession:
+    def test_imports_external_session(self, client, claude_record, workspace) -> None:
+        response = client.post(
+            "/api/v1/forge/sessions/import",
+            json={
+                "provider": "claude-code",
+                "external_id": claude_record.external_id,
+                "name": "imported-login-fix",
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "imported-login-fix"
+        assert data["origin"] == "claude"
+        assert data["external_session_id"] == claude_record.external_id
+        assert data["source"]["type"] == "local_mount"
+        assert data["source"]["local_path"] == str(workspace)
+
+    def test_imported_session_appears_in_listing(self, client, claude_record) -> None:
+        client.post(
+            "/api/v1/forge/sessions/import",
+            json={"provider": "claude-code", "external_id": claude_record.external_id},
+        )
+
+        sessions = client.get("/api/v1/forge/sessions").json()
+        assert len(sessions) == 1
+        assert sessions[0]["origin"] == "claude"
+
+        external = client.get("/api/v1/forge/external-sessions").json()
+        assert external[0]["imported_session_id"] == sessions[0]["id"]
+
+    def test_unknown_external_session_returns_404(self, client) -> None:
+        response = client.post(
+            "/api/v1/forge/sessions/import",
+            json={"provider": "claude-code", "external_id": "missing"},
+        )
+        assert response.status_code == 404
+
+    def test_duplicate_import_returns_409(self, client, claude_record) -> None:
+        body = {"provider": "claude-code", "external_id": claude_record.external_id}
+        assert client.post("/api/v1/forge/sessions/import", json=body).status_code == 201
+
+        response = client.post("/api/v1/forge/sessions/import", json=body)
+        assert response.status_code == 409
+
+    def test_missing_workspace_returns_422(self, repository, session_service, tmp_path) -> None:
+        record = ExternalSessionRecord(
+            provider="claude-code",
+            harness="claude",
+            external_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            workspace_path=str(tmp_path / "gone"),
+            workspace_exists=False,
+        )
+        provider = FakeProvider("claude-code", "claude", [record])
+        external_service = ExternalSessionService([provider], repository, session_service)
+        app = FastAPI()
+        app.include_router(
+            create_router(
+                session_service=session_service,
+                external_session_service=external_service,
+            )
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/api/v1/forge/sessions/import",
+            json={"provider": "claude-code", "external_id": record.external_id},
+        )
+        assert response.status_code == 422
+
+
+class TestResumeAlias:
+    async def test_resume_starts_stopped_session(self, client, repository) -> None:
+        session = Session(
+            name="stopped-session",
+            status=SessionStatus.STOPPED,
+            source=LocalMountSource(local_path="/tmp/ws"),
+        )
+        await repository.create(session)
+
+        response = client.post(f"/api/v1/forge/sessions/{session.id}/resume")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "starting"
+
+    async def test_resume_matches_start_for_running_session(self, client, repository) -> None:
+        session = Session(
+            name="running-session",
+            status=SessionStatus.RUNNING,
+            source=LocalMountSource(local_path="/tmp/ws"),
+        )
+        await repository.create(session)
+
+        response = client.post(f"/api/v1/forge/sessions/{session.id}/resume")
+
+        assert response.status_code == 409
+
+    def test_resume_unknown_session_returns_404(self, client) -> None:
+        response = client.post("/api/v1/forge/sessions/00000000-0000-0000-0000-000000000000/resume")
+        assert response.status_code == 404

--- a/tests/test_adapters/test_rest_external_sessions.py
+++ b/tests/test_adapters/test_rest_external_sessions.py
@@ -103,6 +103,7 @@ class TestListExternalSessions:
         assert data[0]["external_id"] == claude_record.external_id
         assert data[0]["title"] == "Fix the login bug"
         assert data[0]["imported_session_id"] is None
+        assert data[0]["importable"] is True
 
     def test_unknown_provider_returns_404(self, client) -> None:
         response = client.get("/api/v1/forge/external-sessions", params={"provider": "nope"})
@@ -154,6 +155,7 @@ class TestImportSession:
 
         external = client.get("/api/v1/forge/external-sessions").json()
         assert external[0]["imported_session_id"] == sessions[0]["id"]
+        assert external[0]["importable"] is False
 
     def test_unknown_external_session_returns_404(self, client) -> None:
         response = client.post(
@@ -192,6 +194,7 @@ class TestImportSession:
 
         listing = client.get("/api/v1/forge/external-sessions").json()
         assert listing[0]["workspace_allowed"] is False
+        assert listing[0]["importable"] is False
 
         response = client.post(
             "/api/v1/forge/sessions/import",

--- a/tests/test_adapters/test_rest_tenants.py
+++ b/tests/test_adapters/test_rest_tenants.py
@@ -121,6 +121,7 @@ class TestListTenants:
         assert resp.status_code == 200
         svc.list_tenants.assert_called_once_with("root")
 
+
 class _ProvisioningResult:
     def __init__(self, *, success: bool, user_id: str, home_pvc: str | None, errors: list[str]):
         self.success = success
@@ -365,6 +366,7 @@ class TestUpdateTenant:
             max_storage_gb=None,
             tier=None,
         )
+
 
 class TestMembers:
     """Tests for member management endpoints."""

--- a/tests/test_charts/test_ting_chart.py
+++ b/tests/test_charts/test_ting_chart.py
@@ -33,7 +33,7 @@ class TestDeploymentTemplate:
 
     def test_uses_unified_niuu_image_command(self, template_yaml):
         assert ".Values.command" in template_yaml
-        assert 'name: {{ .Chart.Name }}' in template_yaml
+        assert "name: {{ .Chart.Name }}" in template_yaml
 
     def test_has_process_runtime_env_vars(self, template_yaml):
         assert "HOST" in template_yaml

--- a/tests/test_domain/test_external_session_service.py
+++ b/tests/test_domain/test_external_session_service.py
@@ -16,6 +16,7 @@ from volundr.domain.services import SessionService
 from volundr.domain.services.external_sessions import (
     ExternalSessionAlreadyImportedError,
     ExternalSessionNotFoundError,
+    ExternalSessionPathNotAllowedError,
     ExternalSessionProviderNotFoundError,
     ExternalSessionService,
     ExternalSessionWorkspaceError,
@@ -238,6 +239,94 @@ class TestImportSession:
 
         with pytest.raises(ExternalSessionWorkspaceError):
             await service.import_session("claude-code", "claude-1")
+
+
+class TestMountPrefixPolicy:
+    async def test_import_outside_allowed_prefixes_raises(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        allowed = tmp_path / "allowed"
+        outside = tmp_path / "outside"
+        allowed.mkdir()
+        outside.mkdir()
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", outside)],
+        )
+        service = ExternalSessionService(
+            [provider],
+            repository,
+            session_service,
+            allowed_workspace_prefixes=[str(allowed)],
+        )
+
+        with pytest.raises(ExternalSessionPathNotAllowedError):
+            await service.import_session("claude-code", "claude-1")
+
+    async def test_import_under_allowed_prefix_succeeds(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        workspace = tmp_path / "allowed" / "ws"
+        workspace.mkdir(parents=True)
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", workspace)],
+        )
+        service = ExternalSessionService(
+            [provider],
+            repository,
+            session_service,
+            allowed_workspace_prefixes=[str(tmp_path / "allowed")],
+        )
+
+        session = await service.import_session("claude-code", "claude-1")
+
+        assert session.external_session_id == "claude-1"
+
+    async def test_listing_annotates_workspace_allowed(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        allowed = tmp_path / "allowed"
+        outside = tmp_path / "outside"
+        allowed.mkdir()
+        outside.mkdir()
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [
+                _record("claude-code", "claude", "claude-ok", allowed),
+                _record("claude-code", "claude", "claude-denied", outside),
+            ],
+        )
+        service = ExternalSessionService(
+            [provider],
+            repository,
+            session_service,
+            allowed_workspace_prefixes=[str(allowed)],
+        )
+
+        records = await service.list_external_sessions()
+
+        allowed_map = {r.external_id: r.workspace_allowed for r in records}
+        assert allowed_map == {"claude-ok": True, "claude-denied": False}
+
+    async def test_empty_prefixes_allow_all(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", workspace)],
+        )
+        service = ExternalSessionService([provider], repository, session_service)
+
+        records = await service.list_external_sessions()
+
+        assert records[0].workspace_allowed is True
 
 
 class TestExternalResumeOverlay:

--- a/tests/test_domain/test_external_session_service.py
+++ b/tests/test_domain/test_external_session_service.py
@@ -1,0 +1,302 @@
+"""Tests for the external session discovery and import service."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from volundr.domain.models import (
+    ExternalSessionRecord,
+    LocalMountSource,
+    Session,
+    SessionSpec,
+)
+from volundr.domain.ports import ExternalSessionProvider
+from volundr.domain.services import SessionService
+from volundr.domain.services.external_sessions import (
+    ExternalSessionAlreadyImportedError,
+    ExternalSessionNotFoundError,
+    ExternalSessionProviderNotFoundError,
+    ExternalSessionService,
+    ExternalSessionWorkspaceError,
+)
+
+
+class FakeProvider(ExternalSessionProvider):
+    """In-memory external session provider for tests."""
+
+    def __init__(self, name: str, harness: str, records: list[ExternalSessionRecord]):
+        self._name = name
+        self._harness = harness
+        self._records = records
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def harness(self) -> str:
+        return self._harness
+
+    async def list_sessions(self) -> list[ExternalSessionRecord]:
+        return list(self._records)
+
+    async def get_session(self, external_id: str) -> ExternalSessionRecord | None:
+        for record in self._records:
+            if record.external_id == external_id:
+                return record
+        return None
+
+
+def _record(
+    provider: str,
+    harness: str,
+    external_id: str,
+    workspace: Path,
+    *,
+    updated_at: datetime | None = None,
+) -> ExternalSessionRecord:
+    return ExternalSessionRecord(
+        provider=provider,
+        harness=harness,
+        external_id=external_id,
+        workspace_path=str(workspace),
+        title=f"session {external_id}",
+        model="claude-sonnet-4-6",
+        created_at=datetime(2026, 6, 1, 10, 0, tzinfo=UTC),
+        updated_at=updated_at or datetime(2026, 6, 1, 11, 0, tzinfo=UTC),
+        live=False,
+        workspace_exists=workspace.is_dir(),
+    )
+
+
+@pytest.fixture
+def session_service(repository, pod_manager) -> SessionService:
+    return SessionService(repository=repository, pod_manager=pod_manager)
+
+
+class TestListExternalSessions:
+    async def test_merges_providers_newest_first(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        claude = FakeProvider(
+            "claude-code",
+            "claude",
+            [
+                _record(
+                    "claude-code",
+                    "claude",
+                    "claude-1",
+                    workspace,
+                    updated_at=datetime(2026, 6, 1, 9, 0, tzinfo=UTC),
+                )
+            ],
+        )
+        codex = FakeProvider(
+            "codex",
+            "codex",
+            [
+                _record(
+                    "codex",
+                    "codex",
+                    "codex-1",
+                    workspace,
+                    updated_at=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+                )
+            ],
+        )
+        service = ExternalSessionService([claude, codex], repository, session_service)
+
+        records = await service.list_external_sessions()
+
+        assert [r.external_id for r in records] == ["codex-1", "claude-1"]
+
+    async def test_filters_by_provider(self, repository, session_service, tmp_path: Path) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        claude = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", workspace)],
+        )
+        codex = FakeProvider("codex", "codex", [])
+        service = ExternalSessionService([claude, codex], repository, session_service)
+
+        records = await service.list_external_sessions(provider="claude-code")
+
+        assert [r.external_id for r in records] == ["claude-1"]
+
+    async def test_unknown_provider_raises(self, repository, session_service) -> None:
+        service = ExternalSessionService([], repository, session_service)
+
+        with pytest.raises(ExternalSessionProviderNotFoundError):
+            await service.list_external_sessions(provider="nope")
+
+    async def test_annotates_already_imported(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", workspace)],
+        )
+        existing = Session(
+            name="already-imported",
+            origin="claude",
+            external_session_id="claude-1",
+            source=LocalMountSource(local_path=str(workspace)),
+        )
+        await repository.create(existing)
+        service = ExternalSessionService([provider], repository, session_service)
+
+        records = await service.list_external_sessions()
+
+        assert records[0].imported_session_id == existing.id
+
+
+class TestImportSession:
+    async def test_imports_as_volundr_session(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", workspace)],
+        )
+        service = ExternalSessionService([provider], repository, session_service)
+
+        session = await service.import_session("claude-code", "claude-1")
+
+        assert session.origin == "claude"
+        assert session.external_session_id == "claude-1"
+        assert isinstance(session.source, LocalMountSource)
+        assert session.source.local_path == str(workspace)
+        assert session.model == "claude-sonnet-4-6"
+        assert session.name == "claude-import-claude"
+        assert await repository.get(session.id) is not None
+
+    async def test_custom_name_is_used(self, repository, session_service, tmp_path: Path) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", workspace)],
+        )
+        service = ExternalSessionService([provider], repository, session_service)
+
+        session = await service.import_session("claude-code", "claude-1", name="my-import")
+
+        assert session.name == "my-import"
+
+    async def test_unknown_provider_raises(self, repository, session_service) -> None:
+        service = ExternalSessionService([], repository, session_service)
+
+        with pytest.raises(ExternalSessionProviderNotFoundError):
+            await service.import_session("nope", "id-1")
+
+    async def test_unknown_session_raises(self, repository, session_service) -> None:
+        provider = FakeProvider("claude-code", "claude", [])
+        service = ExternalSessionService([provider], repository, session_service)
+
+        with pytest.raises(ExternalSessionNotFoundError):
+            await service.import_session("claude-code", "missing")
+
+    async def test_duplicate_import_raises(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", workspace)],
+        )
+        service = ExternalSessionService([provider], repository, session_service)
+        first = await service.import_session("claude-code", "claude-1")
+
+        with pytest.raises(ExternalSessionAlreadyImportedError) as exc_info:
+            await service.import_session("claude-code", "claude-1")
+
+        assert exc_info.value.session_id == first.id
+
+    async def test_missing_workspace_raises(
+        self, repository, session_service, tmp_path: Path
+    ) -> None:
+        provider = FakeProvider(
+            "claude-code",
+            "claude",
+            [_record("claude-code", "claude", "claude-1", tmp_path / "gone")],
+        )
+        service = ExternalSessionService([provider], repository, session_service)
+
+        with pytest.raises(ExternalSessionWorkspaceError):
+            await service.import_session("claude-code", "claude-1")
+
+
+class TestExternalResumeOverlay:
+    def test_overlay_skipped_without_external_id(self) -> None:
+        session = Session(name="normal")
+        spec = SessionSpec(values={}, pod_spec=None)
+
+        SessionService._overlay_external_resume(session, spec)
+
+        assert "broker" not in spec.values
+
+    def test_claude_session_pins_persistent_transport(self) -> None:
+        session = Session(
+            name="imported",
+            origin="claude",
+            external_session_id="claude-1",
+        )
+        spec = SessionSpec(
+            values={"broker": {"cliType": "claude", "transport": "sdk"}},
+            pod_spec=None,
+        )
+
+        SessionService._overlay_external_resume(session, spec)
+
+        broker = spec.values["broker"]
+        assert broker["resumeSessionId"] == "claude-1"
+        assert broker["cliType"] == "claude"
+        assert broker["transportAdapter"] == (
+            "skuld.transports.persistent_subprocess.PersistentSubprocessTransport"
+        )
+
+    def test_codex_session_uses_websocket_transport(self) -> None:
+        session = Session(
+            name="imported",
+            origin="codex",
+            external_session_id="thread-1",
+        )
+        spec = SessionSpec(values={}, pod_spec=None)
+
+        SessionService._overlay_external_resume(session, spec)
+
+        broker = spec.values["broker"]
+        assert broker["resumeSessionId"] == "thread-1"
+        assert broker["cliType"] == "codex-ws"
+        assert broker["transportAdapter"] == "skuld.transports.codex_ws.CodexWebSocketTransport"
+
+    async def test_pipeline_start_passes_resume_to_pod_manager(
+        self, repository, pod_manager
+    ) -> None:
+        service = SessionService(repository=repository, pod_manager=pod_manager)
+        session = await service.create_session(
+            name="imported",
+            model="claude-sonnet-4-6",
+            source=LocalMountSource(local_path="/tmp/ws"),
+            origin="claude",
+            external_session_id="claude-1",
+        )
+
+        await service._start_with_pipeline(session, None, None, None, False)
+
+        _, spec = pod_manager.start_calls[0]
+        assert spec.values["broker"]["resumeSessionId"] == "claude-1"

--- a/tests/test_domain/test_mount_policy.py
+++ b/tests/test_domain/test_mount_policy.py
@@ -1,0 +1,73 @@
+"""Tests for the shared host path mount policy."""
+
+from pathlib import Path
+
+import pytest
+
+from volundr.domain.mount_policy import ensure_host_path_allowed, is_host_path_allowed
+
+
+class TestIsHostPathAllowed:
+    def test_empty_prefixes_allow_any_path(self, tmp_path: Path) -> None:
+        assert is_host_path_allowed(str(tmp_path), []) is True
+
+    def test_root_requires_explicit_opt_in(self) -> None:
+        assert is_host_path_allowed("/", []) is False
+        assert is_host_path_allowed("/", [], allow_root_mount=True) is True
+
+    def test_path_under_allowed_prefix(self, tmp_path: Path) -> None:
+        nested = tmp_path / "projects" / "repo"
+        nested.mkdir(parents=True)
+
+        assert is_host_path_allowed(str(nested), [str(tmp_path)]) is True
+
+    def test_path_outside_allowed_prefix(self, tmp_path: Path) -> None:
+        allowed = tmp_path / "allowed"
+        outside = tmp_path / "outside"
+        allowed.mkdir()
+        outside.mkdir()
+
+        assert is_host_path_allowed(str(outside), [str(allowed)]) is False
+
+    def test_prefix_match_is_segment_aware(self, tmp_path: Path) -> None:
+        allowed = tmp_path / "data"
+        sneaky = tmp_path / "data-evil"
+        allowed.mkdir()
+        sneaky.mkdir()
+
+        assert is_host_path_allowed(str(sneaky), [str(allowed)]) is False
+
+    def test_symlink_escape_is_denied(self, tmp_path: Path) -> None:
+        allowed = tmp_path / "allowed"
+        outside = tmp_path / "outside"
+        allowed.mkdir()
+        outside.mkdir()
+        escape = allowed / "escape"
+        escape.symlink_to(outside)
+
+        assert is_host_path_allowed(str(escape), [str(allowed)]) is False
+
+    def test_symlinked_prefix_still_matches(self, tmp_path: Path) -> None:
+        real = tmp_path / "real"
+        real.mkdir()
+        (real / "ws").mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(real)
+
+        assert is_host_path_allowed(str(link / "ws"), [str(real)]) is True
+
+
+class TestEnsureHostPathAllowed:
+    def test_allowed_path_passes(self, tmp_path: Path) -> None:
+        ensure_host_path_allowed(str(tmp_path), [str(tmp_path)])
+
+    def test_denied_path_raises(self, tmp_path: Path) -> None:
+        allowed = tmp_path / "allowed"
+        allowed.mkdir()
+
+        with pytest.raises(ValueError, match="not under any allowed prefix"):
+            ensure_host_path_allowed(str(tmp_path / "outside"), [str(allowed)])
+
+    def test_root_raises_without_opt_in(self) -> None:
+        with pytest.raises(ValueError, match="allow_root_mount"):
+            ensure_host_path_allowed("/", [])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -360,6 +360,7 @@ class TestLifespan:
         subscriber.start.assert_awaited_once()
         subscriber.stop.assert_awaited_once()
 
+
 class TestBifrostCatalogLoading:
     """Tests for background Bifrost catalog refresh behavior."""
 

--- a/tests/test_niuu/test_model_runtime.py
+++ b/tests/test_niuu/test_model_runtime.py
@@ -197,8 +197,7 @@ def test_resolve_session_definition_for_models_handles_success_and_errors() -> N
     )
     assert definition is None
     assert (
-        error
-        == "Workflow stages mix multiple model providers; use a single provider per workflow."
+        error == "Workflow stages mix multiple model providers; use a single provider per workflow."
     )
 
     definition, error = resolve_session_definition_for_models(
@@ -287,17 +286,14 @@ def test_validate_session_definition_for_models_covers_all_validation_branches()
         is None
     )
 
-    assert (
-        validate_session_definition_for_models(
-            "skuldClaude",
-            ["gpt-5.5"],
-            session_definitions=definitions,
-            configured_models=_configured_models(),
-        )
-        == (
-            "Session definition 'skuldClaude' does not accept provider 'openai'. "
-            "Compatible providers: anthropic"
-        )
+    assert validate_session_definition_for_models(
+        "skuldClaude",
+        ["gpt-5.5"],
+        session_definitions=definitions,
+        configured_models=_configured_models(),
+    ) == (
+        "Session definition 'skuldClaude' does not accept provider 'openai'. "
+        "Compatible providers: anthropic"
     )
 
 
@@ -316,8 +312,7 @@ def test_transport_adapter_for_session_definition_handles_missing_shapes() -> No
         == ""
     )
     assert (
-        transport_adapter_for_session_definition("badBroker", session_definitions=definitions)
-        == ""
+        transport_adapter_for_session_definition("badBroker", session_definitions=definitions) == ""
     )
     assert (
         transport_adapter_for_session_definition("good", session_definitions=definitions)

--- a/tests/test_niuu/test_outcome.py
+++ b/tests/test_niuu/test_outcome.py
@@ -381,10 +381,7 @@ inion-b.md
     assert result.valid is True
     assert result.fields["verdict"] == "opinion_submitted"
     assert result.fields["summary"].startswith("Wrote Opinion B recommending Qwen3. 6-35B-A3B")
-    assert (
-        result.fields["page_path"]
-        == "council/niu-929-local-model-eval/opinions/opinion-b.md"
-    )
+    assert result.fields["page_path"] == "council/niu-929-local-model-eval/opinions/opinion-b.md"
 
 
 def test_validate_boolean_field() -> None:

--- a/tests/test_niuu/test_postgres_instances.py
+++ b/tests/test_niuu/test_postgres_instances.py
@@ -141,8 +141,7 @@ async def test_ensure_schema_executes_bootstrap_statements() -> None:
 
     assert pool.execute_calls
     assert any(
-        "CREATE TABLE IF NOT EXISTS niuu_instances" in query
-        for query, _ in pool.execute_calls
+        "CREATE TABLE IF NOT EXISTS niuu_instances" in query for query, _ in pool.execute_calls
     )
 
 

--- a/tests/test_niuu/test_rest_volundr.py
+++ b/tests/test_niuu/test_rest_volundr.py
@@ -544,6 +544,22 @@ def test_get_mcp_server_proxies_to_credentials_surface() -> None:
     [
         ("post", "/sessions/s2/stop", "/sessions/s2/stop", {"ok": True}, 200, {"ok": True}),
         (
+            "post",
+            "/sessions/s2/start",
+            "/sessions/s2/start",
+            {"status": "starting"},
+            200,
+            {"status": "starting"},
+        ),
+        (
+            "post",
+            "/sessions/s2/resume",
+            "/sessions/s2/resume",
+            {"status": "starting"},
+            200,
+            {"status": "starting"},
+        ),
+        (
             "patch",
             "/sessions/s2/archive",
             "/sessions/s2/archive",
@@ -689,3 +705,99 @@ def test_proxy_routes_fall_back_to_empty_payloads_when_remote_returns_non_dict_c
         ).json()
         == {}
     )
+
+
+@respx.mock
+def test_external_sessions_aggregates_visible_instances() -> None:
+    client = _client(
+        [
+            _instance("alpha", base_url="http://alpha"),
+            _instance("beta", base_url="http://beta"),
+        ]
+    )
+    respx.get("http://alpha/api/v1/forge/external-sessions").mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "provider": "claude-code",
+                    "external_id": "ext-old",
+                    "updated_at": "2026-06-01T10:00:00Z",
+                }
+            ],
+        )
+    )
+    respx.get("http://beta/api/v1/forge/external-sessions").mock(
+        return_value=Response(
+            200,
+            json=[
+                {
+                    "provider": "codex",
+                    "external_id": "ext-new",
+                    "updated_at": "2026-06-09T10:00:00Z",
+                }
+            ],
+        )
+    )
+
+    response = client.get("/api/v1/forge/external-sessions", headers=_headers())
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["external_id"] for item in payload] == ["ext-new", "ext-old"]
+    assert payload[0]["instance_id"] == "beta"
+    assert payload[1]["instance_id"] == "alpha"
+
+
+@respx.mock
+def test_external_sessions_returns_503_when_no_instance_supports_discovery() -> None:
+    client = _client([_instance("alpha", base_url="http://alpha")])
+    respx.get("http://alpha/api/v1/forge/external-sessions").mock(return_value=Response(503))
+
+    response = client.get("/api/v1/forge/external-sessions", headers=_headers())
+
+    assert response.status_code == 503
+
+
+@respx.mock
+def test_import_session_routes_to_default_instance() -> None:
+    client = _client(
+        [
+            _instance("alpha", base_url="http://alpha", is_default=True),
+            _instance("beta", base_url="http://beta"),
+        ]
+    )
+    route = respx.post("http://alpha/api/v1/forge/sessions/import").mock(
+        return_value=Response(
+            201,
+            json={"id": "imported-1", "origin": "claude"},
+        )
+    )
+
+    response = client.post(
+        "/api/v1/forge/sessions/import",
+        headers=_headers(),
+        json={"provider": "claude-code", "external_id": "ext-1"},
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["id"] == "imported-1"
+    assert payload["instance_id"] == "alpha"
+    assert route.called
+
+
+@respx.mock
+def test_feature_flags_proxies_to_default_instance() -> None:
+    client = _client([_instance("alpha", base_url="http://alpha", is_default=True)])
+    respx.get("http://alpha/api/v1/forge/feature-flags").mock(
+        return_value=Response(
+            200,
+            json={"mini_mode": True, "local_mounts_allowed_prefixes": []},
+        )
+    )
+
+    response = client.get("/api/v1/forge/feature-flags", headers=_headers())
+
+    assert response.status_code == 200
+    assert response.json()["mini_mode"] is True

--- a/tests/test_niuu/test_service_databases.py
+++ b/tests/test_niuu/test_service_databases.py
@@ -44,6 +44,5 @@ def test_bootstrap_sql_is_defined_for_split_services() -> None:
     assert bootstrap_sql_for_service("observatory")
     assert bootstrap_sql_for_service("volundr") == ()
     assert all(
-        "CREATE EXTENSION IF NOT EXISTS pgcrypto" not in statement
-        for statement in guild_sql
+        "CREATE EXTENSION IF NOT EXISTS pgcrypto" not in statement for statement in guild_sql
     )

--- a/tests/test_observatory/test_app.py
+++ b/tests/test_observatory/test_app.py
@@ -170,10 +170,7 @@ class TestObservatoryApp:
             payload = response.json()
             assert payload["title"] == "Observatory"
             assert payload["sections"][0]["id"] == "streams"
-            assert any(
-                field["key"] == "guild_url"
-                for field in payload["sections"][0]["fields"]
-            )
+            assert any(field["key"] == "guild_url" for field in payload["sections"][0]["fields"])
 
     def test_topology_stream_aliases_return_sse(self) -> None:
         first_chunk = asyncio.run(anext(_topology_stream(_FakeDiscoveryService())))

--- a/tests/test_ravn/test_drive_loop_outcome_contract.py
+++ b/tests/test_ravn/test_drive_loop_outcome_contract.py
@@ -986,13 +986,7 @@ summary: post-mortem source captured
         )
 
         counts = _extract_mimir_dream_counts(
-            (
-                "---outcome---\n"
-                "pages_updated: 3\n"
-                "entities_created: 2\n"
-                "lint_fixes: 1\n"
-                "---end---"
-            ),
+            ("---outcome---\npages_updated: 3\nentities_created: 2\nlint_fixes: 1\n---end---"),
             persona,
         )
         assert counts == {"pages_updated": 3, "entities_created": 2, "lint_fixes": 1}

--- a/tests/test_ravn/test_outcome_capture.py
+++ b/tests/test_ravn/test_outcome_capture.py
@@ -232,12 +232,7 @@ class TestValidateMimirOutcomeForPersona:
     async def test_research_outcome_invalid_when_page_has_no_source_ids(self) -> None:
         persona = _research_persona()
         parsed = _parse_outcome_block_for_persona(
-            (
-                "---outcome---\n"
-                "summary: done\n"
-                "page_path: research/example.md\n"
-                "---end---\n"
-            ),
+            ("---outcome---\nsummary: done\npage_path: research/example.md\n---end---\n"),
             persona,
         )
         assert parsed is not None
@@ -267,12 +262,7 @@ class TestValidateMimirOutcomeForPersona:
     async def test_research_outcome_invalid_when_sources_are_self_ingested_page(self) -> None:
         persona = _research_persona()
         parsed = _parse_outcome_block_for_persona(
-            (
-                "---outcome---\n"
-                "summary: done\n"
-                "page_path: research/example.md\n"
-                "---end---\n"
-            ),
+            ("---outcome---\nsummary: done\npage_path: research/example.md\n---end---\n"),
             persona,
         )
         assert parsed is not None

--- a/tests/test_ravn/test_personas/test_http.py
+++ b/tests/test_ravn/test_personas/test_http.py
@@ -226,9 +226,7 @@ class TestLoad:
     def test_load_logs_warning_on_network_error(self, caplog: pytest.LogCaptureFixture) -> None:
         import logging
 
-        respx.get(f"{_BASE}/api/v1/personas/coder").mock(
-            side_effect=httpx.ConnectError("refused")
-        )
+        respx.get(f"{_BASE}/api/v1/personas/coder").mock(side_effect=httpx.ConnectError("refused"))
         with caplog.at_level(logging.WARNING, logger="ravn.adapters.personas.http"):
             _adapter().load("coder")
         assert caplog.records

--- a/tests/test_ravn/test_valkyrie_environment_demo.py
+++ b/tests/test_ravn/test_valkyrie_environment_demo.py
@@ -96,9 +96,10 @@ def test_huddle_flow_includes_human_join_respond_leave_and_replay_snapshot() -> 
     assert events["demo-k8s-a-room-snapshot"].payload["signal_refs"] == [
         "demo-k8s-a-pod-failure-signal"
     ]
-    assert "Proceed within delegated boundary" in events["demo-k8s-a-room-message-human"].payload[
-        "content"
-    ]
+    assert (
+        "Proceed within delegated boundary"
+        in events["demo-k8s-a-room-message-human"].payload["content"]
+    )
     assert events["demo-k8s-a-human-left"].payload["reason"] == "remediation confirmed"
 
 

--- a/tests/test_scripts/test_ravn_setup.py
+++ b/tests/test_scripts/test_ravn_setup.py
@@ -39,7 +39,7 @@ def test_environment_nats_profile_generates_config(tmp_path: Path) -> None:
 
     config = generated.read_text(encoding="utf-8")
     assert "environment:" in config
-    assert "signal_subjects:" in config
+    assert "signal_sources:" in config
     assert "adapter: nats" in config
     assert "servers_env: NATS_URL" in config
     assert "stream_name: ravn_environment" in config
@@ -48,11 +48,11 @@ def test_environment_nats_profile_generates_config(tmp_path: Path) -> None:
     settings = Settings.model_validate(yaml.safe_load(config))
     assert settings.environment.id == "local-dev"
     assert settings.environment.type == "local"
-    assert settings.environment.signal_subjects == [
-        "signal.kubernetes.>",
-        "signal.host.>",
-        "signal.printer.>",
-        "signal.operator.>",
+    assert [source.id for source in settings.environment.signal_sources] == [
+        "kubernetes-events",
+        "host-events",
+        "printer-telemetry",
+        "operator-events",
     ]
     assert settings.mesh.adapter == "nats"
     assert settings.mesh.nats.servers_env == "NATS_URL"

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -947,9 +947,7 @@ class TestBroker:
         assert kwargs["extra_metadata"]["structured_outcome"]["verdict"] == "approve"
 
     @pytest.mark.asyncio
-    async def test_parallel_terminal_node_emits_completion_without_finisher_persona(
-        self, tmp_path
-    ):
+    async def test_parallel_terminal_node_emits_completion_without_finisher_persona(self, tmp_path):
         settings = SkuldSettings(
             session={"id": "sess-1", "workspace_dir": str(tmp_path)},
             room={"enabled": True},
@@ -2373,9 +2371,7 @@ class TestHandleCliEventTraceSpans:
         assert mock_start.await_args.kwargs["kind"] == "tool.call"
         assert mock_start.await_args.kwargs["parent_span_id"] == assistant_span_id
         assert mock_start.await_args.kwargs["attributes"]["tool_use_id"] == "tool-123"
-        assert (
-            mock_start.await_args.kwargs["attributes"]["tool_input"]["command"] == "npm test"
-        )
+        assert mock_start.await_args.kwargs["attributes"]["tool_input"]["command"] == "npm test"
         assert test_broker._trace_assistant_tool_spans["tool-123"] == tool_span_id
 
     @pytest.mark.asyncio

--- a/tests/test_skuld/test_channels.py
+++ b/tests/test_skuld/test_channels.py
@@ -218,9 +218,7 @@ class TestWebSocketChannelInternalFilter:
         await ch.send_event(
             {"type": "content_block_start", "content_block": {"type": "tool_use", "id": "t1"}}
         )
-        await ch.send_event(
-            {"type": "content_block_delta", "delta": {"type": "input_json_delta"}}
-        )
+        await ch.send_event({"type": "content_block_delta", "delta": {"type": "input_json_delta"}})
         await ch.send_event({"type": "content_block_stop"})
         assert mock_ws.send_text.call_count == 3
 
@@ -533,9 +531,7 @@ class TestFormatTelegramEvent:
         assert '<a href="https://example.com">docs</a>' in rendered
 
     def test_render_telegram_html_formats_headings_lists_and_quotes(self):
-        rendered = render_telegram_html(
-            "# Heading\n- bullet\n1. ordered\n> quoted"
-        )
+        rendered = render_telegram_html("# Heading\n- bullet\n1. ordered\n> quoted")
         assert "<b>Heading</b>" in rendered
         assert "• bullet" in rendered
         assert "1. ordered" in rendered
@@ -681,10 +677,7 @@ class TestTelegramChannelMocked:
             "type": "room_message",
             "participant": {"persona": "Skuld", "display_name": "Skuld"},
             "content": (
-                "| Peer | Status |\n"
-                "|------|--------|\n"
-                "| **Skuld** | idle |\n"
-                "| `coder` | blocked |"
+                "| Peer | Status |\n|------|--------|\n| **Skuld** | idle |\n| `coder` | blocked |"
             ),
             "visibility": "public",
         }
@@ -1109,13 +1102,9 @@ class TestTelegramChannelMocked:
 
     @pytest.mark.asyncio
     async def test_start_creates_forum_topic_for_session_mode(self):
-        with patch("skuld.channels.HAS_TELEGRAM", True), patch(
-            "skuld.channels.Bot"
-        ) as bot_cls:
+        with patch("skuld.channels.HAS_TELEGRAM", True), patch("skuld.channels.Bot") as bot_cls:
             bot = AsyncMock()
-            bot.create_forum_topic = AsyncMock(
-                return_value=MagicMock(message_thread_id=321)
-            )
+            bot.create_forum_topic = AsyncMock(return_value=MagicMock(message_thread_id=321))
             bot_cls.return_value = bot
 
             channel = TelegramChannel(
@@ -1136,9 +1125,7 @@ class TestTelegramChannelMocked:
 
     @pytest.mark.asyncio
     async def test_start_fixed_topic_without_thread_falls_back(self):
-        with patch("skuld.channels.HAS_TELEGRAM", True), patch(
-            "skuld.channels.Bot"
-        ) as bot_cls:
+        with patch("skuld.channels.HAS_TELEGRAM", True), patch("skuld.channels.Bot") as bot_cls:
             bot = AsyncMock()
             bot_cls.return_value = bot
 

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -351,15 +351,19 @@ class TestSpawnAppServer:
         mock_process.stderr = None
         mock_process.pid = 12345
 
-        with patch(
-            "skuld.transports.codex_ws.asyncio.create_subprocess_exec",
-            new_callable=AsyncMock,
-        ) as mock_exec, patch(
-            "skuld.transports.codex_ws.resolve_codex_cli",
-            return_value="/Applications/Codex.app/Contents/Resources/codex",
-        ), patch(
-            "skuld.transports.codex_ws.ensure_codex_tool_shims",
-            return_value=(tmp_path / ".skuld-tools" / "bin", {"PATH": "/tmp/shims:/usr/bin"}),
+        with (
+            patch(
+                "skuld.transports.codex_ws.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+            ) as mock_exec,
+            patch(
+                "skuld.transports.codex_ws.resolve_codex_cli",
+                return_value="/Applications/Codex.app/Contents/Resources/codex",
+            ),
+            patch(
+                "skuld.transports.codex_ws.ensure_codex_tool_shims",
+                return_value=(tmp_path / ".skuld-tools" / "bin", {"PATH": "/tmp/shims:/usr/bin"}),
+            ),
         ):
             mock_exec.return_value = mock_process
             await t._spawn_app_server()
@@ -374,9 +378,7 @@ class TestSpawnAppServer:
             assert t._codex_socket_path is not None
             assert call_args[3] == f"unix://{t._codex_socket_path}"
             assert "-c" in call_args
-            assert any(
-                arg == 'mcp_servers.mimir-local.command="python3"' for arg in call_args
-            )
+            assert any(arg == 'mcp_servers.mimir-local.command="python3"' for arg in call_args)
             assert mock_exec.call_args.kwargs["env"]["PATH"] == "/tmp/shims:/usr/bin"
 
     @pytest.mark.asyncio
@@ -391,15 +393,19 @@ class TestSpawnAppServer:
         mock_process.stderr = None
         mock_process.pid = 12345
 
-        with patch(
-            "skuld.transports.codex_ws.asyncio.create_subprocess_exec",
-            new_callable=AsyncMock,
-        ) as mock_exec, patch(
-            "skuld.transports.codex_ws.resolve_codex_cli",
-            return_value="/Applications/Codex.app/Contents/Resources/codex",
-        ), patch(
-            "skuld.transports.codex_ws.ensure_codex_tool_shims",
-            return_value=(tmp_path / ".skuld-tools" / "bin", {}),
+        with (
+            patch(
+                "skuld.transports.codex_ws.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+            ) as mock_exec,
+            patch(
+                "skuld.transports.codex_ws.resolve_codex_cli",
+                return_value="/Applications/Codex.app/Contents/Resources/codex",
+            ),
+            patch(
+                "skuld.transports.codex_ws.ensure_codex_tool_shims",
+                return_value=(tmp_path / ".skuld-tools" / "bin", {}),
+            ),
         ):
             mock_exec.return_value = mock_process
             await t._spawn_app_server()
@@ -417,15 +423,19 @@ class TestSpawnAppServer:
         mock_process.stderr = None
         mock_process.pid = 12345
 
-        with patch(
-            "skuld.transports.codex_ws.asyncio.create_subprocess_exec",
-            new_callable=AsyncMock,
-        ) as mock_exec, patch(
-            "skuld.transports.codex_ws.resolve_codex_cli",
-            return_value="/Applications/Codex.app/Contents/Resources/codex",
-        ), patch(
-            "skuld.transports.codex_ws.ensure_codex_tool_shims",
-            return_value=(tmp_path / ".skuld-tools" / "bin", {}),
+        with (
+            patch(
+                "skuld.transports.codex_ws.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+            ) as mock_exec,
+            patch(
+                "skuld.transports.codex_ws.resolve_codex_cli",
+                return_value="/Applications/Codex.app/Contents/Resources/codex",
+            ),
+            patch(
+                "skuld.transports.codex_ws.ensure_codex_tool_shims",
+                return_value=(tmp_path / ".skuld-tools" / "bin", {}),
+            ),
         ):
             mock_exec.return_value = mock_process
             await t._spawn_app_server()

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -190,6 +190,40 @@ class TestHandshake:
         assert init_event["session_id"] == "thread-abc-123"
 
     @pytest.mark.asyncio
+    async def test_handshake_resumes_seeded_thread(self, tmp_path):
+        """A seeded resume id reattaches via thread/resume instead of thread/start."""
+        t = _make_transport(tmp_path, resume_session_id="thread-imported-1")
+        t._ws = FakeWebSocket()
+        t._alive = True
+
+        calls = []
+
+        async def fake_send_rpc(method, params=None):
+            calls.append((method, params))
+            if method == "initialize":
+                return {"userAgent": "codex"}
+            if method == "thread/resume":
+                return {"thread": {"id": "thread-imported-1"}}
+            return {}
+
+        t._send_rpc = fake_send_rpc
+        t._send_notification = AsyncMock()
+        emit = _collect_emits(t)
+
+        await t._handshake()
+
+        methods = [method for method, _ in calls]
+        assert "thread/resume" in methods
+        assert "thread/start" not in methods
+        resume_params = calls[1][1]
+        assert resume_params["threadId"] == "thread-imported-1"
+        assert t._thread_id == "thread-imported-1"
+
+        init_event = emit.call_args[0][0]
+        assert init_event["type"] == "system"
+        assert init_event["session_id"] == "thread-imported-1"
+
+    @pytest.mark.asyncio
     async def test_handshake_with_system_prompt(self, tmp_path):
         t = _make_transport(tmp_path, system_prompt="Be helpful")
         t._ws = FakeWebSocket()

--- a/tests/test_skuld/test_environment_huddles.py
+++ b/tests/test_skuld/test_environment_huddles.py
@@ -112,9 +112,7 @@ async def test_late_join_replay_orders_human_and_mesh_messages() -> None:
         "valkyrie:k8s",
     ]
     assert [event["threadId"] for event in messages] == ["thread-2", "thread-2"]
-    assert all(
-        event.event_type != event_registry.PARTICIPANT_JOINED for event in published[:2]
-    )
+    assert all(event.event_type != event_registry.PARTICIPANT_JOINED for event in published[:2])
     assert published[-2].event_type == event_registry.ROOM_MESSAGE_RECORDED
     assert published[-1].event_type == event_registry.ROOM_MESSAGE_RECORDED
 

--- a/tests/test_skuld/test_log_aggregate.py
+++ b/tests/test_skuld/test_log_aggregate.py
@@ -55,14 +55,14 @@ def test_aggregate_workspace_logs_filters_by_participant_query_and_level(tmp_pat
         tmp_path / ".flock" / "logs" / "coder.log",
         "\n".join(
             [
-            (
-                "2026-05-01 15:19:51,232 ravn.cli.commands INFO "
-                + "mesh: received outcome event_type=code.requested"
-            ),
-            (
-                "2026-05-01 15:19:58,326 ravn.drive_loop ERROR "
-                + "drive_loop: task failed after 3 retries"
-            ),
+                (
+                    "2026-05-01 15:19:51,232 ravn.cli.commands INFO "
+                    + "mesh: received outcome event_type=code.requested"
+                ),
+                (
+                    "2026-05-01 15:19:58,326 ravn.drive_loop ERROR "
+                    + "drive_loop: task failed after 3 retries"
+                ),
             ]
         ),
     )

--- a/tests/test_skuld/test_persistent_subprocess.py
+++ b/tests/test_skuld/test_persistent_subprocess.py
@@ -84,8 +84,7 @@ def _assistant_line(text: str) -> bytes:
 
 def _system_line(session_id: str) -> bytes:
     return (
-        json.dumps({"type": "system", "subtype": "init", "session_id": session_id}).encode()
-        + b"\n"
+        json.dumps({"type": "system", "subtype": "init", "session_id": session_id}).encode() + b"\n"
     )
 
 
@@ -177,9 +176,7 @@ async def test_start_sends_initial_prompt(tmp_path) -> None:
             _result_line("ack"),
         ]
     )
-    transport = PersistentSubprocessTransport(
-        str(tmp_path), initial_prompt="run setup"
-    )
+    transport = PersistentSubprocessTransport(str(tmp_path), initial_prompt="run setup")
 
     with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
         await transport.start()

--- a/tests/test_skuld/test_persistent_subprocess.py
+++ b/tests/test_skuld/test_persistent_subprocess.py
@@ -279,3 +279,28 @@ async def test_capabilities() -> None:
     assert caps.session_resume is True
     assert caps.interrupt is False
     assert caps.cli_websocket is False
+
+
+def test_seeded_resume_id_makes_first_spawn_resume() -> None:
+    """An imported session id is passed as ``--resume`` on the very first spawn."""
+    transport = PersistentSubprocessTransport(
+        "/tmp",
+        system_prompt="ignored when resuming",
+        resume_session_id="2e877b9f-4b8a-4d46-8f00-03f6163addd5",
+    )
+
+    cmd = transport._build_command()
+
+    resume_index = cmd.index("--resume")
+    assert cmd[resume_index + 1] == "2e877b9f-4b8a-4d46-8f00-03f6163addd5"
+    assert "--append-system-prompt" not in cmd
+    assert transport.session_id == "2e877b9f-4b8a-4d46-8f00-03f6163addd5"
+
+
+def test_no_resume_flag_without_seed() -> None:
+    transport = PersistentSubprocessTransport("/tmp", system_prompt="be helpful")
+
+    cmd = transport._build_command()
+
+    assert "--resume" not in cmd
+    assert "--append-system-prompt" in cmd

--- a/tests/test_skuld/test_tool_shims.py
+++ b/tests/test_skuld/test_tool_shims.py
@@ -14,9 +14,9 @@ def test_ensure_codex_tool_shims_creates_tracker_bridge_without_mimir(tmp_path: 
     assert env["UV_CACHE_DIR"].endswith(".skuld-tools/.uv-cache")
     assert "RAVN_MIMIR_PATH" not in env
     tracker_script = (bin_dir / "tracker_issue").read_text(encoding="utf-8")
-    assert "TRACKER_PATH = \"/api/v1/tracker/issues\"" in tracker_script
+    assert 'TRACKER_PATH = "/api/v1/tracker/issues"' in tracker_script
     assert 'if len(argv) < 2 or argv[1] in {"-h", "--help", "help"}' in tracker_script
-    assert 'usage: tracker_issue update-status <issue-id> <status>' in tracker_script
+    assert "usage: tracker_issue update-status <issue-id> <status>" in tracker_script
     assert "urllib.request" in tracker_script
 
 
@@ -40,7 +40,7 @@ def test_ensure_codex_tool_shims_adds_tracker_and_mimir_bridges(tmp_path: Path) 
     mimir_script = (bin_dir / "mimir_publish_files").read_text(encoding="utf-8")
     assert "PYTHONPATH=" in mimir_script
     assert "UV_CACHE_DIR=" in mimir_script
-    assert "uv\" run --project" in mimir_script or "uv run --project" in mimir_script
+    assert 'uv" run --project' in mimir_script or "uv run --project" in mimir_script
 
 
 def test_ensure_codex_tool_shims_bakes_ravn_config_when_available(

--- a/tests/test_skuld/test_transport.py
+++ b/tests/test_skuld/test_transport.py
@@ -1571,12 +1571,15 @@ class TestCodexSubprocessTransport:
 
         transport.on_event(AsyncMock())
 
-        with patch(
-            "skuld.transports.codex.asyncio.create_subprocess_exec",
-            new_callable=AsyncMock,
-        ) as mock_exec, patch(
-            "skuld.transports.codex.resolve_codex_cli",
-            return_value="/Applications/Codex.app/Contents/Resources/codex",
+        with (
+            patch(
+                "skuld.transports.codex.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+            ) as mock_exec,
+            patch(
+                "skuld.transports.codex.resolve_codex_cli",
+                return_value="/Applications/Codex.app/Contents/Resources/codex",
+            ),
         ):
             mock_exec.return_value = mock_process
             await transport.send_message("refactor the auth module")
@@ -1624,9 +1627,7 @@ class TestCodexSubprocessTransport:
 
             call_args = mock_exec.call_args[0]
             assert "-c" in call_args
-            assert any(
-                arg == 'mcp_servers.mimir-local.command="python3"' for arg in call_args
-            )
+            assert any(arg == 'mcp_servers.mimir-local.command="python3"' for arg in call_args)
 
     @pytest.mark.asyncio
     async def test_send_message_emits_text_delta_for_json_events(self, transport):

--- a/tests/test_skuld/transports/test_sdk.py
+++ b/tests/test_skuld/transports/test_sdk.py
@@ -283,8 +283,9 @@ async def test_send_message_recovers_once_after_turn_timeout(monkeypatch, tmp_pa
     assert factory.client is not None
     assert factory.client.query.await_count == 2
     assert factory.client.query.await_args_list[0].args == ("review the change",)
-    assert "Time budget reached. Stop exploring and conclude immediately" in (
-        factory.client.query.await_args_list[1].args[0]
+    assert (
+        "Time budget reached. Stop exploring and conclude immediately"
+        in (factory.client.query.await_args_list[1].args[0])
     )
     factory.client.interrupt.assert_awaited_once()
     assert [event["type"] for event in received] == ["assistant", "result"]
@@ -1030,28 +1031,41 @@ def test_pending_steers_and_visibility_helpers() -> None:
     assert transport._consume_pending_steers() is None
 
     assert (
+        transport._is_visible_output_event({"type": "assistant", "message": {"content": []}})
+        is False
+    )
+    assert (
         transport._is_visible_output_event(
-            {"type": "assistant", "message": {"content": []}}
+            {"type": "content_block_start", "content_block": {"type": "thinking"}}
+        )
+        is True
+    )
+    assert (
+        transport._is_visible_output_event(
+            {"type": "content_block_delta", "delta": {"thinking": "plan"}}
+        )
+        is True
+    )
+    assert (
+        transport._should_retry_transient_result(
+            _result_message(result="provider status page says overloaded", is_error=True),
+            {"type": "result", "result": "provider status page says overloaded"},
+        )
+        is True
+    )
+    assert (
+        transport._should_retry_transient_result(
+            _result_message(result="hard failure", is_error=False),
+            {"type": "result", "result": "hard failure"},
         )
         is False
     )
-    assert transport._is_visible_output_event(
-        {"type": "content_block_start", "content_block": {"type": "thinking"}}
-    ) is True
-    assert transport._is_visible_output_event(
-        {"type": "content_block_delta", "delta": {"thinking": "plan"}}
-    ) is True
-    assert transport._should_retry_transient_result(
-        _result_message(result="provider status page says overloaded", is_error=True),
-        {"type": "result", "result": "provider status page says overloaded"},
-    ) is True
-    assert transport._should_retry_transient_result(
-        _result_message(result="hard failure", is_error=False),
-        {"type": "result", "result": "hard failure"},
-    ) is False
-    assert transport._should_retry_transient_result(
-        _result_message(result="", is_error=True),
-        {"type": "result", "result": ""},
-    ) is False
+    assert (
+        transport._should_retry_transient_result(
+            _result_message(result="", is_error=True),
+            {"type": "result", "result": ""},
+        )
+        is False
+    )
     assert transport._is_visible_output_event({"type": "assistant", "message": "bad"}) is False
     assert transport._is_visible_output_event({"type": "content_block_delta", "delta": []}) is False

--- a/tests/test_ting/test_services/test_dispatch_service.py
+++ b/tests/test_ting/test_services/test_dispatch_service.py
@@ -1371,9 +1371,7 @@ class TestBuildSpawnRequestPersonaOverrides:
                 "executor": {
                     "adapter": "ravn.adapters.executors.cli.CliTransportExecutor",
                     "kwargs": {
-                        "transport_adapter": (
-                            "skuld.transports.codex_ws.CodexWebSocketTransport"
-                        )
+                        "transport_adapter": ("skuld.transports.codex_ws.CodexWebSocketTransport")
                     },
                 },
             }
@@ -1424,9 +1422,7 @@ class TestBuildSpawnRequestPersonaOverrides:
                 "executor": {
                     "adapter": "ravn.adapters.executors.cli.CliTransportExecutor",
                     "kwargs": {
-                        "transport_adapter": (
-                            "skuld.transports.codex_ws.CodexWebSocketTransport"
-                        )
+                        "transport_adapter": ("skuld.transports.codex_ws.CodexWebSocketTransport")
                     },
                 },
             },
@@ -1438,9 +1434,7 @@ class TestBuildSpawnRequestPersonaOverrides:
                 "executor": {
                     "adapter": "ravn.adapters.executors.cli.CliTransportExecutor",
                     "kwargs": {
-                        "transport_adapter": (
-                            "skuld.transports.codex_ws.CodexWebSocketTransport"
-                        )
+                        "transport_adapter": ("skuld.transports.codex_ws.CodexWebSocketTransport")
                     },
                 },
             },
@@ -1452,9 +1446,7 @@ class TestBuildSpawnRequestPersonaOverrides:
                 "executor": {
                     "adapter": "ravn.adapters.executors.cli.CliTransportExecutor",
                     "kwargs": {
-                        "transport_adapter": (
-                            "skuld.transports.codex_ws.CodexWebSocketTransport"
-                        )
+                        "transport_adapter": ("skuld.transports.codex_ws.CodexWebSocketTransport")
                     },
                 },
             },

--- a/tests/test_ting/test_volundr_factory.py
+++ b/tests/test_ting/test_volundr_factory.py
@@ -85,9 +85,7 @@ class StubInstanceRepo(InstanceRepository):
     def __init__(self, instances: list[RegisteredInstance]) -> None:
         self._instances = list(instances)
 
-    async def list_instances(
-        self, kind: InstanceKind | None = None
-    ) -> list[RegisteredInstance]:
+    async def list_instances(self, kind: InstanceKind | None = None) -> list[RegisteredInstance]:
         if kind is None:
             return list(self._instances)
         return [instance for instance in self._instances if instance.kind == kind]

--- a/tests/test_volundr/test_rest_ravn_personas.py
+++ b/tests/test_volundr/test_rest_ravn_personas.py
@@ -27,9 +27,7 @@ class _InMemoryPersonaRegistry:
     async def list_personas(self, owner_id: str, *, source: str = "all") -> list[PersonaView]:
         active_builtin_names = set(self._builtin_loader.list_builtin_names())
         custom_override_names = {
-            name
-            for name in self._overrides[owner_id]
-            if not self._builtin_loader.is_builtin(name)
+            name for name in self._overrides[owner_id] if not self._builtin_loader.is_builtin(name)
         }
         names = active_builtin_names | custom_override_names
         views: list[PersonaView] = []

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -719,6 +719,7 @@ function toDomainSession(session: VolundrSession): Session {
     tokensOut: 0,
     preview: toSessionPreview(session),
     trackerIssue: session.trackerIssue,
+    origin: session.origin,
   };
 }
 
@@ -755,6 +756,9 @@ function buildSplitVolundrService(
     archiveStoppedSessions: () => forge.archiveStoppedSessions(),
     restoreSession: (sessionId) => forge.restoreSession(sessionId),
     listArchivedSessions: () => forge.listArchivedSessions(),
+    listExternalSessions: () => forge.listExternalSessions(),
+    importExternalSession: (provider, externalId, name) =>
+      forge.importExternalSession(provider, externalId, name),
     getMessages: (sessionId) => forge.getMessages(sessionId),
     sendMessage: (sessionId, content) => forge.sendMessage(sessionId, content),
     subscribeMessages: (sessionId, callback) => forge.subscribeMessages(sessionId, callback),

--- a/web-next/packages/plugin-ting/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-ting/src/adapters/mock.test.ts
@@ -6,6 +6,9 @@ import {
   createMockTrackerService,
   createMockTingSettingsService,
   createMockAuditLogService,
+  createMockDispatchBus,
+  createMockWorkflowService,
+  createMockResearchService,
 } from './mock';
 
 // ---------------------------------------------------------------------------
@@ -82,6 +85,108 @@ describe('createMockTingService', () => {
     expect(result.structure).not.toBeNull();
     expect(result.structure?.phases.length).toBeGreaterThan(0);
   });
+
+  it('decompose returns two phases with one run each', async () => {
+    const svc = createMockTingService();
+    const phases = await svc.decompose('spec', 'repo');
+    expect(phases).toHaveLength(2);
+    expect(phases[0]?.runs).toHaveLength(1);
+    expect(phases[1]?.name).toBe('Phase 2: API layer');
+  });
+
+  it('listRunMessages returns empty for a run without messages', async () => {
+    const svc = createMockTingService();
+    const messages = await svc.listRunMessages('run-without-messages');
+    expect(messages).toEqual([]);
+  });
+
+  it('sendRunMessage attaches the run session id for known runs', async () => {
+    const svc = createMockTingService();
+    const message = await svc.sendRunMessage('00000000-0000-0000-0000-000000000010', 'status?');
+    expect(message.sessionId).toBe('sess-001');
+    expect(message.content).toBe('status?');
+    expect(message.sender).toBe('user');
+
+    const messages = await svc.listRunMessages('00000000-0000-0000-0000-000000000010');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.id).toBe(message.id);
+  });
+
+  it('sendRunMessage falls back to a mock session for unknown runs', async () => {
+    const svc = createMockTingService();
+    const message = await svc.sendRunMessage('run-unknown', 'hello');
+    expect(message.sessionId).toBe('mock-session');
+  });
+
+  it('sendRunMessage appends to an existing message list', async () => {
+    const svc = createMockTingService();
+    await svc.sendRunMessage('run-unknown', 'first');
+    await svc.sendRunMessage('run-unknown', 'second');
+    const messages = await svc.listRunMessages('run-unknown');
+    expect(messages.map((m) => m.content)).toEqual(['first', 'second']);
+  });
+
+  it('assignWorkflow throws for an unknown saga', async () => {
+    const svc = createMockTingService();
+    await expect(svc.assignWorkflow('nope', 'wf-1')).rejects.toThrow('Saga not found: nope');
+  });
+
+  it('assignWorkflow sets workflow fields when an id is given', async () => {
+    const svc = createMockTingService();
+    const saga = await svc.assignWorkflow('00000000-0000-0000-0000-000000000001', 'wf-1');
+    expect(saga.workflowId).toBe('wf-1');
+    expect(saga.workflow).toBe('custom-workflow');
+    expect(saga.workflowVersion).toBe('1.0.0');
+  });
+
+  it('assignWorkflow clears workflow fields when id is null', async () => {
+    const svc = createMockTingService();
+    await svc.assignWorkflow('00000000-0000-0000-0000-000000000001', 'wf-1');
+    const cleared = await svc.assignWorkflow('00000000-0000-0000-0000-000000000001', null);
+    expect(cleared.workflowId).toBeUndefined();
+    expect(cleared.workflow).toBeUndefined();
+    expect(cleared.workflowVersion).toBeUndefined();
+  });
+
+  it('assignTarget throws for an unknown saga', async () => {
+    const svc = createMockTingService();
+    await expect(svc.assignTarget('nope', { mode: 'default' })).rejects.toThrow(
+      'Saga not found: nope',
+    );
+  });
+
+  it('assignTarget pins the saga to an instance', async () => {
+    const svc = createMockTingService();
+    const saga = await svc.assignTarget('00000000-0000-0000-0000-000000000001', {
+      mode: 'instance',
+      instanceId: 'inst-9',
+    });
+    expect(saga.instanceId).toBe('inst-9');
+    expect(saga.instanceName).toBe('Assigned target');
+    expect(saga.targetTags).toBeUndefined();
+    expect(saga.targetMatch).toBeUndefined();
+  });
+
+  it('assignTarget stores tags with an explicit match mode', async () => {
+    const svc = createMockTingService();
+    const saga = await svc.assignTarget('00000000-0000-0000-0000-000000000001', {
+      mode: 'tags',
+      tags: ['gpu'],
+      match: 'any',
+    });
+    expect(saga.targetTags).toEqual(['gpu']);
+    expect(saga.targetMatch).toBe('any');
+    expect(saga.instanceId).toBeUndefined();
+  });
+
+  it('assignTarget defaults the tag match mode to all', async () => {
+    const svc = createMockTingService();
+    const saga = await svc.assignTarget('00000000-0000-0000-0000-000000000001', {
+      mode: 'tags',
+      tags: ['gpu', 'batch'],
+    });
+    expect(saga.targetMatch).toBe('all');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -129,6 +234,19 @@ describe('createMockDispatcherService', () => {
     await svc.setRunning(false);
     const log = await svc.getLog();
     expect(log.some((l) => l.includes('running'))).toBe(true);
+  });
+
+  it('getActivityLog returns all seed events by default', async () => {
+    const svc = createMockDispatcherService();
+    const events = await svc.getActivityLog();
+    expect(events).toHaveLength(4);
+    expect(events[0]?.event).toBe('run.state_changed');
+  });
+
+  it('getActivityLog applies an explicit limit', async () => {
+    const svc = createMockDispatcherService();
+    const events = await svc.getActivityLog(2);
+    expect(events).toHaveLength(2);
   });
 });
 
@@ -210,6 +328,369 @@ describe('createMockTrackerService', () => {
     expect(saga.name).toBe('Niuu Core');
     expect(saga.repos).toEqual(['niuulabs/volundr']);
     expect(saga.status).toBe('active');
+  });
+
+  it('listIssues narrows by milestone id', async () => {
+    const svc = createMockTrackerService();
+    const filtered = await svc.listIssues('proj-niuu-core', 'ms-auth');
+    expect(filtered.length).toBeGreaterThan(0);
+    expect(filtered.every((issue) => issue.milestoneId === 'ms-auth')).toBe(true);
+    expect(await svc.listIssues('proj-niuu-core', 'ms-observatory')).toEqual([]);
+  });
+
+  it('importProject falls back to the project id when the project is unknown', async () => {
+    const svc = createMockTrackerService();
+    const saga = await svc.importProject('proj-unknown', ['niuulabs/volundr']);
+    expect(saga.name).toBe('proj-unknown');
+    expect(saga.slug).toBe('proj-unknown');
+  });
+
+  it('importProject uses the base branch for derived repo refs', async () => {
+    const svc = createMockTrackerService();
+    const saga = await svc.importProject('proj-niuu-core', ['niuulabs/volundr'], 'dev');
+    expect(saga.baseBranch).toBe('dev');
+    expect(saga.repoRefs).toEqual([{ repo: 'niuulabs/volundr', branch: 'dev' }]);
+  });
+
+  it('importProject prefers explicit repo refs from options', async () => {
+    const svc = createMockTrackerService();
+    const saga = await svc.importProject('proj-niuu-core', [], undefined, null, {
+      repoRefs: [
+        { repo: 'niuulabs/ting', branch: 'feat/x' },
+        { repo: 'niuulabs/volundr', branch: 'main' },
+      ],
+    });
+    expect(saga.repos).toEqual(['niuulabs/ting', 'niuulabs/volundr']);
+    expect(saga.baseBranch).toBe('feat/x');
+  });
+
+  it('importProject pins to an instance target', async () => {
+    const svc = createMockTrackerService();
+    const saga = await svc.importProject('proj-niuu-core', ['niuulabs/volundr'], 'main', null, {
+      target: { mode: 'instance', instanceId: 'inst-7' },
+    });
+    expect(saga.instanceId).toBe('inst-7');
+    expect(saga.targetTags).toBeUndefined();
+  });
+
+  it('importProject stores tag targets and defaults match to all', async () => {
+    const svc = createMockTrackerService();
+    const saga = await svc.importProject('proj-niuu-core', ['niuulabs/volundr'], 'main', null, {
+      target: { mode: 'tags', tags: ['gpu'] },
+    });
+    expect(saga.targetTags).toEqual(['gpu']);
+    expect(saga.targetMatch).toBe('all');
+    expect(saga.instanceId).toBeUndefined();
+  });
+
+  it('importProject keeps an explicit tag match mode', async () => {
+    const svc = createMockTrackerService();
+    const saga = await svc.importProject('proj-niuu-core', ['niuulabs/volundr'], 'main', null, {
+      target: { mode: 'tags', tags: ['gpu', 'batch'], match: 'any' },
+    });
+    expect(saga.targetMatch).toBe('any');
+  });
+
+  it('importProject falls back to the legacy instanceId argument', async () => {
+    const svc = createMockTrackerService();
+    const saga = await svc.importProject('proj-niuu-core', ['niuulabs/volundr'], 'main', 'inst-3');
+    expect(saga.instanceId).toBe('inst-3');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMockDispatchBus
+// ---------------------------------------------------------------------------
+
+describe('createMockDispatchBus', () => {
+  it('getQueue returns an empty queue', async () => {
+    const bus = createMockDispatchBus();
+    expect(await bus.getQueue()).toEqual([]);
+  });
+
+  it('getClusters returns copies of the seed clusters', async () => {
+    const bus = createMockDispatchBus();
+    const clusters = await bus.getClusters();
+    expect(clusters.length).toBeGreaterThan(0);
+    expect(clusters[0]).toHaveProperty('connectionId');
+    expect(clusters[0]).toHaveProperty('name');
+  });
+
+  it('approve uses the item connection id when present', async () => {
+    const bus = createMockDispatchBus();
+    const [result] = await bus.approve(
+      [{ sagaId: 's1', issueId: 'NIU-1', repo: 'niuulabs/volundr', connectionId: 'conn-item' }],
+      { connectionId: 'conn-options' },
+    );
+    expect(result?.clusterName).toBe('conn-item');
+    expect(result?.sessionId).toBe('sess-NIU-1');
+    expect(result?.status).toBe('spawned');
+  });
+
+  it('approve falls back to the options connection id', async () => {
+    const bus = createMockDispatchBus();
+    const [result] = await bus.approve(
+      [{ sagaId: 's1', issueId: 'NIU-2', repo: 'niuulabs/volundr' }],
+      { connectionId: 'conn-options' },
+    );
+    expect(result?.clusterName).toBe('conn-options');
+  });
+
+  it('approve defaults the cluster to local', async () => {
+    const bus = createMockDispatchBus();
+    const [result] = await bus.approve([
+      { sagaId: 's1', issueId: 'NIU-3', repo: 'niuulabs/volundr' },
+    ]);
+    expect(result?.clusterName).toBe('local');
+  });
+
+  it('dispatch resolves without error', async () => {
+    const bus = createMockDispatchBus();
+    await expect(bus.dispatch('run-1')).resolves.toBeUndefined();
+  });
+
+  it('dispatchBatch reports all runs as dispatched', async () => {
+    const bus = createMockDispatchBus();
+    const result = await bus.dispatchBatch(['run-1', 'run-2']);
+    expect(result.dispatched).toEqual(['run-1', 'run-2']);
+    expect(result.failed).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMockWorkflowService
+// ---------------------------------------------------------------------------
+
+describe('createMockWorkflowService', () => {
+  it('listWorkflows returns the seed workflows', async () => {
+    const svc = createMockWorkflowService();
+    const workflows = await svc.listWorkflows();
+    expect(workflows.length).toBeGreaterThan(0);
+    expect(workflows[0]?.nodes.length).toBeGreaterThan(0);
+  });
+
+  it('getWorkflow returns a workflow by id', async () => {
+    const svc = createMockWorkflowService();
+    const workflow = await svc.getWorkflow('00000000-0000-0000-0000-000000000a01');
+    expect(workflow?.name).toContain('ship');
+  });
+
+  it('getWorkflow returns null for an unknown id', async () => {
+    const svc = createMockWorkflowService();
+    expect(await svc.getWorkflow('nope')).toBeNull();
+  });
+
+  it('saveWorkflow upserts and deleteWorkflow removes', async () => {
+    const svc = createMockWorkflowService();
+    const existing = await svc.getWorkflow('00000000-0000-0000-0000-000000000a01');
+    const saved = await svc.saveWorkflow({ ...existing!, id: 'wf-new', name: 'fresh workflow' });
+    expect(saved.id).toBe('wf-new');
+    expect((await svc.getWorkflow('wf-new'))?.name).toBe('fresh workflow');
+
+    await svc.deleteWorkflow('wf-new');
+    expect(await svc.getWorkflow('wf-new')).toBeNull();
+  });
+
+  it('launchWorkflow throws for an unknown workflow', async () => {
+    const svc = createMockWorkflowService();
+    await expect(svc.launchWorkflow('nope', { prompt: 'go' })).rejects.toThrow(
+      'Workflow nope not found',
+    );
+  });
+
+  it('launchWorkflow slugifies the prompt', async () => {
+    const svc = createMockWorkflowService();
+    const result = await svc.launchWorkflow('00000000-0000-0000-0000-000000000a01', {
+      prompt: 'Ship The Release!',
+    });
+    expect(result.slug).toBe('ship-the-release');
+    expect(result.status).toBe('starting');
+    expect(result.clusterName).toBe('mock');
+    expect(result.sessionName).toContain('ship-the-release');
+  });
+
+  it('launchWorkflow falls back to the workflow name when prompt is empty', async () => {
+    const svc = createMockWorkflowService();
+    const result = await svc.launchWorkflow('00000000-0000-0000-0000-000000000a01', {
+      prompt: '',
+    });
+    expect(result.slug).toContain('ship');
+  });
+
+  it('launchWorkflow defaults the slug when the prompt has no characters to keep', async () => {
+    const svc = createMockWorkflowService();
+    const result = await svc.launchWorkflow('00000000-0000-0000-0000-000000000a01', {
+      prompt: '!!!',
+    });
+    expect(result.slug).toBe('workflow');
+    expect(result.sessionName).toContain('workflow');
+  });
+
+  it('launchWorkflow honours an explicit session name', async () => {
+    const svc = createMockWorkflowService();
+    const result = await svc.launchWorkflow('00000000-0000-0000-0000-000000000a01', {
+      prompt: 'go',
+      sessionName: 'my-session',
+    });
+    expect(result.sessionName).toBe('my-session');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createMockResearchService
+// ---------------------------------------------------------------------------
+
+describe('createMockResearchService', () => {
+  it('listCampaigns returns the seed campaign', async () => {
+    const svc = createMockResearchService();
+    const campaigns = await svc.listCampaigns();
+    expect(campaigns).toHaveLength(1);
+    expect(campaigns[0]?.slug).toBe('rag-landscape');
+  });
+
+  it('getCampaign returns the seed campaign detail', async () => {
+    const svc = createMockResearchService();
+    const campaign = await svc.getCampaign('rag-landscape');
+    expect(campaign?.status).toBe('running');
+    expect(campaign?.artifacts).toHaveLength(2);
+  });
+
+  it('getCampaign returns null for an unknown slug', async () => {
+    const svc = createMockResearchService();
+    expect(await svc.getCampaign('nope')).toBeNull();
+  });
+
+  it('createCampaign derives the name and slug from the question', async () => {
+    const svc = createMockResearchService();
+    const campaign = await svc.createCampaign({ question: 'How do agents fail?' });
+    expect(campaign.name).toBe('How do agents fail?');
+    expect(campaign.slug).toBe('how-do-agents-fail');
+    expect(campaign.status).toBe('running');
+    expect(campaign.activeStageId).toBe('frame');
+  });
+
+  it('createCampaign uses an explicit workflow id when known', async () => {
+    const svc = createMockResearchService();
+    const campaign = await svc.createCampaign({
+      question: 'q',
+      name: 'Pinned workflow',
+      workflowId: '00000000-0000-0000-0000-000000000a02',
+    });
+    expect(campaign.workflowId).toBe('00000000-0000-0000-0000-000000000a02');
+    expect(campaign.workflowName).toContain('deep-review');
+  });
+
+  it('createCampaign falls back to a seed workflow for unknown workflow ids', async () => {
+    const svc = createMockResearchService();
+    const campaign = await svc.createCampaign({
+      question: 'q',
+      name: 'Fallback workflow',
+      workflowId: 'wf-missing',
+    });
+    expect(campaign.workflowId).toBe('00000000-0000-0000-0000-000000000a01');
+  });
+
+  it('createCampaign generates a placeholder slug for symbol-only names', async () => {
+    const svc = createMockResearchService();
+    const campaign = await svc.createCampaign({ question: '???', name: '###' });
+    expect(campaign.slug).toBe('campaign-2');
+  });
+
+  it('createCampaign records metadata with defaults for omitted fields', async () => {
+    const svc = createMockResearchService();
+    const campaign = await svc.createCampaign({ question: 'metadata defaults' });
+    const detail = await svc.getCampaign(campaign.slug);
+    expect(detail?.metadata).toMatchObject({
+      question: 'metadata defaults',
+      mode: 'exploratory',
+      audience: '',
+      deliverable: '',
+      success: '',
+      constraints: [],
+      repo: '',
+      branch: '',
+    });
+  });
+
+  it('createCampaign keeps explicit metadata fields', async () => {
+    const svc = createMockResearchService();
+    const campaign = await svc.createCampaign({
+      question: 'explicit metadata',
+      mode: 'focused',
+      audience: 'execs',
+      deliverable: 'memo',
+      success: 'decision made',
+      constraints: ['cited sources'],
+      repo: 'niuulabs/volundr',
+      branch: 'main',
+    });
+    const detail = await svc.getCampaign(campaign.slug);
+    expect(detail?.metadata).toMatchObject({
+      mode: 'focused',
+      audience: 'execs',
+      deliverable: 'memo',
+      success: 'decision made',
+      constraints: ['cited sources'],
+      repo: 'niuulabs/volundr',
+      branch: 'main',
+    });
+  });
+
+  it('updateCampaign throws for an unknown slug', async () => {
+    const svc = createMockResearchService();
+    await expect(svc.updateCampaign('nope', { name: 'x' })).rejects.toThrow(
+      'Campaign nope not found',
+    );
+  });
+
+  it('updateCampaign patches name, status and metadata', async () => {
+    const svc = createMockResearchService();
+    const updated = await svc.updateCampaign('rag-landscape', {
+      name: 'RAG landscape v2',
+      status: 'paused',
+      metadata: { audience: 'engineering' },
+    });
+    expect(updated.name).toBe('RAG landscape v2');
+    expect(updated.status).toBe('paused');
+    const detail = await svc.getCampaign('rag-landscape');
+    expect(detail?.metadata.audience).toBe('engineering');
+    expect(detail?.metadata.question).toBe('What does the RAG tooling landscape look like?');
+  });
+
+  it('updateCampaign keeps current values when the patch is empty', async () => {
+    const svc = createMockResearchService();
+    const updated = await svc.updateCampaign('rag-landscape', {});
+    expect(updated.name).toBe('RAG landscape');
+    expect(updated.status).toBe('running');
+  });
+
+  it('deleteCampaign removes the campaign', async () => {
+    const svc = createMockResearchService();
+    await svc.deleteCampaign('rag-landscape');
+    expect(await svc.getCampaign('rag-landscape')).toBeNull();
+    expect(await svc.listCampaigns()).toHaveLength(0);
+  });
+
+  it('listArtifacts returns artifacts or an empty list for unknown slugs', async () => {
+    const svc = createMockResearchService();
+    expect(await svc.listArtifacts('rag-landscape')).toHaveLength(2);
+    expect(await svc.listArtifacts('nope')).toEqual([]);
+  });
+
+  it('getArtifact returns content for a known artifact', async () => {
+    const svc = createMockResearchService();
+    const artifact = await svc.getArtifact(
+      'rag-landscape',
+      'research/campaigns/rag-landscape/brief.md',
+    );
+    expect(artifact?.title).toBe('Brief');
+    expect(artifact?.content).toContain('Mock content');
+  });
+
+  it('getArtifact returns null for unknown paths', async () => {
+    const svc = createMockResearchService();
+    expect(await svc.getArtifact('rag-landscape', 'missing.md')).toBeNull();
+    expect(await svc.getArtifact('nope', 'missing.md')).toBeNull();
   });
 });
 

--- a/web-next/packages/plugin-volundr/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/http.test.ts
@@ -81,6 +81,7 @@ const {
   toEpochMs,
   toDate,
   normalizeSession,
+  normalizeExternalSession,
   normalizeTarget,
   normalizeStats,
   normalizeMessageRole,
@@ -230,6 +231,87 @@ describe('__testables', () => {
     });
     expect(normalizeMessageRole('user')).toBe('user');
     expect(normalizeMessageRole('system')).toBe('assistant');
+  });
+
+  it('normalizes session origin and external session id across fallback forms', () => {
+    const base = {
+      id: 'sess-1',
+      name: 'alpha',
+      source: { type: 'git' as const, repo: 'r', branch: 'main' },
+      status: 'running' as const,
+      model: 'sonnet',
+    };
+
+    expect(
+      normalizeSession({
+        ...base,
+        origin: 'claude',
+        external_session_id: 'ext-1',
+      }),
+    ).toMatchObject({ origin: 'claude', externalSessionId: 'ext-1' });
+
+    expect(
+      normalizeSession({
+        ...base,
+        origin: 'codex',
+        externalSessionId: 'ext-camel',
+      }),
+    ).toMatchObject({ origin: 'codex', externalSessionId: 'ext-camel' });
+
+    const plain = normalizeSession(base);
+    expect(plain.origin).toBeUndefined();
+    expect(plain.externalSessionId).toBeNull();
+  });
+
+  it('normalizes external session payloads with fallback defaults', () => {
+    expect(
+      normalizeExternalSession({
+        provider: 'claude-code',
+        harness: 'claude',
+        external_id: 'ext-1',
+        workspace_path: '/Users/dev/code/volundr',
+        title: 'fix import flow',
+        model: 'claude-sonnet',
+        created_at: '2026-06-01T08:00:00Z',
+        updated_at: '2026-06-01T09:00:00Z',
+        live: true,
+        workspace_exists: true,
+        imported_session_id: 'sess-9',
+      }),
+    ).toEqual({
+      provider: 'claude-code',
+      harness: 'claude',
+      externalId: 'ext-1',
+      workspacePath: '/Users/dev/code/volundr',
+      title: 'fix import flow',
+      model: 'claude-sonnet',
+      createdAt: '2026-06-01T08:00:00Z',
+      updatedAt: '2026-06-01T09:00:00Z',
+      live: true,
+      workspaceExists: true,
+      importedSessionId: 'sess-9',
+    });
+
+    expect(
+      normalizeExternalSession({
+        provider: 'codex',
+        harness: 'codex',
+        external_id: 'ext-2',
+        workspace_path: '/tmp/scratch',
+      }),
+    ).toEqual({
+      provider: 'codex',
+      harness: 'codex',
+      externalId: 'ext-2',
+      workspacePath: '/tmp/scratch',
+      title: '',
+      model: '',
+      createdAt: null,
+      updatedAt: null,
+      live: false,
+      workspaceExists: false,
+      importedSessionId: null,
+    });
   });
 
   it('derives canonical base paths from forge, shared, niuu, and credentials variants', () => {
@@ -1587,6 +1669,99 @@ describe('buildVolundrHttpAdapter', () => {
     const client = makeClient();
     await buildVolundrHttpAdapter(client).listArchivedSessions();
     expect(client.get).toHaveBeenCalledWith('/sessions?status=archived');
+  });
+
+  it('listExternalSessions calls GET /external-sessions and normalizes payloads', async () => {
+    const client = makeClient();
+    client.get.mockResolvedValueOnce([
+      {
+        provider: 'claude-code',
+        harness: 'claude',
+        external_id: 'ext-1',
+        workspace_path: '/Users/dev/code/volundr',
+        title: 'fix import flow',
+        model: 'claude-sonnet',
+        created_at: '2026-06-01T08:00:00Z',
+        updated_at: '2026-06-01T09:00:00Z',
+        live: true,
+        workspace_exists: true,
+        imported_session_id: null,
+      },
+    ]);
+
+    const sessions = await buildVolundrHttpAdapter(client).listExternalSessions();
+
+    expect(client.get).toHaveBeenCalledWith('/external-sessions');
+    expect(sessions).toEqual([
+      expect.objectContaining({
+        provider: 'claude-code',
+        harness: 'claude',
+        externalId: 'ext-1',
+        workspacePath: '/Users/dev/code/volundr',
+        live: true,
+        workspaceExists: true,
+        importedSessionId: null,
+      }),
+    ]);
+  });
+
+  it('listExternalSessions propagates 503 errors so callers can hide the affordance', async () => {
+    const client = makeClient();
+    const unavailable = Object.assign(new Error('External session discovery not available'), {
+      status: 503,
+    });
+    client.get.mockRejectedValueOnce(unavailable);
+
+    await expect(buildVolundrHttpAdapter(client).listExternalSessions()).rejects.toMatchObject({
+      status: 503,
+    });
+  });
+
+  it('importExternalSession posts snake_case body and normalizes the created session', async () => {
+    const client = makeClient();
+    client.post.mockResolvedValueOnce({
+      id: 'sess-imported',
+      name: 'fix import flow',
+      source: { type: 'local_mount', paths: [] },
+      status: 'stopped',
+      model: 'claude-sonnet',
+      origin: 'claude',
+      external_session_id: 'ext-1',
+    });
+
+    const session = await buildVolundrHttpAdapter(client).importExternalSession(
+      'claude-code',
+      'ext-1',
+    );
+
+    expect(client.post).toHaveBeenCalledWith('/sessions/import', {
+      provider: 'claude-code',
+      external_id: 'ext-1',
+    });
+    expect(session).toMatchObject({
+      id: 'sess-imported',
+      origin: 'claude',
+      externalSessionId: 'ext-1',
+    });
+  });
+
+  it('importExternalSession includes the optional name in the request body', async () => {
+    const client = makeClient();
+    client.post.mockResolvedValueOnce({
+      id: 'sess-imported',
+      name: 'renamed',
+      source: { type: 'local_mount', paths: [] },
+      status: 'stopped',
+      model: 'gpt-5-codex',
+    });
+
+    await buildVolundrHttpAdapter(client).importExternalSession('codex', 'ext-2', 'renamed');
+
+    expect(client.post).toHaveBeenCalledWith('/sessions/import', {
+      provider: 'codex',
+      external_id: 'ext-2',
+      name: 'renamed',
+    });
   });
 
   it('createCredential targets the canonical shared credentials route', async () => {

--- a/web-next/packages/plugin-volundr/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/http.test.ts
@@ -289,6 +289,7 @@ describe('__testables', () => {
       updatedAt: '2026-06-01T09:00:00Z',
       live: true,
       workspaceExists: true,
+      workspaceAllowed: true,
       importedSessionId: 'sess-9',
     });
 
@@ -310,8 +311,20 @@ describe('__testables', () => {
       updatedAt: null,
       live: false,
       workspaceExists: false,
+      workspaceAllowed: true,
       importedSessionId: null,
     });
+
+    expect(
+      normalizeExternalSession({
+        provider: 'claude-code',
+        harness: 'claude',
+        external_id: 'ext-3',
+        workspace_path: '/etc/forbidden',
+        workspace_exists: true,
+        workspace_allowed: false,
+      }).workspaceAllowed,
+    ).toBe(false);
   });
 
   it('derives canonical base paths from forge, shared, niuu, and credentials variants', () => {

--- a/web-next/packages/plugin-volundr/src/adapters/http.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/http.ts
@@ -65,6 +65,7 @@ import type {
   VolundrSessionTraceLane,
   VolundrSessionTraceSpan,
   VolundrSessionTraceSummary,
+  ExternalSession,
 } from '../models/volundr.model';
 
 /** Minimal HTTP client — structurally compatible with ApiClient from @niuulabs/query. */
@@ -111,6 +112,8 @@ type SessionPayload = {
   pod_name?: string | null;
   error?: string | null;
   origin?: VolundrSession['origin'];
+  externalSessionId?: string | null;
+  external_session_id?: string | null;
   hostname?: string;
   chatEndpoint?: string | null;
   chat_endpoint?: string | null;
@@ -135,6 +138,20 @@ type SessionPayload = {
   instance_id?: string | null;
   instanceName?: string | null;
   instance_name?: string | null;
+};
+
+type ExternalSessionPayload = {
+  provider: string;
+  harness: ExternalSession['harness'];
+  external_id: string;
+  workspace_path: string;
+  title?: string | null;
+  model?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  live?: boolean;
+  workspace_exists?: boolean;
+  imported_session_id?: string | null;
 };
 
 type StatsPayload = {
@@ -475,6 +492,7 @@ function normalizeSession(session: SessionPayload): VolundrSession {
     podName: session.podName ?? session.pod_name ?? undefined,
     error: session.error ?? undefined,
     origin: session.origin,
+    externalSessionId: session.externalSessionId ?? session.external_session_id ?? null,
     hostname: session.hostname,
     chatEndpoint: session.chatEndpoint ?? session.chat_endpoint ?? undefined,
     codeEndpoint: session.codeEndpoint ?? session.code_endpoint ?? undefined,
@@ -486,6 +504,22 @@ function normalizeSession(session: SessionPayload): VolundrSession {
     tenantId: session.tenantId ?? session.tenant_id ?? undefined,
     instanceId: session.instanceId ?? session.instance_id ?? undefined,
     instanceName: session.instanceName ?? session.instance_name ?? undefined,
+  };
+}
+
+function normalizeExternalSession(payload: ExternalSessionPayload): ExternalSession {
+  return {
+    provider: payload.provider,
+    harness: payload.harness,
+    externalId: payload.external_id,
+    workspacePath: payload.workspace_path,
+    title: payload.title ?? '',
+    model: payload.model ?? '',
+    createdAt: payload.created_at ?? null,
+    updatedAt: payload.updated_at ?? null,
+    live: Boolean(payload.live),
+    workspaceExists: Boolean(payload.workspace_exists),
+    importedSessionId: payload.imported_session_id ?? null,
   };
 }
 
@@ -970,6 +1004,7 @@ export const __testables = {
   toEpochMs,
   toDate,
   normalizeSession,
+  normalizeExternalSession,
   normalizeTarget,
   normalizeStats,
   normalizeMessageRole,
@@ -1498,6 +1533,19 @@ export function buildVolundrHttpAdapter(
       forgeClient
         .get<SessionPayload[]>('/sessions?status=archived')
         .then((sessions) => sessions.map(normalizeSession)),
+
+    listExternalSessions: () =>
+      forgeClient
+        .get<ExternalSessionPayload[]>('/external-sessions')
+        .then((sessions) => sessions.map(normalizeExternalSession)),
+    importExternalSession: async (provider, externalId, name) =>
+      normalizeSession(
+        await forgeClient.post<SessionPayload>('/sessions/import', {
+          provider,
+          external_id: externalId,
+          ...(name ? { name } : {}),
+        }),
+      ),
 
     getConversationHistory: (sessionId) =>
       forgeClient

--- a/web-next/packages/plugin-volundr/src/adapters/http.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/http.ts
@@ -151,6 +151,7 @@ type ExternalSessionPayload = {
   updated_at?: string | null;
   live?: boolean;
   workspace_exists?: boolean;
+  workspace_allowed?: boolean;
   imported_session_id?: string | null;
 };
 
@@ -519,6 +520,7 @@ function normalizeExternalSession(payload: ExternalSessionPayload): ExternalSess
     updatedAt: payload.updated_at ?? null,
     live: Boolean(payload.live),
     workspaceExists: Boolean(payload.workspace_exists),
+    workspaceAllowed: payload.workspace_allowed ?? true,
     importedSessionId: payload.imported_session_id ?? null,
   };
 }

--- a/web-next/packages/plugin-volundr/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.test.ts
@@ -41,6 +41,58 @@ describe('createMockVolundrService', () => {
     expect(session).toBeNull();
   });
 
+  it('listExternalSessions returns seeded external sessions', async () => {
+    const svc = createMockVolundrService();
+    const sessions = await svc.listExternalSessions();
+    expect(sessions.length).toBeGreaterThan(0);
+    expect(sessions[0]).toHaveProperty('provider');
+    expect(sessions[0]).toHaveProperty('externalId');
+    expect(sessions[0]).toHaveProperty('workspaceExists');
+  });
+
+  it('importExternalSession imports a known session and marks it imported', async () => {
+    const svc = createMockVolundrService();
+    const [importable] = (await svc.listExternalSessions()).filter(
+      (session) => session.workspaceExists && !session.importedSessionId,
+    );
+    expect(importable).toBeDefined();
+
+    const imported = await svc.importExternalSession(
+      importable!.provider,
+      importable!.externalId,
+      'renamed',
+    );
+    expect(imported.name).toBe('renamed');
+    expect(imported.origin).toBe(importable!.harness);
+    expect(imported.externalSessionId).toBe(importable!.externalId);
+
+    const refreshed = await svc.listExternalSessions();
+    const row = refreshed.find((session) => session.externalId === importable!.externalId);
+    expect(row?.importedSessionId).toBe(imported.id);
+
+    const sessions = await svc.getSessions();
+    expect(sessions.some((session) => session.id === imported.id)).toBe(true);
+
+    await expect(
+      svc.importExternalSession(importable!.provider, importable!.externalId),
+    ).rejects.toThrow(/already imported/);
+  });
+
+  it('importExternalSession rejects unknown sessions and missing workspaces', async () => {
+    const svc = createMockVolundrService();
+    await expect(svc.importExternalSession('claude-code', 'nope')).rejects.toThrow(
+      /Unknown external session/,
+    );
+
+    const missingWorkspace = (await svc.listExternalSessions()).find(
+      (session) => !session.workspaceExists,
+    );
+    expect(missingWorkspace).toBeDefined();
+    await expect(
+      svc.importExternalSession(missingWorkspace!.provider, missingWorkspace!.externalId),
+    ).rejects.toThrow(/Workspace directory missing/);
+  });
+
   it('getActiveSessions returns only active statuses', async () => {
     const svc = createMockVolundrService();
     const active = await svc.getActiveSessions();

--- a/web-next/packages/plugin-volundr/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.test.ts
@@ -250,6 +250,193 @@ describe('createMockVolundrService', () => {
     expect(preset.name).toBe('fast');
   });
 
+  it('saveLaunchSpec replaces an existing spec with the same id', async () => {
+    const svc = createMockVolundrService();
+    const base = {
+      name: 'original',
+      description: '',
+      isDefault: false,
+      cliTool: 'claude',
+      workloadType: 'default',
+      model: null,
+      systemPrompt: null,
+      resourceConfig: {},
+      mcpServers: [],
+      terminalSidecar: { enabled: false, allowedCommands: [] },
+      skills: [],
+      rules: [],
+      envVars: {},
+      envSecretRefs: [],
+      source: null,
+      integrationIds: [],
+      setupScripts: [],
+      workloadConfig: {},
+    } as const;
+
+    const first = await svc.saveLaunchSpec({ ...base, id: 'spec-dup' });
+    expect(first.name).toBe('original');
+
+    const second = await svc.saveLaunchSpec({ ...base, id: 'spec-dup', name: 'replaced' });
+    expect(second.name).toBe('replaced');
+
+    const userSpecs = await svc.getLaunchSpecs('user');
+    const matching = userSpecs.filter((spec) => spec.id === 'spec-dup');
+    expect(matching).toHaveLength(1);
+    expect(matching[0]?.name).toBe('replaced');
+  });
+
+  it('startSession honours an explicit instance id', async () => {
+    const svc = createMockVolundrService();
+    const session = await svc.startSession({
+      name: 'pinned',
+      source: { type: 'git', repo: 'github.com/niuulabs/volundr', branch: 'main' },
+      model: 'claude-sonnet',
+      instanceId: 'inst-custom',
+    });
+    expect(session.instanceId).toBe('inst-custom');
+    expect(session.instanceName).toBe('Selected Mock Volundr');
+  });
+
+  it('startSession routes gpu-tagged sessions to the gpu instance', async () => {
+    const svc = createMockVolundrService();
+    const session = await svc.startSession({
+      name: 'gpu-job',
+      source: { type: 'git', repo: 'github.com/niuulabs/volundr', branch: 'main' },
+      model: 'claude-sonnet',
+      targetTags: ['gpu'],
+    });
+    expect(session.instanceId).toBe('mock-volundr-gpu');
+    expect(session.instanceName).toBe('Mock Volundr GPU');
+  });
+
+  it('startSession defaults to the default instance for non-gpu tags', async () => {
+    const svc = createMockVolundrService();
+    const session = await svc.startSession({
+      name: 'cpu-job',
+      source: { type: 'git', repo: 'github.com/niuulabs/volundr', branch: 'main' },
+      model: 'claude-sonnet',
+      targetTags: ['batch'],
+    });
+    expect(session.instanceId).toBe('mock-volundr-default');
+    expect(session.instanceName).toBe('Mock Volundr');
+  });
+
+  it('evaluatePermissionAutoApproval approves allowlisted commands', async () => {
+    const svc = createMockVolundrService();
+    const decision = await svc.evaluatePermissionAutoApproval('sess-1', {
+      requestId: 'perm-1',
+      toolName: 'Bash',
+      description: 'start dev server',
+      command: './start-dev --port 3000',
+    });
+    expect(decision.canAutoApprove).toBe(true);
+    expect(decision.reason).toBe('allowed');
+    expect(decision.command).toBe('./start-dev --port 3000');
+    expect(decision.matchedPattern).toBe('^\\s*\\./start-dev');
+  });
+
+  it('evaluatePermissionAutoApproval rejects other commands', async () => {
+    const svc = createMockVolundrService();
+    const decision = await svc.evaluatePermissionAutoApproval('sess-1', {
+      requestId: 'perm-2',
+      toolName: 'Bash',
+      description: 'delete everything',
+      command: 'rm -rf /',
+    });
+    expect(decision.canAutoApprove).toBe(false);
+    expect(decision.reason).toBe('no_allowlist_match');
+    expect(decision.matchedPattern).toBeNull();
+  });
+
+  it('evaluatePermissionAutoApproval handles a missing command', async () => {
+    const svc = createMockVolundrService();
+    const decision = await svc.evaluatePermissionAutoApproval('sess-1', {
+      requestId: 'perm-3',
+      toolName: 'WebFetch',
+      description: 'fetch a page',
+    });
+    expect(decision.canAutoApprove).toBe(false);
+    expect(decision.command).toBeNull();
+  });
+
+  it('importExternalSession rejects sessions outside the allowed mounts', async () => {
+    const svc = createMockVolundrService();
+    const denied = (await svc.listExternalSessions()).find(
+      (session) => session.workspaceExists && !session.workspaceAllowed,
+    );
+    expect(denied).toBeDefined();
+    await expect(svc.importExternalSession(denied!.provider, denied!.externalId)).rejects.toThrow(
+      /outside the allowed mount prefixes/,
+    );
+  });
+
+  it('importExternalSession falls back to the external title when no name is given', async () => {
+    const svc = createMockVolundrService();
+    const importable = (await svc.listExternalSessions()).find(
+      (session) =>
+        session.workspaceExists && session.workspaceAllowed && !session.importedSessionId,
+    );
+    expect(importable).toBeDefined();
+    const imported = await svc.importExternalSession(importable!.provider, importable!.externalId);
+    expect(imported.name).toBe(importable!.title.trim());
+  });
+
+  it('getWorkflowGates returns an empty list for sessions without gates', async () => {
+    const svc = createMockVolundrService();
+    expect(await svc.getWorkflowGates('sess-1')).toEqual([]);
+  });
+
+  it('resolveWorkflowGate fabricates and stores an approved gate', async () => {
+    const svc = createMockVolundrService();
+    const resolved = await svc.resolveWorkflowGate('sess-1', 'gate-1', { decision: 'APPROVE' });
+    expect(resolved.id).toBe('gate-1');
+    expect(resolved.status).toBe('approved');
+    expect(resolved.decision).toBe('APPROVE');
+    expect(resolved.notes).toBe('');
+    expect(resolved.source).toBe('human');
+
+    const gates = await svc.getWorkflowGates('sess-1');
+    expect(gates).toHaveLength(1);
+    expect(gates[0]?.id).toBe('gate-1');
+  });
+
+  it('resolveWorkflowGate updates an existing gate with changes requested', async () => {
+    const svc = createMockVolundrService();
+    await svc.resolveWorkflowGate('sess-1', 'gate-1', { decision: 'APPROVE' });
+    const resolved = await svc.resolveWorkflowGate('sess-1', 'gate-1', {
+      decision: 'CHANGES_REQUESTED',
+      notes: 'needs tests',
+      source: 'reviewer',
+    });
+    expect(resolved.status).toBe('changes_requested');
+    expect(resolved.notes).toBe('needs tests');
+    expect(resolved.source).toBe('reviewer');
+
+    const gates = await svc.getWorkflowGates('sess-1');
+    expect(gates).toHaveLength(1);
+    expect(gates[0]?.status).toBe('changes_requested');
+  });
+
+  it('updateTenant falls back to default quota fields', async () => {
+    const svc = createMockVolundrService();
+    const tenant = await svc.updateTenant('t1', {});
+    expect(tenant.tier).toBe('free');
+    expect(tenant.maxSessions).toBe(5);
+    expect(tenant.maxStorageGb).toBe(10);
+  });
+
+  it('updateTenant keeps explicitly provided quota fields', async () => {
+    const svc = createMockVolundrService();
+    const tenant = await svc.updateTenant('t1', {
+      tier: 'pro',
+      maxSessions: 20,
+      maxStorageGb: 100,
+    });
+    expect(tenant.tier).toBe('pro');
+    expect(tenant.maxSessions).toBe(20);
+    expect(tenant.maxStorageGb).toBe(100);
+  });
+
   it('getSessionDefinitions returns seeded session definitions', async () => {
     const svc = createMockVolundrService();
     const definitions = await svc.getSessionDefinitions();
@@ -389,6 +576,41 @@ describe('createMockSessionStore', () => {
     await store.deleteSession('ds-1');
     expect(cb).not.toHaveBeenCalled();
   });
+
+  it('listSessions filters by clusterId', async () => {
+    const store = createMockSessionStore();
+    const sessions = await store.listSessions({ clusterId: 'Eitri' });
+    expect(sessions.length).toBeGreaterThan(0);
+    expect(sessions.every((s) => s.clusterId === 'Eitri')).toBe(true);
+  });
+
+  it('listSessions filters by ravnId', async () => {
+    const store = createMockSessionStore();
+    const sessions = await store.listSessions({ ravnId: 'r-local' });
+    expect(sessions.length).toBeGreaterThan(0);
+    expect(sessions.every((s) => s.ravnId === 'r-local')).toBe(true);
+  });
+
+  it('listSessions combines filters and returns [] when nothing matches', async () => {
+    const store = createMockSessionStore();
+    const sessions = await store.listSessions({ clusterId: 'Eitri', ravnId: 'r-does-not-exist' });
+    expect(sessions).toEqual([]);
+  });
+
+  it('unsubscribing twice is a no-op', async () => {
+    const store = createMockSessionStore();
+    const stable = vi.fn();
+    const cb = vi.fn();
+    store.subscribe(stable);
+    const unsub = store.subscribe(cb);
+    unsub();
+    unsub();
+    stable.mockClear();
+    cb.mockClear();
+    await store.deleteSession('ds-1');
+    expect(stable).toHaveBeenCalledOnce();
+    expect(cb).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -460,6 +682,51 @@ describe('createMockPtyStream', () => {
     const pty = createMockPtyStream();
     expect(() => pty.send('sess-nobody', 'ls\n')).not.toThrow();
   });
+
+  it('seeds a git transcript for the local session main terminal', () => {
+    vi.useFakeTimers();
+    const pty = createMockPtyStream();
+    const cb = vi.fn();
+    const unsub = pty.subscribe('laptop-volundr-local', cb);
+    vi.advanceTimersByTime(100);
+    expect(cb).toHaveBeenCalledOnce();
+    expect(cb.mock.calls[0]?.[0]).toContain('git log --oneline -5');
+    unsub();
+    vi.useRealTimers();
+  });
+
+  it('seeds a test-run transcript for the tests terminal', () => {
+    vi.useFakeTimers();
+    const pty = createMockPtyStream();
+    const cb = vi.fn();
+    const unsub = pty.subscribe('laptop-volundr-local::tests', cb);
+    vi.advanceTimersByTime(100);
+    expect(cb.mock.calls[0]?.[0]).toContain('pnpm test observatory.perf.test.ts');
+    unsub();
+    vi.useRealTimers();
+  });
+
+  it('seeds a metrics transcript for the view-io terminal', () => {
+    vi.useFakeTimers();
+    const pty = createMockPtyStream();
+    const cb = vi.fn();
+    const unsub = pty.subscribe('laptop-volundr-local::view-io', cb);
+    vi.advanceTimersByTime(100);
+    expect(cb.mock.calls[0]?.[0]).toContain('jq . metrics/render.json');
+    unsub();
+    vi.useRealTimers();
+  });
+
+  it('seeds a bare prompt for unknown local terminals', () => {
+    vi.useFakeTimers();
+    const pty = createMockPtyStream();
+    const cb = vi.fn();
+    const unsub = pty.subscribe('laptop-volundr-local::scratch', cb);
+    vi.advanceTimersByTime(100);
+    expect(cb.mock.calls[0]?.[0]).toBe('scratch $ ');
+    unsub();
+    vi.useRealTimers();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -521,6 +788,53 @@ describe('createMockFileSystemPort', () => {
     await fs.writeFile('sess-1', '/workspace/temp.txt', 'bye');
     await fs.deletePaths('sess-1', ['/workspace/temp.txt']);
     await expect(fs.readFile('sess-1', '/workspace/temp.txt')).rejects.toThrow('File not found');
+  });
+
+  it('writeFile updates the size of an existing file in place', async () => {
+    const fs = createMockFileSystemPort();
+    await fs.writeFile('sess-1', '/workspace/README.md', 'short');
+    await expect(fs.readFile('sess-1', '/workspace/README.md')).resolves.toBe('short');
+    const tree = await fs.listTree('sess-1');
+    const readme = tree.find((node) => node.path === '/workspace/README.md');
+    expect(readme?.size).toBe(5);
+  });
+
+  it('writeFile inserts a new file under its parent directory sorted by name', async () => {
+    const fs = createMockFileSystemPort();
+    await fs.writeFile('sess-1', '/workspace/src/aaa.ts', 'export {};');
+    const children = await fs.expandDirectory('sess-1', '/workspace/src');
+    expect(children.map((child) => child.name)).toEqual(['aaa.ts', 'app.tsx', 'index.ts']);
+    await expect(fs.readFile('sess-1', '/workspace/src/aaa.ts')).resolves.toBe('export {};');
+  });
+
+  it('deletePaths removes a nested file from its parent directory', async () => {
+    const fs = createMockFileSystemPort();
+    await fs.deletePaths('sess-1', ['/workspace/src/index.ts']);
+    const children = await fs.expandDirectory('sess-1', '/workspace/src');
+    expect(children.some((child) => child.path === '/workspace/src/index.ts')).toBe(false);
+    expect(children.some((child) => child.path === '/workspace/src/app.tsx')).toBe(true);
+  });
+
+  it('deletePaths removes a top-level node from the tree root', async () => {
+    const fs = createMockFileSystemPort();
+    await fs.deletePaths('sess-1', ['/workspace/package.json']);
+    const tree = await fs.listTree('sess-1');
+    expect(tree.some((node) => node.path === '/workspace/package.json')).toBe(false);
+  });
+
+  it('deletePaths removes a file inside the secret mount', async () => {
+    const fs = createMockFileSystemPort();
+    await fs.deletePaths('sess-1', ['/mnt/secrets/API_KEY']);
+    const children = await fs.expandDirectory('sess-1', '/mnt/secrets');
+    expect(children).toEqual([]);
+  });
+
+  it('deletePaths ignores unknown paths', async () => {
+    const fs = createMockFileSystemPort();
+    const before = await fs.listTree('sess-1');
+    await fs.deletePaths('sess-1', ['/does/not/exist']);
+    const after = await fs.listTree('sess-1');
+    expect(after.length).toBe(before.length);
   });
 });
 

--- a/web-next/packages/plugin-volundr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.ts
@@ -23,6 +23,7 @@ import type {
   TrackerIssue,
   VolundrWorkspace,
   VolundrWorkflowGate,
+  ExternalSession,
 } from '../models/volundr.model';
 import type { Cluster } from '../domain/cluster';
 import type { Session } from '../domain/session';
@@ -1067,8 +1068,38 @@ const SYSTEM_LAUNCH_SPECS: VolundrLaunchSpec[] = [
   },
 ];
 
+const SEED_EXTERNAL_SESSIONS: ExternalSession[] = [
+  {
+    provider: 'claude-code',
+    harness: 'claude',
+    externalId: 'ext-claude-1',
+    workspacePath: '~/code/niuu/volundr',
+    title: 'refactor session imports',
+    model: 'claude-sonnet',
+    createdAt: '2026-06-01T08:00:00Z',
+    updatedAt: '2026-06-01T09:30:00Z',
+    live: true,
+    workspaceExists: true,
+    importedSessionId: null,
+  },
+  {
+    provider: 'codex',
+    harness: 'codex',
+    externalId: 'ext-codex-1',
+    workspacePath: '~/code/scratch/old-spike',
+    title: '',
+    model: 'gpt-5-codex',
+    createdAt: null,
+    updatedAt: '2026-05-20T12:00:00Z',
+    live: false,
+    workspaceExists: false,
+    importedSessionId: null,
+  },
+];
+
 export function createMockVolundrService(): IVolundrService {
   const sessions = [...SEED_SESSIONS];
+  const externalSessions = SEED_EXTERNAL_SESSIONS.map((session) => ({ ...session }));
   const credentials = new Map(SEED_CREDENTIALS.map((credential) => [credential.name, credential]));
   const launchSpecs = [...SEED_LAUNCH_SPECS];
   const workflowGates = new Map<string, VolundrWorkflowGate[]>();
@@ -1203,6 +1234,37 @@ export function createMockVolundrService(): IVolundrService {
     archiveStoppedSessions: async () => [],
     restoreSession: async () => {},
     listArchivedSessions: async () => [],
+
+    listExternalSessions: async () => externalSessions.map((session) => ({ ...session })),
+    importExternalSession: async (provider, externalId, name) => {
+      const external = externalSessions.find(
+        (session) => session.provider === provider && session.externalId === externalId,
+      );
+      if (!external) {
+        throw new Error(`Unknown external session: ${provider}/${externalId}`);
+      }
+      if (!external.workspaceExists) {
+        throw new Error(`Workspace directory missing for ${externalId}`);
+      }
+      if (external.importedSessionId) {
+        throw new Error(`External session ${externalId} already imported`);
+      }
+      const imported: VolundrSession = {
+        id: `sess-imported-${externalId}`,
+        name: name ?? (external.title.trim() || external.externalId),
+        source: { type: 'git', repo: external.workspacePath, branch: 'main' },
+        status: 'stopped',
+        model: external.model,
+        lastActive: Date.now(),
+        messageCount: 0,
+        tokensUsed: 0,
+        origin: external.harness,
+        externalSessionId: external.externalId,
+      };
+      external.importedSessionId = imported.id;
+      sessions.push(imported);
+      return imported;
+    },
 
     getConversationHistory: async () => ({ turns: [] }),
     getWorkflowGates: async (sessionId) => workflowGates.get(sessionId) ?? [],

--- a/web-next/packages/plugin-volundr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.ts
@@ -1080,6 +1080,7 @@ const SEED_EXTERNAL_SESSIONS: ExternalSession[] = [
     updatedAt: '2026-06-01T09:30:00Z',
     live: true,
     workspaceExists: true,
+    workspaceAllowed: true,
     importedSessionId: null,
   },
   {
@@ -1093,6 +1094,21 @@ const SEED_EXTERNAL_SESSIONS: ExternalSession[] = [
     updatedAt: '2026-05-20T12:00:00Z',
     live: false,
     workspaceExists: false,
+    workspaceAllowed: true,
+    importedSessionId: null,
+  },
+  {
+    provider: 'claude-code',
+    harness: 'claude',
+    externalId: 'ext-claude-denied',
+    workspacePath: '/etc/forbidden',
+    title: 'session outside the mount allowlist',
+    model: 'claude-sonnet',
+    createdAt: '2026-05-28T10:00:00Z',
+    updatedAt: '2026-05-28T11:00:00Z',
+    live: false,
+    workspaceExists: true,
+    workspaceAllowed: false,
     importedSessionId: null,
   },
 ];
@@ -1245,6 +1261,9 @@ export function createMockVolundrService(): IVolundrService {
       }
       if (!external.workspaceExists) {
         throw new Error(`Workspace directory missing for ${externalId}`);
+      }
+      if (!external.workspaceAllowed) {
+        throw new Error(`Workspace for ${externalId} is outside the allowed mount prefixes`);
       }
       if (external.importedSessionId) {
         throw new Error(`External session ${externalId} already imported`);

--- a/web-next/packages/plugin-volundr/src/domain/session.ts
+++ b/web-next/packages/plugin-volundr/src/domain/session.ts
@@ -82,6 +82,8 @@ export interface Session {
   files?: SessionFileStats;
   /** Linked tracker issue when the session was launched from a ticket. */
   trackerIssue?: TrackerIssue;
+  /** Where the session originated ('volundr' | 'claude' | 'codex'); absent means volundr-native. */
+  origin?: string;
 }
 
 /** Legal transitions in the session lifecycle state machine. */

--- a/web-next/packages/plugin-volundr/src/index.ts
+++ b/web-next/packages/plugin-volundr/src/index.ts
@@ -164,4 +164,7 @@ export type {
   SecretType,
   SessionSource,
   SessionDefinition,
+  SessionOrigin,
+  ExternalSession,
+  ExternalSessionHarness,
 } from './models/volundr.model';

--- a/web-next/packages/plugin-volundr/src/models/volundr.model.ts
+++ b/web-next/packages/plugin-volundr/src/models/volundr.model.ts
@@ -66,7 +66,7 @@ export interface ClusterResourceInfo {
 
 export type ModelTier = 'frontier' | 'balanced' | 'execution' | 'reasoning';
 export type ModelProvider = 'cloud' | 'local';
-export type SessionOrigin = 'managed' | 'manual';
+export type SessionOrigin = 'managed' | 'manual' | 'volundr' | 'claude' | 'codex';
 
 export interface VolundrModel {
   name: string;
@@ -154,6 +154,7 @@ export interface VolundrSession {
   podName?: string;
   error?: string;
   origin?: SessionOrigin;
+  externalSessionId?: string | null;
   hostname?: string;
   chatEndpoint?: string;
   codeEndpoint?: string;
@@ -165,6 +166,27 @@ export interface VolundrSession {
   tenantId?: string;
   instanceId?: string;
   instanceName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// External CLI sessions (Claude Code / Codex discovered on the host)
+// ---------------------------------------------------------------------------
+
+export type ExternalSessionHarness = 'claude' | 'codex';
+
+export interface ExternalSession {
+  provider: string;
+  harness: ExternalSessionHarness;
+  externalId: string;
+  workspacePath: string;
+  title: string;
+  model: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+  live: boolean;
+  workspaceExists: boolean;
+  /** Volundr session id when the session has already been imported. */
+  importedSessionId: string | null;
 }
 
 export type WorkflowGateStatus = 'pending' | 'approved' | 'changes_requested';

--- a/web-next/packages/plugin-volundr/src/models/volundr.model.ts
+++ b/web-next/packages/plugin-volundr/src/models/volundr.model.ts
@@ -185,6 +185,8 @@ export interface ExternalSession {
   updatedAt: string | null;
   live: boolean;
   workspaceExists: boolean;
+  /** Whether the workspace passes the server's allowed mount prefix policy. */
+  workspaceAllowed: boolean;
   /** Volundr session id when the session has already been imported. */
   importedSessionId: string | null;
 }

--- a/web-next/packages/plugin-volundr/src/ports/IVolundrService.ts
+++ b/web-next/packages/plugin-volundr/src/ports/IVolundrService.ts
@@ -53,6 +53,7 @@ import type {
   VolundrWorkflowGate,
   VolundrSessionTrace,
   VolundrSessionTraceSummary,
+  ExternalSession,
 } from '../models/volundr.model';
 
 export interface VolundrConversationTurn {
@@ -178,6 +179,16 @@ export interface IVolundrService {
   archiveStoppedSessions(): Promise<string[]>;
   restoreSession(sessionId: string): Promise<void>;
   listArchivedSessions(): Promise<VolundrSession[]>;
+
+  // External CLI sessions (Claude Code / Codex discovered on the host).
+  // listExternalSessions rejects with a 503-status error when discovery is
+  // not enabled on the server — callers treat that as "feature unavailable".
+  listExternalSessions(): Promise<ExternalSession[]>;
+  importExternalSession(
+    provider: string,
+    externalId: string,
+    name?: string,
+  ): Promise<VolundrSession>;
 
   // Messaging
   getConversationHistory(sessionId: string): Promise<VolundrConversationHistory>;

--- a/web-next/packages/plugin-volundr/src/ui/ImportExternalSessionsDialog.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/ImportExternalSessionsDialog.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import {
+  ImportExternalSessionsDialog,
+  externalSessionKey,
+  externalSessionTitle,
+  externalSessionActivityTs,
+} from './ImportExternalSessionsDialog';
+import { createMockVolundrService } from '../adapters/mock';
+import type { IVolundrService } from '../ports/IVolundrService';
+import type { ExternalSession, VolundrSession } from '../models/volundr.model';
+
+function makeExternalSession(overrides: Partial<ExternalSession> = {}): ExternalSession {
+  return {
+    provider: 'claude-code',
+    harness: 'claude',
+    externalId: 'ext-1',
+    workspacePath: '/Users/dev/code/volundr',
+    title: 'fix import flow',
+    model: 'claude-sonnet',
+    createdAt: '2026-06-01T08:00:00Z',
+    updatedAt: '2026-06-01T09:00:00Z',
+    live: false,
+    workspaceExists: true,
+    importedSessionId: null,
+    ...overrides,
+  };
+}
+
+function makeImportedSession(overrides: Partial<VolundrSession> = {}): VolundrSession {
+  return {
+    id: 'sess-imported',
+    name: 'fix import flow',
+    source: { type: 'git', repo: '/Users/dev/code/volundr', branch: 'main' },
+    status: 'stopped',
+    model: 'claude-sonnet',
+    lastActive: Date.now(),
+    messageCount: 0,
+    tokensUsed: 0,
+    origin: 'claude',
+    externalSessionId: 'ext-1',
+    ...overrides,
+  };
+}
+
+function wrap(
+  volundr: IVolundrService,
+  props: Partial<Parameters<typeof ImportExternalSessionsDialog>[0]> = {},
+) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <ServicesProvider services={{ volundr }}>
+        <ImportExternalSessionsDialog open onOpenChange={() => {}} {...props} />
+      </ServicesProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ImportExternalSessionsDialog helpers', () => {
+  it('derives row keys, titles, and activity timestamps with fallbacks', () => {
+    const session = makeExternalSession();
+    expect(externalSessionKey(session)).toBe('claude-code:ext-1');
+    expect(externalSessionTitle(session)).toBe('fix import flow');
+    expect(externalSessionTitle(makeExternalSession({ title: '   ' }))).toBe('ext-1');
+    expect(externalSessionActivityTs(session)).toBe(Date.parse('2026-06-01T09:00:00Z'));
+    expect(externalSessionActivityTs(makeExternalSession({ updatedAt: null }))).toBe(
+      Date.parse('2026-06-01T08:00:00Z'),
+    );
+    expect(
+      externalSessionActivityTs(makeExternalSession({ updatedAt: null, createdAt: null })),
+    ).toBeNull();
+    expect(
+      externalSessionActivityTs(makeExternalSession({ updatedAt: 'not-a-date', createdAt: null })),
+    ).toBeNull();
+  });
+});
+
+describe('ImportExternalSessionsDialog', () => {
+  it('lists external sessions with harness label, title, workspace path, and activity', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi
+      .fn()
+      .mockResolvedValue([makeExternalSession(), makeExternalSession({ externalId: 'ext-2' })]);
+
+    wrap(volundr);
+
+    await waitFor(() => expect(screen.getByTestId('external-session-list')).toBeInTheDocument());
+    const row = screen.getByTestId('external-session-row-ext-1');
+    expect(row).toHaveTextContent('Claude Code');
+    expect(row).toHaveTextContent('fix import flow');
+    expect(row).toHaveTextContent('/Users/dev/code/volundr');
+    expect(row).toHaveTextContent(/ago/i);
+    expect(screen.getByTestId('external-session-row-ext-2')).toBeInTheDocument();
+  });
+
+  it('falls back to the external id when the title is empty', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi
+      .fn()
+      .mockResolvedValue([makeExternalSession({ title: '', harness: 'codex' })]);
+
+    wrap(volundr);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-row-ext-1')).toHaveTextContent('ext-1'),
+    );
+    expect(screen.getByTestId('external-session-row-ext-1')).toHaveTextContent('Codex');
+  });
+
+  it('shows a live badge only for live sessions', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi
+      .fn()
+      .mockResolvedValue([
+        makeExternalSession({ live: true }),
+        makeExternalSession({ externalId: 'ext-2', live: false }),
+      ]);
+
+    wrap(volundr);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-live-ext-1')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('external-session-live-ext-2')).not.toBeInTheDocument();
+  });
+
+  it('disables the import button with an explanation when the workspace is missing', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi
+      .fn()
+      .mockResolvedValue([makeExternalSession({ workspaceExists: false })]);
+
+    wrap(volundr);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-import-ext-1')).toBeInTheDocument(),
+    );
+    const button = screen.getByTestId('external-session-import-ext-1');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('title', 'Cannot import: workspace directory no longer exists');
+    expect(screen.getByTestId('external-session-missing-workspace-ext-1')).toBeInTheDocument();
+  });
+
+  it('shows an imported state instead of the button when already imported', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi
+      .fn()
+      .mockResolvedValue([makeExternalSession({ importedSessionId: 'sess-9' })]);
+
+    wrap(volundr);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-imported-ext-1')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('external-session-import-ext-1')).not.toBeInTheDocument();
+  });
+
+  it('imports a session, refreshes the list, and notifies the parent', async () => {
+    const volundr = createMockVolundrService();
+    const listExternalSessions = vi
+      .fn()
+      .mockResolvedValueOnce([makeExternalSession()])
+      .mockResolvedValue([makeExternalSession({ importedSessionId: 'sess-imported' })]);
+    const importExternalSession = vi.fn().mockResolvedValue(makeImportedSession());
+    volundr.listExternalSessions = listExternalSessions;
+    volundr.importExternalSession = importExternalSession;
+    const onImported = vi.fn();
+
+    wrap(volundr, { onImported });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-import-ext-1')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId('external-session-import-ext-1'));
+
+    await waitFor(() => expect(importExternalSession).toHaveBeenCalledWith('claude-code', 'ext-1'));
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-imported-ext-1')).toBeInTheDocument(),
+    );
+    expect(listExternalSessions.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(onImported).toHaveBeenCalledWith(expect.objectContaining({ id: 'sess-imported' }));
+  });
+
+  it('surfaces an inline error when the import fails', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi.fn().mockResolvedValue([makeExternalSession()]);
+    volundr.importExternalSession = vi
+      .fn()
+      .mockRejectedValue(new Error('Workspace directory missing'));
+
+    wrap(volundr);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-import-ext-1')).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId('external-session-import-ext-1'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-import-error-ext-1')).toHaveTextContent(
+        'Workspace directory missing',
+      ),
+    );
+  });
+
+  it('shows a graceful unavailable state on 503 instead of an error', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('not available'), { status: 503 }));
+
+    wrap(volundr);
+
+    await waitFor(() => expect(screen.getByText(/discovery unavailable/i)).toBeInTheDocument());
+    expect(screen.queryByText(/failed to discover/i)).not.toBeInTheDocument();
+  });
+
+  it('shows an error state for non-503 failures', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi.fn().mockRejectedValue(new Error('boom'));
+
+    wrap(volundr);
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to discover external sessions/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText('boom')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when no sessions are discovered', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi.fn().mockResolvedValue([]);
+
+    wrap(volundr);
+
+    await waitFor(() =>
+      expect(screen.getByText(/no external sessions found/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('shows a loading state while discovering', () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi.fn().mockReturnValue(new Promise(() => {}));
+
+    wrap(volundr);
+
+    expect(screen.getByText(/discovering external sessions/i)).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-volundr/src/ui/ImportExternalSessionsDialog.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/ImportExternalSessionsDialog.test.tsx
@@ -24,6 +24,7 @@ function makeExternalSession(overrides: Partial<ExternalSession> = {}): External
     updatedAt: '2026-06-01T09:00:00Z',
     live: false,
     workspaceExists: true,
+    workspaceAllowed: true,
     importedSessionId: null,
     ...overrides,
   };
@@ -142,6 +143,26 @@ describe('ImportExternalSessionsDialog', () => {
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('title', 'Cannot import: workspace directory no longer exists');
     expect(screen.getByTestId('external-session-missing-workspace-ext-1')).toBeInTheDocument();
+  });
+
+  it('disables the import button when the workspace violates the mount policy', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi
+      .fn()
+      .mockResolvedValue([makeExternalSession({ workspaceAllowed: false })]);
+
+    wrap(volundr);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-import-ext-1')).toBeInTheDocument(),
+    );
+    const button = screen.getByTestId('external-session-import-ext-1');
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute(
+      'title',
+      'Cannot import: workspace is outside the allowed mount prefixes',
+    );
+    expect(screen.getByTestId('external-session-workspace-not-allowed-ext-1')).toBeInTheDocument();
   });
 
   it('shows an imported state instead of the button when already imported', async () => {

--- a/web-next/packages/plugin-volundr/src/ui/ImportExternalSessionsDialog.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/ImportExternalSessionsDialog.tsx
@@ -1,0 +1,229 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import {
+  Dialog,
+  DialogContent,
+  EmptyState,
+  ErrorState,
+  LiveBadge,
+  LoadingState,
+  cn,
+  relTime,
+} from '@niuulabs/ui';
+import { FolderGit2 } from 'lucide-react';
+import { CliBadge } from './atoms/CliBadge';
+import {
+  isExternalSessionsUnavailableError,
+  useExternalSessions,
+} from './hooks/useExternalSessions';
+import type { ExternalSession, VolundrSession } from '../models/volundr.model';
+import type { IVolundrService } from '../ports/IVolundrService';
+
+export interface ImportExternalSessionsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after a session was imported and caches were invalidated. */
+  onImported?: (session: VolundrSession) => void | Promise<void>;
+}
+
+export function externalSessionKey(session: ExternalSession): string {
+  return `${session.provider}:${session.externalId}`;
+}
+
+export function externalSessionTitle(session: ExternalSession): string {
+  return session.title.trim() || session.externalId;
+}
+
+export function externalSessionActivityTs(session: ExternalSession): number | null {
+  const value = session.updatedAt ?? session.createdAt;
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function ExternalSessionRow({
+  session,
+  busy,
+  error,
+  onImport,
+}: {
+  session: ExternalSession;
+  busy: boolean;
+  error?: string;
+  onImport: () => void;
+}) {
+  const activityTs = externalSessionActivityTs(session);
+
+  return (
+    <li
+      className="niuu:flex niuu:items-start niuu:gap-3 niuu:border-b niuu:border-border-subtle niuu:px-3 niuu:py-2.5 niuu:last:border-b-0"
+      data-testid={`external-session-row-${session.externalId}`}
+    >
+      <div className="niuu:flex niuu:min-w-0 niuu:flex-1 niuu:flex-col niuu:gap-1">
+        <div className="niuu:flex niuu:min-w-0 niuu:items-center niuu:gap-2">
+          <CliBadge cli={session.harness} />
+          <span className="niuu:truncate niuu:font-mono niuu:text-[13px] niuu:font-medium niuu:text-text-primary">
+            {externalSessionTitle(session)}
+          </span>
+          {session.live ? (
+            <span
+              className="niuu:flex-shrink-0"
+              data-testid={`external-session-live-${session.externalId}`}
+            >
+              <LiveBadge label="LIVE" />
+            </span>
+          ) : null}
+        </div>
+        <div className="niuu:flex niuu:min-w-0 niuu:flex-wrap niuu:items-center niuu:gap-x-3 niuu:gap-y-0.5 niuu:font-mono niuu:text-[10px] niuu:text-text-muted">
+          <span
+            className="niuu:flex niuu:min-w-0 niuu:items-center niuu:gap-1.5"
+            title={session.workspacePath}
+          >
+            <FolderGit2 className="niuu:h-3 niuu:w-3 niuu:flex-shrink-0 niuu:text-text-faint" />
+            <span className="niuu:truncate">{session.workspacePath}</span>
+          </span>
+          {activityTs !== null ? <span>{relTime(activityTs)}</span> : null}
+          {session.model ? <span className="niuu:text-text-faint">{session.model}</span> : null}
+        </div>
+        {!session.workspaceExists ? (
+          <span
+            className="niuu:font-mono niuu:text-[10px] niuu:text-text-faint"
+            data-testid={`external-session-missing-workspace-${session.externalId}`}
+          >
+            workspace directory no longer exists
+          </span>
+        ) : null}
+        {error ? (
+          <span
+            className="niuu:font-mono niuu:text-[10px] niuu:text-critical"
+            data-testid={`external-session-import-error-${session.externalId}`}
+          >
+            {error}
+          </span>
+        ) : null}
+      </div>
+      {session.importedSessionId ? (
+        <span
+          className="niuu:mt-0.5 niuu:flex-shrink-0 niuu:rounded-md niuu:border niuu:border-border-subtle niuu:bg-bg-tertiary niuu:px-2.5 niuu:py-1 niuu:font-mono niuu:text-[10px] niuu:text-text-muted"
+          data-testid={`external-session-imported-${session.externalId}`}
+        >
+          Imported
+        </span>
+      ) : (
+        <button
+          type="button"
+          onClick={onImport}
+          disabled={busy || !session.workspaceExists}
+          title={
+            session.workspaceExists
+              ? `Import ${externalSessionTitle(session)}`
+              : 'Cannot import: workspace directory no longer exists'
+          }
+          className={cn(
+            'niuu:mt-0.5 niuu:flex-shrink-0 niuu:rounded-md niuu:border niuu:px-2.5 niuu:py-1 niuu:font-mono niuu:text-[10px] niuu:transition-colors',
+            session.workspaceExists
+              ? 'niuu:border-brand/40 niuu:bg-brand/10 niuu:text-brand niuu:hover:bg-brand/15'
+              : 'niuu:border-border-subtle niuu:text-text-faint',
+            'niuu:disabled:cursor-not-allowed niuu:disabled:opacity-50',
+          )}
+          data-testid={`external-session-import-${session.externalId}`}
+        >
+          {busy ? 'Importing…' : 'Import'}
+        </button>
+      )}
+    </li>
+  );
+}
+
+export function ImportExternalSessionsDialog({
+  open,
+  onOpenChange,
+  onImported,
+}: ImportExternalSessionsDialogProps) {
+  const volundr = useService<IVolundrService>('volundr');
+  const queryClient = useQueryClient();
+  const externalQuery = useExternalSessions();
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [importErrors, setImportErrors] = useState<Record<string, string>>({});
+
+  const unavailable = isExternalSessionsUnavailableError(externalQuery.error);
+  const sessions = externalQuery.data ?? [];
+
+  async function handleImport(session: ExternalSession) {
+    if (busyKey) return;
+    const key = externalSessionKey(session);
+    setBusyKey(key);
+    setImportErrors((current) => {
+      const next = { ...current };
+      delete next[key];
+      return next;
+    });
+    try {
+      const imported = await volundr.importExternalSession(session.provider, session.externalId);
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['volundr', 'domain-sessions'] }),
+        queryClient.invalidateQueries({ queryKey: ['volundr', 'history'] }),
+      ]);
+      await externalQuery.refetch();
+      await onImported?.(imported);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Import failed';
+      setImportErrors((current) => ({ ...current, [key]: message }));
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        title="Import CLI Sessions"
+        description="Claude Code and Codex sessions discovered on the host can be imported as Völundr sessions."
+      >
+        <div data-testid="import-external-sessions-panel">
+          {externalQuery.isLoading && <LoadingState label="Discovering external sessions…" />}
+          {externalQuery.isError && unavailable && (
+            <EmptyState
+              title="Discovery unavailable"
+              description="External session discovery is not enabled on this server."
+            />
+          )}
+          {externalQuery.isError && !unavailable && (
+            <ErrorState
+              title="Failed to discover external sessions"
+              message={
+                externalQuery.error instanceof Error ? externalQuery.error.message : 'Unknown error'
+              }
+            />
+          )}
+          {externalQuery.isSuccess && sessions.length === 0 && (
+            <EmptyState
+              title="No external sessions found"
+              description="No Claude Code or Codex sessions were discovered on the host."
+            />
+          )}
+          {externalQuery.isSuccess && sessions.length > 0 && (
+            <ul
+              className="niuu:max-h-96 niuu:overflow-y-auto niuu:rounded-lg niuu:border niuu:border-border-subtle niuu:bg-bg-tertiary"
+              data-testid="external-session-list"
+            >
+              {sessions.map((session) => {
+                const key = externalSessionKey(session);
+                return (
+                  <ExternalSessionRow
+                    key={key}
+                    session={session}
+                    busy={busyKey === key}
+                    error={importErrors[key]}
+                    onImport={() => void handleImport(session)}
+                  />
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web-next/packages/plugin-volundr/src/ui/ImportExternalSessionsDialog.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/ImportExternalSessionsDialog.tsx
@@ -54,6 +54,12 @@ function ExternalSessionRow({
   onImport: () => void;
 }) {
   const activityTs = externalSessionActivityTs(session);
+  const importable = session.workspaceExists && session.workspaceAllowed;
+  const importTitle = !session.workspaceExists
+    ? 'Cannot import: workspace directory no longer exists'
+    : !session.workspaceAllowed
+      ? 'Cannot import: workspace is outside the allowed mount prefixes'
+      : `Import ${externalSessionTitle(session)}`;
 
   return (
     <li
@@ -94,6 +100,14 @@ function ExternalSessionRow({
             workspace directory no longer exists
           </span>
         ) : null}
+        {session.workspaceExists && !session.workspaceAllowed ? (
+          <span
+            className="niuu:font-mono niuu:text-[10px] niuu:text-text-faint"
+            data-testid={`external-session-workspace-not-allowed-${session.externalId}`}
+          >
+            workspace is outside the allowed mount prefixes
+          </span>
+        ) : null}
         {error ? (
           <span
             className="niuu:font-mono niuu:text-[10px] niuu:text-critical"
@@ -114,15 +128,11 @@ function ExternalSessionRow({
         <button
           type="button"
           onClick={onImport}
-          disabled={busy || !session.workspaceExists}
-          title={
-            session.workspaceExists
-              ? `Import ${externalSessionTitle(session)}`
-              : 'Cannot import: workspace directory no longer exists'
-          }
+          disabled={busy || !importable}
+          title={importTitle}
           className={cn(
             'niuu:mt-0.5 niuu:flex-shrink-0 niuu:rounded-md niuu:border niuu:px-2.5 niuu:py-1 niuu:font-mono niuu:text-[10px] niuu:transition-colors',
-            session.workspaceExists
+            importable
               ? 'niuu:border-brand/40 niuu:bg-brand/10 niuu:text-brand niuu:hover:bg-brand/15'
               : 'niuu:border-border-subtle niuu:text-text-faint',
             'niuu:disabled:cursor-not-allowed niuu:disabled:opacity-50',

--- a/web-next/packages/plugin-volundr/src/ui/LaunchCatalogPage.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchCatalogPage.test.tsx
@@ -1,0 +1,276 @@
+import { describe, expect, it } from 'vitest';
+import { screen, waitFor, within } from '@testing-library/react';
+import { LaunchCatalogPage } from './LaunchCatalogPage';
+import { renderWithVolundr } from '../testing/renderWithVolundr';
+import { createMockVolundrService } from '../adapters/mock';
+import type { VolundrLaunchSpec } from '../models/volundr.model';
+
+function makeSpec(
+  overrides: Partial<VolundrLaunchSpec> & Pick<VolundrLaunchSpec, 'name'>,
+): VolundrLaunchSpec {
+  return {
+    name: overrides.name,
+    scope: overrides.scope ?? 'user',
+    id: 'id' in overrides ? (overrides.id ?? null) : `spec-${overrides.name}`,
+    description: overrides.description ?? '',
+    isDefault: overrides.isDefault ?? false,
+    sessionDefinition: overrides.sessionDefinition ?? null,
+    workloadType: overrides.workloadType ?? 'default',
+    model: overrides.model ?? null,
+    systemPrompt: overrides.systemPrompt ?? null,
+    resourceConfig: overrides.resourceConfig ?? {},
+    mcpServers: overrides.mcpServers ?? [],
+    envVars: overrides.envVars ?? {},
+    envSecretRefs: overrides.envSecretRefs ?? [],
+    workloadConfig: overrides.workloadConfig ?? {},
+    repos: overrides.repos ?? [],
+    source: overrides.source ?? null,
+    setupScripts: overrides.setupScripts ?? [],
+    workspaceLayout: overrides.workspaceLayout ?? {},
+    cliTool: overrides.cliTool ?? 'claude',
+    terminalSidecar: overrides.terminalSidecar ?? { enabled: false, allowedCommands: [] },
+    skills: overrides.skills ?? [],
+    rules: overrides.rules ?? [],
+    integrationIds: overrides.integrationIds ?? [],
+    createdAt: overrides.createdAt ?? '2026-01-01T00:00:00Z',
+    updatedAt: overrides.updatedAt ?? '2026-01-01T00:00:00Z',
+  };
+}
+
+function renderWithSpecs(specs: VolundrLaunchSpec[]) {
+  return renderWithVolundr(<LaunchCatalogPage />, {
+    service: {
+      ...createMockVolundrService(),
+      getLaunchSpecs: async () => specs,
+    },
+  });
+}
+
+async function waitForPage() {
+  await waitFor(() => expect(screen.getByTestId('launch-catalog-page')).toBeInTheDocument());
+}
+
+describe('LaunchCatalogPage', () => {
+  it('renders loading state while specs resolve', () => {
+    renderWithVolundr(<LaunchCatalogPage />, {
+      service: {
+        ...createMockVolundrService(),
+        getLaunchSpecs: () => new Promise<never>(() => {}),
+      },
+    });
+
+    expect(screen.getByText(/loading launch catalog/i)).toBeInTheDocument();
+  });
+
+  it('renders error state with the Error message', async () => {
+    renderWithVolundr(<LaunchCatalogPage />, {
+      service: {
+        ...createMockVolundrService(),
+        getLaunchSpecs: async () => {
+          throw new Error('catalog unavailable');
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load launch catalog/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText('catalog unavailable')).toBeInTheDocument();
+  });
+
+  it('renders a generic error message for non-Error rejections', async () => {
+    renderWithVolundr(<LaunchCatalogPage />, {
+      service: {
+        ...createMockVolundrService(),
+        getLaunchSpecs: () => Promise.reject('string failure'),
+      },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/failed to load launch catalog/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Unknown error')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when no specs are configured', async () => {
+    renderWithSpecs([]);
+
+    await waitForPage();
+    expect(screen.getByText(/no launch specs configured yet/i)).toBeInTheDocument();
+  });
+
+  it('renders header copy and one card per spec', async () => {
+    renderWithSpecs([makeSpec({ name: 'alpha-spec' }), makeSpec({ name: 'beta-spec' })]);
+
+    await waitForPage();
+    expect(screen.getByText('Launch Catalog')).toBeInTheDocument();
+    expect(screen.getByText(/preloaded catalog specs/i)).toBeInTheDocument();
+    expect(screen.getByText('alpha-spec')).toBeInTheDocument();
+    expect(screen.getByText('beta-spec')).toBeInTheDocument();
+    expect(screen.queryByText(/no launch specs configured yet/i)).not.toBeInTheDocument();
+  });
+
+  it('renders specs from the default mock service', async () => {
+    renderWithVolundr(<LaunchCatalogPage />);
+
+    await waitForPage();
+    expect(screen.getAllByRole('article').length).toBeGreaterThan(0);
+  });
+
+  it('shows the default badge only for default specs', async () => {
+    renderWithSpecs([
+      makeSpec({ name: 'default-spec', isDefault: true, workloadType: 'worker' }),
+      makeSpec({ name: 'plain-spec', isDefault: false, workloadType: 'worker' }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('default')).toBeInTheDocument();
+    const plainCard = screen.getByText('plain-spec').closest('article');
+    expect(plainCard).not.toBeNull();
+    expect(within(plainCard!).queryByText('default')).not.toBeInTheDocument();
+  });
+
+  it('falls back to placeholder copy when description is empty', async () => {
+    renderWithSpecs([
+      makeSpec({ name: 'described', description: 'Runs the nightly batch.' }),
+      makeSpec({ name: 'undescribed', description: '' }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('Runs the nightly batch.')).toBeInTheDocument();
+    expect(screen.getByText('No description configured.')).toBeInTheDocument();
+  });
+
+  it('shows the scope label on each card', async () => {
+    renderWithSpecs([
+      makeSpec({ name: 'sys-spec', scope: 'system', id: null }),
+      makeSpec({ name: 'user-spec', scope: 'user' }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('system')).toBeInTheDocument();
+    expect(screen.getByText('user')).toBeInTheDocument();
+  });
+
+  it('prefers sessionDefinition over workloadType for the runtime field', async () => {
+    renderWithSpecs([
+      makeSpec({ name: 'with-def', sessionDefinition: 'skuldClaude', workloadType: 'default' }),
+      makeSpec({ name: 'without-def', sessionDefinition: null, workloadType: 'batch-runner' }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('skuldClaude')).toBeInTheDocument();
+    expect(screen.getByText('batch-runner')).toBeInTheDocument();
+  });
+
+  it('renders the model or a launch-time placeholder', async () => {
+    renderWithSpecs([
+      makeSpec({ name: 'with-model', model: 'claude-sonnet' }),
+      makeSpec({ name: 'without-model', model: null }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('claude-sonnet')).toBeInTheDocument();
+    expect(screen.getByText('selected at launch')).toBeInTheDocument();
+  });
+
+  it('formats full resource config with cpu, memory and gpu', async () => {
+    renderWithSpecs([
+      makeSpec({
+        name: 'beefy',
+        resourceConfig: { cpu: '4', memory: '8Gi', gpu: '1' },
+      }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('cpu 4 · mem 8Gi · gpu 1')).toBeInTheDocument();
+  });
+
+  it('omits gpu when it is "0" and falls back when nothing is set', async () => {
+    renderWithSpecs([
+      makeSpec({ name: 'zero-gpu', resourceConfig: { cpu: '2', memory: '4Gi', gpu: '0' } }),
+      makeSpec({ name: 'no-resources', resourceConfig: {} }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('cpu 2 · mem 4Gi')).toBeInTheDocument();
+    expect(screen.getByText('default resources')).toBeInTheDocument();
+  });
+
+  it('formats partial resource config without cpu', async () => {
+    renderWithSpecs([makeSpec({ name: 'mem-only', resourceConfig: { memory: '2Gi' } })]);
+
+    await waitForPage();
+    expect(screen.getByText('mem 2Gi')).toBeInTheDocument();
+  });
+
+  it('shows launch-time placeholder when no source is configured', async () => {
+    renderWithSpecs([makeSpec({ name: 'no-source', source: null })]);
+
+    await waitForPage();
+    expect(screen.getByText('source selected at launch')).toBeInTheDocument();
+  });
+
+  it('formats git sources as repo @ branch', async () => {
+    renderWithSpecs([
+      makeSpec({
+        name: 'git-source',
+        source: { type: 'git', repo: 'github.com/niuulabs/volundr', branch: 'main' },
+      }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('github.com/niuulabs/volundr @ main')).toBeInTheDocument();
+  });
+
+  it('formats local mounts using local_path when present', async () => {
+    renderWithSpecs([
+      makeSpec({
+        name: 'local-path',
+        source: { type: 'local_mount', local_path: '/home/dev/proj', paths: [] },
+      }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('/home/dev/proj')).toBeInTheDocument();
+  });
+
+  it('falls back to the first mount host_path for local mounts', async () => {
+    renderWithSpecs([
+      makeSpec({
+        name: 'host-path',
+        source: {
+          type: 'local_mount',
+          paths: [{ host_path: '/mnt/host/code', mount_path: '/workspace', read_only: false }],
+        },
+      }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('/mnt/host/code')).toBeInTheDocument();
+  });
+
+  it('labels pathless local mounts as "local mount"', async () => {
+    renderWithSpecs([makeSpec({ name: 'bare-mount', source: { type: 'local_mount', paths: [] } })]);
+
+    await waitForPage();
+    expect(screen.getByText('local mount')).toBeInTheDocument();
+  });
+
+  it('lists configured MCP servers and hides the row when empty', async () => {
+    renderWithSpecs([
+      makeSpec({
+        name: 'with-mcp',
+        mcpServers: [
+          { name: 'mimir', type: 'stdio' },
+          { name: 'bifrost', type: 'stdio' },
+        ],
+      }),
+      makeSpec({ name: 'without-mcp', mcpServers: [] }),
+    ]);
+
+    await waitForPage();
+    expect(screen.getByText('mimir')).toBeInTheDocument();
+    expect(screen.getByText('bifrost')).toBeInTheDocument();
+  });
+});

--- a/web-next/packages/plugin-volundr/src/ui/SessionsPage.helpers.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/SessionsPage.helpers.test.ts
@@ -9,6 +9,7 @@ import {
   looksLikeRepoLabel,
   repoGroupLabel,
   sessionActivityTs,
+  sessionOriginBadge,
   shortenRepoLabel,
   toGroupTestId,
 } from './SessionsPage';
@@ -115,5 +116,13 @@ describe('SessionsPage helpers', () => {
 
     const forgeGroups = groupByForge(sessions);
     expect(forgeGroups.map((group) => group.label)).toEqual(['Forge Z', 'forge-a']);
+  });
+
+  it('derives origin badges only for external CLI origins', () => {
+    expect(sessionOriginBadge({ origin: 'claude' })).toBe('claude');
+    expect(sessionOriginBadge({ origin: 'codex' })).toBe('codex');
+    expect(sessionOriginBadge({ origin: 'volundr' })).toBeNull();
+    expect(sessionOriginBadge({ origin: 'manual' })).toBeNull();
+    expect(sessionOriginBadge({ origin: undefined })).toBeNull();
   });
 });

--- a/web-next/packages/plugin-volundr/src/ui/SessionsPage.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionsPage.test.tsx
@@ -112,6 +112,7 @@ function makeSession(
     files: overrides.files,
     sagaId: overrides.sagaId,
     runId: overrides.runId,
+    origin: overrides.origin,
   };
 }
 
@@ -402,6 +403,95 @@ describe('SessionsPage', () => {
     await waitFor(() => expect(deleteSession).toHaveBeenCalledTimes(2));
     expect(deleteSession).toHaveBeenCalledWith('stopped-1');
     expect(deleteSession).toHaveBeenCalledWith('stopped-2');
+  });
+
+  it('shows an origin badge on imported sessions but not on volundr-native ones', async () => {
+    const store = createSessionStoreWithSessions([
+      makeSession({ id: 'imp-1', personaName: 'imported claude', state: 'idle', origin: 'claude' }),
+      makeSession({ id: 'imp-2', personaName: 'imported codex', state: 'idle', origin: 'codex' }),
+      makeSession({ id: 'native-1', personaName: 'native', state: 'running', origin: 'volundr' }),
+      makeSession({ id: 'native-2', personaName: 'legacy', state: 'running' }),
+    ]);
+
+    wrap(store);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('session-origin-badge-imp-1')).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('session-origin-badge-imp-1')).toHaveTextContent('claude');
+    expect(screen.getByTestId('session-origin-badge-imp-2')).toHaveTextContent('codex');
+    expect(screen.queryByTestId('session-origin-badge-native-1')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('session-origin-badge-native-2')).not.toBeInTheDocument();
+  });
+
+  it('opens the import dialog from the sidebar import button', async () => {
+    wrap();
+
+    await waitFor(() => expect(screen.getByTestId('pod-import-button')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('pod-import-button'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('import-external-sessions-panel')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Import CLI Sessions')).toBeInTheDocument();
+  });
+
+  it('hides the import affordance when discovery is unavailable (503)', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('not available'), { status: 503 }));
+
+    wrap(createMockSessionStore(), volundr);
+
+    await waitFor(() => expect(screen.getByTestId('pod-launch-button')).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByTestId('pod-import-button')).not.toBeInTheDocument());
+  });
+
+  it('keeps the import affordance for non-503 discovery errors', async () => {
+    const volundr = createMockVolundrService();
+    volundr.listExternalSessions = vi.fn().mockRejectedValue(new Error('boom'));
+
+    wrap(createMockSessionStore(), volundr);
+
+    await waitFor(() => expect(screen.getByTestId('pod-import-button')).toBeInTheDocument());
+  });
+
+  it('imports an external session and refreshes the sessions list', async () => {
+    const store = createSessionStoreWithSessions([
+      makeSession({ id: 'ds-1', personaName: 'existing', state: 'running' }),
+    ]);
+    const listSessions = vi.spyOn(store, 'listSessions');
+    const volundr = createMockVolundrService();
+    const importExternalSession = vi.fn().mockResolvedValue({
+      id: 'sess-imported',
+      name: 'imported session',
+      source: { type: 'git', repo: '~/code/niuu/volundr', branch: 'main' },
+      status: 'stopped',
+      model: 'claude-sonnet',
+      lastActive: Date.now(),
+      messageCount: 0,
+      tokensUsed: 0,
+      origin: 'claude',
+      externalSessionId: 'ext-claude-1',
+    });
+    volundr.importExternalSession = importExternalSession;
+
+    wrap(store, volundr);
+
+    await waitFor(() => expect(screen.getByTestId('pod-import-button')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('pod-import-button'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('external-session-import-ext-claude-1')).toBeInTheDocument(),
+    );
+    const callsBeforeImport = listSessions.mock.calls.length;
+    fireEvent.click(screen.getByTestId('external-session-import-ext-claude-1'));
+
+    await waitFor(() =>
+      expect(importExternalSession).toHaveBeenCalledWith('claude-code', 'ext-claude-1'),
+    );
+    await waitFor(() => expect(listSessions.mock.calls.length).toBeGreaterThan(callsBeforeImport));
   });
 
   it('navigates back to the sessions list when deleting the selected stopped session', async () => {

--- a/web-next/packages/plugin-volundr/src/ui/SessionsPage.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionsPage.tsx
@@ -13,9 +13,23 @@ import {
   DialogContent,
 } from '@niuulabs/ui';
 import type { DotState } from '@niuulabs/ui';
-import { Check, Clock3, FolderGit2, Search, SquareTerminal, Ticket, Trash2 } from 'lucide-react';
+import {
+  Check,
+  Clock3,
+  Download,
+  FolderGit2,
+  Search,
+  SquareTerminal,
+  Ticket,
+  Trash2,
+} from 'lucide-react';
 import { LaunchWizard } from './LaunchWizard';
+import { ImportExternalSessionsDialog } from './ImportExternalSessionsDialog';
 import { useSessionList } from './hooks/useSessionStore';
+import {
+  isExternalSessionsUnavailableError,
+  useExternalSessions,
+} from './hooks/useExternalSessions';
 import { groupByState } from './sessions/groupByState';
 import { LiveSessionDetailPage } from './LiveSessionDetailPage';
 import type { Session, SessionState } from '../domain/session';
@@ -95,6 +109,15 @@ export function toGroupTestId(label: string): string {
 
 export function sessionActivityTs(session: Session): number {
   return new Date(session.lastActivityAt ?? session.startedAt).getTime();
+}
+
+const EXTERNAL_ORIGINS = new Set(['claude', 'codex']);
+
+/** External origins ('claude' / 'codex') get a badge; volundr-native rows do not. */
+export function sessionOriginBadge(session: Pick<Session, 'origin'>): string | null {
+  if (!session.origin) return null;
+  if (!EXTERNAL_ORIGINS.has(session.origin)) return null;
+  return session.origin;
 }
 
 export function compareSessionsByActivity(a: Session, b: Session): number {
@@ -186,6 +209,7 @@ function PodEntry({
     previewLabel && looksLikeRepoLabel(previewLabel) ? compactSourceParts(previewLabel) : null;
   const showPreviewFallback = previewLabel && !sourceParts;
   const forgeLabel = session.clusterName ?? session.clusterId;
+  const originBadge = sessionOriginBadge(session);
   return (
     <button
       type="button"
@@ -251,6 +275,17 @@ function PodEntry({
                     forge
                   </span>
                   <span className="niuu:truncate niuu:text-brand">{forgeLabel}</span>
+                </span>
+              ) : null}
+              {originBadge ? (
+                <span
+                  className="niuu:inline-flex niuu:flex-shrink-0 niuu:items-center niuu:rounded-full niuu:border niuu:border-border-subtle niuu:bg-bg-tertiary niuu:px-2 niuu:py-0.5"
+                  title={`Imported from ${originBadge}`}
+                  data-testid={`session-origin-badge-${session.id}`}
+                >
+                  <span className="niuu:text-[9px] niuu:uppercase niuu:tracking-[0.14em] niuu:text-text-secondary">
+                    {originBadge}
+                  </span>
                 </span>
               ) : null}
               {sourceParts ? (
@@ -363,10 +398,13 @@ export function SessionsPage() {
   const [selectedStoppedIds, setSelectedStoppedIds] = useState<Set<string>>(new Set());
   const [deleteStoppedOpen, setDeleteStoppedOpen] = useState(false);
   const [launchOpen, setLaunchOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
   const volundr = useService<IVolundrService>('volundr');
   const queryClient = useQueryClient();
 
   const sessionsQuery = useSessionList();
+  const externalSessionsQuery = useExternalSessions();
+  const importUnavailable = isExternalSessionsUnavailableError(externalSessionsQuery.error);
   const allSessions = useMemo(() => sessionsQuery.data ?? [], [sessionsQuery.data]);
   const stoppedSessionCount = useMemo(
     () => allSessions.filter((session) => session.state === 'terminated').length,
@@ -630,6 +668,18 @@ export function SessionsPage() {
                   >
                     +
                   </button>
+                  {!importUnavailable ? (
+                    <button
+                      type="button"
+                      onClick={() => setImportOpen(true)}
+                      className="niuu:flex niuu:h-7 niuu:w-7 niuu:flex-shrink-0 niuu:items-center niuu:justify-center niuu:rounded-lg niuu:border niuu:border-border-subtle niuu:bg-bg-elevated niuu:text-text-muted niuu:transition-colors niuu:hover:border-brand/40 niuu:hover:text-brand"
+                      data-testid="pod-import-button"
+                      aria-label="Import external CLI sessions"
+                      title="Import external CLI sessions"
+                    >
+                      <Download className="niuu:h-3.5 niuu:w-3.5" />
+                    </button>
+                  ) : null}
                   <div className="niuu:flex niuu:min-w-0 niuu:flex-1 niuu:items-center niuu:gap-2 niuu:rounded-xl niuu:border niuu:border-border-subtle niuu:bg-bg-tertiary niuu:px-2 niuu:py-1 niuu:shadow-[inset_0_1px_0_rgba(255,255,255,0.02)] niuu:focus-within:border-brand/50 niuu:focus-within:ring-1 niuu:focus-within:ring-brand/20">
                     <Search
                       className="niuu:h-4 niuu:w-4 niuu:flex-shrink-0 niuu:text-text-muted"
@@ -828,6 +878,13 @@ export function SessionsPage() {
         </DialogContent>
       </Dialog>
       <LaunchWizard open={launchOpen} onOpenChange={setLaunchOpen} />
+      <ImportExternalSessionsDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        onImported={async () => {
+          await sessionsQuery.refetch();
+        }}
+      />
     </>
   );
 }

--- a/web-next/packages/plugin-volundr/src/ui/hooks/useExternalSessions.ts
+++ b/web-next/packages/plugin-volundr/src/ui/hooks/useExternalSessions.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { IVolundrService } from '../../ports/IVolundrService';
+
+export const EXTERNAL_SESSIONS_QUERY_KEY = ['volundr', 'external-sessions'] as const;
+
+/**
+ * The backend answers 503 when external-session discovery is not enabled
+ * (e.g. non-mini mode). Callers hide the import affordance instead of
+ * surfacing an error.
+ */
+export function isExternalSessionsUnavailableError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  return (error as { status?: number }).status === 503;
+}
+
+/** Queries discoverable external CLI sessions (Claude Code / Codex) on the host. */
+export function useExternalSessions() {
+  const volundr = useService<IVolundrService>('volundr');
+  return useQuery({
+    queryKey: EXTERNAL_SESSIONS_QUERY_KEY,
+    queryFn: () => volundr.listExternalSessions(),
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/web-next/pnpm-lock.yaml
+++ b/web-next/pnpm-lock.yaml
@@ -717,26 +717,26 @@ importers:
         version: link:../ui
       lucide-react:
         specifier: ^1.17.0
-        version: 1.17.0(react@19.2.6)
+        version: 1.17.0(react@19.2.7)
     devDependencies:
       '@niuulabs/design-tokens':
         specifier: workspace:*
         version: link:../design-tokens
       '@tanstack/react-query':
         specifier: ^5.100.14
-        version: 5.100.14(react@19.2.6)
+        version: 5.101.0(react@19.2.7)
       '@tanstack/react-router':
         specifier: ^1.170.10
-        version: 1.170.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.170.11(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@testing-library/react':
         specifier: ^16.1.0
-        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@testing-library/user-event':
         specifier: ^14.5.2
         version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/react':
         specifier: ^19.2.15
-        version: 19.2.15
+        version: 19.2.16
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.15)
@@ -748,7 +748,7 @@ importers:
         version: 16.1.1(postcss@8.5.15)
       react:
         specifier: ^19.2.6
-        version: 19.2.6
+        version: 19.2.7
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -760,7 +760,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.7)(@vitest/coverage-v8@4.1.7)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3))
+        version: 4.1.8(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.8.3))
 
   packages/plugin-volundr:
     dependencies:


### PR DESCRIPTION
## Summary

Volundr can now discover coding sessions started outside the platform — directly with the Claude Code or Codex CLIs on the host — import them as Volundr sessions, and restart them with their native conversation history intact. It also fixes the session start button, which was dead at two layers.

### What was broken
- The web UI's start button posted to `POST /sessions/{id}/resume`, a route that never existed on the backend (only `/start`).
- In the full host profile the niuu gateway additionally proxied neither `/start` nor `/resume`, so even `/start` was unreachable through the dev stack.

### What's new
- **Hexagonal discovery layer**: `ExternalSessionProvider` port with two local-host adapters scanning `~/.claude/projects` and `~/.codex/sessions` (dynamic adapter pattern, auto-enabled in mini mode via `external_sessions.enabled: null` → follows `local_mounts.mini_mode`).
- **API**: `GET /external-sessions` (live/importable/imported annotations, `?provider=` filter), `POST /sessions/import`, `POST /sessions/{id}/resume` as an alias of `/start`. `SessionResponse` gains `origin` + `external_session_id` (migration `000045`, both locations). `GET /feature-flags` now lists `local_mounts_allowed_prefixes`.
- **Resume-with-history**: starting an imported session pins a resume-capable transport and threads the native id through `LocalProcessPodManager` → Skuld: Claude reattaches via `claude --resume`, Codex via the `thread/resume` app-server RPC.
- **Mount prefix policy**: shared symlink-aware domain helper (`volundr.domain.mount_policy`) now enforced on imports (403), the mini-mode `local_path` workspace branch (closing a pre-existing gap in the regular create path), and the local-mount contributor (previously bypassable via symlinks and broken for macOS `/tmp`).
- **Gateway**: proxies for start/resume (owner-routed), import (default-instance), feature-flags, and an external-sessions aggregator; `_normalize_timestamp` now parses ISO 8601 so aggregated ordering works with real payloads.
- **web-next**: import dialog on the sessions page (live badge, per-row importable gating with reasons, imported state), origin badges on session rows, models/ports/adapters extended.
- **Docs**: orchestrator guide gains mini-mode setup notes and a full external-session discovery/import/resume contract for AI controllers.
- **Pre-existing fixes**: stale `environment-nats` smoke test, missing `flock.*` sleipnir registry constants, repo-wide ruff format drift (62 files), web-next global branch coverage raised 83.51% → 84.35% to clear the existing 84% gate.

## Type of Change
- [x] Feature (`feat:`)
- [x] Bug fix (`fix:`)
- [x] Documentation (`docs:`)

## Test Plan
- All five backend CI matrix jobs run locally with their coverage gates: volundr 85.21%, ravn 85.07%, ting 85.85%, bifrost 93.31%, sleipnir 97.51% (14,500+ tests).
- Integration tests against real PostgreSQL with migration `000045` applied: 19 passed.
- web-next: 4,908 tests, coverage gate green (branches 84.35% ≥ 84%), typecheck/eslint/prettier clean; helm lint clean.
- End-to-end on a real host through `./start-dev`: discovered 400 real sessions (200 Claude + 200 Codex), imported a Claude session containing a known codeword, resumed it through the API (`claude --resume` observed in the process table), and the resumed agent answered the codeword from history; same flow proven for Codex via `thread/resume`, and stop→resume proven for a Volundr-origin session.

## Checklist
- [x] Tests pass locally
- [x] Code follows project conventions
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)