### PR TITLE
fix: forge reliability pass from xteo fork + context-restoring resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,47 @@
+# Volundr / Niuu platform
 
-## Initial Task
+Monorepo for the Niuu agent platform. The detailed, binding conventions live in
+`.claude/rules/*.md` — read those before changing code. This file is the map.
 
-This is a routing smoke test. Report that the tag-targeted session started.
+## Packages (`src/`)
+
+| Package | Role |
+|---|---|
+| `volundr` | Forge backend — session lifecycle, workspaces, chronicles, REST API (`/api/v1/forge`) |
+| `skuld` | Per-session broker — wraps the Claude/Codex/OpenCode CLIs, WebSocket chat, file manager |
+| `niuu` | Shared host/gateway — mounts plugin APIs, instance registry, the forge aggregate router |
+| `ting` | Autonomous dispatcher — sagas, runs, tracker integration (must never import `volundr`) |
+| `ravn` | Agent runtime — personas, flocks, Valkyries, mesh |
+| `bifrost` | Model gateway and catalog |
+| `sleipnir` | Event bus / event-type registry |
+| `cli` | `niuu` CLI — `niuu platform up` runs the whole stack in mini mode |
+
+Everything follows hexagonal architecture: `domain/` (models + services) →
+`ports/` (interfaces) → `adapters/` (implementations); composition happens in
+each package's `main.py`. See `.claude/rules/architecture.md` and
+`.claude/rules/module-boundaries.md`.
+
+## Dev commands
+
+```bash
+./start-dev                       # full local stack on :8080 (mini mode, embedded postgres)
+./stop-dev
+make verify                       # ruff lint + full backend test suite
+uv run --extra dev pytest -q      # backend tests directly
+cd web-next && pnpm test          # web tests (coverage-gated)
+```
+
+## Key rules (the short version)
+
+- Migrations go in BOTH `migrations/` and the Helm configmap — `.claude/rules/migrations.md`
+- Raw SQL with asyncpg, no ORM — `.claude/rules/database.md`
+- 85% coverage gates on backend and web; never lower them — `.claude/rules/testing.md`
+- Conventional commits — `.claude/rules/commits.md`
+- New adapters use dynamic `adapter:` + kwargs config — `.claude/rules/dynamic-adapters.md`
+- `web-next/` is Tailwind + tokens and has its own `web-next/CLAUDE.md`; legacy `web/` rules differ
+
+## Docs
+
+- `docs/openclaw-session-orchestrator-guide.md` — how an AI controller drives
+  Forge sessions end to end (API contracts, SSE, WebSocket, event-log replay)
+- `docs/operator/` — operator-facing feature guides

--- a/charts/skuld-planner/values.yaml
+++ b/charts/skuld-planner/values.yaml
@@ -133,7 +133,11 @@ envSecrets:
     secretKey: api-key
 
 # Plain environment variables
-envVars: []
+envVars:
+  # Cluster pods have no ~/.claude login — keep API-key auth for Claude
+  # transports (host/mini-mode defaults to the claude.ai subscription).
+  - name: SKULD__CLAUDE_AUTH
+    value: "api_key"
 
 # Envoy sidecar proxy (JWT validation, header extraction)
 envoy:

--- a/charts/skuld/values.yaml
+++ b/charts/skuld/values.yaml
@@ -246,7 +246,12 @@ envSecrets:
 
 # -- Plain environment variables injected into the skuld broker container.
 # Use for non-secret configuration like proxy URLs or auth tokens.
-envVars: []
+envVars:
+  # Cluster pods have no ~/.claude login, so Claude transports must keep the
+  # injected ANTHROPIC_API_KEY. Host/mini-mode deployments default to the
+  # host's claude.ai subscription instead (see skuld.transports.claude_env).
+  - name: SKULD__CLAUDE_AUTH
+    value: "api_key"
 # Example: Anthropic-compatible proxy endpoint (replaces api.baseUrl/authToken)
 # - name: ANTHROPIC_BASE_URL
 #   value: "https://proxy.example.com"

--- a/charts/volundr/templates/migrations-configmap.yaml
+++ b/charts/volundr/templates/migrations-configmap.yaml
@@ -1196,4 +1196,14 @@ data:
 
     ALTER TABLE sessions DROP COLUMN IF EXISTS external_session_id;
     ALTER TABLE sessions DROP COLUMN IF EXISTS origin;
+
+  000046_session_cli_session_id.up.sql: |
+    -- Capture the CLI/agent conversation id (Claude session UUID or Codex thread
+    -- id) reported by the broker at runtime, so a stopped session can be resumed
+    -- with its prior conversation on restart.
+
+    ALTER TABLE sessions ADD COLUMN IF NOT EXISTS cli_session_id VARCHAR(255);
+
+  000046_session_cli_session_id.down.sql: |
+    ALTER TABLE sessions DROP COLUMN IF EXISTS cli_session_id;
 {{- end }}

--- a/charts/volundr/templates/migrations-configmap.yaml
+++ b/charts/volundr/templates/migrations-configmap.yaml
@@ -1180,6 +1180,7 @@ data:
 
     ALTER TABLE volundr_launch_specs RENAME TO volundr_presets;
 
+
   000045_session_origin.up.sql: |
     -- Track where a session originated (volundr, claude, codex) and the native
     -- CLI session/thread id for sessions imported from an external harness.
@@ -1206,4 +1207,33 @@ data:
 
   000046_session_cli_session_id.down.sql: |
     ALTER TABLE sessions DROP COLUMN IF EXISTS cli_session_id;
+
+  000047_session_event_log.up.sql: |
+    -- Durable, append-only, full-fidelity per-session event log. Preserves the
+    -- complete agent output (text, thinking, tool_use, tool_result, deltas)
+    -- ordered by a monotonic per-session `seq` so any client can replay the full
+    -- transcript from a cursor regardless of whether a socket was attached.
+    -- PRIMARY KEY (session_id, seq) makes at-least-once ingestion idempotent.
+    -- No FK to sessions: history survives session deletion.
+    CREATE TABLE IF NOT EXISTS session_event_log (
+        session_id   UUID NOT NULL,
+        seq          BIGINT NOT NULL,
+        kind         VARCHAR(64) NOT NULL,
+        role         VARCHAR(32),
+        request_id   TEXT,
+        payload      JSONB NOT NULL DEFAULT '{}',
+        ts           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (session_id, seq)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_session_event_log_session_seq
+        ON session_event_log(session_id, seq);
+
+    CREATE INDEX IF NOT EXISTS idx_session_event_log_request
+        ON session_event_log(session_id, request_id);
+  000047_session_event_log.down.sql: |
+    DROP INDEX IF EXISTS idx_session_event_log_request;
+    DROP INDEX IF EXISTS idx_session_event_log_session_seq;
+    DROP TABLE IF EXISTS session_event_log;
 {{- end }}

--- a/docs/openclaw-session-orchestrator-guide.md
+++ b/docs/openclaw-session-orchestrator-guide.md
@@ -176,6 +176,12 @@ Volundr's Forge session-create API uses `definition` to pick the runtime, for ex
 - `skuldClaude`
 - `skuldCodex`
 - `skuldOpenCode`
+- `skuldClaudeRemote` — Claude Code Remote Control: the broker launches
+  `claude remote-control` and surfaces a pairing URL
+  (`https://claude.ai/code?environment=env_...`) as an assistant turn and as a
+  structured `remote_control` event. The NATIVE app drives the conversation —
+  the broker cannot send turns into these sessions.
+- `skuldCodexRemote` — fails fast until the standalone Codex install exists.
 
 Example:
 
@@ -252,6 +258,39 @@ local workspaces and CLI session stores. An empty
 `local_mounts_allowed_prefixes` means any host directory may be used as a
 session workspace; a non-empty list restricts workspaces (and external session
 imports) to those path prefixes.
+
+#### Defaults worth knowing (and their switches)
+
+- **Default model** is `claude-opus-4-8` platform-wide; Claude sessions run at
+  model-aware reasoning effort (`xhigh` on Opus 4.7/4.8, `max` on 4.6), Codex
+  at `high`. Pick cheaper models/efforts explicitly when cost matters.
+- **Stop summarization is OFF** by default — stopping a session no longer burns
+  an LLM pass to write a chronicle summary. Re-enable with
+  `SKULD__CHRONICLE_ON_STOP_ENABLED=true`.
+- **The chronicle watcher is OFF** by default (it tailed session JSONL and
+  posted timeline events most deployments never read). Re-enable with
+  `SKULD__CHRONICLE_WATCHER_ENABLED=true`.
+- **Liveness reconciliation is OFF** by default. When enabled, a background
+  reconciler marks `running` sessions with no activity heartbeat for
+  `stale_after_seconds` as `stopped`, clears their endpoints, and stamps a
+  `liveness:` error (which the next heartbeat or restart clears). Brokers
+  currently report activity only on STATE CHANGES, so use a generous threshold
+  or a quiet-but-alive session may be falsely reaped:
+
+  ```yaml
+  session_liveness:
+    enabled: true
+    stale_after_seconds: 7200
+    check_interval_seconds: 120
+  ```
+
+- **Human-in-the-loop AskUserQuestion is OFF** by default. When
+  `SKULD__ASK_USER_QUESTION_ENABLED=true`, Claude tool permissions route over
+  the control protocol: every tool is auto-allowed EXCEPT `AskUserQuestion`,
+  which is emitted to clients as an `ask_user_question` event and BLOCKS the
+  turn until some client sends `ask_user_answer` over the session WebSocket.
+  Only enable this when your controller (or a human UI) actually answers those
+  events — otherwise a questioning agent hangs its turn forever.
 
 #### `session_definitions` overrides are partial now
 
@@ -594,6 +633,24 @@ If needed:
 <chat_endpoint>?access_token=<token>
 ```
 
+### Human-in-the-loop question frames (optional)
+
+When the deployment runs with `SKULD__ASK_USER_QUESTION_ENABLED=true`, the
+broker may emit:
+
+```json
+{"type": "ask_user_question", "request_id": "q-1", "question": "...", "options": [...]}
+```
+
+The turn blocks until a client answers:
+
+```json
+{"type": "ask_user_answer", "request_id": "q-1", "answer": "beta"}
+```
+
+A controller that cannot meaningfully answer should surface the question to a
+human rather than auto-answering.
+
 ### What to send
 
 The simplest valid user frame is:
@@ -755,6 +812,30 @@ Expected response:
   "session_id": "<id>"
 }
 ```
+
+### Durable event-log replay (full fidelity)
+
+Every CLI frame a session produces — assistant text, thinking, tool_use,
+tool_result, deltas — is durably captured to an append-only per-session event
+log, whether or not any client socket was attached. This is the
+strongest-fidelity transcript source and the right way to reconstruct history
+after a reconnect:
+
+```http
+GET /api/v1/forge/sessions/{id}/log/head     -> {"latest_seq": 726}
+GET /api/v1/forge/sessions/{id}/log?after=0  -> [ {seq, kind, role, payload, ts}, ... ]
+```
+
+Controller rules:
+
+- Replay returns a JSON LIST ordered by `seq`; page with `after=<last seq>`
+  until you reach `latest_seq`.
+- `ts` is the EMISSION time stamped by the broker at capture, so replayed
+  timelines reflect when things actually happened.
+- Human turns are mirrored into the log too, so a pure log replay shows the
+  full dialogue.
+- History survives session deletion (no FK); there is currently NO retention
+  policy, so operators of busy deployments should plan pruning.
 
 ### Read conversation history
 

--- a/migrations/000046_session_cli_session_id.down.sql
+++ b/migrations/000046_session_cli_session_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN IF EXISTS cli_session_id;

--- a/migrations/000046_session_cli_session_id.up.sql
+++ b/migrations/000046_session_cli_session_id.up.sql
@@ -1,0 +1,5 @@
+-- Capture the CLI/agent conversation id (Claude session UUID or Codex thread
+-- id) reported by the broker at runtime, so a stopped session can be resumed
+-- with its prior conversation on restart.
+
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS cli_session_id VARCHAR(255);

--- a/migrations/000047_session_event_log.down.sql
+++ b/migrations/000047_session_event_log.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_session_event_log_request;
+DROP INDEX IF EXISTS idx_session_event_log_session_seq;
+DROP TABLE IF EXISTS session_event_log;

--- a/migrations/000047_session_event_log.up.sql
+++ b/migrations/000047_session_event_log.up.sql
@@ -1,0 +1,33 @@
+-- Durable, append-only, full-fidelity per-session event log.
+--
+-- Unlike session_events (analytics previews, CASCADE-deleted with the session),
+-- this table preserves the COMPLETE agent output verbatim — assistant text,
+-- thinking, tool_use, tool_result, deltas — ordered by a monotonic per-session
+-- `seq`. It is the source of truth for transcript replay: any client (web or
+-- iOS) can resume from a cursor (`seq`) and reconstruct the full conversation
+-- regardless of whether a socket was attached when the events were produced.
+--
+-- The producer (skuld) assigns `seq` monotonically per session (it is the sole
+-- writer for a session's CLI), so the PRIMARY KEY (session_id, seq) makes
+-- ingestion idempotent under at-least-once retries (ON CONFLICT DO NOTHING).
+--
+-- No FK to sessions: the log survives session deletion (same posture as
+-- chronicle_events after migration 000038) so history is never lost.
+
+CREATE TABLE IF NOT EXISTS session_event_log (
+    session_id   UUID NOT NULL,
+    seq          BIGINT NOT NULL,
+    kind         VARCHAR(64) NOT NULL,
+    role         VARCHAR(32),
+    request_id   TEXT,
+    payload      JSONB NOT NULL DEFAULT '{}',
+    ts           TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_at   TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (session_id, seq)
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_event_log_session_seq
+    ON session_event_log(session_id, seq);
+
+CREATE INDEX IF NOT EXISTS idx_session_event_log_request
+    ON session_event_log(session_id, request_id);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pydantic>=2.13.4",
     "pydantic-settings>=2.14.1",
     "pyyaml>=6.0.3",
-    "claude-agent-sdk==0.2.89",
+    "claude-agent-sdk==0.2.96",
     "asyncpg>=0.31.0",
     "httpx>=0.28.1",
     "idna>=3.18",

--- a/src/bifrost/config.py
+++ b/src/bifrost/config.py
@@ -120,6 +120,19 @@ def _default_models() -> list[ManagedModelConfig]:
     """Built-in Bifrost model catalog used when no explicit catalog is configured."""
     return [
         ManagedModelConfig(
+            id="claude-opus-4-8",
+            name="Claude Opus 4.8 (1M)",
+            vendor="anthropic",
+            provider=ManagedModelProvider.CLOUD,
+            tier=ManagedModelTier.FRONTIER,
+            color="#8B5CF6",
+            description="Anthropic frontier reasoning model, 1M-token context.",
+            cost_per_million_tokens=15.0,
+            session_definition="skuldClaude",
+            supports_tools=True,
+            supports_thinking=True,
+        ),
+        ManagedModelConfig(
             id="claude-opus-4-7",
             name="Claude Opus 4.7",
             vendor="anthropic",

--- a/src/niuu/adapters/inbound/rest_volundr.py
+++ b/src/niuu/adapters/inbound/rest_volundr.py
@@ -701,6 +701,62 @@ def create_volundr_router(
     ) -> dict[str, Any]:
         return await _start_session_on_owner(request, session_id, principal, "resume")
 
+    @router.post("/sessions/{session_id}/activity", status_code=status.HTTP_204_NO_CONTENT)
+    async def report_activity(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> Response:
+        # Skuld brokers post activity heartbeats (incl. the cli_session_id used
+        # for restart resume) to the public /api/v1/forge prefix; without this
+        # proxy they 404 at the aggregate and the session never becomes
+        # resumable in the full host profile.
+        instance, _ = await _find_session_owner(
+            service,
+            principal,
+            request,
+            session_id,
+            embedded_app=embedded_forge_app,
+        )
+        response = await _request_remote(
+            instance,
+            request,
+            method="POST",
+            path=f"/sessions/{session_id}/activity",
+            json_body=body,
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @router.post("/sessions/{session_id}/usage", status_code=status.HTTP_201_CREATED)
+    async def report_usage(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        # Token-usage reports take the same broker ingestion path as activity.
+        instance, _ = await _find_session_owner(
+            service,
+            principal,
+            request,
+            session_id,
+            embedded_app=embedded_forge_app,
+        )
+        response = await _request_remote(
+            instance,
+            request,
+            method="POST",
+            path=f"/sessions/{session_id}/usage",
+            json_body=body,
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return _with_instance(payload, instance) if isinstance(payload, dict) else {}
+
     @router.post("/sessions/{session_id}/stop")
     async def stop_session(
         request: Request,

--- a/src/niuu/adapters/inbound/rest_volundr.py
+++ b/src/niuu/adapters/inbound/rest_volundr.py
@@ -761,6 +761,75 @@ def create_volundr_router(
     ) -> dict[str, Any]:
         return await _start_session_on_owner(request, session_id, principal, "resume")
 
+    @router.post("/sessions/{session_id}/log", status_code=status.HTTP_201_CREATED)
+    async def append_log(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        instance, _ = await _find_session_owner(
+            service, principal, request, session_id, embedded_app=embedded_forge_app
+        )
+        response = await _request_remote(
+            instance,
+            request,
+            method="POST",
+            path=f"/sessions/{session_id}/log",
+            json_body=body,
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    @router.get("/sessions/{session_id}/log/head")
+    async def get_log_head(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        instance, _ = await _find_session_owner(
+            service, principal, request, session_id, embedded_app=embedded_forge_app
+        )
+        response = await _request_remote(
+            instance,
+            request,
+            method="GET",
+            path=f"/sessions/{session_id}/log/head",
+            params=_query_params(request),
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    @router.get("/sessions/{session_id}/log")
+    async def get_log(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        principal: Principal = Depends(extract_principal),
+    ) -> Any:
+        instance, _ = await _find_session_owner(
+            service, principal, request, session_id, embedded_app=embedded_forge_app
+        )
+        response = await _request_remote(
+            instance,
+            request,
+            method="GET",
+            path=f"/sessions/{session_id}/log",
+            params=_query_params(request),
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        # The backing replay endpoint returns a JSON LIST of log entries
+        # (response_model=list[SessionLogEntryResponse]). Pass it through
+        # verbatim: coercing a non-dict to {"entries": []} silently dropped the
+        # ENTIRE transcript, so the web's durable-log replay rendered nothing
+        # ("session looks dead / no final message") even with hundreds of
+        # frames stored (latest_seq high, replay empty).
+        return response.json()
+
     @router.post("/sessions/{session_id}/activity", status_code=status.HTTP_204_NO_CONTENT)
     async def report_activity(
         request: Request,

--- a/src/niuu/adapters/inbound/rest_volundr.py
+++ b/src/niuu/adapters/inbound/rest_volundr.py
@@ -1010,4 +1010,106 @@ def create_volundr_router(
         _ensure_remote_success(response)
         return response.json()
 
+    # --- Skuld broker telemetry ingestion -----------------------------------
+    # The in-instance Skuld broker POSTs trace spans, session events, and
+    # chronicle-timeline entries back to the Forge API. These were missing
+    # from the aggregate (same gap class as the activity/usage routes above),
+    # so every session logged 404/405 noise. Session-keyed routes resolve the
+    # owning instance; span/event telemetry carries no session id in the
+    # path, so it forwards to the default backing instance (correct for
+    # single-instance/mini deployments — the only place a broker reports to).
+
+    async def _forward_to_default(
+        request: Request,
+        principal: Principal,
+        *,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        instance = await _resolve_target_instance(service, principal, None)
+        return await _request_remote(
+            instance,
+            request,
+            method=method,
+            path=path,
+            json_body=body,
+            embedded_app=embedded_forge_app,
+        )
+
+    @router.post("/chronicles/{session_id}/timeline", status_code=status.HTTP_201_CREATED)
+    async def post_chronicle_timeline(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        instance, _ = await _find_session_owner(
+            service, principal, request, session_id, embedded_app=embedded_forge_app
+        )
+        response = await _request_remote(
+            instance,
+            request,
+            method="POST",
+            path=f"/chronicles/{session_id}/timeline",
+            json_body=body,
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    @router.post("/spans/start", status_code=status.HTTP_201_CREATED)
+    async def span_start(
+        request: Request,
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        response = await _forward_to_default(
+            request, principal, method="POST", path="/spans/start", body=body
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    @router.post("/spans/complete", status_code=status.HTTP_201_CREATED)
+    async def span_complete(
+        request: Request,
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        response = await _forward_to_default(
+            request, principal, method="POST", path="/spans/complete", body=body
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    @router.post("/spans/{span_id}/finish")
+    async def span_finish(
+        request: Request,
+        span_id: str = Path(description="Trace span identifier"),
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        response = await _forward_to_default(
+            request, principal, method="POST", path=f"/spans/{span_id}/finish", body=body
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
+    @router.post("/events", status_code=status.HTTP_201_CREATED)
+    async def post_event(
+        request: Request,
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        response = await _forward_to_default(
+            request, principal, method="POST", path="/events", body=body
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return payload if isinstance(payload, dict) else {}
+
     return router

--- a/src/niuu/adapters/inbound/rest_volundr.py
+++ b/src/niuu/adapters/inbound/rest_volundr.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
 import httpx
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response, status
+from fastapi.responses import StreamingResponse
 from starlette.types import ASGIApp
 
 from niuu.adapters.inbound.auth import extract_principal
@@ -336,6 +338,64 @@ def create_volundr_router(
             reverse=True,
         )
         return sessions
+
+    @router.get("/sessions/stream")
+    async def stream_sessions(
+        request: Request,
+        principal: Principal = Depends(extract_principal),
+    ) -> StreamingResponse:
+        """Proxy the backing instance's Server-Sent Events session stream.
+
+        MUST be declared before GET /sessions/{session_id} — otherwise the
+        literal path "stream" is captured as a session id, the request falls
+        through to a session lookup, and the frontend's FleetStream hangs on a
+        connection that never emits an event (status frozen until a manual
+        reload). Single-instance/mini deployments stream the default backing
+        instance; fleet-wide fan-in across instances is a separate feature.
+        """
+        instance = await _resolve_target_instance(service, principal, None)
+        headers = _forward_headers(request)
+        embedded = _uses_embedded_transport(instance)
+
+        # For the in-process instance, subscribe to its event bus directly.
+        # httpx's ASGITransport buffers the entire response and never returns for
+        # an infinite stream, so it cannot proxy SSE — but the embedded volundr
+        # app shares this process, so we read its broadcaster. If it is somehow
+        # unavailable, fail fast with 503 so the frontend degrades to polling
+        # (a hung 200 stream would freeze status until a manual reload).
+        broadcaster = None
+        if embedded:
+            broadcaster = getattr(getattr(embedded_forge_app, "state", None), "broadcaster", None)
+            if broadcaster is None:
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail="Session event stream unavailable",
+                )
+
+        async def _proxy() -> Any:
+            if embedded:
+                async for event in broadcaster.subscribe():
+                    if await request.is_disconnected():
+                        break
+                    yield (
+                        f"event: {event.type.value}\ndata: {json.dumps(event.data)}\n\n"
+                    ).encode()
+                return
+            url = build_remote_url(instance.base_url, "/api/v1/forge", "/sessions/stream")
+            async with httpx.AsyncClient(timeout=None) as client:
+                async with client.stream("GET", url, headers=headers) as resp:
+                    async for chunk in resp.aiter_raw():
+                        yield chunk
+
+        return StreamingResponse(
+            _proxy(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no",
+            },
+        )
 
     @router.get("/sessions/{session_id}")
     async def get_session(

--- a/src/niuu/adapters/inbound/rest_volundr.py
+++ b/src/niuu/adapters/inbound/rest_volundr.py
@@ -773,6 +773,35 @@ def create_volundr_router(
         payload = response.json()
         return _with_instance(payload, instance) if isinstance(payload, dict) else {}
 
+    @router.put("/sessions/{session_id}")
+    async def update_session(
+        request: Request,
+        session_id: str = Path(description="Volundr session identifier"),
+        body: dict[str, Any] = Body(default_factory=dict),
+        principal: Principal = Depends(extract_principal),
+    ) -> dict[str, Any]:
+        # Rename/update (contract §2.1: PUT /sessions/{id} with {name|model|…}).
+        # The aggregate owns /api/v1/forge but only registered GET/DELETE on this
+        # path, so web + iOS renames 405'd — same gap class as activity/log/start.
+        instance, _ = await _find_session_owner(
+            service,
+            principal,
+            request,
+            session_id,
+            embedded_app=embedded_forge_app,
+        )
+        response = await _request_remote(
+            instance,
+            request,
+            method="PUT",
+            path=f"/sessions/{session_id}",
+            json_body=body,
+            embedded_app=embedded_forge_app,
+        )
+        _ensure_remote_success(response)
+        payload = response.json()
+        return _with_instance(payload, instance) if isinstance(payload, dict) else {}
+
     @router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
     async def delete_session(
         request: Request,

--- a/src/niuu/app.py
+++ b/src/niuu/app.py
@@ -659,6 +659,12 @@ def build_root_app(
             try:
                 async with ws_client.connect(
                     f"ws://127.0.0.1:{port}/session",
+                    # The broker replays the FULL conversation history as one
+                    # frame on connect; long sessions exceed the websockets
+                    # client's 1 MiB default, which killed the broker leg with
+                    # 1009 ("message too big") and trapped browsers in an
+                    # infinite reconnect loop. 64 MiB headroom.
+                    max_size=2**26,
                     additional_headers={
                         **{
                             k.decode(): v.decode()

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -4186,6 +4186,13 @@ class Broker:
             "turn_count": self._artifacts.turn_count,
             "duration_seconds": self._artifacts.duration_seconds,
         }
+        # Ride the CLI/agent conversation id upward so Volundr can persist it
+        # and resume the conversation when the session is restarted. Works for
+        # both Claude (session UUID) and Codex (thread id) — every
+        # resume-capable transport implements .session_id.
+        cli_session_id = self._transport.session_id if self._transport else None
+        if cli_session_id:
+            metadata["cli_session_id"] = cli_session_id
         if extra_metadata:
             metadata.update(extra_metadata)
 

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -5316,8 +5316,13 @@ async def upload_file_raw(
     base_real = os.path.realpath(str(base))
     # Containment checks are inlined (not _check_within_base) so the
     # realpath + startswith barrier is visible to CodeQL's path-injection
-    # query in the same dataflow scope as the filesystem sinks below.
+    # query in the same dataflow scope as the filesystem sinks below. The
+    # bare startswith(base_real) is the shape the query recognises; the
+    # separator-anchored check after it rules out /base vs /base-evil
+    # prefix collisions.
     target_real = os.path.realpath(os.path.join(base_real, sanitized))
+    if not target_real.startswith(base_real):
+        raise HTTPException(400, "Path traversal not allowed")
     if target_real != base_real and not target_real.startswith(base_real + os.sep):
         raise HTTPException(400, "Path traversal not allowed")
     if sanitized in ("", ".") or os.path.isdir(target_real):
@@ -5332,6 +5337,8 @@ async def upload_file_raw(
         )
 
     parent_real = os.path.realpath(os.path.dirname(target_real))
+    if not parent_real.startswith(base_real):
+        raise HTTPException(400, "Path traversal not allowed")
     if parent_real != base_real and not parent_real.startswith(base_real + os.sep):
         raise HTTPException(400, "Path traversal not allowed")
     os.makedirs(parent_real, exist_ok=True)

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -1115,7 +1115,9 @@ class Broker:
     def _flush_pending_assistant_turn(self, metadata: dict | None = None) -> None:
         """Save any accumulated assistant content as a conversation turn."""
         content = self._pending_assistant_content
-        if not content:
+        # Save when there's text OR captured parts (tool_use/tool_result/reasoning)
+        # — a tool-only assistant turn (no prose) must still persist its tool cards.
+        if not content and not self._pending_assistant_parts:
             return
 
         # Flush remaining reasoning
@@ -2904,6 +2906,24 @@ class Broker:
                 )
         elif tool_result_only_user_event:
             await self._finish_assistant_tool_trace_spans_from_user_event(data)
+            # Persist tool_result blocks onto the open assistant turn so the saved
+            # conversation carries tool OUTPUT (not just the call) for read-back.
+            tr_msg = data.get("message", {})
+            tr_blocks = tr_msg.get("content", []) if isinstance(tr_msg, dict) else []
+            for tr_block in tr_blocks or []:
+                if (
+                    isinstance(tr_block, dict)
+                    and tr_block.get("type") == "tool_result"
+                    and tr_block.get("tool_use_id")
+                ):
+                    self._pending_assistant_parts.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tr_block.get("tool_use_id"),
+                            "content": tr_block.get("content"),
+                            "is_error": bool(tr_block.get("is_error")),
+                        }
+                    )
         elif event_type == "result":
             asyncio.create_task(self._report_activity_state("idle"))
             if self._pending_explicit_human_response_count == 0:
@@ -2915,30 +2935,44 @@ class Broker:
         # We also handle the HTTP streaming format (content_block_delta, result)
         # for backward compatibility.
         if event_type == "assistant":
-            # Extract content from the assistant message
+            # Extract content and ACCUMULATE parts across the messages of one turn
+            # (a tool_use message, then the final text), so the SAVED conversation
+            # turn carries tool calls + reasoning — not just text — and reloads with
+            # its tool cards. Parts are reset on flush, not per message.
             message = data.get("message", {})
             content_blocks = message.get("content", [])
             if isinstance(content_blocks, list) and content_blocks:
                 text_parts = []
-                reasoning_parts = []
                 for block in content_blocks:
                     if not isinstance(block, dict):
                         continue
-                    if block.get("type") == "text" and block.get("text"):
+                    btype = block.get("type")
+                    if btype == "text" and block.get("text"):
                         text_parts.append(block["text"])
-                    elif block.get("type") == "thinking" and block.get("thinking"):
-                        reasoning_parts.append(block["thinking"])
+                        self._pending_assistant_parts.append(
+                            {"type": "text", "text": block["text"]}
+                        )
+                    elif btype == "thinking" and block.get("thinking"):
+                        # Keep last 500 chars per reasoning block as a summary.
+                        self._pending_assistant_parts.append(
+                            {"type": "reasoning", "text": str(block["thinking"])[-500:]}
+                        )
+                    elif btype == "tool_use" and block.get("id"):
+                        self._pending_assistant_parts.append(
+                            {
+                                "type": "tool_use",
+                                "id": block.get("id"),
+                                "name": block.get("name"),
+                                "input": block.get("input") or {},
+                            }
+                        )
                 text_content = "\n".join(text_parts)
                 if text_content:
-                    self._pending_assistant_content = text_content
-                    self._pending_assistant_parts = []
-                    if reasoning_parts:
-                        # Keep last 500 chars of reasoning as summary
-                        combined = "\n".join(reasoning_parts)
-                        self._pending_assistant_parts.append(
-                            {"type": "reasoning", "text": combined[-500:]}
-                        )
-                    self._pending_assistant_parts.append({"type": "text", "text": text_content})
+                    self._pending_assistant_content = (
+                        f"{self._pending_assistant_content}\n{text_content}"
+                        if self._pending_assistant_content
+                        else text_content
+                    )
 
         # HTTP streaming format: accumulate deltas
         if event_type == "content_block_delta":

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -3947,6 +3947,11 @@ class Broker:
             "kind": str(data.get("type", "unknown"))[:64],
             "payload": data,
             "request_id": self._extract_request_id(data),
+            # Emission time, captured HERE — without it the ingest stamps
+            # arrival time, which skews replayed timelines whenever the POST
+            # batch lags (rate-limit stalls, backend hiccups). Clients replay
+            # these ts so an old session shows when things actually happened.
+            "ts": datetime.now(UTC).isoformat(),
         }
         role = data.get("role")
         if isinstance(role, str):

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -3231,6 +3231,15 @@ class Broker:
                     auto_approved=False,
                 )
 
+            # AskUserQuestion: a human answered a question the agent asked.
+            # Resolves the blocking can_use_tool future in SDKTransport.
+            case "ask_user_answer":
+                await self._transport.send_control(
+                    "ask_user_answer",
+                    request_id=data.get("request_id", ""),
+                    answers=data.get("answers", []),
+                )
+
             # Phase 3: interrupt current turn
             case "interrupt":
                 await self._transport.send_control("interrupt")

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -1495,6 +1495,7 @@ class Broker:
             ),
             "mcp_servers": self._settings.mcp_servers,
             "resume_session_id": self._settings.session.resume_session_id,
+            "ask_user_question_enabled": self._settings.ask_user_question_enabled,
         }
 
     def _create_transport(self) -> CLITransport:

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -1611,6 +1611,16 @@ class Broker:
             else:
                 logger.info("Initial prompt configured — auto-starting transport in background")
                 asyncio.create_task(self._auto_start_transport())
+        elif self._conversation_turns:
+            # Resumed/restarted session (no new initial prompt, but prior history
+            # was loaded). Warm the transport eagerly so it is already alive when
+            # the next user message arrives. The message-delivery path connects a
+            # WebSocket and closes immediately after sending; a cold transport's
+            # ~280ms lazy-start outlasts that connection and the first message is
+            # dropped (no reply). Warming here makes a restarted session behave
+            # like a never-stopped one, where steering works.
+            logger.info("Resumed session with prior history — warming transport in background")
+            asyncio.create_task(self._auto_start_transport())
 
         # Start mesh adapter if enabled (after transport is ready)
         if self._settings.mesh.enabled:

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -5299,6 +5299,51 @@ async def upload_files(
     return {"entries": uploaded}
 
 
+@app.put("/api/files/upload")
+async def upload_file_raw(
+    request: Request,
+    path: str,
+    root: str = "workspace",
+) -> dict:
+    """Write raw request-body bytes to a single workspace-relative file.
+
+    Raw-body mirror of ``download_file``: ``path`` is the destination *file*
+    (not a directory), confined identically (reject absolute/.. + realpath guard).
+    """
+    _validate_root(root)
+    base = _resolve_root(root)
+    sanitized = _sanitize_relative(path)
+    base_real = os.path.realpath(str(base))
+    target_real = os.path.realpath(os.path.join(base_real, sanitized))
+    _check_within_base(base_real, target_real)
+    if sanitized in ("", ".") or os.path.isdir(target_real):
+        raise HTTPException(400, "path must name a file, not a directory")
+
+    body = await request.body()
+    max_size = broker._settings.max_upload_size_bytes
+    if len(body) > max_size:
+        raise HTTPException(
+            413,
+            f"File exceeds maximum upload size ({max_size} bytes)",
+        )
+
+    parent_real = os.path.realpath(os.path.dirname(target_real))
+    _check_within_base(base_real, parent_real)
+    os.makedirs(parent_real, exist_ok=True)
+
+    with open(target_real, "wb") as f:
+        f.write(body)
+
+    stat = os.stat(target_real)
+    return {
+        "name": os.path.basename(target_real),
+        "path": os.path.relpath(target_real, base_real),
+        "type": "file",
+        "size": stat.st_size,
+        "modified": datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
+    }
+
+
 class MkdirRequest(BaseModel):
     path: str
     root: str = "workspace"

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -987,6 +987,15 @@ class Broker:
         self._flock_completion_reported = False
         self._session_start_reported = False
         self._event_sequence = 0
+        # Durable full-fidelity event log (session_event_log). Every CLI frame is
+        # buffered here and flushed to Volundr by a background worker, independent
+        # of any attached channel — so nothing is dropped when no client is
+        # connected, and any client can replay the full transcript from a cursor.
+        self._event_log_seq = 0
+        self._event_log_buffer: list[dict] = []
+        self._event_log_lock = asyncio.Lock()
+        self._event_log_task: asyncio.Task[None] | None = None
+        self._event_log_stopping = False
         self._activity_state: str = "idle"
         self._last_activity_report: float = 0.0
         self._conversation_turns: list[ConversationTurn] = []
@@ -1597,6 +1606,9 @@ class Broker:
             asyncio.create_task(self._chronicle_watcher.start())
             logger.info("Chronicle watcher started for %s", watch_dir)
 
+        # Start the durable event-log worker (full-fidelity transcript capture)
+        await self._init_event_log()
+
         # Auto-start transport when an initial prompt is configured
         # (dispatched sessions should begin work immediately, not wait
         # for a browser to connect). Run as a background task so the
@@ -1649,6 +1661,9 @@ class Broker:
         # Stop chronicle watcher first (flush pending events)
         if self._chronicle_watcher:
             await self._chronicle_watcher.stop()
+
+        # Drain and stop the durable event-log worker so the last turn persists
+        await self._stop_event_log()
 
         if self._peer_watchdog_task is not None:
             self._peer_watchdog_task.cancel()
@@ -2813,6 +2828,11 @@ class Broker:
     async def _handle_cli_event(self, data: dict) -> None:
         """Forward a CLI event to all connected channels."""
         event_type = data.get("type", "unknown")
+
+        # Durably capture EVERY frame first — before any channel/broadcast logic —
+        # so agent output is never lost when no client is attached.
+        self._enqueue_event_log(data)
+
         if event_type == "control_request":
             self._track_pending_permission_request(data)
 
@@ -3895,6 +3915,130 @@ class Broker:
                 "workflow_enabled": bool(self._has_workflow_trigger()),
             },
         )
+
+    # -- Durable event log (full-fidelity transcript capture) -----------------
+
+    FORGE_LOG_PATH_TEMPLATE = "/api/v1/forge/sessions/{sid}/log"
+
+    @staticmethod
+    def _extract_request_id(data: dict) -> str | None:
+        """Best-effort turn correlation id from a raw CLI frame."""
+        rid = data.get("request_id")
+        if isinstance(rid, str) and rid:
+            return rid
+        msg = data.get("message")
+        if isinstance(msg, dict):
+            inner = msg.get("request_id")
+            if isinstance(inner, str) and inner:
+                return inner
+        return None
+
+    def _enqueue_event_log(self, data: dict) -> None:
+        """Buffer a raw CLI frame for durable persistence. Never raises.
+
+        Runs for every frame regardless of attached channels — this is what
+        guarantees no agent output is dropped when no client is connected.
+        """
+        if not self._settings.event_log_enabled or not self.volundr_api_url:
+            return
+        self._event_log_seq += 1
+        entry = {
+            "seq": self._event_log_seq,
+            "kind": str(data.get("type", "unknown"))[:64],
+            "payload": data,
+            "request_id": self._extract_request_id(data),
+        }
+        role = data.get("role")
+        if isinstance(role, str):
+            entry["role"] = role[:32]
+        self._event_log_buffer.append(entry)
+        # Safety valve: cap memory if the backend is unreachable for a long time.
+        # Dropping the oldest is the least-bad option vs OOM-killing the broker,
+        # and is logged loudly so the loss is visible.
+        overflow = len(self._event_log_buffer) - self._settings.event_log_max_buffer
+        if overflow > 0:
+            del self._event_log_buffer[:overflow]
+            logger.warning(
+                "event log buffer overflow — dropped %d oldest frames (backend unreachable?)",
+                overflow,
+            )
+
+    async def _event_log_flush_loop(self) -> None:
+        """Background worker: drain the event-log buffer to Volundr with retry."""
+        interval = self._settings.event_log_flush_interval_ms / 1000.0
+        while not self._event_log_stopping:
+            await asyncio.sleep(interval)
+            try:
+                await self._flush_event_log()
+            except Exception:
+                logger.debug("event log flush iteration failed", exc_info=True)
+
+    async def _flush_event_log(self) -> None:
+        """Send one batch from the front of the buffer. Removes only on success."""
+        if not self.volundr_api_url:
+            return
+        async with self._event_log_lock:
+            batch = self._event_log_buffer[: self._settings.event_log_batch_size]
+        if not batch:
+            return
+
+        client = await self._get_http_client()
+        path = self.FORGE_LOG_PATH_TEMPLATE.format(sid=self.session_id)
+        try:
+            response = await client.post(path, json={"entries": batch})
+        except Exception:
+            logger.debug("event log POST failed — will retry", exc_info=True)
+            return
+        if response.status_code >= 300:
+            logger.debug(
+                "event log POST rejected (%d): %s — will retry",
+                response.status_code,
+                response.text[:200],
+            )
+            return
+        # Idempotent on (session_id, seq), so removing exactly the sent count is
+        # safe even if newer frames were appended during the POST.
+        async with self._event_log_lock:
+            del self._event_log_buffer[: len(batch)]
+
+    async def _init_event_log(self) -> None:
+        """Resume the seq counter from the backend so restarts don't collide.
+
+        The PK is (session_id, seq); if a restarted broker reset seq to 0 its
+        appends would hit ON CONFLICT DO NOTHING and silently vanish. Seeding
+        from the stored head keeps the sequence monotonic across restarts.
+        """
+        if not self._settings.event_log_enabled or not self.volundr_api_url:
+            return
+        client = await self._get_http_client()
+        path = self.FORGE_LOG_PATH_TEMPLATE.format(sid=self.session_id) + "/head"
+        try:
+            response = await client.get(path)
+            if response.status_code < 300:
+                self._event_log_seq = int(response.json().get("latest_seq", 0))
+        except Exception:
+            logger.debug("event log head fetch failed — starting seq at 0", exc_info=True)
+        self._event_log_task = asyncio.create_task(self._event_log_flush_loop())
+        logger.info("Durable event log started (resume seq=%d)", self._event_log_seq)
+
+    async def _stop_event_log(self) -> None:
+        """Drain remaining frames and stop the worker on shutdown."""
+        self._event_log_stopping = True
+        if self._event_log_task is not None:
+            self._event_log_task.cancel()
+            await asyncio.gather(self._event_log_task, return_exceptions=True)
+            self._event_log_task = None
+        # Final best-effort drain so the last turn isn't lost on shutdown.
+        for _ in range(self._settings.event_log_max_buffer):
+            async with self._event_log_lock:
+                remaining = len(self._event_log_buffer)
+            if remaining == 0:
+                return
+            before = remaining
+            await self._flush_event_log()
+            async with self._event_log_lock:
+                if len(self._event_log_buffer) >= before:
+                    return  # made no progress (backend down) — give up
 
     async def _emit_pipeline_event(
         self,

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -1549,6 +1549,9 @@ class Broker:
         ):
             turn_id = str(uuid.uuid4())
             self._append_turn(ConversationTurn(id=turn_id, role="user", content=prompt))
+            # The initial prompt is a human turn too — persist it to the durable
+            # log so log-only replay opens with the operator's first message.
+            self._enqueue_human_turn_event(prompt, turn_id)
             try:
                 await self._channels.broadcast(
                     {"type": "user_confirmed", "id": turn_id, "content": prompt}
@@ -3367,6 +3370,9 @@ class Broker:
                         content=content_str,
                     )
                 )
+                # Mirror the human turn into the durable event log so log-only
+                # transcript replay (web/iOS) includes it.
+                self._enqueue_human_turn_event(content_str, msg_id)
                 now = datetime.now(UTC)
                 await self._complete_trace_span(
                     kind="turn.user",
@@ -3967,6 +3973,28 @@ class Broker:
                 "event log buffer overflow — dropped %d oldest frames (backend unreachable?)",
                 overflow,
             )
+
+    def _enqueue_human_turn_event(self, content: str, turn_id: str) -> None:
+        """Persist a HUMAN message to the durable event log as a user frame.
+
+        The CLI never echoes the operator's own prompt as a text frame — only
+        tool_results arrive with role=user — so a transcript replayed purely
+        from the durable log (web Code tab, iOS) omitted every human turn ("the
+        transcript doesn't show my message"). Synthesize a string-content user
+        frame, which the replay reducers render directly as a user turn (and
+        string content distinguishes it from the CLI's block-list tool_result
+        user frames).
+        """
+        if not content:
+            return
+        self._enqueue_event_log(
+            {
+                "type": "user",
+                "role": "user",
+                "uuid": turn_id,
+                "message": {"role": "user", "content": content},
+            }
+        )
 
     async def _event_log_flush_loop(self) -> None:
         """Background worker: drain the event-log buffer to Volundr with retry."""

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -5314,8 +5314,12 @@ async def upload_file_raw(
     base = _resolve_root(root)
     sanitized = _sanitize_relative(path)
     base_real = os.path.realpath(str(base))
+    # Containment checks are inlined (not _check_within_base) so the
+    # realpath + startswith barrier is visible to CodeQL's path-injection
+    # query in the same dataflow scope as the filesystem sinks below.
     target_real = os.path.realpath(os.path.join(base_real, sanitized))
-    _check_within_base(base_real, target_real)
+    if target_real != base_real and not target_real.startswith(base_real + os.sep):
+        raise HTTPException(400, "Path traversal not allowed")
     if sanitized in ("", ".") or os.path.isdir(target_real):
         raise HTTPException(400, "path must name a file, not a directory")
 
@@ -5328,7 +5332,8 @@ async def upload_file_raw(
         )
 
     parent_real = os.path.realpath(os.path.dirname(target_real))
-    _check_within_base(base_real, parent_real)
+    if parent_real != base_real and not parent_real.startswith(base_real + os.sep):
+        raise HTTPException(400, "Path traversal not allowed")
     os.makedirs(parent_real, exist_ok=True)
 
     with open(target_real, "wb") as f:

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -1637,6 +1637,13 @@ class Broker:
             # like a never-stopped one, where steering works.
             logger.info("Resumed session with prior history — warming transport in background")
             asyncio.create_task(self._auto_start_transport())
+        elif "RemoteControl" in (self._settings.transport_adapter or ""):
+            # Remote-control sessions take no initial prompt (the native app
+            # drives them), so neither branch above fires — but we still want the
+            # RC server launched immediately so the pairing URL is ready without
+            # waiting for a browser to connect.
+            logger.info("Remote-control session — launching the RC server in background")
+            asyncio.create_task(self._auto_start_transport())
 
         # Start mesh adapter if enabled (after transport is ready)
         if self._settings.mesh.enabled:
@@ -2836,6 +2843,16 @@ class Broker:
         # so agent output is never lost when no client is attached.
         self._enqueue_event_log(data)
 
+        if event_type == "remote_control":
+            # A remote-control transport reporting its pairing URL. Surface it as
+            # a real assistant turn (conversation history + durable-log replay +
+            # live channels) so every client shows the link to hand off to the
+            # native app.
+            url = str(data.get("url") or "").strip()
+            if url:
+                await self._surface_remote_control_url(url)
+            return
+
         if event_type == "control_request":
             self._track_pending_permission_request(data)
 
@@ -3995,6 +4012,34 @@ class Broker:
                 "message": {"role": "user", "content": content},
             }
         )
+
+    async def _surface_remote_control_url(self, url: str) -> None:
+        """Surface a remote-control pairing URL as an assistant turn everywhere.
+
+        Appends it to conversation history (the conversation endpoint), enqueues a
+        renderable assistant frame to the durable log (log-only replay), and
+        broadcasts to any live channels — so whichever surface a client uses, the
+        hand-off link to the native app is visible.
+        """
+        notice = (
+            "🔗 **Remote control ready.** Drive this session from the Claude app "
+            f"or claude.ai/code:\n\n{url}\n\n"
+            "Open the link (or scan the QR in the host terminal) to attach the "
+            "native app. This session is controlled remotely — messages typed "
+            "here are not sent to the agent."
+        )
+        turn_id = str(uuid.uuid4())
+        self._append_turn(ConversationTurn(id=turn_id, role="assistant", content=notice))
+        frame = {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": notice}]},
+        }
+        self._enqueue_event_log(frame)
+        try:
+            await self._channels.broadcast(frame)
+        except Exception:
+            logger.debug("remote-control URL broadcast failed", exc_info=True)
+        logger.info("Remote control pairing URL surfaced for session %s: %s", self.session_id, url)
 
     async def _event_log_flush_loop(self) -> None:
         """Background worker: drain the event-log buffer to Volundr with retry."""

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -4726,6 +4726,12 @@ class Broker:
         await self._emit_session_ended_event()
         await self._publish_mesh_outcome()
 
+        # The chronicle SUMMARY (an LLM pass on stop) is opt-in — OFF by default
+        # in our pipeline. The session-ended signals above (Ting run tracking,
+        # mesh outcome) still fire; only the extra summarization is gated.
+        if not self._settings.chronicle_on_stop_enabled:
+            return
+
         if not self.volundr_api_url:
             return
 

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -264,7 +264,10 @@ class SkuldSettings(BaseSettings):
     service_tenant_id: str = Field(default="default")
     persistence_mount_path: str = Field(default="/volundr/sessions")
     archive_store: ArchiveStoreConfig = Field(default_factory=ArchiveStoreConfig)
-    chronicle_watcher_enabled: bool = Field(default=True)
+    # OFF by default in our pipeline: the watcher tails session JSONL and POSTs
+    # chronicle timeline events we don't use (and which 405 through the guild
+    # aggregate). Opt in with SKULD__CHRONICLE_WATCHER_ENABLED=true.
+    chronicle_watcher_enabled: bool = Field(default=False)
     chronicle_watcher_debounce_ms: int = Field(default=500)
     # Generate + report a Chronicle SUMMARY (an LLM pass) when a session stops.
     # OFF by default in our pipeline: stopping a session must NOT trigger an

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -266,6 +266,11 @@ class SkuldSettings(BaseSettings):
     archive_store: ArchiveStoreConfig = Field(default_factory=ArchiveStoreConfig)
     chronicle_watcher_enabled: bool = Field(default=True)
     chronicle_watcher_debounce_ms: int = Field(default=500)
+    # Generate + report a Chronicle SUMMARY (an LLM pass) when a session stops.
+    # OFF by default in our pipeline: stopping a session must NOT trigger an
+    # extra summarization (cost / latency / unwanted behavior). Opt in with
+    # SKULD__CHRONICLE_ON_STOP_ENABLED=true.
+    chronicle_on_stop_enabled: bool = Field(default=False)
     # Durable full-fidelity event log: every CLI frame is appended to the
     # Volundr session_event_log so any client can replay the full transcript
     # (including the in-flight turn) regardless of whether a socket is attached.

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -189,7 +189,7 @@ class SkuldSessionConfig(BaseModel):
 
     id: str = Field(default="unknown")
     name: str = Field(default="unknown")
-    model: str = Field(default="claude-sonnet-4-6")
+    model: str = Field(default="claude-opus-4-8")
     workspace_dir: str | None = Field(default=None)
     system_prompt: str = Field(default="")
     initial_prompt: str = Field(default="")
@@ -288,7 +288,7 @@ class SkuldSettings(BaseSettings):
             if val:
                 self.session.name = val
 
-        if self.session.model == "claude-sonnet-4-6":
+        if self.session.model == "claude-opus-4-8":
             val = os.environ.get("MODEL")
             if val:
                 self.session.model = val

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -248,6 +248,15 @@ class SkuldSettings(BaseSettings):
     approval_policy: str = Field(default="")
     sandbox: str = Field(default="")
     agent_teams: bool = Field(default=False)
+    ask_user_question_enabled: bool = Field(
+        default=False,
+        description=(
+            "Route Claude tool permissions over the control protocol so "
+            "AskUserQuestion reaches a human (requires a client that answers "
+            "ask_user_question events). Off by default: sessions keep the "
+            "classic bypassPermissions behavior."
+        ),
+    )
     host: str = Field(default="0.0.0.0")
     port: int = Field(default=8081)
     volundr_api_url: str = Field(default="")

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -266,6 +266,13 @@ class SkuldSettings(BaseSettings):
     archive_store: ArchiveStoreConfig = Field(default_factory=ArchiveStoreConfig)
     chronicle_watcher_enabled: bool = Field(default=True)
     chronicle_watcher_debounce_ms: int = Field(default=500)
+    # Durable full-fidelity event log: every CLI frame is appended to the
+    # Volundr session_event_log so any client can replay the full transcript
+    # (including the in-flight turn) regardless of whether a socket is attached.
+    event_log_enabled: bool = Field(default=True)
+    event_log_batch_size: int = Field(default=100)
+    event_log_flush_interval_ms: int = Field(default=500)
+    event_log_max_buffer: int = Field(default=50_000)
     max_upload_size_bytes: int = Field(default=104_857_600)  # 100 MB
     mcp_servers: list[dict[str, Any]] = Field(default_factory=list)
     telegram: TelegramConfig = Field(default_factory=TelegramConfig)

--- a/src/skuld/transports/claude_env.py
+++ b/src/skuld/transports/claude_env.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -31,7 +32,9 @@ def claude_spawn_env() -> dict[str, str]:
         return {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
 
     env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE" and k not in _API_KEY_VARS}
-    if not (Path.home() / ".claude" / ".credentials.json").exists():
+    # On macOS the CLI stores its OAuth login in the Keychain, so the
+    # credentials file only signals a missing login on other platforms.
+    if sys.platform != "darwin" and not (Path.home() / ".claude" / ".credentials.json").exists():
         logger.warning(
             "SKULD__CLAUDE_AUTH=subscription but ~/.claude/.credentials.json is "
             "missing on this host — run `claude login`, or set "

--- a/src/skuld/transports/claude_env.py
+++ b/src/skuld/transports/claude_env.py
@@ -1,0 +1,40 @@
+"""Shared spawn-env construction for the Claude CLI/SDK transports.
+
+Default auth = the host's claude.ai subscription (the OAuth login in
+``~/.claude``), exactly like an interactive ``claude`` shell: the
+platform-injected ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_AUTH_TOKEN`` are STRIPPED
+from the child env so the CLI falls back to the stored login. Rationale: the
+deploy env's API key belongs to an org without data retention enabled, which
+400s on retention-gated models (``claude-fable-5``) that the same host's
+subscription login can use.
+
+Set ``SKULD__CLAUDE_AUTH=api_key`` to restore API-key billing (the key vars are
+kept). ``CLAUDECODE`` is always dropped — a nested-session marker that breaks
+the spawned CLI.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_API_KEY_VARS = ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+
+
+def claude_spawn_env() -> dict[str, str]:
+    """Build the child env for a Claude CLI/SDK spawn (see module docstring)."""
+    mode = os.environ.get("SKULD__CLAUDE_AUTH", "subscription").strip().lower()
+    if mode == "api_key":
+        return {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+
+    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE" and k not in _API_KEY_VARS}
+    if not (Path.home() / ".claude" / ".credentials.json").exists():
+        logger.warning(
+            "SKULD__CLAUDE_AUTH=subscription but ~/.claude/.credentials.json is "
+            "missing on this host — run `claude login`, or set "
+            "SKULD__CLAUDE_AUTH=api_key to use the platform API key"
+        )
+    return env

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -139,11 +139,15 @@ class CodexWebSocketTransport(CLITransport):
         codex_port: int = 0,
         mcp_servers: list[dict] | None = None,
         resume_session_id: str = "",
+        reasoning_effort: str = "",
         **_kwargs: object,
     ) -> None:
         super().__init__()
         self.workspace_dir = workspace_dir
         self._model = model
+        # Default Codex to HIGH reasoning effort when none is specified — push new
+        # sessions to think hard by default (Codex has no `max` tier).
+        self._reasoning_effort = reasoning_effort or "high"
         self._skip_permissions = skip_permissions
         self._approval_policy = approval_policy.strip()
         self._sandbox = sandbox.strip()
@@ -152,7 +156,7 @@ class CodexWebSocketTransport(CLITransport):
         self._codex_port = codex_port or _pick_free_port()
         self._mcp_servers = list(mcp_servers or [])
         self._mcp_overrides = build_codex_mcp_overrides(self._mcp_servers)
-        self._resume_session_id = resume_session_id
+        self._resume_session_id = (resume_session_id or "").strip() or None
         self._env = dict(os.environ)
 
         self._process: asyncio.subprocess.Process | None = None
@@ -435,6 +439,22 @@ class CodexWebSocketTransport(CLITransport):
             }
             if self._model:
                 thread_params["model"] = self._model
+            # Reasoning effort -> codex thread param. Codex accepts
+            # minimal/low/medium/high; map extra-high/xhigh/max to the highest
+            # supported value so an unknown alias can never break the session.
+            if self._reasoning_effort:
+                _eff = self._reasoning_effort.strip().lower()
+                _map = {
+                    "minimal": "minimal",
+                    "low": "low",
+                    "medium": "medium",
+                    "high": "high",
+                    "extra-high": "high",
+                    "extra_high": "high",
+                    "xhigh": "high",
+                    "max": "high",
+                }
+                thread_params["modelReasoningEffort"] = _map.get(_eff, "high")
             thread_params.update(self._permission_thread_params())
             if self._system_prompt:
                 # baseInstructions = role/persona ("you are a service developer…")

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -416,6 +416,7 @@ class CodexWebSocketTransport(CLITransport):
 
         await self._send_notification("initialized")
 
+<<<<<<< HEAD
         if self._resume_session_id:
             # Imported/external session — reattach to the existing thread
             # instead of starting a fresh one.
@@ -426,6 +427,40 @@ class CodexWebSocketTransport(CLITransport):
             if self._model:
                 resume_params["model"] = self._model
             resume_params.update(self._permission_thread_params())
+=======
+        thread_params: dict = {
+            "experimentalRawEvents": False,
+            "persistExtendedHistory": True,
+            "cwd": self.workspace_dir,
+        }
+        if self._model:
+            thread_params["model"] = self._model
+        # Reasoning effort -> codex thread param. Codex accepts
+        # minimal/low/medium/high; map extra-high/xhigh/max to the highest
+        # supported value so an unknown alias can never break the session.
+        if self._reasoning_effort:
+            _eff = self._reasoning_effort.strip().lower()
+            _map = {
+                "minimal": "minimal",
+                "low": "low",
+                "medium": "medium",
+                "high": "high",
+                "extra-high": "high",
+                "extra_high": "high",
+                "xhigh": "high",
+                "max": "high",
+            }
+            thread_params["modelReasoningEffort"] = _map.get(_eff, "high")
+        # fast_mode is a Claude Code concept; codex has no equivalent thread
+        # param, so it is intentionally accepted-but-not-emitted here.
+        thread_params.update(self._permission_thread_params())
+        if self._system_prompt:
+            # baseInstructions = role/persona ("you are a service developer…")
+            # developerInstructions = per-session task instructions
+            # Skuld provides a single system_prompt that combines both,
+            # so we set it as baseInstructions (persistent identity).
+            thread_params["baseInstructions"] = self._system_prompt
+>>>>>>> ae132f40 (feat(models): default frontier models (Opus 4.8 / Codex) across volundr/forge)
 
             result = await self._send_rpc("thread/resume", resume_params)
             thread = result.get("thread", {})

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -416,7 +416,6 @@ class CodexWebSocketTransport(CLITransport):
 
         await self._send_notification("initialized")
 
-<<<<<<< HEAD
         if self._resume_session_id:
             # Imported/external session — reattach to the existing thread
             # instead of starting a fresh one.
@@ -427,40 +426,6 @@ class CodexWebSocketTransport(CLITransport):
             if self._model:
                 resume_params["model"] = self._model
             resume_params.update(self._permission_thread_params())
-=======
-        thread_params: dict = {
-            "experimentalRawEvents": False,
-            "persistExtendedHistory": True,
-            "cwd": self.workspace_dir,
-        }
-        if self._model:
-            thread_params["model"] = self._model
-        # Reasoning effort -> codex thread param. Codex accepts
-        # minimal/low/medium/high; map extra-high/xhigh/max to the highest
-        # supported value so an unknown alias can never break the session.
-        if self._reasoning_effort:
-            _eff = self._reasoning_effort.strip().lower()
-            _map = {
-                "minimal": "minimal",
-                "low": "low",
-                "medium": "medium",
-                "high": "high",
-                "extra-high": "high",
-                "extra_high": "high",
-                "xhigh": "high",
-                "max": "high",
-            }
-            thread_params["modelReasoningEffort"] = _map.get(_eff, "high")
-        # fast_mode is a Claude Code concept; codex has no equivalent thread
-        # param, so it is intentionally accepted-but-not-emitted here.
-        thread_params.update(self._permission_thread_params())
-        if self._system_prompt:
-            # baseInstructions = role/persona ("you are a service developer…")
-            # developerInstructions = per-session task instructions
-            # Skuld provides a single system_prompt that combines both,
-            # so we set it as baseInstructions (persistent identity).
-            thread_params["baseInstructions"] = self._system_prompt
->>>>>>> ae132f40 (feat(models): default frontier models (Opus 4.8 / Codex) across volundr/forge)
 
             result = await self._send_rpc("thread/resume", resume_params)
             thread = result.get("thread", {})

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -220,7 +220,9 @@ class CodexWebSocketTransport(CLITransport):
             await self._start_fallback_transport(exc)
             return
 
-        if self._initial_prompt:
+        # On resume the prior thread's history is reloaded, so don't replay
+        # the initial prompt (it was already part of that conversation).
+        if self._initial_prompt and not self._resume_session_id:
             await self.send_message(self._initial_prompt)
 
     async def stop(self) -> None:

--- a/src/skuld/transports/persistent_subprocess.py
+++ b/src/skuld/transports/persistent_subprocess.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 from contextlib import suppress
 from typing import Any
 

--- a/src/skuld/transports/persistent_subprocess.py
+++ b/src/skuld/transports/persistent_subprocess.py
@@ -26,8 +26,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import logging
+import os
 from contextlib import suppress
 from typing import Any
 
@@ -46,6 +46,8 @@ from skuld.transports.mcp_config import build_claude_mcp_config
 from skuld.transports.tool_shims import ensure_codex_tool_shims
 
 logger = logging.getLogger("skuld.transport")
+
+_DEFAULT_PERMISSION_MODE = "bypassPermissions"
 
 # StreamReader buffer for Claude stdout — single JSON events (esp. tool
 # results or large file reads) routinely exceed asyncio's default 64 KB
@@ -91,6 +93,7 @@ class PersistentSubprocessTransport(CLITransport):
         initial_prompt: str = "",
         mcp_servers: list[dict] | None = None,
         resume_session_id: str = "",
+        ask_user_question_enabled: bool = False,
     ) -> None:
         super().__init__()
         self.workspace_dir = workspace_dir
@@ -99,6 +102,7 @@ class PersistentSubprocessTransport(CLITransport):
         self._agent_teams = agent_teams
         self._system_prompt = system_prompt
         self._initial_prompt = initial_prompt
+        self._ask_user_question_enabled = ask_user_question_enabled
         self._raw_mcp_servers = list(mcp_servers or [])
         self._mcp_config = build_claude_mcp_config(mcp_servers or [])
         self._initial_prompt_sent = False
@@ -234,16 +238,17 @@ class PersistentSubprocessTransport(CLITransport):
         ]
         if self._model:
             cmd.extend(["--model", self._model])
-        # NOTE: we intentionally do NOT pass --permission-mode bypassPermissions
-        # even when skip_permissions is set. Bypass auto-allows every tool and
-        # gives us no way to intercept AskUserQuestion. Instead we route ALL
-        # permission requests over the stdio control protocol and answer them
-        # ourselves (allow everything except AskUserQuestion). The CLI only
-        # routes can_use_tool over stdout when --permission-prompt-tool=stdio is
-        # set (this is exactly what the Python Agent SDK does under the hood);
-        # without it the CLI auto-dismisses AskUserQuestion. See
-        # _handle_control_request.
-        cmd.extend(["--permission-prompt-tool", "stdio"])
+        if self._ask_user_question_enabled:
+            # Do NOT pass --permission-mode bypassPermissions in this mode —
+            # bypass auto-allows every tool and gives us no way to intercept
+            # AskUserQuestion. Instead route ALL permission requests over the
+            # stdio control protocol and answer them ourselves (allow everything
+            # except AskUserQuestion, which blocks for a human answer). The CLI
+            # only routes can_use_tool over stdout when
+            # --permission-prompt-tool=stdio is set; see _handle_control_request.
+            cmd.extend(["--permission-prompt-tool", "stdio"])
+        elif self._skip_permissions:
+            cmd.extend(["--permission-mode", _DEFAULT_PERMISSION_MODE])
         # ``--resume`` applies when re-spawning after a crash or when a
         # resume id was seeded for an imported session. Otherwise the first
         # spawn has no session yet — Claude assigns one in its first
@@ -290,9 +295,11 @@ class PersistentSubprocessTransport(CLITransport):
             self._read_stdout_loop(),
             name="claude-stdout-reader",
         )
-        # Register as the control-protocol peer so the CLI routes can_use_tool
-        # permission requests to us over stdout (instead of auto-handling them).
-        await self._send_initialize()
+        if self._ask_user_question_enabled:
+            # Register as the control-protocol peer so the CLI routes
+            # can_use_tool permission requests to us over stdout (instead of
+            # auto-handling them).
+            await self._send_initialize()
 
     async def _write_stdin(self, payload: dict[str, Any]) -> None:
         """Serialize one JSON line to the CLI's stdin. Locked so concurrent

--- a/src/skuld/transports/persistent_subprocess.py
+++ b/src/skuld/transports/persistent_subprocess.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import logging
 from contextlib import suppress
 from typing import Any
@@ -46,12 +47,35 @@ from skuld.transports.tool_shims import ensure_codex_tool_shims
 
 logger = logging.getLogger("skuld.transport")
 
-_DEFAULT_PERMISSION_MODE = "bypassPermissions"
 # StreamReader buffer for Claude stdout — single JSON events (esp. tool
 # results or large file reads) routinely exceed asyncio's default 64 KB
 # line limit and cause LimitOverrunError. 10 MB covers realistic worst
 # cases without unbounded memory.
 _STDOUT_LINE_LIMIT_BYTES = 10 * 1024 * 1024
+
+
+def _format_answer_message(questions: list[dict[str, Any]], answers: object) -> str:
+    """Build the tool_result text the model reads after a human answers an
+    AskUserQuestion. `answers` is a list aligned to `questions`, each entry like
+    {"answer": str | list[str]} (optionally "header"/"question"). Tolerant of
+    shape drift from clients. (The headless CLI's native "allow + updatedInput"
+    answer path does NOT deliver answers — verified live — so we convey the
+    choice via the permission DENY message, which the model reads and acts on.)"""
+    answer_list = answers if isinstance(answers, list) else []
+    lines: list[str] = []
+    for i, q in enumerate(questions):
+        entry = answer_list[i] if i < len(answer_list) else {}
+        chosen: object = entry.get("answer") if isinstance(entry, dict) else entry
+        if isinstance(chosen, list):
+            chosen = ", ".join(str(c) for c in chosen)
+        header = ""
+        if isinstance(q, dict):
+            header = str(q.get("header") or q.get("question") or "")
+        label = header or f"Question {i + 1}"
+        shown = chosen if chosen not in (None, "") else "(no answer)"
+        lines.append(f"- {label}: {shown}")
+    body = "\n".join(lines) if lines else "(no answer)"
+    return f"The user answered your question(s):\n{body}\nProceed using these answers."
 
 
 class PersistentSubprocessTransport(CLITransport):
@@ -89,6 +113,16 @@ class PersistentSubprocessTransport(CLITransport):
         # which reattaches to an imported/external Claude session.
         self._session_id: str | None = resume_session_id or None
         self._last_result: dict | None = None
+        # Permission control protocol (stream-json) — lets us answer the CLI's
+        # can_use_tool requests. We allow every tool EXCEPT AskUserQuestion,
+        # which we route to a human and answer with their choice. Replaces the
+        # old bypassPermissions flag (which auto-allowed everything and gave us
+        # no hook to intercept questions).
+        self._stdin_lock = asyncio.Lock()
+        self._pending_questions: dict[str, asyncio.Future] = {}
+        self._question_seq = 0
+        self._pending_control: dict[str, asyncio.Future] = {}
+        self._control_seq = 0
 
     # ------------------------------------------------------------------
     # CLITransport interface
@@ -153,6 +187,15 @@ class PersistentSubprocessTransport(CLITransport):
         # Wake any waiter so it doesn't hang.
         if self._turn_done is not None:
             self._turn_done.set()
+        # Cancel any in-flight question/control waiters.
+        for fut in list(self._pending_questions.values()):
+            if not fut.done():
+                fut.cancel()
+        self._pending_questions.clear()
+        for fut in list(self._pending_control.values()):
+            if not fut.done():
+                fut.cancel()
+        self._pending_control.clear()
 
     async def send_message(self, content: str) -> None:
         """Write a user message and block until the turn's ``result`` arrives.
@@ -191,8 +234,16 @@ class PersistentSubprocessTransport(CLITransport):
         ]
         if self._model:
             cmd.extend(["--model", self._model])
-        if self._skip_permissions:
-            cmd.extend(["--permission-mode", _DEFAULT_PERMISSION_MODE])
+        # NOTE: we intentionally do NOT pass --permission-mode bypassPermissions
+        # even when skip_permissions is set. Bypass auto-allows every tool and
+        # gives us no way to intercept AskUserQuestion. Instead we route ALL
+        # permission requests over the stdio control protocol and answer them
+        # ourselves (allow everything except AskUserQuestion). The CLI only
+        # routes can_use_tool over stdout when --permission-prompt-tool=stdio is
+        # set (this is exactly what the Python Agent SDK does under the hood);
+        # without it the CLI auto-dismisses AskUserQuestion. See
+        # _handle_control_request.
+        cmd.extend(["--permission-prompt-tool", "stdio"])
         # ``--resume`` applies when re-spawning after a crash or when a
         # resume id was seeded for an imported session. Otherwise the first
         # spawn has no session yet — Claude assigns one in its first
@@ -239,20 +290,155 @@ class PersistentSubprocessTransport(CLITransport):
             self._read_stdout_loop(),
             name="claude-stdout-reader",
         )
+        # Register as the control-protocol peer so the CLI routes can_use_tool
+        # permission requests to us over stdout (instead of auto-handling them).
+        await self._send_initialize()
+
+    async def _write_stdin(self, payload: dict[str, Any]) -> None:
+        """Serialize one JSON line to the CLI's stdin. Locked so concurrent
+        writers (turn messages + control responses) never interleave bytes."""
+        async with self._stdin_lock:
+            proc = self._process
+            if proc is None or proc.stdin is None or proc.stdin.is_closing():
+                raise RuntimeError("Claude stdin not available")
+            try:
+                proc.stdin.write(json.dumps(payload).encode("utf-8") + b"\n")
+                await proc.stdin.drain()
+            except Exception as exc:
+                raise RuntimeError(f"Failed to write to Claude stdin: {exc}") from exc
 
     async def _write_user_message(self, content: str) -> None:
-        proc = self._process
-        if proc is None or proc.stdin is None or proc.stdin.is_closing():
-            raise RuntimeError("Claude stdin not available")
-        payload: dict[str, Any] = {
-            "type": "user",
-            "message": {"role": "user", "content": content},
-        }
+        await self._write_stdin({"type": "user", "message": {"role": "user", "content": content}})
+
+    # ---- Permission control protocol (stream-json) -------------------------
+
+    async def _send_initialize(self) -> None:
+        """Handshake that registers us as the control-protocol peer so the CLI
+        sends can_use_tool requests to stdout. Best-effort: log and proceed on
+        timeout/failure (the CLI still emits requests in default mode)."""
+        self._control_seq += 1
+        req_id = f"req_{self._control_seq}_{os.urandom(4).hex()}"
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending_control[req_id] = fut
         try:
-            proc.stdin.write(json.dumps(payload).encode("utf-8") + b"\n")
-            await proc.stdin.drain()
+            await self._write_stdin(
+                {
+                    "type": "control_request",
+                    "request_id": req_id,
+                    "request": {"subtype": "initialize", "hooks": None},
+                }
+            )
+            await asyncio.wait_for(fut, timeout=30)
+        except Exception:
+            logger.warning(
+                "PersistentSubprocessTransport: initialize handshake failed/timed out",
+                exc_info=True,
+            )
+        finally:
+            self._pending_control.pop(req_id, None)
+
+    def _handle_control_response(self, data: dict[str, Any]) -> None:
+        resp = data.get("response") or {}
+        req_id = resp.get("request_id")
+        fut = self._pending_control.get(str(req_id)) if req_id else None
+        if fut is None or fut.done():
+            return
+        if resp.get("subtype") == "error":
+            fut.set_exception(Exception(str(resp.get("error") or "control error")))
+        else:
+            fut.set_result(resp)
+
+    async def _handle_control_request(self, data: dict[str, Any]) -> None:
+        """Answer a CLI control request. Only can_use_tool is supported: allow
+        every tool, except AskUserQuestion which is routed to a human."""
+        req_id = str(data.get("request_id") or "")
+        request = data.get("request") or {}
+        subtype = request.get("subtype")
+        try:
+            if subtype == "can_use_tool":
+                tool_name = request.get("tool_name")
+                tool_input = request.get("input") or {}
+                if tool_name == "AskUserQuestion":
+                    response = await self._answer_ask_user_question(
+                        tool_input, request.get("tool_use_id")
+                    )
+                else:
+                    response = {"behavior": "allow", "updatedInput": tool_input}
+                await self._write_stdin(
+                    {
+                        "type": "control_response",
+                        "response": {
+                            "subtype": "success",
+                            "request_id": req_id,
+                            "response": response,
+                        },
+                    }
+                )
+            else:
+                await self._write_stdin(
+                    {
+                        "type": "control_response",
+                        "response": {
+                            "subtype": "error",
+                            "request_id": req_id,
+                            "error": f"Unsupported control subtype: {subtype}",
+                        },
+                    }
+                )
         except Exception as exc:
-            raise RuntimeError(f"Failed to write to Claude stdin: {exc}") from exc
+            logger.warning("control_request handling failed", exc_info=True)
+            try:
+                await self._write_stdin(
+                    {
+                        "type": "control_response",
+                        "response": {
+                            "subtype": "error",
+                            "request_id": req_id,
+                            "error": str(exc),
+                        },
+                    }
+                )
+            except Exception:
+                pass
+
+    async def _answer_ask_user_question(
+        self, tool_input: dict[str, Any], tool_use_id: object
+    ) -> dict[str, Any]:
+        """Surface an AskUserQuestion to clients, block until one answers, then
+        return a permission DENY whose message carries the chosen option(s)."""
+        questions = tool_input.get("questions") if isinstance(tool_input, dict) else None
+        if not questions:
+            return {"behavior": "deny", "message": "No questions were provided."}
+        self._question_seq += 1
+        request_id = f"askq-{self._question_seq}-{os.urandom(4).hex()}"
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending_questions[request_id] = fut
+        await self._emit(
+            {
+                "type": "ask_user_question",
+                "request_id": request_id,
+                "tool_use_id": tool_use_id,
+                "questions": questions,
+            }
+        )
+        try:
+            answers = await fut
+        except asyncio.CancelledError:
+            return {"behavior": "deny", "message": "The question was cancelled."}
+        finally:
+            self._pending_questions.pop(request_id, None)
+        return {"behavior": "deny", "message": _format_answer_message(questions, answers)}
+
+    async def send_control(self, subtype: str, **kwargs: object) -> None:
+        """Only ask_user_answer is handled here (resolves a pending question).
+        Other control types are not supported by this transport (see
+        capabilities) and are never dispatched."""
+        if subtype == "ask_user_answer":
+            request_id = str(kwargs.get("request_id") or "")
+            answers = kwargs.get("answers")
+            fut = self._pending_questions.get(request_id)
+            if fut is not None and not fut.done():
+                fut.set_result(answers if answers is not None else [])
 
     async def _read_stdout_loop(self) -> None:
         """Demultiplex Claude's stdout JSON stream.
@@ -285,7 +471,18 @@ class PersistentSubprocessTransport(CLITransport):
                         text[:200],
                     )
                     continue
-                if data.get("type") == "system":
+                mtype = data.get("type")
+                # Permission control protocol: responses resolve our pending
+                # host requests (initialize); requests (can_use_tool) are
+                # handled in a task so awaiting a human answer doesn't stall the
+                # reader. Neither is fanned out as a normal event.
+                if mtype == "control_response":
+                    self._handle_control_response(data)
+                    continue
+                if mtype == "control_request":
+                    asyncio.create_task(self._handle_control_request(data))
+                    continue
+                if mtype == "system":
                     sid = data.get("session_id")
                     if isinstance(sid, str) and sid:
                         self._session_id = sid

--- a/src/skuld/transports/persistent_subprocess.py
+++ b/src/skuld/transports/persistent_subprocess.py
@@ -41,6 +41,7 @@ from niuu.adapters.cli.runtime import (
     stop_subprocess as _stop_process,
 )
 from niuu.ports.cli import CLITransport, TransportCapabilities
+from skuld.transports.claude_env import claude_spawn_env
 from skuld.transports.mcp_config import build_claude_mcp_config
 from skuld.transports.tool_shims import ensure_codex_tool_shims
 
@@ -203,7 +204,7 @@ class PersistentSubprocessTransport(CLITransport):
 
     async def _spawn(self) -> None:
         cmd = self._build_command()
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env = claude_spawn_env()  # subscription auth by default (SKULD__CLAUDE_AUTH)
         if self._agent_teams:
             env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
         _, shim_env = ensure_codex_tool_shims(

--- a/src/skuld/transports/persistent_subprocess.py
+++ b/src/skuld/transports/persistent_subprocess.py
@@ -115,6 +115,10 @@ class PersistentSubprocessTransport(CLITransport):
         """Spawn Claude (if not already running) and send the initial prompt."""
         if not self.is_alive:
             await self._spawn()
+        # On resume the prior conversation (including its initial prompt) is
+        # reloaded, so replaying the initial prompt would double-seed history.
+        if self._session_id:
+            self._initial_prompt_sent = True
         if not self._initial_prompt or self._initial_prompt_sent:
             return
         self._initial_prompt_sent = True

--- a/src/skuld/transports/remote_control.py
+++ b/src/skuld/transports/remote_control.py
@@ -31,6 +31,7 @@ import logging
 import os
 import re
 import signal
+import subprocess
 from contextlib import suppress
 
 from niuu.ports.cli import CLITransport, TransportCapabilities
@@ -206,6 +207,41 @@ class RemoteControlTransport(CLITransport):
                     {"type": "remote_control", "subtype": "resurface", "url": self._url}
                 )
 
+    @staticmethod
+    def _iter_processes() -> list[tuple[int, str]]:
+        """Yield (pid, command line) for every visible process.
+
+        Reads ``/proc`` where it exists (Linux); falls back to ``ps`` output on
+        macOS, where mini-mode brokers run and ``/proc`` is absent — without the
+        fallback ``stop()`` would silently leave the detached RC worker running.
+        """
+        entries: list[tuple[int, str]] = []
+        proc_paths = glob.glob("/proc/[0-9]*/cmdline")
+        if proc_paths:
+            for path in proc_paths:
+                try:
+                    raw = open(path, "rb").read()
+                except Exception:
+                    continue
+                cl = raw.replace(b"\0", b" ").decode("utf-8", "replace")
+                entries.append((int(path.rsplit("/", 2)[1]), cl))
+            return entries
+        try:
+            out = subprocess.run(
+                ["ps", "-axo", "pid=,command="],
+                capture_output=True,
+                text=True,
+                check=False,
+            ).stdout
+        except Exception:
+            return entries
+        for line in out.splitlines():
+            parts = line.strip().split(None, 1)
+            if len(parts) != 2 or not parts[0].isdigit():
+                continue
+            entries.append((int(parts[0]), parts[1]))
+        return entries
+
     def _sweep_kill(self, sig: int) -> int:
         """Signal every ``remote-control`` process carrying our unique token.
 
@@ -217,14 +253,10 @@ class RemoteControlTransport(CLITransport):
         if not self._token:
             return 0
         killed = 0
-        for path in glob.glob("/proc/[0-9]*/cmdline"):
-            try:
-                cl = open(path, "rb").read().replace(b"\0", b" ").decode("utf-8", "replace")
-            except Exception:
-                continue
+        for pid, cl in self._iter_processes():
             if "remote-control" in cl and self._token in cl:
                 with suppress(Exception):
-                    os.kill(int(path.rsplit("/", 2)[1]), sig)
+                    os.kill(pid, sig)
                     killed += 1
         return killed
 

--- a/src/skuld/transports/remote_control.py
+++ b/src/skuld/transports/remote_control.py
@@ -1,0 +1,325 @@
+"""RemoteControlTransport — launch ``claude remote-control`` and surface its pairing URL.
+
+Unlike the broker-driven transports (which spawn ``claude -p --stream-json`` and
+drive the conversation themselves), this transport runs Claude Code in its native
+**Remote Control** mode: a long-lived server that pairs with Anthropic's relay so
+the Claude mobile app / claude.ai/code can attach to and DRIVE the session.
+
+The broker is NOT the conversation driver here — it is a supervisor. This
+transport's jobs are:
+
+  * spawn ``claude remote-control --name <name> --spawn same-dir [--permission-mode ...]``
+    in the session workspace,
+  * scrape the pairing URL (``https://claude.ai/code?environment=env_...``) out of
+    the TUI's ANSI-wrapped stdout,
+  * surface it — emit it both as a visible assistant turn (so the link lands in
+    the transcript / durable-log replay) and as a structured ``remote_control``
+    event the broker can persist as a session field,
+  * keep the process alive (the broker's heartbeat keeps the Volundr session
+    live) and terminate it on stop.
+
+``send_message`` does not reach the agent — the native app owns the conversation —
+so it just re-surfaces the pairing link. Auth: ``claude remote-control`` requires
+claude.ai OAuth (``~/.claude/.credentials.json``), inherited from the broker env.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import glob
+import logging
+import os
+import re
+import signal
+from contextlib import suppress
+
+from niuu.ports.cli import CLITransport, TransportCapabilities
+
+logger = logging.getLogger("skuld.transport")
+
+# Strip terminal control sequences from the remote-control TUI before scraping.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+# The pairing handle Claude prints once connected to the relay.
+_URL_RE = re.compile(r"https://claude\.ai/code\?environment=env_[A-Za-z0-9_-]+")
+# Lines worth surfacing when a launch fails before pairing.
+_ERROR_HINT = re.compile(r"error|failed|not (logged in|authenticated)|unauthor|denied|enable", re.I)
+_STDOUT_LIMIT = 1 * 1024 * 1024
+
+
+class RemoteControlTransport(CLITransport):
+    """Launch ``claude remote-control`` and surface its pairing URL.
+
+    A degenerate transport: it does not drive a conversation (the native app
+    does), it launches the Remote Control server and reports the pairing link.
+    """
+
+    def __init__(
+        self,
+        workspace_dir: str,
+        model: str = "",
+        session_id: str = "",
+        skip_permissions: bool = False,
+        **_kwargs: object,
+    ) -> None:
+        super().__init__()
+        self.workspace_dir = workspace_dir
+        self._model = model
+        self._session_id_hint = session_id
+        self._skip_permissions = skip_permissions
+        self._process: asyncio.subprocess.Process | None = None
+        self._reader_task: asyncio.Task[None] | None = None
+        self._url: str | None = None
+        # Unique token baked into --name so stop() can find + kill this session's
+        # foreground client AND its detached per-environment worker (which
+        # reparents to a subreaper and survives the foreground) — without
+        # touching the shared singleton daemon (~/.claude/daemon).
+        self._token = (str(session_id).strip() or "")[:12]
+
+    # ------------------------------------------------------------------
+    # CLITransport interface
+    # ------------------------------------------------------------------
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        # The native app drives the conversation; the broker can't send turns.
+        return TransportCapabilities(send_message=False)
+
+    @property
+    def session_id(self) -> str | None:
+        return None
+
+    @property
+    def last_result(self) -> dict | None:
+        return None
+
+    @property
+    def is_alive(self) -> bool:
+        proc = self._process
+        return proc is not None and proc.returncode is None
+
+    @property
+    def remote_control_url(self) -> str | None:
+        return self._url
+
+    def _build_command(self) -> list[str]:
+        binary = os.environ.get("SKULD__CLI_BINARY", "claude")
+        base = os.environ.get("SKULD__SESSION__NAME") or "volundr"
+        # Bake the unique token into the display name so the worker process
+        # carries it in argv (the handle stop() uses to target only this session).
+        name = f"{base}-{self._token}" if self._token else base
+        # The native app uses the host permission mode for the sessions it spawns.
+        perm = os.environ.get("SKULD__REMOTE_CONTROL_PERMISSION_MODE") or (
+            "bypassPermissions" if self._skip_permissions else "default"
+        )
+        return [
+            binary,
+            "remote-control",
+            "--name",
+            name,
+            "--spawn",
+            "same-dir",
+            "--permission-mode",
+            perm,
+        ]
+
+    async def start(self) -> None:
+        if self.is_alive:
+            return
+        cmd = self._build_command()
+        logger.info("RemoteControlTransport: launching %s", " ".join(cmd))
+        # Remote Control REQUIRES claude.ai OAuth. An inherited ANTHROPIC_API_KEY
+        # (set in the deploy/agent-service env) forces API-key auth and Claude
+        # refuses to start RC ("ANTHROPIC_API_KEY is set … unset it"). Strip the
+        # API-key auth vars so RC uses the host's OAuth credentials (~/.claude).
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+        }
+        self._process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=self.workspace_dir,
+            env=env,
+            limit=_STDOUT_LIMIT,
+        )
+        self._reader_task = asyncio.create_task(self._read_output())
+
+    async def _read_output(self) -> None:
+        proc = self._process
+        if proc is None or proc.stdout is None:
+            return
+        lines = 0
+        tail: list[str] = []
+        try:
+            while True:
+                raw = await proc.stdout.readline()
+                if not raw:
+                    break
+                line = _ANSI_RE.sub("", raw.decode("utf-8", errors="replace")).strip()
+                if not line:
+                    continue
+                lines += 1
+                tail.append(line)
+                del tail[:-8]
+                logger.debug("rc> %s", line[:200])
+                if _ERROR_HINT.search(line):
+                    logger.warning("RemoteControlTransport: %s", line[:300])
+                if self._url is None:
+                    match = _URL_RE.search(line)
+                    if match:
+                        await self._on_url(match.group(0))
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            logger.error("RemoteControlTransport reader failed", exc_info=True)
+        # Reader ended = stdout EOF = process exiting. Surface why, since a silent
+        # early exit (before the pairing URL) is the failure we need to debug.
+        with suppress(Exception):
+            rc = await asyncio.wait_for(proc.wait(), timeout=5)
+            if self._url is None:
+                logger.warning(
+                    "RemoteControlTransport: claude remote-control exited rc=%s after %d "
+                    "output line(s) WITHOUT a pairing URL. Last output: %s",
+                    rc,
+                    lines,
+                    " | ".join(tail) or "(none)",
+                )
+            else:
+                logger.info("RemoteControlTransport: process exited rc=%s", rc)
+
+    async def _on_url(self, url: str) -> None:
+        self._url = url
+        logger.info("RemoteControlTransport: pairing URL captured: %s", url)
+        # Structured event — the broker surfaces it as an assistant turn across
+        # the conversation history, durable-log replay, and live channels.
+        with suppress(Exception):
+            await self._emit({"type": "remote_control", "subtype": "paired", "url": url})
+
+    async def send_message(self, content: str) -> None:
+        # The native app owns the conversation; re-surface the pairing link.
+        if self._url:
+            with suppress(Exception):
+                await self._emit(
+                    {"type": "remote_control", "subtype": "resurface", "url": self._url}
+                )
+
+    def _sweep_kill(self, sig: int) -> int:
+        """Signal every ``remote-control`` process carrying our unique token.
+
+        Catches both the foreground client and the detached per-environment
+        worker (it reparents away from the broker, so a plain child-kill misses
+        it). The token is specific to this session, so the shared singleton
+        daemon and other sessions' RC processes are untouched.
+        """
+        if not self._token:
+            return 0
+        killed = 0
+        for path in glob.glob("/proc/[0-9]*/cmdline"):
+            try:
+                cl = open(path, "rb").read().replace(b"\0", b" ").decode("utf-8", "replace")
+            except Exception:
+                continue
+            if "remote-control" in cl and self._token in cl:
+                with suppress(Exception):
+                    os.kill(int(path.rsplit("/", 2)[1]), sig)
+                    killed += 1
+        return killed
+
+    async def stop(self) -> None:
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            with suppress(Exception, asyncio.CancelledError):
+                await self._reader_task
+            self._reader_task = None
+        # Kill the foreground client first (graceful), then sweep any token-tagged
+        # survivor (the detached worker), escalating to SIGKILL.
+        proc = self._process
+        if proc is not None and proc.returncode is None:
+            with suppress(ProcessLookupError):
+                proc.send_signal(signal.SIGTERM)
+            with suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(proc.wait(), timeout=5)
+        self._sweep_kill(signal.SIGTERM)
+        await asyncio.sleep(1)
+        self._sweep_kill(signal.SIGKILL)
+        self._process = None
+
+
+# Path the managed Codex remote-control daemon requires (standalone installer
+# only — the npm `@openai/codex` install cannot manage it).
+_CODEX_STANDALONE = "~/.codex/packages/standalone/current/codex"
+
+
+class CodexRemoteControlTransport(CLITransport):
+    """Codex Remote Control — experimental, gated on the standalone Codex install.
+
+    `codex remote-control` (managed app-server daemon + control socket that the
+    native Codex app attaches to) only runs from the standalone installer's fixed
+    path; the npm `codex` errors with "managed standalone Codex install not
+    found". Until that install exists this transport fails fast with a clear,
+    actionable notice rather than spawning a broken process. The launch/pairing
+    path is intentionally not wired yet (the user opted for "Claude now, Codex
+    stubbed").
+    """
+
+    def __init__(
+        self,
+        workspace_dir: str,
+        model: str = "",
+        session_id: str = "",
+        **_kwargs: object,
+    ) -> None:
+        super().__init__()
+        self.workspace_dir = workspace_dir
+        self._model = model
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(send_message=False)
+
+    @property
+    def session_id(self) -> str | None:
+        return None
+
+    @property
+    def last_result(self) -> dict | None:
+        return None
+
+    @property
+    def is_alive(self) -> bool:
+        return False
+
+    async def _notice(self) -> None:
+        if os.path.exists(os.path.expanduser(_CODEX_STANDALONE)):
+            text = (
+                "Codex Remote Control (experimental): the standalone install was "
+                "detected, but the launch/pairing path is not wired yet. Use the "
+                "Claude Remote Control session type for now."
+            )
+        else:
+            text = (
+                "⚠️ **Codex Remote Control is not available on this host yet.**\n\n"
+                "It needs the *standalone* Codex install (`curl … install.sh`) — the "
+                "npm `codex` install can't manage the remote-control daemon (missing "
+                f"`{_CODEX_STANDALONE}`). Install standalone Codex, then this session "
+                "type will pair like Claude Remote Control. (Experimental.)"
+            )
+        with suppress(Exception):
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+                }
+            )
+
+    async def start(self) -> None:
+        await self._notice()
+
+    async def send_message(self, content: str) -> None:
+        await self._notice()
+
+    async def stop(self) -> None:
+        return None

--- a/src/skuld/transports/sdk.py
+++ b/src/skuld/transports/sdk.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 import re
 from dataclasses import asdict
 from typing import Any
@@ -40,6 +39,7 @@ from claude_agent_sdk.types import (
 
 from niuu.adapters.cli.runtime import filter_cli_event as _filter_event
 from niuu.ports.cli import CLITransport, TransportCapabilities
+from skuld.transports.claude_env import claude_spawn_env
 from skuld.transports.mcp_config import build_sdk_mcp_servers
 from skuld.transports.tool_shims import ensure_codex_tool_shims
 
@@ -502,7 +502,7 @@ class SDKTransport(CLITransport):
             return
 
     async def _connect_client(self) -> None:
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env = claude_spawn_env()  # subscription auth by default (SKULD__CLAUDE_AUTH)
         if self._agent_teams:
             env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
         _, shim_env = ensure_codex_tool_shims(

--- a/src/skuld/transports/sdk.py
+++ b/src/skuld/transports/sdk.py
@@ -292,6 +292,7 @@ class SDKTransport(CLITransport):
         mcp_servers: list[dict] | None = None,
         turn_timeout_s: float = _DEFAULT_TURN_TIMEOUT_S,
         resume_session_id: str | None = None,
+        ask_user_question_enabled: bool = False,
     ) -> None:
         super().__init__()
         self.workspace_dir = workspace_dir
@@ -301,6 +302,7 @@ class SDKTransport(CLITransport):
         self._system_prompt = system_prompt
         self._initial_prompt = initial_prompt
         self._resume_session_id = (resume_session_id or "").strip() or None
+        self._ask_user_question_enabled = ask_user_question_enabled
         self._raw_mcp_servers = list(mcp_servers or [])
         self._mcp_servers = build_sdk_mcp_servers(mcp_servers or [])
         self._turn_timeout_s = max(float(turn_timeout_s or 0.0), 0.0)
@@ -651,14 +653,15 @@ class SDKTransport(CLITransport):
             # A fresh Forge session must NEVER --continue the cwd's project history.
             "continue_conversation": False,
             "env": env,
-            # Route tool permissions through our handler so AskUserQuestion can be
-            # answered by a human (blocks until a client responds); all other
-            # tools are allowed. Requires streaming mode (we use it). NOTE: when
-            # skip_permissions sets bypassPermissions below, the SDK bypasses this
-            # callback entirely — so interactive Q&A only works on the default
-            # (non-bypass) permission path.
-            "can_use_tool": self._on_can_use_tool,
         }
+        if self._ask_user_question_enabled:
+            # Route tool permissions through our handler so AskUserQuestion can
+            # be answered by a human (blocks until a client responds); all other
+            # tools are allowed. Requires streaming mode (we use it). NOTE: when
+            # skip_permissions sets bypassPermissions below, the SDK bypasses
+            # this callback entirely — so interactive Q&A only works on the
+            # default (non-bypass) permission path.
+            option_kwargs["can_use_tool"] = self._on_can_use_tool
         if self._skip_permissions:
             option_kwargs["permission_mode"] = _DEFAULT_PERMISSION_MODE
         if self._resume_session_id:

--- a/src/skuld/transports/sdk.py
+++ b/src/skuld/transports/sdk.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import uuid
 from dataclasses import asdict
 from typing import Any
 
@@ -51,6 +52,25 @@ _TRANSIENT_ERROR_RE = re.compile(
 )
 _MAX_TRANSIENT_RETRIES = 1
 _DEFAULT_TURN_TIMEOUT_S = 0.0
+
+
+def _claude_effort_for_model(model: str) -> str:
+    """Reasoning effort to push a new Claude session to, by model.
+
+    Effort scale (Anthropic): low < medium < high < xhigh < max (default high).
+    Claude Code's "ultracode" == `xhigh` (NOT a separate level), which Anthropic
+    recommends for Opus 4.7/4.8 coding (`max` overthinks + costs more, reserved for
+    frontier problems). `xhigh` is Opus-4.7/4.8 only; `max` covers Sonnet 4.6 /
+    Opus 4.6. Unknown models fall back to the SDK default to avoid API rejection.
+    """
+    m = (model or "").lower()
+    if "opus-4-8" in m or "opus-4-7" in m:
+        return "xhigh"
+    if "opus-4-6" in m or "sonnet-4-6" in m or "opus-4-5" in m:
+        return "max"
+    return "high"
+
+
 _SDK_TIMEOUT_RECOVERY_PROMPT = (
     "Time budget reached. Stop exploring and conclude immediately using the current "
     "workspace state. Do not do more investigation. Return only the required final "
@@ -523,9 +543,12 @@ class SDKTransport(CLITransport):
             "mcp_servers": self._mcp_servers,
             "include_partial_messages": True,
             "thinking": {"type": "adaptive", "display": "summarized"},
-            # Default Claude to MAX reasoning effort ("ultra") — push new sessions
-            # to think hardest by default (Anthropic `effort` param, Opus/Sonnet 4.6+).
-            "effort": "max",
+            # Push new sessions to the highest sensible reasoning effort by model
+            # (xhigh = Claude Code's "ultracode" level on Opus 4.7/4.8; max on
+            # Sonnet 4.6 / Opus 4.6). Anthropic `effort` param.
+            "effort": _claude_effort_for_model(self._model),
+            # A fresh Forge session must NEVER --continue the cwd's project history.
+            "continue_conversation": False,
             "env": env,
         }
         if self._skip_permissions:
@@ -533,7 +556,15 @@ class SDKTransport(CLITransport):
         if self._resume_session_id:
             # Reload the prior conversation so the agent continues where it
             # left off. ClaudeAgentOptions.resume is supported by the pinned SDK.
+            # Do NOT also set session_id — the SDK forbids session_id + resume
+            # unless fork_session is set.
             option_kwargs["resume"] = self._resume_session_id
+        else:
+            # No explicit resume: pin a brand-new Claude session id so the CLI
+            # starts FRESH instead of attaching to the cwd's most-recent native
+            # session (~/.claude/projects/<hashed-cwd>/) — the "new session
+            # continues the folder's old history" bug. --session-id needs a UUID.
+            option_kwargs["session_id"] = str(uuid.uuid4())
         options = ClaudeAgentOptions(**option_kwargs)
         client = ClaudeSDKClient(options)
         self._client = await client.__aenter__()

--- a/src/skuld/transports/sdk.py
+++ b/src/skuld/transports/sdk.py
@@ -257,6 +257,27 @@ def _to_stream_json(message: object) -> dict[str, Any] | None:
     return None
 
 
+def _format_answer_message(questions: list[dict[str, Any]], answers: object) -> str:
+    """Build the tool_result text the model reads after a human answers an
+    AskUserQuestion. `answers` is a list aligned to `questions`, each entry like
+    {"answer": str | list[str]} (optionally "header"/"question"). Tolerant of
+    shape drift from clients."""
+    answer_list = answers if isinstance(answers, list) else []
+    lines: list[str] = []
+    for i, q in enumerate(questions):
+        entry = answer_list[i] if i < len(answer_list) else {}
+        chosen: object = entry.get("answer") if isinstance(entry, dict) else entry
+        if isinstance(chosen, list):
+            chosen = ", ".join(str(c) for c in chosen)
+        header = ""
+        if isinstance(q, dict):
+            header = str(q.get("header") or q.get("question") or "")
+        label = header or f"Question {i + 1}"
+        lines.append(f"- {label}: {chosen if chosen not in (None, '') else '(no answer)'}")
+    body = "\n".join(lines) if lines else "(no answer)"
+    return f"The user answered your question(s):\n{body}\nProceed using these answers."
+
+
 class SDKTransport(CLITransport):
     """Claude SDK-backed transport that preserves existing broker event shapes."""
 
@@ -292,6 +313,11 @@ class SDKTransport(CLITransport):
         self._turn_active = False
         self._pending_steers: list[str] = []
         self._steer_interrupt_requested = False
+        # AskUserQuestion human-in-the-loop: request_id -> Future resolved when a
+        # client answers (via send_control "ask_user_answer"). See
+        # _handle_ask_user_question / _on_can_use_tool.
+        self._pending_questions: dict[str, asyncio.Future] = {}
+        self._question_seq = 0
 
     @property
     def capabilities(self) -> TransportCapabilities:
@@ -468,8 +494,83 @@ class SDKTransport(CLITransport):
             return
         await client.interrupt()
 
+    async def _on_can_use_tool(
+        self, tool_name: str, tool_input: dict[str, Any], context: object
+    ) -> object:
+        """Permission callback. AskUserQuestion is routed to a human (blocks until
+        a client answers); every other tool is allowed (preserving the prior
+        default-mode behavior where the SDK ran without a permission handler).
+
+        ExitPlanMode is intentionally auto-allowed + display-only (product
+        decision): we never run formal plan mode, so there is no plan to gate.
+        """
+        from claude_agent_sdk import PermissionResultAllow
+
+        if tool_name == "AskUserQuestion":
+            return await self._handle_ask_user_question(tool_input, context)
+        return PermissionResultAllow()
+
+    async def _handle_ask_user_question(
+        self, tool_input: dict[str, Any], context: object
+    ) -> object:
+        """Surface an AskUserQuestion to connected clients and block until one
+        answers, then hand the chosen option(s) back to the agent.
+
+        Mechanism (verified live): the SDK's "allow + updated_input" path does NOT
+        deliver answers in headless mode (the CLI emits an empty "answered"
+        template). Returning a Deny whose *message* states the chosen option(s)
+        DOES reach the model as the tool_result, and it continues correctly. So we
+        deny-with-answer rather than allow.
+        """
+        from claude_agent_sdk import PermissionResultDeny
+
+        questions = tool_input.get("questions") if isinstance(tool_input, dict) else None
+        if not questions:
+            return PermissionResultDeny(message="No questions were provided.")
+
+        self._question_seq += 1
+        request_id = f"askq-{self._question_seq}-{uuid.uuid4().hex[:8]}"
+        tool_use_id = getattr(context, "tool_use_id", None)
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending_questions[request_id] = fut
+
+        await self._emit_event(
+            {
+                "type": "ask_user_question",
+                "request_id": request_id,
+                "tool_use_id": tool_use_id,
+                "questions": questions,
+            }
+        )
+
+        try:
+            answers = await fut
+        except asyncio.CancelledError:
+            return PermissionResultDeny(
+                message="The question was cancelled before the user answered."
+            )
+        finally:
+            self._pending_questions.pop(request_id, None)
+
+        return PermissionResultDeny(message=_format_answer_message(questions, answers))
+
+    def resolve_question(self, request_id: str, answers: object) -> bool:
+        """Resolve a pending AskUserQuestion future with a client's answers.
+        Returns True if a matching pending question was found."""
+        fut = self._pending_questions.get(str(request_id)) if request_id else None
+        if fut is None or fut.done():
+            return False
+        fut.set_result(answers if answers is not None else [])
+        return True
+
     async def send_control(self, subtype: str, **kwargs: object) -> None:
         """Handle runtime control messages against the live SDK session."""
+        if subtype == "ask_user_answer":
+            request_id = kwargs.get("request_id")
+            answers = kwargs.get("answers")
+            self.resolve_question(str(request_id or ""), answers)
+            return
+
         client = self._client
         if client is None:
             return
@@ -550,6 +651,13 @@ class SDKTransport(CLITransport):
             # A fresh Forge session must NEVER --continue the cwd's project history.
             "continue_conversation": False,
             "env": env,
+            # Route tool permissions through our handler so AskUserQuestion can be
+            # answered by a human (blocks until a client responds); all other
+            # tools are allowed. Requires streaming mode (we use it). NOTE: when
+            # skip_permissions sets bypassPermissions below, the SDK bypasses this
+            # callback entirely — so interactive Q&A only works on the default
+            # (non-bypass) permission path.
+            "can_use_tool": self._on_can_use_tool,
         }
         if self._skip_permissions:
             option_kwargs["permission_mode"] = _DEFAULT_PERMISSION_MODE

--- a/src/skuld/transports/sdk.py
+++ b/src/skuld/transports/sdk.py
@@ -523,6 +523,9 @@ class SDKTransport(CLITransport):
             "mcp_servers": self._mcp_servers,
             "include_partial_messages": True,
             "thinking": {"type": "adaptive", "display": "summarized"},
+            # Default Claude to MAX reasoning effort ("ultra") — push new sessions
+            # to think hardest by default (Anthropic `effort` param, Opus/Sonnet 4.6+).
+            "effort": "max",
             "env": env,
         }
         if self._skip_permissions:

--- a/src/skuld/transports/sdk.py
+++ b/src/skuld/transports/sdk.py
@@ -5,8 +5,6 @@ converting typed SDK messages back into the dict events Skuld already emits.
 
 Known gaps versus ``PersistentSubprocessTransport``:
 
-- No session resume after process death; the Python SDK does not expose
-  ``--resume`` recovery.
 - No slash-command transport surface such as ``/clear`` or ``/compact``.
 - Mid-turn injection still requires ``interrupt()`` followed by a new query,
   which drops the in-flight partial assistant turn per SDK semantics.
@@ -252,6 +250,7 @@ class SDKTransport(CLITransport):
         initial_prompt: str = "",
         mcp_servers: list[dict] | None = None,
         turn_timeout_s: float = _DEFAULT_TURN_TIMEOUT_S,
+        resume_session_id: str | None = None,
     ) -> None:
         super().__init__()
         self.workspace_dir = workspace_dir
@@ -260,6 +259,7 @@ class SDKTransport(CLITransport):
         self._agent_teams = agent_teams
         self._system_prompt = system_prompt
         self._initial_prompt = initial_prompt
+        self._resume_session_id = (resume_session_id or "").strip() or None
         self._raw_mcp_servers = list(mcp_servers or [])
         self._mcp_servers = build_sdk_mcp_servers(mcp_servers or [])
         self._turn_timeout_s = max(float(turn_timeout_s or 0.0), 0.0)
@@ -276,7 +276,7 @@ class SDKTransport(CLITransport):
     @property
     def capabilities(self) -> TransportCapabilities:
         return TransportCapabilities(
-            session_resume=False,
+            session_resume=True,
             interrupt=True,
             steer=True,
             steering_mode="interrupt_resume",
@@ -304,6 +304,10 @@ class SDKTransport(CLITransport):
         """Connect the SDK client and optionally send the initial prompt."""
         if not self.is_alive:
             await self._connect_client()
+        # On resume the prior conversation (including its initial prompt) is
+        # reloaded, so replaying the initial prompt would double-seed history.
+        if self._resume_session_id:
+            self._initial_prompt_sent = True
         if not self._initial_prompt or self._initial_prompt_sent:
             return
         self._initial_prompt_sent = True
@@ -523,6 +527,10 @@ class SDKTransport(CLITransport):
         }
         if self._skip_permissions:
             option_kwargs["permission_mode"] = _DEFAULT_PERMISSION_MODE
+        if self._resume_session_id:
+            # Reload the prior conversation so the agent continues where it
+            # left off. ClaudeAgentOptions.resume is supported by the pinned SDK.
+            option_kwargs["resume"] = self._resume_session_id
         options = ClaudeAgentOptions(**option_kwargs)
         client = ClaudeSDKClient(options)
         self._client = await client.__aenter__()

--- a/src/skuld/transports/sdk_websocket.py
+++ b/src/skuld/transports/sdk_websocket.py
@@ -48,6 +48,7 @@ class SdkWebSocketTransport(CLITransport):
         system_prompt: str = "",
         initial_prompt: str = "",
         mcp_servers: list[dict] | None = None,
+        resume_session_id: str | None = None,
     ) -> None:
         super().__init__()
         self.workspace_dir = workspace_dir
@@ -58,6 +59,7 @@ class SdkWebSocketTransport(CLITransport):
         self._agent_teams = agent_teams
         self._system_prompt = system_prompt
         self._initial_prompt = initial_prompt
+        self._resume_session_id = (resume_session_id or "").strip() or None
         self._raw_mcp_servers = list(mcp_servers or [])
         self._mcp_config = build_claude_mcp_config(mcp_servers or [])
         self._process: asyncio.subprocess.Process | None = None
@@ -81,7 +83,10 @@ class SdkWebSocketTransport(CLITransport):
         if self._spawning:
             logger.info("start() called but already spawning, skipping")
             return
-        await self._spawn()
+        # On a cold start that carries a prior conversation id, resume it so
+        # the CLI reloads history (the existing --resume path plus the
+        # initial-prompt suppression then fire).
+        await self._spawn(resume_session_id=self._resume_session_id)
 
     async def _spawn(self, resume_session_id: str | None = None) -> None:
         """Spawn the CLI process with --sdk-url."""

--- a/src/skuld/transports/sdk_websocket.py
+++ b/src/skuld/transports/sdk_websocket.py
@@ -8,7 +8,6 @@ overrides, but it should not be the default Claude path.
 import asyncio
 import json
 import logging
-import os
 import uuid
 
 from fastapi import WebSocket
@@ -23,6 +22,7 @@ from niuu.adapters.cli.runtime import (
     stop_subprocess as _stop_process,
 )
 from niuu.ports.cli import CLITransport, TransportCapabilities
+from skuld.transports.claude_env import claude_spawn_env
 from skuld.transports.mcp_config import build_claude_mcp_config
 from skuld.transports.tool_shims import ensure_codex_tool_shims
 
@@ -130,7 +130,7 @@ class SdkWebSocketTransport(CLITransport):
             resume_id,
         )
 
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env = claude_spawn_env()  # subscription auth by default (SKULD__CLAUDE_AUTH)
         if self._agent_teams:
             env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
         _, shim_env = ensure_codex_tool_shims(
@@ -140,12 +140,9 @@ class SdkWebSocketTransport(CLITransport):
         if shim_env:
             env.update(shim_env)
 
-        if "ANTHROPIC_API_KEY" not in env:
-            logger.warning(
-                "ANTHROPIC_API_KEY not found in environment — "
-                "CLI may fail to authenticate with the API"
-            )
-
+        # No ANTHROPIC_API_KEY check here: subscription mode strips it on
+        # purpose (the CLI authenticates with the host's claude.ai login);
+        # claude_spawn_env warns if the login credentials are missing.
         logger.debug("CLI spawn command: %s", " ".join(cmd))
         logger.debug("CLI spawn env: CLAUDECODE unset, AGENT_TEAMS=%s", self._agent_teams)
 

--- a/src/skuld/transports/subprocess.py
+++ b/src/skuld/transports/subprocess.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 from typing import Any
 
 from niuu.adapters.cli.runtime import (
@@ -18,6 +17,7 @@ from niuu.adapters.cli.runtime import (
     stop_subprocess as _stop_process,
 )
 from niuu.ports.cli import CLITransport, TransportCapabilities
+from skuld.transports.claude_env import claude_spawn_env
 from skuld.transports.mcp_config import build_claude_mcp_config
 from skuld.transports.tool_shims import ensure_codex_tool_shims
 
@@ -157,7 +157,7 @@ class SubprocessTransport(CLITransport):
         logger.info("Running Claude CLI (session=%s)", self._session_id)
         logger.debug("Claude CLI command: %s", " ".join(cmd))
 
-        env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+        env = claude_spawn_env()  # subscription auth by default (SKULD__CLAUDE_AUTH)
         if self._agent_teams:
             env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
         _, shim_env = ensure_codex_tool_shims(

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -579,6 +579,10 @@ class SessionResponse(BaseModel):
         default=None,
         description="Native CLI session id for imported sessions",
     )
+    cli_session_id: str | None = Field(
+        default=None,
+        description="Captured CLI/agent conversation id; present once the session is resumable",
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -638,6 +642,7 @@ class SessionResponse(BaseModel):
             workload_type=session.workload_type,
             origin=session.origin,
             external_session_id=session.external_session_id,
+            cli_session_id=session.cli_session_id,
         )
 
 

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -2084,10 +2084,28 @@ def create_router(
 
         try:
             async with connect(ws_url, **connect_kwargs) as ws:
-                # Send immediately. Draining startup traffic here can delay or
-                # drop the first user turn for transports that emit welcome or
-                # capability events while still coming online.
+                # Send immediately. Draining startup traffic *before* sending can
+                # delay or drop the first user turn for transports that emit
+                # welcome or capability events while still coming online.
                 await ws.send(json.dumps({"type": "user", "content": content}))
+
+                # Then hold the socket open for a short, bounded grace so the
+                # broker's receive loop actually consumes the frame before we
+                # close. A just-restarted broker may still be warming its
+                # transport on this very connection; closing instantly races that
+                # startup and silently drops the message (HTTP 200 "sent" but no
+                # assistant reply). Drain-and-discard broker frames until the
+                # deadline; the cap keeps send latency bounded even while the
+                # assistant streams a reply back over the same channel.
+                import asyncio
+                import contextlib
+
+                async def _drain() -> None:
+                    while True:
+                        await ws.recv()
+
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(_drain(), timeout=0.75)
         except Exception as e:
             raise HTTPException(
                 status_code=status.HTTP_502_BAD_GATEWAY,

--- a/src/volundr/adapters/inbound/rest_session_log.py
+++ b/src/volundr/adapters/inbound/rest_session_log.py
@@ -1,0 +1,186 @@
+"""REST adapter for the durable session event log (full-fidelity transcript).
+
+Two endpoints:
+  * ``POST /sessions/{id}/log``       — append frames (producer: skuld), idempotent
+  * ``GET  /sessions/{id}/log``       — cursor replay (consumers: web, iOS)
+
+The log is the transcript source of truth. Producers append every frame with a
+monotonic per-session ``seq``; consumers replay from ``?after=<seq>`` so a client
+attaching at any time — including mid-turn or on a fresh device — reconstructs the
+full conversation, with nothing dropped.
+"""
+
+import logging
+from datetime import UTC, datetime
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Path, Query, Request, status
+from pydantic import BaseModel, Field
+
+from volundr.domain.models import SessionLogEntry
+from volundr.domain.ports import SessionEventLogRepository
+from volundr.domain.services.session import SessionAccessDeniedError, SessionService
+
+logger = logging.getLogger(__name__)
+
+MAX_LOG_BATCH = 1000
+DEFAULT_REPLAY_LIMIT = 1000
+MAX_REPLAY_LIMIT = 5000
+MAX_KIND_LENGTH = 64
+
+
+class LogEntryIngest(BaseModel):
+    """A single full-fidelity frame submitted by the producer."""
+
+    seq: int = Field(..., ge=0, description="Monotonic per-session sequence number")
+    kind: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_KIND_LENGTH,
+        description="Wire frame type (assistant, content_block_delta, tool_use, ...)",
+    )
+    payload: dict = Field(default_factory=dict, description="Raw frame, preserved verbatim")
+    role: str | None = Field(default=None, max_length=32)
+    request_id: str | None = Field(default=None, description="Turn correlation id")
+    ts: datetime | None = Field(default=None, description="Frame timestamp (defaults to now)")
+
+
+class LogBatchRequest(BaseModel):
+    """Batch of frames to append (producer retries are idempotent on seq)."""
+
+    entries: list[LogEntryIngest] = Field(..., min_length=1, max_length=MAX_LOG_BATCH)
+
+
+class LogAppendResponse(BaseModel):
+    """Result of an append: how many submitted and the new cursor head."""
+
+    submitted: int = Field(description="Number of entries submitted")
+    latest_seq: int = Field(description="Highest seq now stored for the session")
+
+
+class LogHeadResponse(BaseModel):
+    """Cursor head for a session's log (highest seq stored)."""
+
+    latest_seq: int = Field(description="Highest seq stored for the session, 0 if none")
+
+
+class SessionLogEntryResponse(BaseModel):
+    """A single replayed frame."""
+
+    session_id: UUID
+    seq: int
+    kind: str
+    role: str | None = None
+    request_id: str | None = None
+    payload: dict
+    ts: str
+
+    @classmethod
+    def from_entry(cls, entry: SessionLogEntry) -> "SessionLogEntryResponse":
+        return cls(
+            session_id=entry.session_id,
+            seq=entry.seq,
+            kind=entry.kind,
+            role=entry.role,
+            request_id=entry.request_id,
+            payload=entry.payload,
+            ts=entry.ts.isoformat(),
+        )
+
+
+def create_session_log_router(
+    log_repository: SessionEventLogRepository,
+    session_service: SessionService | None = None,
+    *,
+    prefix: str = "/api/v1/forge",
+) -> APIRouter:
+    """Create the FastAPI router for the durable session event log."""
+    router = APIRouter(prefix=prefix)
+
+    async def _check_access(request: Request, session_id: UUID, action: str) -> None:
+        if session_service is None:
+            return
+        from volundr.adapters.inbound.auth import extract_principal
+
+        principal = await extract_principal(request)
+        session = await session_service.get_session(session_id)
+        if session is None:
+            return
+        try:
+            await session_service._check_access(session, principal, action)
+        except SessionAccessDeniedError:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Not authorized to access the event log for session {session_id}",
+            )
+
+    @router.post(
+        "/sessions/{session_id}/log",
+        response_model=LogAppendResponse,
+        status_code=status.HTTP_201_CREATED,
+        tags=["Events"],
+    )
+    async def append_log(
+        request: Request,
+        data: LogBatchRequest,
+        session_id: UUID = Path(description="Session UUID to append frames for"),
+    ) -> LogAppendResponse:
+        """Append full-fidelity frames to the session's durable log (idempotent)."""
+        await _check_access(request, session_id, "emit_event")
+        now = datetime.now(UTC)
+        entries = [
+            SessionLogEntry(
+                session_id=session_id,
+                seq=item.seq,
+                kind=item.kind,
+                payload=item.payload,
+                ts=item.ts or now,
+                role=item.role,
+                request_id=item.request_id,
+            )
+            for item in data.entries
+        ]
+        submitted = await log_repository.append(entries)
+        latest = await log_repository.latest_seq(session_id)
+        return LogAppendResponse(submitted=submitted, latest_seq=latest)
+
+    @router.get(
+        "/sessions/{session_id}/log/head",
+        response_model=LogHeadResponse,
+        tags=["Events"],
+    )
+    async def log_head(
+        request: Request,
+        session_id: UUID = Path(description="Session UUID to read the log cursor head for"),
+    ) -> LogHeadResponse:
+        """Return the highest seq stored — lets a producer resume after restart."""
+        await _check_access(request, session_id, "read")
+        latest = await log_repository.latest_seq(session_id)
+        return LogHeadResponse(latest_seq=latest)
+
+    @router.get(
+        "/sessions/{session_id}/log",
+        response_model=list[SessionLogEntryResponse],
+        tags=["Events"],
+    )
+    async def replay_log(
+        request: Request,
+        session_id: UUID = Path(description="Session UUID to replay the log for"),
+        after: int = Query(
+            default=0,
+            ge=0,
+            description="Return frames with seq greater than this cursor",
+        ),
+        limit: int = Query(
+            default=DEFAULT_REPLAY_LIMIT,
+            ge=1,
+            le=MAX_REPLAY_LIMIT,
+            description="Maximum number of frames to return",
+        ),
+    ) -> list[SessionLogEntryResponse]:
+        """Replay the session transcript from a cursor (full fidelity)."""
+        await _check_access(request, session_id, "read")
+        entries = await log_repository.read_after(session_id, after_seq=after, limit=limit)
+        return [SessionLogEntryResponse.from_entry(e) for e in entries]
+
+    return router

--- a/src/volundr/adapters/outbound/local_process.py
+++ b/src/volundr/adapters/outbound/local_process.py
@@ -841,21 +841,18 @@ class LocalProcessPodManager(PodManager):
         )
 
     @staticmethod
-    def _write_claude_md(workspace: Path, spec: SessionSpec) -> None:
-        """Write CLAUDE.md with system prompt and session config."""
-        session_vals = spec.values.get("session", {})
-        system_prompt = session_vals.get("systemPrompt", "")
-        initial_prompt = session_vals.get("initialPrompt", "")
+    def _write_claude_md(_workspace: Path, _spec: SessionSpec) -> None:
+        """No-op (deactivated in our pipeline).
 
-        parts: list[str] = []
-        if system_prompt:
-            parts.append(system_prompt)
-        if initial_prompt:
-            parts.append(f"\n## Initial Task\n\n{initial_prompt}")
-
-        if parts:
-            claude_md = workspace / "CLAUDE.md"
-            claude_md.write_text("\n".join(parts), encoding="utf-8")
+        The system prompt AND the initial task are both delivered to the agent
+        through the transport — the Claude SDK ``system_prompt`` option and
+        ``--append-system-prompt`` for the subprocess transports, plus
+        ``send_message`` for the initial prompt. The previous behavior wrote them
+        into the workspace ``CLAUDE.md``, which CLOBBERED any real project
+        CLAUDE.md and left a stale ``## Initial Task`` that bled into every later
+        session — and any other Claude Code agent — that ran in the same folder.
+        """
+        return
 
     # ------------------------------------------------------------------
     # Process spawning & monitoring

--- a/src/volundr/adapters/outbound/local_process.py
+++ b/src/volundr/adapters/outbound/local_process.py
@@ -55,7 +55,10 @@ logger = logging.getLogger(__name__)
 # Default configuration values
 DEFAULT_WORKSPACES_DIR = "~/.niuu/workspaces"
 DEFAULT_CLAUDE_BINARY = "claude"
-DEFAULT_MAX_CONCURRENT = 4
+# Capable hosts run many sessions comfortably (each ~0.5 GB); the practical
+# ceiling is the Claude/Codex *subscription* concurrency, not the box. Deployments
+# override this via pod_manager.max_concurrent in config.yaml.
+DEFAULT_MAX_CONCURRENT = 16
 DEFAULT_SDK_PORT_START = 9100
 DEFAULT_STOP_TIMEOUT = 10
 DEFAULT_STATE_FILE = "~/.niuu/forge-state.json"
@@ -479,8 +482,26 @@ class LocalProcessPodManager(PodManager):
         """Provision workspace, spawn Claude process, return endpoints."""
         session_id = str(session.id)
 
-        if len(self._active_sessions()) >= self._max_concurrent:
+        active = self._reconcile_active()
+        if len(active) >= self._max_concurrent:
+            detail = ", ".join(
+                f"{sid[:8]}:{self._processes[sid].state.value}(pid={self._processes[sid].pid})"
+                for sid in active
+            )
+            logger.warning(
+                "Max concurrent reached: %d/%d slots in use [%s] — rejecting new session %s",
+                len(active),
+                self._max_concurrent,
+                detail,
+                session_id[:8],
+            )
             raise RuntimeError(f"Max concurrent sessions ({self._max_concurrent}) reached")
+        logger.info(
+            "Provisioning session %s (%d/%d concurrent slots in use)",
+            session_id[:8],
+            len(active),
+            self._max_concurrent,
+        )
 
         workspace = await self._provision_workspace(session, spec)
         port = self._port_allocator.allocate()
@@ -1635,3 +1656,34 @@ class LocalProcessPodManager(PodManager):
             for sid, info in self._processes.items()
             if info.state in (ProcessState.RUNNING, ProcessState.STARTING)
         ]
+
+    def _reconcile_active(self) -> list[str]:
+        """Active session IDs, after reaping entries whose process is dead.
+
+        ``_monitor_process`` only reaps a session when its broker exits while the
+        monitor task is alive. Brokers orphaned by a hard kill (or a dead monitor)
+        keep their RUNNING/STARTING slot forever, which eventually trips the
+        concurrent-session cap with *phantom* sessions ("Max concurrent reached"
+        with nothing really running). Verify pid liveness here so the cap reflects
+        real in-flight work. A STARTING entry with no pid yet is mid-spawn — left
+        alone.
+        """
+        reaped: list[str] = []
+        for sid, info in self._processes.items():
+            if info.state not in (ProcessState.RUNNING, ProcessState.STARTING):
+                continue
+            if info.pid is not None and not self._is_process_alive(info.pid):
+                info.state = ProcessState.STOPPED
+                if info.port is not None:
+                    self._port_allocator.release(info.port)
+                if info.flock_base_port is not None:
+                    self._allocated_flock_base_ports.discard(info.flock_base_port)
+                reaped.append(sid)
+        if reaped:
+            self._persist_state()
+            logger.warning(
+                "Reaped %d phantom session(s) holding concurrent slots (process dead): %s",
+                len(reaped),
+                ", ".join(s[:8] for s in reaped),
+            )
+        return self._active_sessions()

--- a/src/volundr/adapters/outbound/pg_session_event_log.py
+++ b/src/volundr/adapters/outbound/pg_session_event_log.py
@@ -1,0 +1,94 @@
+"""PostgreSQL adapter for the durable, append-only session event log.
+
+Implements :class:`SessionEventLogRepository`. Writes are idempotent on
+(session_id, seq) via ON CONFLICT DO NOTHING, so the producer (skuld) can retry
+at-least-once without creating duplicates. Reads are cursor-based (seq) so any
+client can resume a full transcript replay.
+"""
+
+import json
+import logging
+from uuid import UUID
+
+import asyncpg
+
+from volundr.domain.models import SessionLogEntry
+from volundr.domain.ports import SessionEventLogRepository
+
+logger = logging.getLogger(__name__)
+
+
+class PostgresSessionEventLog(SessionEventLogRepository):
+    """PostgreSQL adapter for the full-fidelity session event log."""
+
+    def __init__(self, pool: asyncpg.Pool):
+        self._pool = pool
+
+    async def append(self, entries: list[SessionLogEntry]) -> int:
+        if not entries:
+            return 0
+        args = [self._entry_to_args(e) for e in entries]
+        await self._pool.executemany(
+            """INSERT INTO session_event_log
+               (session_id, seq, kind, role, request_id, payload, ts)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)
+               ON CONFLICT (session_id, seq) DO NOTHING""",
+            args,
+        )
+        return len(entries)
+
+    async def read_after(
+        self,
+        session_id: UUID,
+        after_seq: int = 0,
+        limit: int = 1000,
+    ) -> list[SessionLogEntry]:
+        rows = await self._pool.fetch(
+            """SELECT session_id, seq, kind, role, request_id, payload, ts
+               FROM session_event_log
+               WHERE session_id = $1 AND seq > $2
+               ORDER BY seq ASC
+               LIMIT $3""",
+            session_id,
+            after_seq,
+            limit,
+        )
+        return [self._row_to_entry(r) for r in rows]
+
+    async def latest_seq(self, session_id: UUID) -> int:
+        value = await self._pool.fetchval(
+            "SELECT MAX(seq) FROM session_event_log WHERE session_id = $1",
+            session_id,
+        )
+        if value is None:
+            return 0
+        return int(value)
+
+    # -- Internal helpers -----------------------------------------------------
+
+    @staticmethod
+    def _entry_to_args(entry: SessionLogEntry) -> tuple:
+        return (
+            entry.session_id,
+            entry.seq,
+            entry.kind,
+            entry.role,
+            entry.request_id,
+            json.dumps(entry.payload),
+            entry.ts,
+        )
+
+    @staticmethod
+    def _row_to_entry(row: asyncpg.Record) -> SessionLogEntry:
+        payload = row["payload"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        return SessionLogEntry(
+            session_id=row["session_id"],
+            seq=row["seq"],
+            kind=row["kind"],
+            payload=payload,
+            ts=row["ts"],
+            role=row["role"],
+            request_id=row["request_id"],
+        )

--- a/src/volundr/adapters/outbound/postgres.py
+++ b/src/volundr/adapters/outbound/postgres.py
@@ -1,7 +1,7 @@
 """PostgreSQL adapter for session repository."""
 
 import json
-from datetime import UTC
+from datetime import UTC, datetime
 from uuid import UUID
 
 import asyncpg
@@ -152,6 +152,18 @@ class PostgresSessionRepository(SessionRepository):
             session.cli_session_id,
         )
         return session
+
+    async def list_stale_running(self, older_than: datetime) -> "list[Session]":
+        """Return RUNNING sessions whose last_active is at/before older_than."""
+        rows = await self._pool.fetch(
+            """SELECT * FROM sessions
+               WHERE status = $1
+                 AND COALESCE(last_active, created_at) <= $2
+               ORDER BY last_active ASC""",
+            SessionStatus.RUNNING.value,
+            older_than,
+        )
+        return [self._row_to_session(row) for row in rows]
 
     async def delete(self, session_id: UUID) -> bool:
         """Delete a session by ID."""

--- a/src/volundr/adapters/outbound/postgres.py
+++ b/src/volundr/adapters/outbound/postgres.py
@@ -26,10 +26,10 @@ class PostgresSessionRepository(SessionRepository):
                  created_at, updated_at, last_active, message_count, tokens_used,
                  pod_name, error, tracker_issue_id, issue_tracker_url,
                  launch_spec_id, archived_at, owner_id, tenant_id, workload_type,
-                 origin, external_session_id)
+                 origin, external_session_id, cli_session_id)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
                     $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21,
-                    $22, $23)
+                    $22, $23, $24)
             """,
             session.id,
             session.name,
@@ -54,6 +54,7 @@ class PostgresSessionRepository(SessionRepository):
             session.workload_type,
             session.origin,
             session.external_session_id,
+            session.cli_session_id,
         )
         return session
 
@@ -123,7 +124,7 @@ class PostgresSessionRepository(SessionRepository):
                 pod_name = $12, error = $13, tracker_issue_id = $14,
                 issue_tracker_url = $15, launch_spec_id = $16, archived_at = $17,
                 owner_id = $18, tenant_id = $19, workload_type = $20,
-                origin = $21, external_session_id = $22
+                origin = $21, external_session_id = $22, cli_session_id = $23
             WHERE id = $1
             """,
             session.id,
@@ -148,6 +149,7 @@ class PostgresSessionRepository(SessionRepository):
             session.workload_type,
             session.origin,
             session.external_session_id,
+            session.cli_session_id,
         )
         return session
 
@@ -201,6 +203,7 @@ class PostgresSessionRepository(SessionRepository):
             workload_type=row.get("workload_type") or "session",
             origin=row.get("origin") or "volundr",
             external_session_id=row.get("external_session_id"),
+            cli_session_id=row.get("cli_session_id"),
         )
 
     @staticmethod

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -377,6 +377,44 @@ def _default_session_definitions() -> dict[str, SessionDefinitionConfig]:
                 },
             },
         ),
+        "skuldClaudeRemote": SessionDefinitionConfig(
+            enabled=True,
+            display_name="Claude Remote Control",
+            description=(
+                "Claude Code in Remote Control mode — pair with the Claude app or "
+                "claude.ai/code; the native app drives the session"
+            ),
+            labels=["session", "claude", "remote-control"],
+            default_model="",
+            compatible_providers=["anthropic"],
+            defaults={
+                "broker": {
+                    "cliType": "claude",
+                    "transportAdapter": "skuld.transports.remote_control.RemoteControlTransport",
+                    "agentTeams": False,
+                },
+            },
+        ),
+        "skuldCodexRemote": SessionDefinitionConfig(
+            enabled=True,
+            display_name="Codex Remote Control",
+            description=(
+                "Codex Remote Control — requires the standalone Codex install; "
+                "fails fast with guidance until it exists"
+            ),
+            labels=["session", "codex", "remote-control"],
+            default_model="",
+            compatible_providers=["openai"],
+            defaults={
+                "broker": {
+                    "cliType": "codex",
+                    "transportAdapter": (
+                        "skuld.transports.remote_control.CodexRemoteControlTransport"
+                    ),
+                    "agentTeams": False,
+                },
+            },
+        ),
     }
 
 

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -553,11 +553,15 @@ class SessionLivenessConfig(BaseModel):
     see nothing). The reconciler marks running sessions that have gone silent —
     no activity heartbeat for ``stale_after_seconds`` — as ``stopped`` and clears
     their endpoints, so the list reflects reality and clients stop dialing dead
-    brokers. The threshold is generous: an idle-but-alive broker still reports
-    activity periodically.
+    brokers.
+
+    Disabled by default: brokers currently report activity only on STATE
+    CHANGES, so a quiet-but-alive session can go silent for long stretches and
+    would be falsely reaped. Enable with a generous stale_after_seconds (or
+    once periodic broker heartbeats land).
     """
 
-    enabled: bool = Field(default=True)
+    enabled: bool = Field(default=False)
     stale_after_seconds: int = Field(default=600, ge=30)
     check_interval_seconds: int = Field(default=120, ge=10)
 

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -319,7 +319,7 @@ def _default_session_definitions() -> dict[str, SessionDefinitionConfig]:
             display_name="Claude Code",
             description="Anthropic Claude — full IDE with terminal, tools, and MCP",
             labels=["session", "claude"],
-            default_model="claude-sonnet-4-6",
+            default_model="claude-opus-4-8",
             compatible_providers=["anthropic"],
             defaults={
                 "broker": {
@@ -479,7 +479,7 @@ class ChronicleConfig(BaseModel):
     """Chronicle feature configuration."""
 
     auto_create_on_stop: bool = Field(default=True)
-    summary_model: str = Field(default="claude-haiku-4-5-20251001")
+    summary_model: str = Field(default="claude-opus-4-8")
     summary_max_tokens: int = Field(default=2000)
     retention_days: int | None = Field(default=None)  # None = keep forever
 

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -545,6 +545,23 @@ class EventPipelineConfig(BaseModel):
     otel: OtelConfig = Field(default_factory=OtelConfig)
 
 
+class SessionLivenessConfig(BaseModel):
+    """Liveness reconciliation for running sessions.
+
+    A session whose broker has died can otherwise sit in ``running`` forever
+    with a stale ``chat_endpoint`` (clients then open a socket to a tombstone and
+    see nothing). The reconciler marks running sessions that have gone silent —
+    no activity heartbeat for ``stale_after_seconds`` — as ``stopped`` and clears
+    their endpoints, so the list reflects reality and clients stop dialing dead
+    brokers. The threshold is generous: an idle-but-alive broker still reports
+    activity periodically.
+    """
+
+    enabled: bool = Field(default=True)
+    stale_after_seconds: int = Field(default=600, ge=30)
+    check_interval_seconds: int = Field(default=120, ge=10)
+
+
 class SleipnirConfig(BaseModel):
     """Sleipnir platform event bus integration (optional).
 
@@ -1446,6 +1463,7 @@ class Settings(BaseSettings):
     chronicle: ChronicleConfig = Field(default_factory=ChronicleConfig)
     archive_store: ArchiveStoreConfig = Field(default_factory=ArchiveStoreConfig)
     event_pipeline: EventPipelineConfig = Field(default_factory=EventPipelineConfig)
+    session_liveness: SessionLivenessConfig = Field(default_factory=SessionLivenessConfig)
     sleipnir: SleipnirConfig = Field(default_factory=SleipnirConfig)
     identity: IdentityConfig = Field(default_factory=IdentityConfig)
     authorization: AuthorizationConfig = Field(default_factory=AuthorizationConfig)

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -861,6 +861,32 @@ class SessionEvent:
 
 
 @dataclass(frozen=True)
+class SessionLogEntry:
+    """One full-fidelity, append-only frame in a session's durable event log.
+
+    Unlike :class:`SessionEvent` (analytics previews), this preserves the
+    COMPLETE agent output verbatim — assistant text, thinking, tool_use,
+    tool_result, deltas — ordered by a monotonic per-session ``seq``. It is the
+    source of truth for transcript replay: any client can resume from a cursor
+    (``seq``) and reconstruct the full conversation regardless of whether a
+    socket was attached when the frames were produced.
+
+    ``kind`` is the open-vocabulary wire frame type (e.g. ``assistant``,
+    ``content_block_delta``, ``tool_use``, ``tool_result``, ``result``,
+    ``user``). ``payload`` is the raw frame, preserved without truncation.
+    ``request_id`` correlates frames to the turn that produced them.
+    """
+
+    session_id: UUID
+    seq: int
+    kind: str
+    payload: dict
+    ts: datetime
+    role: str | None = None
+    request_id: str | None = None
+
+
+@dataclass(frozen=True)
 class SessionSpan:
     """A hierarchical timing span recorded for a Volundr session."""
 

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -426,6 +426,15 @@ class Session(BaseModel):
         max_length=255,
         description="Native CLI session/thread id for imported sessions",
     )
+    cli_session_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description=(
+            "CLI/agent conversation id (Claude session UUID or Codex thread id) "
+            "captured at runtime, used to resume the prior conversation when the "
+            "session is restarted."
+        ),
+    )
 
     model_config = {"frozen": False}
 

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -48,6 +48,7 @@ from volundr.domain.models import (
     SessionCommunicationTarget,
     SessionEvent,
     SessionEventType,
+    SessionLogEntry,
     SessionSpan,
     SessionSpec,
     SessionStatus,
@@ -514,6 +515,37 @@ class SessionEventRepository(ABC):
     @abstractmethod
     async def delete_by_session(self, session_id: UUID) -> int:
         """Delete all events for a session. Returns count deleted."""
+
+
+class SessionEventLogRepository(ABC):
+    """Read/write port for the durable, append-only, full-fidelity event log.
+
+    This is the transcript source of truth (see :class:`SessionLogEntry`).
+    Writes are idempotent on (session_id, seq) so the producer can retry
+    at-least-once without creating duplicates, and reads are cursor-based so any
+    client can resume a full replay from the last seq it saw.
+    """
+
+    @abstractmethod
+    async def append(self, entries: list[SessionLogEntry]) -> int:
+        """Append entries idempotently (by session_id+seq).
+
+        Returns the number of entries submitted. Existing (session_id, seq)
+        rows are left untouched (ON CONFLICT DO NOTHING).
+        """
+
+    @abstractmethod
+    async def read_after(
+        self,
+        session_id: UUID,
+        after_seq: int = 0,
+        limit: int = 1000,
+    ) -> list[SessionLogEntry]:
+        """Return entries with seq > after_seq, ordered by seq ascending."""
+
+    @abstractmethod
+    async def latest_seq(self, session_id: UUID) -> int:
+        """Return the highest seq stored for a session, or 0 if none."""
 
 
 class SessionSpanRepository(ABC):

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -115,6 +115,14 @@ class SessionRepository(ABC):
         """Update an existing session."""
 
     @abstractmethod
+    async def list_stale_running(self, older_than: datetime) -> list[Session]:
+        """Return RUNNING sessions whose last_active is at/before older_than.
+
+        Used by liveness reconciliation to find sessions whose broker has gone
+        silent (no activity heartbeat) and should be marked stopped.
+        """
+
+    @abstractmethod
     async def delete(self, session_id: UUID) -> bool:
         """Delete a session. Returns True if deleted, False if not found."""
 

--- a/src/volundr/domain/services/session.py
+++ b/src/volundr/domain/services/session.py
@@ -354,6 +354,13 @@ class SessionService:
         if session is None:
             raise SessionNotFoundError(session_id)
 
+        # The broker rides the CLI/agent conversation id on activity reports.
+        # Persist it as a first-class field (so the session can be resumed after
+        # a stop) and keep it OUT of activity_metadata, which is clobbered below.
+        cli_session_id = metadata.pop("cli_session_id", None)
+        if cli_session_id and cli_session_id != session.cli_session_id:
+            session.cli_session_id = cli_session_id
+
         session.activity_state = state
         session.activity_metadata = metadata
         # Treat each activity report as a liveness heartbeat so the reconciler can
@@ -801,32 +808,37 @@ class SessionService:
             contributions.append(contribution)
 
         spec = SessionSpec.merge(contributions)
-        self._overlay_external_resume(session, spec)
+        self._overlay_resume_session(session, spec)
         return await self._pod_manager.start(session, spec=spec)
 
     @staticmethod
-    def _overlay_external_resume(session: Session, spec: SessionSpec) -> None:
-        """Force broker config to resume the native CLI session when imported.
+    def _overlay_resume_session(session: Session, spec: SessionSpec) -> None:
+        """Seed the broker with a conversation id to resume, when one exists.
 
-        Imported sessions carry the harness's own session/thread id. The
-        broker must use a resume-capable transport: Claude's default SDK
-        transport cannot resume, so imported Claude sessions are pinned to
-        the persistent subprocess transport (``claude --resume``); Codex
-        resumes through the WebSocket transport's ``thread/resume`` RPC.
+        Imported sessions carry the harness's own session/thread id
+        (``external_session_id``) and must be pinned to a resume-capable
+        transport for their origin. Volundr-born sessions carry the
+        ``cli_session_id`` captured from broker activity reports — restarting
+        them reloads the prior conversation on whatever transport their
+        definition selects (SDK, persistent subprocess, and Codex WebSocket
+        all support resume).
         """
-        if not session.external_session_id:
+        if session.external_session_id:
+            broker = spec.values.setdefault("broker", {})
+            broker["resumeSessionId"] = session.external_session_id
+            if session.origin == "claude":
+                broker["cliType"] = "claude"
+                broker["transportAdapter"] = (
+                    "skuld.transports.persistent_subprocess.PersistentSubprocessTransport"
+                )
+            if session.origin == "codex":
+                broker["cliType"] = "codex-ws"
+                broker["transportAdapter"] = "skuld.transports.codex_ws.CodexWebSocketTransport"
             return
 
-        broker = spec.values.setdefault("broker", {})
-        broker["resumeSessionId"] = session.external_session_id
-        if session.origin == "claude":
-            broker["cliType"] = "claude"
-            broker["transportAdapter"] = (
-                "skuld.transports.persistent_subprocess.PersistentSubprocessTransport"
-            )
-        if session.origin == "codex":
-            broker["cliType"] = "codex-ws"
-            broker["transportAdapter"] = "skuld.transports.codex_ws.CodexWebSocketTransport"
+        if session.cli_session_id:
+            broker = spec.values.setdefault("broker", {})
+            broker.setdefault("resumeSessionId", session.cli_session_id)
 
     async def _run_cleanup(
         self,

--- a/src/volundr/domain/services/session.py
+++ b/src/volundr/domain/services/session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from uuid import NAMESPACE_URL, UUID, uuid5
 
@@ -389,6 +389,40 @@ class SessionService:
         if self._should_auto_stop_after_activity(updated, state, metadata):
             self._schedule_activity_stop(updated.id)
         return updated
+
+    async def reconcile_liveness(self, stale_after_seconds: int) -> int:
+        """Mark running sessions with no recent activity heartbeat as stopped.
+
+        A session whose broker has died otherwise sits in ``running`` forever
+        with a stale ``chat_endpoint``; clients then open a socket to a tombstone
+        and see nothing. Reconciling clears the endpoint and flips the status to
+        ``stopped`` (resumable) so the list reflects reality.
+
+        Returns the number of sessions reconciled.
+        """
+        threshold = datetime.now(UTC) - timedelta(seconds=stale_after_seconds)
+        stale = await self._repository.list_stale_running(threshold)
+        reconciled = 0
+        for session in stale:
+            stopped = session.model_copy(
+                update={
+                    "status": SessionStatus.STOPPED,
+                    "chat_endpoint": None,
+                    "code_endpoint": None,
+                    "error": "liveness: no activity heartbeat — broker presumed dead",
+                    "updated_at": datetime.now(UTC),
+                }
+            )
+            result = await self._repository.update(stopped)
+            reconciled += 1
+            logger.warning(
+                "Liveness: marked stale running session %s as stopped (last_active=%s)",
+                session.id,
+                session.last_active,
+            )
+            if self._broadcaster is not None:
+                await self._broadcaster.publish_session_updated(result)
+        return reconciled
 
     def _should_auto_stop_after_activity(
         self,

--- a/src/volundr/domain/services/session.py
+++ b/src/volundr/domain/services/session.py
@@ -356,6 +356,14 @@ class SessionService:
 
         session.activity_state = state
         session.activity_metadata = metadata
+        # Treat each activity report as a liveness heartbeat so the reconciler can
+        # tell a live-but-idle session from one whose broker has died.
+        session.last_active = datetime.now(UTC)
+        # A heartbeat is PROOF OF LIFE — a lingering liveness verdict is now
+        # demonstrably false, so clear it (only liveness errors: real failure
+        # records from other paths must stay visible).
+        if session.error and session.error.startswith("liveness:"):
+            session.error = None
         updated = await self._repository.update(session)
 
         if self._broadcaster is not None:
@@ -645,6 +653,11 @@ class SessionService:
                 "status": SessionStatus.STARTING,
                 "chat_endpoint": chat_endpoint,
                 "code_endpoint": None,
+                # A restart is an explicit "bring it back": stale failure
+                # detail (e.g. the liveness reaper's "broker presumed dead")
+                # must not survive onto the healthy relaunched session — the
+                # clients render `error` as a Session-error banner verbatim.
+                "error": None,
                 "updated_at": datetime.now(UTC),
                 "workload_type": workload_type,
             }

--- a/src/volundr/domain/services/token.py
+++ b/src/volundr/domain/services/token.py
@@ -109,7 +109,18 @@ class TokenService:
         if session is None:
             raise SessionNotFoundError(session_id)
 
-        if session.status != SessionStatus.RUNNING:
+        # Accept usage during any *live* phase, not just RUNNING. The broker
+        # reports the first turn's tokens within ~2s of spawn — while the session
+        # is still PROVISIONING (the readiness poll flips it to RUNNING at ~5s).
+        # Rejecting those reports with 409 silently dropped the opening turn's
+        # tokens (the long-standing tokens_used=0 symptom). Only terminal/idle-
+        # before-start states should refuse usage.
+        live_statuses = (
+            SessionStatus.STARTING,
+            SessionStatus.PROVISIONING,
+            SessionStatus.RUNNING,
+        )
+        if session.status not in live_statuses:
             raise SessionNotRunningError(session_id, session.status)
 
         # Use pre-calculated cost when provided, fall back to pricing table

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -48,6 +48,7 @@ from volundr.adapters.inbound.rest_oauth import create_canonical_oauth_router
 from volundr.adapters.inbound.rest_prompts import create_prompts_router
 from volundr.adapters.inbound.rest_resources import create_resources_router
 from volundr.adapters.inbound.rest_secrets import create_canonical_secrets_router
+from volundr.adapters.inbound.rest_session_log import create_session_log_router
 from volundr.adapters.inbound.rest_trace import create_trace_router
 from volundr.adapters.inbound.rest_tracker import create_canonical_tracker_router
 from volundr.adapters.outbound.bifrost_catalog_http import HttpBifrostCatalogAdapter
@@ -57,6 +58,7 @@ from volundr.adapters.outbound.git_registry import create_git_registry
 from volundr.adapters.outbound.linear import LinearAdapter
 from volundr.adapters.outbound.memory_secrets import InMemorySecretManager
 from volundr.adapters.outbound.pg_event_sink import PostgresEventSink
+from volundr.adapters.outbound.pg_session_event_log import PostgresSessionEventLog
 from volundr.adapters.outbound.postgres import PostgresSessionRepository
 from volundr.adapters.outbound.postgres_chronicles import PostgresChronicleRepository
 from volundr.adapters.outbound.postgres_communication_cursors import (
@@ -965,6 +967,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 prefix="/api/v1/forge",
             )
             app.include_router(events_router)
+
+            # Durable full-fidelity transcript log: ingest (skuld) + cursor replay
+            session_event_log = PostgresSessionEventLog(pool)
+            session_log_router = create_session_log_router(
+                session_event_log,
+                session_service=session_service,
+                prefix="/api/v1/forge",
+            )
+            app.include_router(session_log_router)
+
             trace_router = create_trace_router(
                 span_repository,
                 session_service=session_service,

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -389,6 +389,31 @@ async def _broadcast_periodic_updates(
             logger.exception("SSE periodic broadcast failed")
 
 
+async def _reconcile_liveness_loop(
+    session_service: SessionService,
+    *,
+    interval_seconds: int,
+    stale_after_seconds: int,
+) -> None:
+    """Periodically mark running sessions whose broker has gone silent as stopped."""
+    logger.info(
+        "Liveness reconciliation started, interval=%ds stale_after=%ds",
+        interval_seconds,
+        stale_after_seconds,
+    )
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            count = await session_service.reconcile_liveness(stale_after_seconds)
+            if count:
+                logger.info("Liveness: reconciled %d stale running session(s)", count)
+        except asyncio.CancelledError:
+            logger.info("Liveness reconciliation task cancelled")
+            break
+        except Exception:
+            logger.exception("Liveness reconciliation iteration failed")
+
+
 def _create_otel_providers(otel_cfg):  # pragma: no cover
     """Build OTel TracerProvider + MeterProvider from config.
 
@@ -1016,6 +1041,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             background_task = asyncio.create_task(
                 _broadcast_periodic_updates(broadcaster, stats_service)
             )
+
+            # Start liveness reconciliation: expire running sessions whose broker
+            # has gone silent so clients stop dialing dead chat endpoints.
+            liveness_task: asyncio.Task | None = None
+            if settings.session_liveness.enabled:
+                liveness_task = asyncio.create_task(
+                    _reconcile_liveness_loop(
+                        session_service,
+                        interval_seconds=settings.session_liveness.check_interval_seconds,
+                        stale_after_seconds=settings.session_liveness.stale_after_seconds,
+                    )
+                )
             if settings.telegram_ingress.enabled:
                 await telegram_ingress.start()
             else:
@@ -1039,6 +1076,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     await background_task
                 except asyncio.CancelledError:
                     pass  # Expected: task cancellation during shutdown
+                if liveness_task is not None:
+                    liveness_task.cancel()
+                    try:
+                        await liveness_task
+                    except asyncio.CancelledError:
+                        pass  # Expected: task cancellation during shutdown
                 await event_ingestion.close_all()
                 if hasattr(pod_manager, "close"):
                     await pod_manager.close()

--- a/src/volundr/session_archive.py
+++ b/src/volundr/session_archive.py
@@ -122,6 +122,37 @@ def load_workspace_transcript(workspace_dir: str | Path, session_id: str) -> dic
     return _normalise_transcript_payload(data)
 
 
+def _archive_owned_by(
+    workspace_dir: str | Path | None,
+    *,
+    session_id: str | None,
+    archive_location: str = "workspace",
+    archive_path: str | Path | None = None,
+) -> bool:
+    """True when the archive at this root belongs to ``session_id``.
+
+    Workspace-scoped archives live at ONE shared path per workspace
+    (``.volundr/archive``) — ``archive_root`` ignores the session id for that
+    location. Without this guard a freshly created session in a workspace with
+    prior history is served the PREVIOUS session's transcript while its broker
+    is still starting (the "new session born full of old content" ghost-replay
+    bug). The manifest records the owning session; an archive without a
+    manifest (legacy) stays readable to avoid regressions.
+    """
+    if not session_id:
+        return True
+    manifest = load_archive_manifest(
+        workspace_dir,
+        session_id=session_id,
+        archive_location=archive_location,
+        archive_path=archive_path,
+    )
+    if not isinstance(manifest, dict):
+        return True
+    owner = manifest.get("session_id")
+    return not owner or str(owner) == str(session_id)
+
+
 def load_archive_transcript(
     workspace_dir: str | Path | None,
     *,
@@ -129,7 +160,7 @@ def load_archive_transcript(
     archive_location: str = "workspace",
     archive_path: str | Path | None = None,
 ) -> dict[str, Any] | None:
-    """Load the normalized archived transcript if present."""
+    """Load the normalized archived transcript if present (and owned)."""
     try:
         path = archive_transcript_json_path(
             workspace_dir,
@@ -140,6 +171,13 @@ def load_archive_transcript(
     except ValueError:
         return None
     if not path.exists():
+        return None
+    if not _archive_owned_by(
+        workspace_dir,
+        session_id=session_id,
+        archive_location=archive_location,
+        archive_path=archive_path,
+    ):
         return None
     data = _read_json(path)
     return _normalise_transcript_payload(data)
@@ -194,7 +232,7 @@ def load_archive_logs(
     archive_location: str = "workspace",
     archive_path: str | Path | None = None,
 ) -> dict[str, Any] | None:
-    """Load archived aggregate logs if present."""
+    """Load archived aggregate logs if present (and owned — see transcript)."""
     try:
         path = archive_logs_aggregate_path(
             workspace_dir,
@@ -205,6 +243,13 @@ def load_archive_logs(
     except ValueError:
         return None
     if not path.exists():
+        return None
+    if not _archive_owned_by(
+        workspace_dir,
+        session_id=session_id,
+        archive_location=archive_location,
+        archive_path=archive_path,
+    ):
         return None
     return _read_json(path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,13 @@ class InMemorySessionRepository(SessionRepository):
         self._sessions[session.id] = session
         return session
 
+    async def list_stale_running(self, older_than):
+        return [
+            s
+            for s in self._sessions.values()
+            if s.status == SessionStatus.RUNNING and (s.last_active or s.created_at) <= older_than
+        ]
+
     async def delete(self, session_id: UUID) -> bool:
         if session_id in self._sessions:
             del self._sessions[session_id]

--- a/tests/test_adapters/test_local_process.py
+++ b/tests/test_adapters/test_local_process.py
@@ -524,19 +524,17 @@ class TestWorkspaceProvisioning:
         assert workspace.exists()
         assert workspace == tmp_workspaces / str(git_session.id)
 
-    async def test_writes_claude_md(
+    async def test_does_not_write_claude_md(
         self,
         manager: LocalProcessPodManager,
         git_session: Session,
         default_spec: SessionSpec,
     ) -> None:
-        """CLAUDE.md is written with system prompt."""
+        """Prompts are delivered via the transport — CLAUDE.md is never written
+        (it used to clobber real project files and bleed into later sessions)."""
         with patch.object(manager, "_clone_repo", new_callable=AsyncMock):
             workspace = await manager._provision_workspace(git_session, default_spec)
-        claude_md = workspace / "CLAUDE.md"
-        assert claude_md.exists()
-        content = claude_md.read_text()
-        assert "You are a helpful assistant." in content
+        assert not (workspace / "CLAUDE.md").exists()
 
     async def test_local_mount_path_outside_allowed_prefixes_is_rejected(
         self,
@@ -610,14 +608,16 @@ class TestWorkspaceProvisioning:
         clone_repo.assert_not_called()
         assert workspace == project.resolve()
         assert not (manager._workspaces_dir / str(session.id)).exists()
-        assert "You are a helpful assistant." in (project / "CLAUDE.md").read_text()
+        # The user's real project directory is left untouched.
+        assert not (project / "CLAUDE.md").exists()
 
-    async def test_writes_claude_md_with_initial_prompt(
+    async def test_does_not_write_claude_md_with_initial_prompt(
         self,
         manager: LocalProcessPodManager,
         git_session: Session,
     ) -> None:
-        """CLAUDE.md includes initial prompt when provided."""
+        """Even with prompts configured, CLAUDE.md is not written — prompts go
+        through the transport (system_prompt option / send_message)."""
         spec = SessionSpec(
             values={
                 "session": {
@@ -629,9 +629,7 @@ class TestWorkspaceProvisioning:
         )
         with patch.object(manager, "_clone_repo", new_callable=AsyncMock):
             workspace = await manager._provision_workspace(git_session, spec)
-        content = (workspace / "CLAUDE.md").read_text()
-        assert "Initial Task" in content
-        assert "Do the thing." in content
+        assert not (workspace / "CLAUDE.md").exists()
 
     async def test_no_claude_md_when_no_prompts(
         self,

--- a/tests/test_adapters/test_local_process.py
+++ b/tests/test_adapters/test_local_process.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import signal
 import socket
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -122,6 +124,13 @@ def _mock_provision(mgr: LocalProcessPodManager) -> patch:
         new_callable=AsyncMock,
         return_value=WS,
     )
+
+
+def _reaped_child_pid() -> int:
+    """Spawn and immediately reap a child so its pid is guaranteed dead."""
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    return proc.pid
 
 
 def _mock_spawn(
@@ -1956,11 +1965,40 @@ class TestStartStop:
 
         with (
             _mock_provision(mgr),
-            _mock_spawn(mgr),
+            # A live pid — the cap reconciler reaps sessions whose process is
+            # dead, so a fake dead pid would silently free the slot.
+            _mock_spawn(mgr, pid=os.getpid()),
         ):
             await mgr.start(session1, spec)
             with pytest.raises(RuntimeError, match="Max concurrent sessions"):
                 await mgr.start(session2, spec)
+
+    async def test_dead_process_frees_concurrent_slot(
+        self,
+        tmp_workspaces: Path,
+        tmp_state_file: Path,
+    ) -> None:
+        """A session whose broker died no longer holds a phantom slot."""
+        mgr = LocalProcessPodManager(
+            workspaces_dir=str(tmp_workspaces),
+            claude_binary="/usr/bin/fake-claude",
+            max_concurrent=1,
+            state_file=str(tmp_state_file),
+        )
+        session1 = Session(id=uuid4(), name="s1")
+        session2 = Session(id=uuid4(), name="s2")
+        spec = SessionSpec(values={}, pod_spec=PodSpecAdditions())
+
+        with (
+            _mock_provision(mgr),
+            # pid that is guaranteed dead: spawn a child and wait for it
+            _mock_spawn(mgr, pid=_reaped_child_pid()),
+        ):
+            await mgr.start(session1, spec)
+            # The dead session is reaped, freeing the slot — no raise.
+            await mgr.start(session2, spec)
+
+        assert mgr._processes[str(session1.id)].state == ProcessState.STOPPED
 
     async def test_start_failure_releases_port(
         self,

--- a/tests/test_adapters/test_pg_session_event_log.py
+++ b/tests/test_adapters/test_pg_session_event_log.py
@@ -1,0 +1,116 @@
+"""Tests for the PostgresSessionEventLog adapter."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from volundr.adapters.outbound.pg_session_event_log import PostgresSessionEventLog
+from volundr.domain.models import SessionLogEntry
+
+
+def _make_entry(**overrides) -> SessionLogEntry:
+    defaults = {
+        "session_id": uuid4(),
+        "seq": 1,
+        "kind": "assistant",
+        "payload": {"type": "assistant", "content": [{"type": "text", "text": "hi"}]},
+        "ts": datetime.now(UTC),
+        "role": "assistant",
+        "request_id": "forge-web-1",
+    }
+    defaults.update(overrides)
+    return SessionLogEntry(**defaults)
+
+
+class TestAppend:
+    async def test_append_uses_executemany_with_conflict_clause(self):
+        pool = AsyncMock()
+        log = PostgresSessionEventLog(pool)
+        sid = uuid4()
+        entries = [_make_entry(session_id=sid, seq=i) for i in range(3)]
+
+        submitted = await log.append(entries)
+
+        assert submitted == 3
+        pool.executemany.assert_called_once()
+        sql, args = pool.executemany.call_args[0]
+        assert "INSERT INTO session_event_log" in sql
+        assert "ON CONFLICT (session_id, seq) DO NOTHING" in sql
+        assert len(args) == 3
+        # payload is serialized to a JSON string for the JSONB column
+        assert isinstance(args[0][5], str)
+
+    async def test_append_empty_is_noop(self):
+        pool = AsyncMock()
+        log = PostgresSessionEventLog(pool)
+
+        submitted = await log.append([])
+
+        assert submitted == 0
+        pool.executemany.assert_not_called()
+
+
+class TestReadAfter:
+    async def test_read_after_queries_by_cursor_ordered(self):
+        sid = uuid4()
+        ts = datetime.now(UTC)
+        pool = AsyncMock()
+        pool.fetch.return_value = [
+            {
+                "session_id": sid,
+                "seq": 5,
+                "kind": "content_block_delta",
+                "role": None,
+                "request_id": "r1",
+                "payload": {"delta": {"text": "x"}},
+                "ts": ts,
+            }
+        ]
+        log = PostgresSessionEventLog(pool)
+
+        entries = await log.read_after(sid, after_seq=4, limit=10)
+
+        sql, *params = pool.fetch.call_args[0]
+        assert "seq > $2" in sql
+        assert "ORDER BY seq ASC" in sql
+        assert params == [sid, 4, 10]
+        assert len(entries) == 1
+        assert entries[0].seq == 5
+        assert entries[0].kind == "content_block_delta"
+        assert entries[0].payload == {"delta": {"text": "x"}}
+
+    async def test_read_after_decodes_json_string_payload(self):
+        sid = uuid4()
+        pool = AsyncMock()
+        pool.fetch.return_value = [
+            {
+                "session_id": sid,
+                "seq": 1,
+                "kind": "tool_result",
+                "role": "user",
+                "request_id": None,
+                "payload": '{"tool_use_id": "abc", "content": "ok"}',
+                "ts": datetime.now(UTC),
+            }
+        ]
+        log = PostgresSessionEventLog(pool)
+
+        entries = await log.read_after(sid)
+
+        assert entries[0].payload == {"tool_use_id": "abc", "content": "ok"}
+
+
+class TestLatestSeq:
+    async def test_latest_seq_returns_max(self):
+        pool = AsyncMock()
+        pool.fetchval.return_value = 42
+        log = PostgresSessionEventLog(pool)
+
+        assert await log.latest_seq(uuid4()) == 42
+
+    async def test_latest_seq_zero_when_empty(self):
+        pool = AsyncMock()
+        pool.fetchval.return_value = None
+        log = PostgresSessionEventLog(pool)
+
+        assert await log.latest_seq(uuid4()) == 0

--- a/tests/test_adapters/test_rest_session_log.py
+++ b/tests/test_adapters/test_rest_session_log.py
@@ -1,0 +1,118 @@
+"""Tests for the durable session event log REST endpoints."""
+
+from uuid import uuid4
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from volundr.adapters.inbound.rest_session_log import create_session_log_router
+from volundr.domain.models import SessionLogEntry
+from volundr.domain.ports import SessionEventLogRepository
+
+
+class InMemoryLog(SessionEventLogRepository):
+    """In-memory, idempotent log for endpoint tests."""
+
+    def __init__(self):
+        self._rows: dict[tuple, SessionLogEntry] = {}
+
+    async def append(self, entries: list[SessionLogEntry]) -> int:
+        for e in entries:
+            self._rows.setdefault((e.session_id, e.seq), e)
+        return len(entries)
+
+    async def read_after(self, session_id, after_seq=0, limit=1000) -> list[SessionLogEntry]:
+        rows = [e for (sid, seq), e in self._rows.items() if sid == session_id and seq > after_seq]
+        rows.sort(key=lambda e: e.seq)
+        return rows[:limit]
+
+    async def latest_seq(self, session_id) -> int:
+        seqs = [seq for (sid, seq) in self._rows if sid == session_id]
+        return max(seqs) if seqs else 0
+
+
+def _client() -> tuple[TestClient, InMemoryLog]:
+    repo = InMemoryLog()
+    app = FastAPI()
+    app.include_router(create_session_log_router(repo, session_service=None))
+    return TestClient(app), repo
+
+
+def _frame(seq: int, kind: str = "assistant", **extra) -> dict:
+    return {"seq": seq, "kind": kind, "payload": {"n": seq}, **extra}
+
+
+class TestAppend:
+    def test_append_returns_submitted_and_latest_seq(self):
+        client, _ = _client()
+        sid = str(uuid4())
+
+        resp = client.post(
+            f"/api/v1/forge/sessions/{sid}/log",
+            json={"entries": [_frame(1), _frame(2, "result")]},
+        )
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body == {"submitted": 2, "latest_seq": 2}
+
+    def test_append_is_idempotent_on_seq(self):
+        client, _ = _client()
+        sid = str(uuid4())
+        payload = {"entries": [_frame(1)]}
+
+        client.post(f"/api/v1/forge/sessions/{sid}/log", json=payload)
+        client.post(f"/api/v1/forge/sessions/{sid}/log", json=payload)
+
+        resp = client.get(f"/api/v1/forge/sessions/{sid}/log")
+        assert len(resp.json()) == 1
+
+    def test_append_rejects_empty_batch(self):
+        client, _ = _client()
+        sid = str(uuid4())
+
+        resp = client.post(f"/api/v1/forge/sessions/{sid}/log", json={"entries": []})
+
+        assert resp.status_code == 422
+
+
+class TestReplay:
+    def test_replay_returns_frames_after_cursor_in_order(self):
+        client, _ = _client()
+        sid = str(uuid4())
+        client.post(
+            f"/api/v1/forge/sessions/{sid}/log",
+            json={"entries": [_frame(1), _frame(2), _frame(3)]},
+        )
+
+        resp = client.get(f"/api/v1/forge/sessions/{sid}/log", params={"after": 1})
+
+        seqs = [e["seq"] for e in resp.json()]
+        assert seqs == [2, 3]
+
+    def test_replay_full_transcript_from_zero(self):
+        client, _ = _client()
+        sid = str(uuid4())
+        client.post(
+            f"/api/v1/forge/sessions/{sid}/log",
+            json={
+                "entries": [
+                    _frame(1, "assistant", role="assistant", request_id="r1"),
+                    _frame(2, "tool_use", request_id="r1"),
+                    _frame(3, "tool_result", role="user"),
+                ]
+            },
+        )
+
+        resp = client.get(f"/api/v1/forge/sessions/{sid}/log")
+
+        body = resp.json()
+        assert [e["kind"] for e in body] == ["assistant", "tool_use", "tool_result"]
+        assert body[0]["request_id"] == "r1"
+        assert body[0]["session_id"] == sid
+
+    def test_replay_empty_session_is_empty_list(self):
+        client, _ = _client()
+        resp = client.get(f"/api/v1/forge/sessions/{uuid4()}/log")
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/tests/test_charts/test_skuld_chart.py
+++ b/tests/test_charts/test_skuld_chart.py
@@ -63,9 +63,11 @@ class TestValuesDefaults:
         assert env_secrets[0]["secretName"] == "anthropic-api-key"
         assert env_secrets[0]["secretKey"] == "api-key"
 
-    def test_env_vars_defaults_to_empty_list(self, values_yaml):
-        """Test envVars defaults to an empty list."""
-        assert values_yaml["envVars"] == []
+    def test_env_vars_default_pins_api_key_auth(self, values_yaml):
+        """Cluster pods have no ~/.claude login — Claude transports must keep
+        the injected ANTHROPIC_API_KEY rather than the subscription default."""
+        env_vars = values_yaml["envVars"]
+        assert env_vars == [{"name": "SKULD__CLAUDE_AUTH", "value": "api_key"}]
 
     def test_service_exposes_single_entry_port(self, values_yaml):
         """Test service configuration has single nginx entry port."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1002,3 +1002,19 @@ class TestEventPipelineConfig:
         assert isinstance(settings.event_pipeline, EventPipelineConfig)
         assert settings.event_pipeline.rabbitmq.enabled is False
         assert settings.event_pipeline.otel.enabled is False
+
+
+def test_builtin_remote_control_definitions_present():
+    """Remote Control session types ship as built-ins like the other skuld*
+    definitions, wired to the remote-control transports."""
+    from volundr.config import _default_session_definitions
+
+    defs = _default_session_definitions()
+    claude_rc = defs["skuldClaudeRemote"]
+    assert claude_rc.defaults["broker"]["transportAdapter"] == (
+        "skuld.transports.remote_control.RemoteControlTransport"
+    )
+    codex_rc = defs["skuldCodexRemote"]
+    assert codex_rc.defaults["broker"]["transportAdapter"] == (
+        "skuld.transports.remote_control.CodexRemoteControlTransport"
+    )

--- a/tests/test_domain/test_external_session_service.py
+++ b/tests/test_domain/test_external_session_service.py
@@ -334,7 +334,7 @@ class TestExternalResumeOverlay:
         session = Session(name="normal")
         spec = SessionSpec(values={}, pod_spec=None)
 
-        SessionService._overlay_external_resume(session, spec)
+        SessionService._overlay_resume_session(session, spec)
 
         assert "broker" not in spec.values
 
@@ -349,7 +349,7 @@ class TestExternalResumeOverlay:
             pod_spec=None,
         )
 
-        SessionService._overlay_external_resume(session, spec)
+        SessionService._overlay_resume_session(session, spec)
 
         broker = spec.values["broker"]
         assert broker["resumeSessionId"] == "claude-1"
@@ -366,12 +366,37 @@ class TestExternalResumeOverlay:
         )
         spec = SessionSpec(values={}, pod_spec=None)
 
-        SessionService._overlay_external_resume(session, spec)
+        SessionService._overlay_resume_session(session, spec)
 
         broker = spec.values["broker"]
         assert broker["resumeSessionId"] == "thread-1"
         assert broker["cliType"] == "codex-ws"
         assert broker["transportAdapter"] == "skuld.transports.codex_ws.CodexWebSocketTransport"
+
+    def test_cli_session_id_seeds_resume_for_volundr_sessions(self) -> None:
+        """A volundr-born session resumes its own captured conversation —
+        no transport pinning, the definition's transport handles it."""
+        session = Session(name="own-session", cli_session_id="sess-own-1")
+        spec = SessionSpec(values={}, pod_spec=None)
+
+        SessionService._overlay_resume_session(session, spec)
+
+        broker = spec.values["broker"]
+        assert broker["resumeSessionId"] == "sess-own-1"
+        assert "transportAdapter" not in broker
+
+    def test_external_session_id_wins_over_cli_session_id(self) -> None:
+        session = Session(
+            name="imported",
+            origin="claude",
+            external_session_id="ext-1",
+            cli_session_id="own-1",
+        )
+        spec = SessionSpec(values={}, pod_spec=None)
+
+        SessionService._overlay_resume_session(session, spec)
+
+        assert spec.values["broker"]["resumeSessionId"] == "ext-1"
 
     async def test_pipeline_start_passes_resume_to_pod_manager(
         self, repository, pod_manager

--- a/tests/test_niuu/test_rest_volundr.py
+++ b/tests/test_niuu/test_rest_volundr.py
@@ -943,3 +943,57 @@ def test_sse_stream_embedded_without_broadcaster_returns_503() -> None:
     response = client.get("/api/v1/forge/sessions/stream", headers=_headers())
 
     assert response.status_code == 503
+
+
+@respx.mock
+def test_event_log_proxies_forward_to_owner() -> None:
+    """Broker log ingest + cursor replay route through the aggregate."""
+    client = _client([_instance("beta", base_url="http://beta")])
+    respx.get("http://beta/api/v1/forge/sessions/s2").mock(
+        return_value=Response(200, json={"id": "s2"})
+    )
+    ingest = respx.post("http://beta/api/v1/forge/sessions/s2/log").mock(
+        return_value=Response(201, json={"appended": 2})
+    )
+    head = respx.get("http://beta/api/v1/forge/sessions/s2/log/head").mock(
+        return_value=Response(200, json={"latest_seq": 41})
+    )
+
+    assert (
+        client.post(
+            "/api/v1/forge/sessions/s2/log",
+            headers=_headers(),
+            json={"entries": [{"seq": 40}, {"seq": 41}]},
+        ).status_code
+        == 201
+    )
+    assert (
+        client.get("/api/v1/forge/sessions/s2/log/head", headers=_headers()).json()["latest_seq"]
+        == 41
+    )
+    assert ingest.called and head.called
+
+
+@respx.mock
+def test_event_log_replay_passes_list_through_verbatim() -> None:
+    """The replay endpoint returns a LIST — coercing it to a dict previously
+    discarded the entire transcript."""
+    client = _client([_instance("beta", base_url="http://beta")])
+    respx.get("http://beta/api/v1/forge/sessions/s2").mock(
+        return_value=Response(200, json={"id": "s2"})
+    )
+    respx.get("http://beta/api/v1/forge/sessions/s2/log").mock(
+        return_value=Response(
+            200,
+            json=[{"seq": 1, "kind": "assistant"}, {"seq": 2, "kind": "result"}],
+        )
+    )
+
+    payload = client.get(
+        "/api/v1/forge/sessions/s2/log",
+        headers=_headers(),
+        params={"after": 0},
+    ).json()
+
+    assert isinstance(payload, list)
+    assert [entry["seq"] for entry in payload] == [1, 2]

--- a/tests/test_niuu/test_rest_volundr.py
+++ b/tests/test_niuu/test_rest_volundr.py
@@ -876,3 +876,70 @@ def test_usage_report_proxies_to_owner() -> None:
     assert response.status_code == 201
     assert response.json()["recorded"] is True
     assert route.called
+
+
+@respx.mock
+def test_chronicle_timeline_post_proxies_to_owner() -> None:
+    client = _client([_instance("beta", base_url="http://beta")])
+    respx.get("http://beta/api/v1/forge/sessions/s2").mock(
+        return_value=Response(200, json={"id": "s2"})
+    )
+    route = respx.post("http://beta/api/v1/forge/chronicles/s2/timeline").mock(
+        return_value=Response(201, json={"recorded": True})
+    )
+
+    response = client.post(
+        "/api/v1/forge/chronicles/s2/timeline",
+        headers=_headers(),
+        json={"event": "message_user"},
+    )
+
+    assert response.status_code == 201
+    assert route.called
+
+
+@respx.mock
+def test_span_and_event_telemetry_forward_to_default_instance() -> None:
+    client = _client([_instance("alpha", base_url="http://alpha", is_default=True)])
+    start = respx.post("http://alpha/api/v1/forge/spans/start").mock(
+        return_value=Response(201, json={"span_id": "sp-1"})
+    )
+    complete = respx.post("http://alpha/api/v1/forge/spans/complete").mock(
+        return_value=Response(201, json={"ok": True})
+    )
+    finish = respx.post("http://alpha/api/v1/forge/spans/sp-1/finish").mock(
+        return_value=Response(200, json={"ok": True})
+    )
+    events = respx.post("http://alpha/api/v1/forge/events").mock(
+        return_value=Response(201, json={"ok": True})
+    )
+
+    assert client.post("/api/v1/forge/spans/start", headers=_headers(), json={}).status_code == 201
+    assert (
+        client.post("/api/v1/forge/spans/complete", headers=_headers(), json={}).status_code == 201
+    )
+    assert (
+        client.post("/api/v1/forge/spans/sp-1/finish", headers=_headers(), json={}).status_code
+        == 200
+    )
+    assert client.post("/api/v1/forge/events", headers=_headers(), json={}).status_code == 201
+    assert start.called and complete.called and finish.called and events.called
+
+
+def test_sse_stream_embedded_without_broadcaster_returns_503() -> None:
+    embedded = FastAPI()
+    client = _client(
+        [
+            _instance(
+                "local",
+                base_url="embedded://local-forge",
+                is_default=True,
+                config={"transport": "embedded"},
+            )
+        ],
+        embedded_forge_app=embedded,
+    )
+
+    response = client.get("/api/v1/forge/sessions/stream", headers=_headers())
+
+    assert response.status_code == 503

--- a/tests/test_niuu/test_rest_volundr.py
+++ b/tests/test_niuu/test_rest_volundr.py
@@ -671,6 +671,34 @@ def test_proxy_routes_forward_to_session_owner(
 
 
 @respx.mock
+def test_update_session_proxies_put_rename_to_owner_with_body() -> None:
+    # PUT /sessions/{id} (rename/update, contract §2.1) — the aggregate only
+    # registered GET/DELETE on this path, so web + iOS renames 405'd.
+    client = _client([_instance("beta", base_url="http://beta")])
+    respx.get("http://beta/api/v1/forge/sessions/s2").mock(
+        return_value=Response(200, json={"id": "s2", "name": "old-name"})
+    )
+    route = respx.put("http://beta/api/v1/forge/sessions/s2").mock(
+        return_value=Response(200, json={"id": "s2", "name": "new-name"})
+    )
+
+    response = client.put(
+        "/api/v1/forge/sessions/s2",
+        headers=_headers(),
+        json={"name": "new-name"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["name"] == "new-name"
+    assert payload["instance_id"] == "beta"
+    assert route.called
+    import json as _json
+
+    assert _json.loads(route.calls.last.request.content) == {"name": "new-name"}
+
+
+@respx.mock
 def test_proxy_routes_fall_back_to_empty_payloads_when_remote_returns_non_dict_content() -> None:
     client = _client([_instance("beta", base_url="http://beta")])
     respx.get("http://beta/api/v1/forge/sessions/s2").mock(

--- a/tests/test_niuu/test_rest_volundr.py
+++ b/tests/test_niuu/test_rest_volundr.py
@@ -829,3 +829,50 @@ def test_feature_flags_proxies_to_default_instance() -> None:
 
     assert response.status_code == 200
     assert response.json()["mini_mode"] is True
+
+
+@respx.mock
+def test_activity_report_proxies_to_owner_with_body() -> None:
+    """Broker activity heartbeats (incl. cli_session_id for resume) must reach
+    the owning instance through the aggregate, not 404 at the gateway."""
+    client = _client([_instance("beta", base_url="http://beta")])
+    respx.get("http://beta/api/v1/forge/sessions/s2").mock(
+        return_value=Response(200, json={"id": "s2"})
+    )
+    route = respx.post("http://beta/api/v1/forge/sessions/s2/activity").mock(
+        return_value=Response(204)
+    )
+
+    response = client.post(
+        "/api/v1/forge/sessions/s2/activity",
+        headers=_headers(),
+        json={"state": "active", "metadata": {"cli_session_id": "sess-1"}},
+    )
+
+    assert response.status_code == 204
+    assert route.called
+    import json as _json
+
+    sent = _json.loads(route.calls.last.request.content)
+    assert sent["metadata"]["cli_session_id"] == "sess-1"
+
+
+@respx.mock
+def test_usage_report_proxies_to_owner() -> None:
+    client = _client([_instance("beta", base_url="http://beta")])
+    respx.get("http://beta/api/v1/forge/sessions/s2").mock(
+        return_value=Response(200, json={"id": "s2"})
+    )
+    route = respx.post("http://beta/api/v1/forge/sessions/s2/usage").mock(
+        return_value=Response(201, json={"recorded": True})
+    )
+
+    response = client.post(
+        "/api/v1/forge/sessions/s2/usage",
+        headers=_headers(),
+        json={"tokens": 1200, "model": "claude-opus-4-8"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["recorded"] is True
+    assert route.called

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -288,6 +288,24 @@ class TestSessionProvisioningState:
         assert result.chat_endpoint is not None
 
     @pytest.mark.asyncio
+    async def test_start_session_clears_stale_error(self, service, repository):
+        """Restart is an explicit "bring it back" — a stale failure verdict
+        (e.g. the liveness reaper's "broker presumed dead") must not survive
+        onto the relaunched session, or clients banner a healthy session."""
+        session = await service.create_session(
+            name="Test",
+            model="claude-sonnet-4-20250514",
+            source=GitSource(repo="https://github.com/test/repo", branch="main"),
+        )
+        stamped = session.model_copy(
+            update={"error": "liveness: no activity heartbeat — broker presumed dead"}
+        )
+        await repository.update(stamped)
+
+        result = await service.start_session(session.id)
+        assert result.error is None
+
+    @pytest.mark.asyncio
     async def test_poll_readiness_transitions_to_running(self, service, repository):
         """Background poller transitions PROVISIONING -> RUNNING on success."""
         session = await service.create_session(

--- a/tests/test_services/test_activity.py
+++ b/tests/test_services/test_activity.py
@@ -56,6 +56,39 @@ class TestUpdateActivity:
         assert updated.activity_metadata == metadata
 
     @pytest.mark.asyncio
+    async def test_update_activity_clears_stale_liveness_error(self, service, repository):
+        """A heartbeat is proof of life — a lingering liveness verdict is
+        demonstrably false and must clear (the clients render `error` as a
+        Session-error banner on an otherwise healthy running session)."""
+        session = await service.create_session(
+            name="Test",
+            model="claude-sonnet-4-20250514",
+            source=GitSource(repo="https://github.com/test/repo", branch="main"),
+        )
+        stamped = session.model_copy(
+            update={"error": "liveness: no activity heartbeat — broker presumed dead"}
+        )
+        await repository.update(stamped)
+
+        updated = await service.update_activity(session.id, SessionActivityState.ACTIVE, {})
+        assert updated.error is None
+
+    @pytest.mark.asyncio
+    async def test_update_activity_keeps_non_liveness_errors(self, service, repository):
+        """Only liveness verdicts clear on heartbeat — real failure detail from
+        other paths stays visible."""
+        session = await service.create_session(
+            name="Test",
+            model="claude-sonnet-4-20250514",
+            source=GitSource(repo="https://github.com/test/repo", branch="main"),
+        )
+        stamped = session.model_copy(update={"error": "provisioning failed: no disk"})
+        await repository.update(stamped)
+
+        updated = await service.update_activity(session.id, SessionActivityState.ACTIVE, {})
+        assert updated.error == "provisioning failed: no disk"
+
+    @pytest.mark.asyncio
     async def test_update_activity_broadcasts_event(self, service, broadcaster):
         """update_activity should broadcast a SESSION_ACTIVITY event."""
         session = await service.create_session(

--- a/tests/test_services/test_activity.py
+++ b/tests/test_services/test_activity.py
@@ -89,6 +89,28 @@ class TestUpdateActivity:
         assert updated.error == "provisioning failed: no disk"
 
     @pytest.mark.asyncio
+    async def test_update_activity_persists_cli_session_id(self, service):
+        """A cli_session_id in the report is persisted on the session and kept
+        out of activity_metadata (so it survives a stop for resume)."""
+        session = await service.create_session(
+            name="Resumable",
+            model="claude-opus-4-8",
+            source=GitSource(repo="https://github.com/test/repo", branch="main"),
+        )
+        assert session.cli_session_id is None
+
+        updated = await service.update_activity(
+            session.id,
+            SessionActivityState.ACTIVE,
+            {"turn_count": 1, "cli_session_id": "claude-abc-123"},
+        )
+
+        assert updated.cli_session_id == "claude-abc-123"
+        assert "cli_session_id" not in updated.activity_metadata
+        reloaded = await service.get_session(session.id)
+        assert reloaded.cli_session_id == "claude-abc-123"
+
+    @pytest.mark.asyncio
     async def test_update_activity_broadcasts_event(self, service, broadcaster):
         """update_activity should broadcast a SESSION_ACTIVITY event."""
         session = await service.create_session(

--- a/tests/test_services/test_liveness_reconciliation.py
+++ b/tests/test_services/test_liveness_reconciliation.py
@@ -1,0 +1,104 @@
+"""Tests for SessionService.reconcile_liveness (G6 — dead-broker detection)."""
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+import pytest
+
+from tests.conftest import InMemorySessionRepository
+from volundr.domain.models import (
+    GitSource,
+    Session,
+    SessionActivityState,
+    SessionStatus,
+)
+from volundr.domain.services.session import SessionService
+
+
+def _session(status: SessionStatus, last_active: datetime) -> Session:
+    return Session(
+        id=uuid4(),
+        name="s",
+        model="claude-opus-4-8",
+        source=GitSource(type="git", repo_url="https://example.com/r.git", branch="main"),
+        status=status,
+        chat_endpoint="ws://host:8080/s/x/session",
+        code_endpoint="file:///x",
+        pod_name="local-x",
+        created_at=last_active,
+        last_active=last_active,
+    )
+
+
+@pytest.fixture
+def repo() -> InMemorySessionRepository:
+    return InMemorySessionRepository()
+
+
+@pytest.fixture
+def service(repo, pod_manager, broadcaster) -> SessionService:
+    return SessionService(
+        repository=repo,
+        pod_manager=pod_manager,
+        broadcaster=broadcaster,
+        validate_repos=False,
+    )
+
+
+class TestReconcileLiveness:
+    async def test_marks_stale_running_session_stopped_and_clears_endpoint(self, service, repo):
+        old = datetime.now(UTC) - timedelta(seconds=3600)
+        stale = _session(SessionStatus.RUNNING, old)
+        await repo.create(stale)
+
+        count = await service.reconcile_liveness(stale_after_seconds=600)
+
+        assert count == 1
+        updated = await repo.get(stale.id)
+        assert updated.status == SessionStatus.STOPPED
+        assert updated.chat_endpoint is None
+        assert updated.code_endpoint is None
+        assert "liveness" in (updated.error or "")
+
+    async def test_keeps_recently_active_running_session(self, service, repo):
+        fresh = _session(SessionStatus.RUNNING, datetime.now(UTC))
+        await repo.create(fresh)
+
+        count = await service.reconcile_liveness(stale_after_seconds=600)
+
+        assert count == 0
+        assert (await repo.get(fresh.id)).status == SessionStatus.RUNNING
+
+    async def test_ignores_non_running_sessions(self, service, repo):
+        old = datetime.now(UTC) - timedelta(seconds=3600)
+        for st in (SessionStatus.STARTING, SessionStatus.PROVISIONING, SessionStatus.STOPPED):
+            await repo.create(_session(st, old))
+
+        count = await service.reconcile_liveness(stale_after_seconds=600)
+
+        assert count == 0
+
+    async def test_returns_count_across_multiple_stale(self, service, repo):
+        old = datetime.now(UTC) - timedelta(seconds=3600)
+        for _ in range(3):
+            await repo.create(_session(SessionStatus.RUNNING, old))
+
+        count = await service.reconcile_liveness(stale_after_seconds=600)
+
+        assert count == 3
+
+
+class TestActivityRefreshesLastActive:
+    async def test_update_activity_bumps_last_active(self, service, repo):
+        old = datetime.now(UTC) - timedelta(seconds=3600)
+        session = _session(SessionStatus.RUNNING, old)
+        await repo.create(session)
+
+        before = datetime.now(UTC)
+        updated = await service.update_activity(
+            session.id, SessionActivityState.ACTIVE, metadata={}
+        )
+
+        assert updated.last_active >= before
+        # and a heartbeat keeps it out of the stale set
+        assert await service.reconcile_liveness(stale_after_seconds=600) == 0

--- a/tests/test_services/test_liveness_reconciliation.py
+++ b/tests/test_services/test_liveness_reconciliation.py
@@ -102,3 +102,11 @@ class TestActivityRefreshesLastActive:
         assert updated.last_active >= before
         # and a heartbeat keeps it out of the stale set
         assert await service.reconcile_liveness(stale_after_seconds=600) == 0
+
+
+def test_liveness_reaper_disabled_by_default():
+    """Brokers only report activity on state changes today, so the reaper
+    would falsely reap quiet-but-alive sessions — it must be opt-in."""
+    from volundr.config import SessionLivenessConfig
+
+    assert SessionLivenessConfig().enabled is False

--- a/tests/test_session_archive.py
+++ b/tests/test_session_archive.py
@@ -225,3 +225,43 @@ def test_load_workspace_transcript_rejects_non_object_json(tmp_path):
 
     with pytest.raises(ValueError, match="Expected JSON object"):
         load_workspace_transcript(tmp_path, "sess-3")
+
+
+def test_workspace_archive_not_served_to_a_different_session(tmp_path):
+    """The ghost-replay bug: workspace archives are SHARED per workspace
+    (archive_root ignores session_id for location="workspace"), so the loader
+    must verify manifest ownership — a NEW session in a workspace with prior
+    history must NOT inherit the previous session's transcript/logs."""
+    import json as _json
+
+    from volundr.session_archive import (
+        archive_logs_aggregate_path,
+        archive_manifest_path,
+        archive_transcript_json_path,
+        load_archive_logs,
+        load_archive_transcript,
+    )
+
+    owner = "11111111-1111-1111-1111-111111111111"
+    stranger = "22222222-2222-2222-2222-222222222222"
+
+    tpath = archive_transcript_json_path(tmp_path, session_id=owner)
+    tpath.parent.mkdir(parents=True, exist_ok=True)
+    tpath.write_text(_json.dumps({"turns": [{"role": "user", "content": "old stuff"}]}))
+    lpath = archive_logs_aggregate_path(tmp_path, session_id=owner)
+    lpath.parent.mkdir(parents=True, exist_ok=True)
+    lpath.write_text(_json.dumps({"lines": ["old log"]}))
+    mpath = archive_manifest_path(tmp_path, session_id=owner)
+    mpath.write_text(_json.dumps({"version": 1, "session_id": owner}))
+
+    # The owner still reads its archive.
+    assert load_archive_transcript(tmp_path, session_id=owner) is not None
+    assert load_archive_logs(tmp_path, session_id=owner) is not None
+
+    # A different session in the SAME workspace gets nothing.
+    assert load_archive_transcript(tmp_path, session_id=stranger) is None
+    assert load_archive_logs(tmp_path, session_id=stranger) is None
+
+    # Legacy archive without a manifest stays readable (no regression).
+    mpath.unlink()
+    assert load_archive_transcript(tmp_path, session_id=stranger) is not None

--- a/tests/test_skuld/test_activity_reporting.py
+++ b/tests/test_skuld/test_activity_reporting.py
@@ -175,3 +175,39 @@ class TestCliEventActivityIntegration:
 
             idle_calls = [c for c in mock_report.call_args_list if c[0][0] == "idle"]
             assert len(idle_calls) >= 1
+
+    @pytest.mark.asyncio
+    async def test_report_activity_rides_cli_session_id(self, test_broker):
+        """The transport's conversation id rides on the activity report so
+        Volundr can persist it and resume the session after a restart."""
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_client.post = AsyncMock(return_value=mock_response)
+        test_broker._http_client = mock_client
+        test_broker._http_client_jwt = None
+        transport = MagicMock()
+        transport.session_id = "claude-sess-42"
+        test_broker._transport = transport
+
+        await test_broker._report_activity_state("active")
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert payload["metadata"]["cli_session_id"] == "claude-sess-42"
+
+    @pytest.mark.asyncio
+    async def test_report_activity_omits_cli_session_id_when_absent(self, test_broker):
+        mock_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_client.post = AsyncMock(return_value=mock_response)
+        test_broker._http_client = mock_client
+        test_broker._http_client_jwt = None
+        transport = MagicMock()
+        transport.session_id = None
+        test_broker._transport = transport
+
+        await test_broker._report_activity_state("active")
+
+        payload = mock_client.post.call_args[1]["json"]
+        assert "cli_session_id" not in payload["metadata"]

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -2574,6 +2574,9 @@ class TestReportChronicle:
 
     @pytest.mark.asyncio
     async def test_report_chronicle_posts_to_api(self, test_broker):
+        # Stop-summarization is opt-in (OFF by default); this test exercises
+        # the enabled path.
+        test_broker._settings.chronicle_on_stop_enabled = True
         test_broker._artifacts.turn_count = 3
         test_broker._artifacts.files_changed = ["/src/main.py"]
 
@@ -2644,7 +2647,20 @@ class TestReportChronicle:
         mock_client.post.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_report_chronicle_skipped_by_default(self, test_broker):
+        """Stop summarization is OFF by default — no chronicle POST fires."""
+        test_broker._artifacts.turn_count = 3
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock()
+        test_broker._http_client = mock_client
+        test_broker._transport = None
+
+        await test_broker._report_chronicle()
+
+        assert mock_client.post.call_count == 0
+
     async def test_report_chronicle_posts_for_flock_outcome_without_turns(self, test_broker):
+        test_broker._settings.chronicle_on_stop_enabled = True
         test_broker._artifacts.structured_outcome = {
             "summary": "Reviewer approved the changes",
             "files_changed": ["proofs/marker.txt"],

--- a/tests/test_skuld/test_claude_env.py
+++ b/tests/test_skuld/test_claude_env.py
@@ -1,0 +1,58 @@
+"""Tests for the shared Claude spawn-env builder (subscription-auth default).
+
+The deploy env injects ANTHROPIC_API_KEY for the platform; Claude sessions must
+NOT inherit it by default — the spawned CLI authenticates with the host's
+claude.ai login instead (API-key orgs without data retention 400 on
+retention-gated models like claude-fable-5). SKULD__CLAUDE_AUTH=api_key is the
+escape hatch that restores the old behavior.
+"""
+
+from unittest.mock import patch
+
+from skuld.transports.claude_env import claude_spawn_env
+
+
+class TestClaudeSpawnEnv:
+    def test_subscription_default_strips_api_key_vars(self):
+        fake = {
+            "PATH": "/usr/bin",
+            "ANTHROPIC_API_KEY": "sk-test",
+            "ANTHROPIC_AUTH_TOKEN": "tok",
+            "CLAUDECODE": "1",
+        }
+        with patch.dict("os.environ", fake, clear=True):
+            env = claude_spawn_env()
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_AUTH_TOKEN" not in env
+        assert "CLAUDECODE" not in env
+        assert env["PATH"] == "/usr/bin"
+
+    def test_api_key_mode_keeps_key_but_still_drops_claudecode(self):
+        fake = {
+            "PATH": "/usr/bin",
+            "ANTHROPIC_API_KEY": "sk-test",
+            "CLAUDECODE": "1",
+            "SKULD__CLAUDE_AUTH": "api_key",
+        }
+        with patch.dict("os.environ", fake, clear=True):
+            env = claude_spawn_env()
+        assert env["ANTHROPIC_API_KEY"] == "sk-test"
+        assert "CLAUDECODE" not in env
+
+    def test_mode_is_case_insensitive_and_trimmed(self):
+        fake = {
+            "ANTHROPIC_API_KEY": "sk-test",
+            "SKULD__CLAUDE_AUTH": "  API_KEY  ",
+        }
+        with patch.dict("os.environ", fake, clear=True):
+            env = claude_spawn_env()
+        assert env["ANTHROPIC_API_KEY"] == "sk-test"
+
+    def test_unknown_mode_falls_back_to_subscription(self):
+        fake = {
+            "ANTHROPIC_API_KEY": "sk-test",
+            "SKULD__CLAUDE_AUTH": "whatever",
+        }
+        with patch.dict("os.environ", fake, clear=True):
+            env = claude_spawn_env()
+        assert "ANTHROPIC_API_KEY" not in env

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -2573,3 +2573,34 @@ class TestConfigIntegration:
 
         settings = SkuldSettings(cli_type="codex")
         assert settings.transport_adapter == "skuld.transports.codex.CodexSubprocessTransport"
+
+
+class TestResumeInitialPromptSkip:
+    @pytest.mark.asyncio
+    async def test_start_skips_initial_prompt_on_resume(self, tmp_path):
+        """On resume the prior thread already contains the initial prompt."""
+        t = _make_transport(
+            tmp_path,
+            initial_prompt="kick off",
+            resume_session_id="thread-resume-1",
+        )
+        t._spawn_app_server = AsyncMock()
+        t._connect_ws = AsyncMock()
+        t._handshake = AsyncMock()
+        t.send_message = AsyncMock()
+
+        await t.start()
+
+        t.send_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_sends_initial_prompt_without_resume(self, tmp_path):
+        t = _make_transport(tmp_path, initial_prompt="kick off")
+        t._spawn_app_server = AsyncMock()
+        t._connect_ws = AsyncMock()
+        t._handshake = AsyncMock()
+        t.send_message = AsyncMock()
+
+        await t.start()
+
+        t.send_message.assert_awaited_once_with("kick off")

--- a/tests/test_skuld/test_config.py
+++ b/tests/test_skuld/test_config.py
@@ -18,7 +18,7 @@ class TestSkuldSessionConfig:
         config = SkuldSessionConfig()
         assert config.id == "unknown"
         assert config.name == "unknown"
-        assert config.model == "claude-sonnet-4-6"
+        assert config.model == "claude-opus-4-8"
         assert config.workspace_dir is None
 
     def test_explicit_values(self):
@@ -60,7 +60,7 @@ class TestSkuldSettings:
         assert s.volundr_api_url == ""
         assert s.session.id == "unknown"
         assert s.session.name == "unknown"
-        assert s.session.model == "claude-sonnet-4-6"
+        assert s.session.model == "claude-opus-4-8"
         assert s.persistence_mount_path == "/volundr/sessions"
         assert s.peer_watchdog.enabled is True
         assert s.peer_watchdog.poll_seconds == 5.0

--- a/tests/test_skuld/test_event_log.py
+++ b/tests/test_skuld/test_event_log.py
@@ -1,0 +1,155 @@
+"""Tests for the broker's durable full-fidelity event log producer."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from skuld.broker import Broker
+from skuld.config import SkuldSettings
+
+
+def _broker(tmp_path, **overrides) -> Broker:
+    settings = SkuldSettings(
+        session={"id": "s1", "workspace_dir": str(tmp_path)},
+        volundr_api_url=overrides.pop("volundr_api_url", "http://volundr.test"),
+        **overrides,
+    )
+    return Broker(settings=settings)
+
+
+def _resp(status: int = 201) -> MagicMock:
+    r = MagicMock()
+    r.status_code = status
+    r.text = ""
+    return r
+
+
+class TestEnqueue:
+    def test_enqueue_assigns_monotonic_seq_and_captures_frame(self, tmp_path):
+        b = _broker(tmp_path)
+        b._enqueue_event_log({"type": "assistant", "role": "assistant", "message": {"x": 1}})
+        b._enqueue_event_log({"type": "content_block_delta", "delta": {"text": "hi"}})
+
+        assert [e["seq"] for e in b._event_log_buffer] == [1, 2]
+        assert b._event_log_buffer[0]["kind"] == "assistant"
+        assert b._event_log_buffer[0]["role"] == "assistant"
+        # full frame preserved verbatim (no truncation)
+        assert b._event_log_buffer[1]["payload"] == {
+            "type": "content_block_delta",
+            "delta": {"text": "hi"},
+        }
+
+    def test_enqueue_extracts_request_id(self, tmp_path):
+        b = _broker(tmp_path)
+        b._enqueue_event_log({"type": "result", "request_id": "forge-web-7"})
+        b._enqueue_event_log({"type": "assistant", "message": {"request_id": "forge-web-8"}})
+
+        assert b._event_log_buffer[0]["request_id"] == "forge-web-7"
+        assert b._event_log_buffer[1]["request_id"] == "forge-web-8"
+
+    def test_enqueue_noop_when_disabled(self, tmp_path):
+        b = _broker(tmp_path, event_log_enabled=False)
+        b._enqueue_event_log({"type": "assistant"})
+        assert b._event_log_buffer == []
+
+    def test_enqueue_noop_without_api_url(self, tmp_path):
+        b = _broker(tmp_path, volundr_api_url="")
+        b._enqueue_event_log({"type": "assistant"})
+        assert b._event_log_buffer == []
+
+    def test_overflow_drops_oldest(self, tmp_path):
+        b = _broker(tmp_path, event_log_max_buffer=3)
+        for i in range(5):
+            b._enqueue_event_log({"type": "content_block_delta", "i": i})
+
+        # only the newest 3 survive, but seq keeps climbing (never reused)
+        assert len(b._event_log_buffer) == 3
+        assert [e["seq"] for e in b._event_log_buffer] == [3, 4, 5]
+
+
+class TestFlush:
+    async def test_flush_posts_batch_and_removes_on_success(self, tmp_path):
+        b = _broker(tmp_path, event_log_batch_size=10)
+        for i in range(3):
+            b._enqueue_event_log({"type": "assistant", "i": i})
+
+        client = AsyncMock()
+        client.post.return_value = _resp(201)
+        with patch.object(b, "_get_http_client", AsyncMock(return_value=client)):
+            await b._flush_event_log()
+
+        client.post.assert_awaited_once()
+        path, kwargs = client.post.call_args[0][0], client.post.call_args[1]
+        assert path == "/api/v1/forge/sessions/s1/log"
+        assert len(kwargs["json"]["entries"]) == 3
+        assert b._event_log_buffer == []  # removed after success
+
+    async def test_flush_keeps_buffer_on_http_error(self, tmp_path):
+        b = _broker(tmp_path)
+        b._enqueue_event_log({"type": "assistant"})
+
+        client = AsyncMock()
+        client.post.return_value = _resp(503)
+        with patch.object(b, "_get_http_client", AsyncMock(return_value=client)):
+            await b._flush_event_log()
+
+        assert len(b._event_log_buffer) == 1  # retained for retry
+
+    async def test_flush_keeps_buffer_on_exception(self, tmp_path):
+        b = _broker(tmp_path)
+        b._enqueue_event_log({"type": "assistant"})
+
+        client = AsyncMock()
+        client.post.side_effect = RuntimeError("network down")
+        with patch.object(b, "_get_http_client", AsyncMock(return_value=client)):
+            await b._flush_event_log()
+
+        assert len(b._event_log_buffer) == 1
+
+    async def test_flush_removes_only_sent_count_when_appended_during_post(self, tmp_path):
+        b = _broker(tmp_path, event_log_batch_size=2)
+        b._enqueue_event_log({"type": "a"})
+        b._enqueue_event_log({"type": "b"})
+
+        async def _post(*_args, **_kwargs):
+            # a frame arrives mid-flight
+            b._enqueue_event_log({"type": "c"})
+            return _resp(201)
+
+        client = AsyncMock()
+        client.post.side_effect = _post
+        with patch.object(b, "_get_http_client", AsyncMock(return_value=client)):
+            await b._flush_event_log()
+
+        # only the 2 sent were removed; the late 'c' remains
+        assert [e["kind"] for e in b._event_log_buffer] == ["c"]
+
+    async def test_flush_empty_buffer_is_noop(self, tmp_path):
+        b = _broker(tmp_path)
+        client = AsyncMock()
+        with patch.object(b, "_get_http_client", AsyncMock(return_value=client)):
+            await b._flush_event_log()
+        client.post.assert_not_called()
+
+
+class TestInitResume:
+    async def test_init_resumes_seq_from_backend_head(self, tmp_path):
+        b = _broker(tmp_path)
+        client = AsyncMock()
+        head = MagicMock()
+        head.status_code = 200
+        head.json.return_value = {"latest_seq": 41}
+        client.get.return_value = head
+
+        with patch.object(b, "_get_http_client", AsyncMock(return_value=client)):
+            await b._init_event_log()
+        # cancel the worker the init spun up
+        await b._stop_event_log()
+
+        assert b._event_log_seq == 41
+        # next captured frame continues after the stored head (no PK collision)
+        b._enqueue_event_log({"type": "assistant"})
+        assert b._event_log_buffer[-1]["seq"] == 42
+
+    async def test_init_noop_when_disabled(self, tmp_path):
+        b = _broker(tmp_path, event_log_enabled=False)
+        await b._init_event_log()
+        assert b._event_log_task is None

--- a/tests/test_skuld/test_file_manager.py
+++ b/tests/test_skuld/test_file_manager.py
@@ -123,6 +123,79 @@ class TestFileUploadEndpoint:
         assert response.status_code == 400
 
 
+class TestFileUploadRawEndpoint:
+    """Tests for PUT /api/files/upload (raw-body, path names the destination file)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_workspace(self, tmp_path):
+        self._original_workspace = broker.workspace_dir
+        broker.workspace_dir = str(tmp_path)
+        self.workspace = tmp_path
+        self.client = TestClient(app, raise_server_exceptions=False)
+        yield
+        broker.workspace_dir = self._original_workspace
+
+    def test_put_writes_file(self):
+        response = self.client.put(
+            "/api/files/upload", params={"path": "note.txt"}, content=b"hello raw"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "note.txt"
+        assert data["path"] == "note.txt"
+        assert data["size"] == 9
+        assert (self.workspace / "note.txt").read_bytes() == b"hello raw"
+
+    def test_put_creates_parent_directories(self):
+        response = self.client.put(
+            "/api/files/upload",
+            params={"path": ".lexi/attachments/photo.jpg"},
+            content=b"\xff\xd8jpegbytes",
+        )
+        assert response.status_code == 200
+        assert (self.workspace / ".lexi/attachments/photo.jpg").read_bytes() == b"\xff\xd8jpegbytes"
+
+    def test_put_overwrites_existing_file(self):
+        (self.workspace / "note.txt").write_text("old")
+        response = self.client.put("/api/files/upload", params={"path": "note.txt"}, content=b"new")
+        assert response.status_code == 200
+        assert (self.workspace / "note.txt").read_bytes() == b"new"
+
+    def test_put_path_traversal_blocked(self):
+        response = self.client.put(
+            "/api/files/upload", params={"path": "../../evil.txt"}, content=b"bad"
+        )
+        assert response.status_code == 400
+
+    def test_put_empty_path_rejected(self):
+        response = self.client.put("/api/files/upload", params={"path": ""}, content=b"bad")
+        assert response.status_code == 400
+        assert "must name a file" in response.json()["detail"]
+
+    def test_put_directory_path_rejected(self):
+        (self.workspace / "dir").mkdir()
+        response = self.client.put("/api/files/upload", params={"path": "dir"}, content=b"bad")
+        assert response.status_code == 400
+        assert "must name a file" in response.json()["detail"]
+
+    def test_put_invalid_root(self):
+        response = self.client.put(
+            "/api/files/upload", params={"path": "x.txt", "root": "invalid"}, content=b"x"
+        )
+        assert response.status_code == 400
+
+    def test_put_oversize_body_rejected(self):
+        original = broker._settings.max_upload_size_bytes
+        broker._settings.max_upload_size_bytes = 4
+        try:
+            response = self.client.put(
+                "/api/files/upload", params={"path": "big.bin"}, content=b"12345"
+            )
+            assert response.status_code == 413
+        finally:
+            broker._settings.max_upload_size_bytes = original
+
+
 class TestMkdirEndpoint:
     """Tests for POST /api/files/mkdir."""
 

--- a/tests/test_skuld/test_persistent_subprocess.py
+++ b/tests/test_skuld/test_persistent_subprocess.py
@@ -319,3 +319,31 @@ async def test_seeded_resume_skips_initial_prompt(tmp_path) -> None:
 
     assert proc.stdin.buf == bytearray()
     await transport.stop()
+
+
+def test_flag_off_keeps_bypass_permissions_and_no_control_protocol() -> None:
+    """Default: classic bypassPermissions behavior, no stdio permission tool."""
+    transport = PersistentSubprocessTransport("/tmp", skip_permissions=True)
+
+    cmd = transport._build_command()
+
+    assert "--permission-mode" in cmd
+    assert "bypassPermissions" in cmd
+    assert "--permission-prompt-tool" not in cmd
+
+
+def test_flag_on_routes_permissions_over_stdio() -> None:
+    """SKULD__ASK_USER_QUESTION_ENABLED routes permissions over the control
+    protocol so AskUserQuestion reaches a human; bypassPermissions would
+    auto-dismiss it."""
+    transport = PersistentSubprocessTransport(
+        "/tmp",
+        skip_permissions=True,
+        ask_user_question_enabled=True,
+    )
+
+    cmd = transport._build_command()
+
+    assert "--permission-prompt-tool" in cmd
+    assert "stdio" in cmd
+    assert "--permission-mode" not in cmd

--- a/tests/test_skuld/test_persistent_subprocess.py
+++ b/tests/test_skuld/test_persistent_subprocess.py
@@ -347,3 +347,171 @@ def test_flag_on_routes_permissions_over_stdio() -> None:
     assert "--permission-prompt-tool" in cmd
     assert "stdio" in cmd
     assert "--permission-mode" not in cmd
+
+
+class TestPermissionControlProtocol:
+    """The stdio control protocol behind SKULD__ASK_USER_QUESTION_ENABLED."""
+
+    def _transport_with_stdin(self, tmp_path) -> tuple[PersistentSubprocessTransport, MagicMock]:
+        transport = PersistentSubprocessTransport(str(tmp_path), ask_user_question_enabled=True)
+        proc = _make_proc([])
+        transport._process = proc
+        return transport, proc
+
+    @pytest.mark.asyncio
+    async def test_can_use_tool_allows_ordinary_tools(self, tmp_path) -> None:
+        transport, proc = self._transport_with_stdin(tmp_path)
+
+        await transport._handle_control_request(
+            {
+                "type": "control_request",
+                "request_id": "req-1",
+                "request": {
+                    "subtype": "can_use_tool",
+                    "tool_name": "Write",
+                    "input": {"file_path": "/tmp/x"},
+                },
+            }
+        )
+
+        written = json.loads(bytes(proc.stdin.buf).decode())
+        assert written["response"]["subtype"] == "success"
+        assert written["response"]["response"]["behavior"] == "allow"
+        assert written["response"]["response"]["updatedInput"] == {"file_path": "/tmp/x"}
+
+    @pytest.mark.asyncio
+    async def test_unsupported_subtype_returns_error(self, tmp_path) -> None:
+        transport, proc = self._transport_with_stdin(tmp_path)
+
+        await transport._handle_control_request(
+            {"request_id": "req-2", "request": {"subtype": "hook_callback"}}
+        )
+
+        written = json.loads(bytes(proc.stdin.buf).decode())
+        assert written["response"]["subtype"] == "error"
+        assert "Unsupported" in written["response"]["error"]
+
+    @pytest.mark.asyncio
+    async def test_ask_user_question_blocks_until_answered(self, tmp_path) -> None:
+        """The full HITL loop: question emitted to clients, turn blocks, the
+        ask_user_answer control resolves it as a deny-with-message the model
+        reads."""
+        transport, proc = self._transport_with_stdin(tmp_path)
+        events: list[dict] = []
+
+        async def collect(event: dict) -> None:
+            events.append(event)
+
+        transport.on_event(collect)
+
+        task = asyncio.create_task(
+            transport._handle_control_request(
+                {
+                    "request_id": "req-3",
+                    "request": {
+                        "subtype": "can_use_tool",
+                        "tool_name": "AskUserQuestion",
+                        "tool_use_id": "toolu_1",
+                        "input": {
+                            "questions": [
+                                {
+                                    "header": "Color",
+                                    "question": "Pick one",
+                                    "options": ["red", "blue"],
+                                }
+                            ]
+                        },
+                    },
+                }
+            )
+        )
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if events:
+                break
+        question = events[0]
+        assert question["type"] == "ask_user_question"
+        assert not task.done(), "the turn must block until a client answers"
+
+        await transport.send_control(
+            "ask_user_answer",
+            request_id=question["request_id"],
+            answers=[{"answer": "blue"}],
+        )
+        await asyncio.wait_for(task, timeout=2)
+
+        written = json.loads(bytes(proc.stdin.buf).decode())
+        response = written["response"]["response"]
+        assert response["behavior"] == "deny"
+        assert "Color: blue" in response["message"]
+
+    @pytest.mark.asyncio
+    async def test_ask_user_question_without_questions_denies(self, tmp_path) -> None:
+        transport, _ = self._transport_with_stdin(tmp_path)
+
+        response = await transport._answer_ask_user_question({}, "toolu_2")
+
+        assert response["behavior"] == "deny"
+        assert "No questions" in response["message"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_answer_request_id_is_ignored(self, tmp_path) -> None:
+        transport, _ = self._transport_with_stdin(tmp_path)
+        await transport.send_control("ask_user_answer", request_id="nope", answers=[])
+
+    @pytest.mark.asyncio
+    async def test_initialize_handshake_resolves_on_control_response(self, tmp_path) -> None:
+        transport, proc = self._transport_with_stdin(tmp_path)
+
+        task = asyncio.create_task(transport._send_initialize())
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if proc.stdin.buf:
+                break
+        sent = json.loads(bytes(proc.stdin.buf).decode())
+        assert sent["request"]["subtype"] == "initialize"
+
+        transport._handle_control_response(
+            {
+                "type": "control_response",
+                "response": {"subtype": "success", "request_id": sent["request_id"]},
+            }
+        )
+        await asyncio.wait_for(task, timeout=2)
+
+    def test_control_response_error_sets_exception(self, tmp_path) -> None:
+        transport = PersistentSubprocessTransport(str(tmp_path))
+        loop = asyncio.new_event_loop()
+        try:
+            fut = loop.create_future()
+            transport._pending_control["req-err"] = fut
+            transport._handle_control_response(
+                {"response": {"subtype": "error", "request_id": "req-err", "error": "boom"}}
+            )
+            assert fut.done() and isinstance(fut.exception(), Exception)
+        finally:
+            loop.close()
+
+
+class TestAnswerFormatting:
+    def test_multi_question_multi_answer(self) -> None:
+        from skuld.transports.persistent_subprocess import _format_answer_message
+
+        text = _format_answer_message(
+            [
+                {"header": "Color", "question": "Pick"},
+                {"question": "Size?"},
+                {"header": "Extras"},
+            ],
+            [{"answer": "blue"}, {"answer": ["s", "m"]}],
+        )
+
+        assert "- Color: blue" in text
+        assert "- Size?: s, m" in text
+        assert "- Extras: (no answer)" in text
+
+    def test_non_list_answers_tolerated(self) -> None:
+        from skuld.transports.persistent_subprocess import _format_answer_message
+
+        text = _format_answer_message([{"header": "Q"}], "garbage")
+        assert "- Q: (no answer)" in text

--- a/tests/test_skuld/test_persistent_subprocess.py
+++ b/tests/test_skuld/test_persistent_subprocess.py
@@ -301,3 +301,21 @@ def test_no_resume_flag_without_seed() -> None:
 
     assert "--resume" not in cmd
     assert "--append-system-prompt" in cmd
+
+
+@pytest.mark.asyncio
+async def test_seeded_resume_skips_initial_prompt(tmp_path) -> None:
+    """On resume the prior conversation already contains the initial prompt —
+    replaying it would double-seed history."""
+    proc = _make_proc([])
+    transport = PersistentSubprocessTransport(
+        str(tmp_path),
+        initial_prompt="kick off the task",
+        resume_session_id="sess-resume-1",
+    )
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+        await transport.start()
+
+    assert proc.stdin.buf == bytearray()
+    await transport.stop()

--- a/tests/test_skuld/test_remote_control.py
+++ b/tests/test_skuld/test_remote_control.py
@@ -169,3 +169,107 @@ class TestCodexStub:
     def test_capabilities_disable_send_message(self):
         caps = CodexRemoteControlTransport("/tmp").capabilities
         assert caps.send_message is False
+
+
+class TestProcessIteration:
+    def test_ps_fallback_parses_pid_and_command(self):
+        fake_ps = "  101 claude remote-control --name volundr-tok\n  bad line\n 103 claude daemon\n"
+        with (
+            patch("skuld.transports.remote_control.glob.glob", return_value=[]),
+            patch(
+                "skuld.transports.remote_control.subprocess.run",
+                return_value=type("R", (), {"stdout": fake_ps})(),
+            ),
+        ):
+            entries = RemoteControlTransport._iter_processes()
+
+        assert (101, "claude remote-control --name volundr-tok") in entries
+        assert (103, "claude daemon") in entries
+        assert len(entries) == 2
+
+    def test_ps_failure_returns_empty(self):
+        with (
+            patch("skuld.transports.remote_control.glob.glob", return_value=[]),
+            patch(
+                "skuld.transports.remote_control.subprocess.run",
+                side_effect=OSError("no ps"),
+            ),
+        ):
+            assert RemoteControlTransport._iter_processes() == []
+
+    def test_sweep_without_token_is_noop(self):
+        transport = RemoteControlTransport("/tmp")
+        assert transport._sweep_kill(15) == 0
+
+
+class TestStopAndResurface:
+    @pytest.mark.asyncio
+    async def test_stop_terminates_and_sweeps(self):
+        import signal as _signal
+
+        transport = RemoteControlTransport("/tmp", session_id="tok12345")
+
+        class _Proc:
+            returncode = None
+            signals: list[int] = []
+
+            def send_signal(self, sig):
+                self.signals.append(sig)
+                self.returncode = 0
+
+            async def wait(self):
+                return 0
+
+        proc = _Proc()
+        transport._process = proc
+        swept: list[int] = []
+        with patch.object(transport, "_sweep_kill", side_effect=lambda sig: swept.append(sig) or 0):
+            await transport.stop()
+
+        assert _signal.SIGTERM in proc.signals
+        assert _signal.SIGTERM in swept
+
+    @pytest.mark.asyncio
+    async def test_send_message_resurfaces_pairing_url(self):
+        transport = RemoteControlTransport("/tmp", session_id="tok12345")
+        transport._url = "https://claude.ai/code?environment=env_abc"
+        events: list[dict] = []
+
+        async def collect(event: dict) -> None:
+            events.append(event)
+
+        transport.on_event(collect)
+        await transport.send_message("hello?")
+
+        resurfaced = [e for e in events if e.get("type") == "remote_control"]
+        assert resurfaced and resurfaced[0]["url"].endswith("env_abc")
+
+
+class TestCodexNotice:
+    @pytest.mark.asyncio
+    async def test_notice_when_standalone_missing(self):
+        transport = CodexRemoteControlTransport("/tmp")
+        events: list[dict] = []
+
+        async def collect(event: dict) -> None:
+            events.append(event)
+
+        transport.on_event(collect)
+        with patch("os.path.exists", return_value=False):
+            await transport._notice()
+
+        assert events, "a notice event must be emitted"
+
+    @pytest.mark.asyncio
+    async def test_notice_when_standalone_present(self):
+        transport = CodexRemoteControlTransport("/tmp")
+        events: list[dict] = []
+
+        async def collect(event: dict) -> None:
+            events.append(event)
+
+        transport.on_event(collect)
+        with patch("os.path.exists", return_value=True):
+            await transport._notice()
+
+        assert events

--- a/tests/test_skuld/test_remote_control.py
+++ b/tests/test_skuld/test_remote_control.py
@@ -1,0 +1,171 @@
+"""Tests for the Remote Control transports.
+
+The Claude transport launches ``claude remote-control``, scrapes the pairing
+URL from the ANSI TUI, and emits a structured ``remote_control`` event; the
+Codex variant fails fast until the standalone install exists.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from skuld.transports.remote_control import (
+    _ANSI_RE,
+    _URL_RE,
+    CodexRemoteControlTransport,
+    RemoteControlTransport,
+)
+
+
+class TestCommandConstruction:
+    def test_name_carries_session_token(self, monkeypatch):
+        monkeypatch.setenv("SKULD__SESSION__NAME", "my-session")
+        transport = RemoteControlTransport("/tmp", session_id="abcdef12-3456-7890")
+
+        cmd = transport._build_command()
+
+        assert cmd[:2] == ["claude", "remote-control"]
+        assert "--name" in cmd
+        name = cmd[cmd.index("--name") + 1]
+        assert name == "my-session-abcdef12-345"
+        assert "--spawn" in cmd
+        assert "same-dir" in cmd
+
+    def test_permission_mode_follows_skip_permissions(self, monkeypatch):
+        monkeypatch.delenv("SKULD__REMOTE_CONTROL_PERMISSION_MODE", raising=False)
+        bypass = RemoteControlTransport("/tmp", skip_permissions=True)._build_command()
+        default = RemoteControlTransport("/tmp", skip_permissions=False)._build_command()
+
+        assert bypass[bypass.index("--permission-mode") + 1] == "bypassPermissions"
+        assert default[default.index("--permission-mode") + 1] == "default"
+
+    def test_permission_mode_env_override(self, monkeypatch):
+        monkeypatch.setenv("SKULD__REMOTE_CONTROL_PERMISSION_MODE", "acceptEdits")
+        cmd = RemoteControlTransport("/tmp", skip_permissions=True)._build_command()
+
+        assert cmd[cmd.index("--permission-mode") + 1] == "acceptEdits"
+
+    def test_capabilities_disable_send_message(self):
+        caps = RemoteControlTransport("/tmp").capabilities
+        assert caps.send_message is False
+
+
+class TestPairingUrlScrape:
+    def test_url_regex_matches_pairing_link(self):
+        line = "Open https://claude.ai/code?environment=env_AbC-123_xyz to pair"
+        match = _URL_RE.search(line)
+        assert match is not None
+        assert match.group(0) == "https://claude.ai/code?environment=env_AbC-123_xyz"
+
+    def test_ansi_sequences_are_stripped_before_scraping(self):
+        decorated = "\x1b[1m\x1b[32mhttps://claude.ai/code?environment=env_tok\x1b[0m"
+        clean = _ANSI_RE.sub("", decorated)
+        assert _URL_RE.search(clean) is not None
+
+    @pytest.mark.asyncio
+    async def test_reader_emits_remote_control_event(self):
+        transport = RemoteControlTransport("/tmp", session_id="tok12345")
+        events: list[dict] = []
+
+        async def collect(event: dict) -> None:
+            events.append(event)
+
+        transport.on_event(collect)
+
+        class _Stdout:
+            def __init__(self):
+                self._lines = [
+                    b"\x1b[2J booting remote control...\n",
+                    b"pair here: https://claude.ai/code?environment=env_test_123\n",
+                    b"",
+                ]
+
+            async def readline(self):
+                return self._lines.pop(0)
+
+        class _Proc:
+            stdout = _Stdout()
+            returncode = None
+
+            async def wait(self):
+                self.returncode = 0
+                return 0
+
+        transport._process = _Proc()
+        await transport._read_output()
+
+        assert transport.remote_control_url == ("https://claude.ai/code?environment=env_test_123")
+        paired = [e for e in events if e.get("type") == "remote_control"]
+        assert paired and paired[0]["url"].endswith("env_test_123")
+
+
+class TestSpawnEnv:
+    @pytest.mark.asyncio
+    async def test_start_strips_api_key_auth_vars(self, monkeypatch):
+        """Remote Control refuses to start under API-key auth — the spawn env
+        must drop ANTHROPIC_API_KEY/AUTH_TOKEN so OAuth is used."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok")
+        transport = RemoteControlTransport("/tmp", session_id="tok12345")
+        captured: dict = {}
+
+        async def fake_exec(*cmd, **kwargs):
+            captured["env"] = kwargs.get("env", {})
+
+            class _P:
+                returncode = None
+                stdout = None
+                pid = 4242
+
+                async def wait(self):
+                    return 0
+
+            return _P()
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            await transport.start()
+
+        assert "ANTHROPIC_API_KEY" not in captured["env"]
+        assert "ANTHROPIC_AUTH_TOKEN" not in captured["env"]
+        if transport._reader_task is not None:
+            transport._reader_task.cancel()
+
+
+class TestSweepKill:
+    def test_sweep_targets_only_token_processes(self):
+        transport = RemoteControlTransport("/tmp", session_id="uniquetok999")
+        seen: list[int] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            seen.append(pid)
+
+        process_table = {
+            101: "claude remote-control --name volundr-uniquetok999 --spawn same-dir",
+            102: "claude remote-control --name volundr-othertoken --spawn same-dir",
+            103: "claude daemon",
+        }
+
+        with (
+            patch.object(transport, "_iter_processes", return_value=process_table.items()),
+            patch("os.kill", side_effect=fake_kill),
+        ):
+            killed = transport._sweep_kill(15)
+
+        assert killed == 1
+        assert seen == [101]
+
+
+class TestCodexStub:
+    @pytest.mark.asyncio
+    async def test_send_message_is_rejected(self):
+        transport = CodexRemoteControlTransport("/tmp")
+        transport._emit = AsyncMock()
+
+        await transport.start()
+        assert transport.is_alive is False
+
+    def test_capabilities_disable_send_message(self):
+        caps = CodexRemoteControlTransport("/tmp").capabilities
+        assert caps.send_message is False

--- a/tests/test_skuld/transports/test_sdk.py
+++ b/tests/test_skuld/transports/test_sdk.py
@@ -428,7 +428,8 @@ def test_capabilities() -> None:
     assert caps.interrupt is True
     assert caps.steer is True
     assert caps.steering_mode == "interrupt_resume"
-    assert caps.session_resume is False
+    # SDKTransport supports resume via ClaudeAgentOptions.resume.
+    assert caps.session_resume is True
     assert caps.set_model is True
     assert caps.set_permission_mode is True
 
@@ -1069,3 +1070,35 @@ def test_pending_steers_and_visibility_helpers() -> None:
     )
     assert transport._is_visible_output_event({"type": "assistant", "message": "bad"}) is False
     assert transport._is_visible_output_event({"type": "content_block_delta", "delta": []}) is False
+
+
+@pytest.mark.asyncio
+async def test_resume_session_id_sets_resume_option_and_skips_initial_prompt(
+    monkeypatch, tmp_path
+) -> None:
+    """A seeded resume id reloads the prior conversation: ClaudeAgentOptions.resume
+    is set and the initial prompt is NOT replayed (it is already in history)."""
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(
+        workspace_dir=str(tmp_path),
+        initial_prompt="Warm up.",
+        resume_session_id="sess-resume-1",
+    )
+
+    await transport.start()
+
+    assert factory.options.resume == "sess-resume-1"
+    assert factory.client.query.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_no_resume_option_without_seed(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path))
+    await transport.start()
+
+    assert factory.options.resume is None

--- a/tests/test_skuld/transports/test_sdk.py
+++ b/tests/test_skuld/transports/test_sdk.py
@@ -1129,3 +1129,72 @@ async def test_flag_on_registers_can_use_tool_callback(monkeypatch, tmp_path) ->
     await transport.start()
 
     assert factory.options.can_use_tool == transport._on_can_use_tool
+
+
+class TestAskUserQuestionHandlers:
+    @pytest.mark.asyncio
+    async def test_can_use_tool_allows_ordinary_tools(self, tmp_path) -> None:
+        from claude_agent_sdk import PermissionResultAllow
+
+        transport = SDKTransport(workspace_dir=str(tmp_path), ask_user_question_enabled=True)
+
+        result = await transport._on_can_use_tool("Write", {"file_path": "/tmp/x"}, None)
+
+        assert isinstance(result, PermissionResultAllow)
+
+    @pytest.mark.asyncio
+    async def test_ask_user_question_blocks_until_resolved(self, tmp_path) -> None:
+        from claude_agent_sdk import PermissionResultDeny
+
+        transport = SDKTransport(workspace_dir=str(tmp_path), ask_user_question_enabled=True)
+        events: list[dict] = []
+
+        async def collect(event: dict) -> None:
+            events.append(event)
+
+        transport.on_event(collect)
+
+        task = asyncio.create_task(
+            transport._on_can_use_tool(
+                "AskUserQuestion",
+                {"questions": [{"header": "Env", "question": "Which env?"}]},
+                None,
+            )
+        )
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if events:
+                break
+        question = next(e for e in events if e.get("type") == "ask_user_question")
+        assert not task.done()
+
+        assert transport.resolve_question(question["request_id"], [{"answer": "prod"}]) is True
+        result = await asyncio.wait_for(task, timeout=2)
+
+        assert isinstance(result, PermissionResultDeny)
+        assert "Env: prod" in result.message
+
+    @pytest.mark.asyncio
+    async def test_ask_user_question_without_questions_denies(self, tmp_path) -> None:
+        from claude_agent_sdk import PermissionResultDeny
+
+        transport = SDKTransport(workspace_dir=str(tmp_path))
+
+        result = await transport._handle_ask_user_question({}, None)
+
+        assert isinstance(result, PermissionResultDeny)
+        assert "No questions" in result.message
+
+    @pytest.mark.asyncio
+    async def test_send_control_routes_ask_user_answer(self, tmp_path) -> None:
+        transport = SDKTransport(workspace_dir=str(tmp_path))
+        fut = asyncio.get_event_loop().create_future()
+        transport._pending_questions["askq-x"] = fut
+
+        await transport.send_control("ask_user_answer", request_id="askq-x", answers=["a"])
+
+        assert fut.done() and fut.result() == ["a"]
+
+    def test_resolve_question_unknown_id_returns_false(self, tmp_path) -> None:
+        transport = SDKTransport(workspace_dir=str(tmp_path))
+        assert transport.resolve_question("missing", []) is False

--- a/tests/test_skuld/transports/test_sdk.py
+++ b/tests/test_skuld/transports/test_sdk.py
@@ -1102,3 +1102,30 @@ async def test_no_resume_option_without_seed(monkeypatch, tmp_path) -> None:
     await transport.start()
 
     assert factory.options.resume is None
+
+
+@pytest.mark.asyncio
+async def test_flag_off_omits_can_use_tool_callback(monkeypatch, tmp_path) -> None:
+    """Default: no permission callback — the SDK keeps its classic behavior."""
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(workspace_dir=str(tmp_path), skip_permissions=True)
+    await transport.start()
+
+    assert factory.options.can_use_tool is None
+    assert factory.options.permission_mode == "bypassPermissions"
+
+
+@pytest.mark.asyncio
+async def test_flag_on_registers_can_use_tool_callback(monkeypatch, tmp_path) -> None:
+    factory = _ClientFactory([[]])
+    monkeypatch.setattr("skuld.transports.sdk.ClaudeSDKClient", factory)
+
+    transport = SDKTransport(
+        workspace_dir=str(tmp_path),
+        ask_user_question_enabled=True,
+    )
+    await transport.start()
+
+    assert factory.options.can_use_tool == transport._on_can_use_tool

--- a/tests/test_volundr/test_session_definition_contributor.py
+++ b/tests/test_volundr/test_session_definition_contributor.py
@@ -186,4 +186,4 @@ class TestDefaultSessionDefinitions:
         context = SessionContext()
         result = await contributor.contribute(_mock_session(), context)
         assert result.values["broker"]["cliType"] == "claude"
-        assert result.values["model"] == "claude-sonnet-4-6"
+        assert result.values["model"] == "claude-opus-4-8"

--- a/uv.lock
+++ b/uv.lock
@@ -335,20 +335,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.89"
+version = "0.2.96"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/a9/a585d8a5089339d0c39c2b85b2fca9138db1863b385ce6fc7ed4fd4bf8fb/claude_agent_sdk-0.2.89.tar.gz", hash = "sha256:6a1ad0751a255882c5422198779144c094eb74e86c3f7ef00bcd27fbd6527c30", size = 253312, upload-time = "2026-06-03T21:43:40.891Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/e8/ce86f503f0e1548440ae3e35dbe99da6ba76715bc135c8c9f5f7c2bdd7d6/claude_agent_sdk-0.2.96.tar.gz", hash = "sha256:1932030ab114da9398e94bcc86b177b6ff579f5740238fb5c87751f8e745f572", size = 253659, upload-time = "2026-06-10T21:14:12.703Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/12/a12bfeab1a7c7f96642a2a3e08272038e19bed7a8751f9e250f91b878d2e/claude_agent_sdk-0.2.89-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c344e0e4c4a8a0c4e3d84efdffdef29d467203002ab5c898af2178498c61d82d", size = 64452653, upload-time = "2026-06-03T21:43:45.993Z" },
-    { url = "https://files.pythonhosted.org/packages/08/71/26fc80a2083f8427a284a3c4e29701b6e4acd1a753bdd62555d6f4b358a6/claude_agent_sdk-0.2.89-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:f84d4f48b1f9926e24665b910013f77dfce2b0ed1dca64c3c350a383009b5dd3", size = 66513584, upload-time = "2026-06-03T21:43:51.221Z" },
-    { url = "https://files.pythonhosted.org/packages/22/1b/88fe49274e9a1bb3b7623f04ca3a0a82358082bf0d29d42e9bc32050461d/claude_agent_sdk-0.2.89-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:be8663d990879578d101d4153dfad3a6ec38642a9d542f56de4f0a7051f8d284", size = 74080592, upload-time = "2026-06-03T21:43:57.602Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/47/56fb2e0bbf128b41edb9e15b79622cd0b41585c63f4e691287f6609af679/claude_agent_sdk-0.2.89-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:8a078e6fa06a66530bb5c58fd068a15438456f8b597bec870dd8e053a618278d", size = 74251641, upload-time = "2026-06-03T21:44:03.329Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ab/edbedca3e4599e9a3d96bd38ae3266ef2106bfc90fe9867181717c271030/claude_agent_sdk-0.2.89-py3-none-win_amd64.whl", hash = "sha256:a34ebd796f69ec2f2e41b0412b325de4a8aab042c2149079a07efddf04cc6899", size = 74869839, upload-time = "2026-06-03T21:44:09.736Z" },
+    { url = "https://files.pythonhosted.org/packages/df/63/7651f888af06cb7524b247babc8021e9046cef457c4a9be33e8e4994e3da/claude_agent_sdk-0.2.96-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9bbf12b5b645f462e9c6e3c08c62c13fbfe156f125d25772178558b774cb3fe6", size = 65751202, upload-time = "2026-06-10T21:14:15.862Z" },
+    { url = "https://files.pythonhosted.org/packages/52/68/26150eecf5d2ad1cbad2e5c2266bd1fc4a7934429e5e2759920d61140ec8/claude_agent_sdk-0.2.96-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:56528acd1920e90df71aa29c97cd17b97943d2e5628cb9ec93ae6a61ba2da3ba", size = 67803554, upload-time = "2026-06-10T21:14:19.39Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3a/919e6177126acd7b37995864110a6b3f597591e80eacac1a4b8ae8f9aeb2/claude_agent_sdk-0.2.96-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:966a3227590f419f00798cdfb2ed81159f2b578ecbdd23d8ac39fe23e7c8e0bb", size = 75342676, upload-time = "2026-06-10T21:14:22.761Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ac/658381a6594176deeefa5f847bc43d99d60704ee99f9c86753d4a7655338/claude_agent_sdk-0.2.96-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:339e1589b784ed1912a7dfe567ebfdfd8d0b919717d7293ccb9272b0ac89e229", size = 75514017, upload-time = "2026-06-10T21:14:25.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/40/406f3498ebee470575a5166d256547a4103f4e126ff031d91f37bf012824/claude_agent_sdk-0.2.96-py3-none-win_amd64.whl", hash = "sha256:0e2674a16a26be597b5417823f38c0c488cfa79122cc87bedb442ac46f687f20", size = 76124918, upload-time = "2026-06-10T21:14:33.175Z" },
 ]
 
 [[package]]
@@ -2401,7 +2401,7 @@ dev = [
 requires-dist = [
     { name = "aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=9.6.2" },
     { name = "asyncpg", specifier = ">=0.31.0" },
-    { name = "claude-agent-sdk", specifier = "==0.2.89" },
+    { name = "claude-agent-sdk", specifier = "==0.2.96" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = ">=48.0.0" },
     { name = "cryptography", marker = "extra == 'encryption'", specifier = ">=48.0.0" },
     { name = "fastapi", specifier = ">=0.136.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -335,20 +335,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.2.87"
+version = "0.2.89"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "mcp" },
     { name = "sniffio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/dc/e2afd59a1dd6484b6500245fa2331a0d8c0b68e6c180bc29d8ce9540f38a/claude_agent_sdk-0.2.87.tar.gz", hash = "sha256:56f02a49a97f7be37e0cd7323494d1c09e52fb0db7ab94f53bba8a230bb4bd0e", size = 252063, upload-time = "2026-05-23T04:19:25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/a9/a585d8a5089339d0c39c2b85b2fca9138db1863b385ce6fc7ed4fd4bf8fb/claude_agent_sdk-0.2.89.tar.gz", hash = "sha256:6a1ad0751a255882c5422198779144c094eb74e86c3f7ef00bcd27fbd6527c30", size = 253312, upload-time = "2026-06-03T21:43:40.891Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/4e/b83c4c6ec1e0b63e9d4d58ba9a5abfd9936c55b8ee4c06b88f5e93bdfd70/claude_agent_sdk-0.2.87-py3-none-macosx_11_0_arm64.whl", hash = "sha256:52204a9609dec3aa96032afd48c07d72e05d13311faf614978f17b61326e6e31", size = 63037960, upload-time = "2026-05-23T04:19:29.056Z" },
-    { url = "https://files.pythonhosted.org/packages/13/d7/5fb02260c5b95c66e108c35e046d4d66011921251f7896274b6b21594f14/claude_agent_sdk-0.2.87-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:1713e34e50b830ecac54386d39af14e3a2775f833f1ef715eb53566eaa1b6325", size = 65095745, upload-time = "2026-05-23T04:19:32.533Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/84/1061f6580bbbc78de629467abf051cdbbabe71b982297b401e3fde65c7e0/claude_agent_sdk-0.2.87-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:e9e23119d2a02ad1ea1a2707214db98f5baf2c8809577186629843ddfcb8ec18", size = 72725120, upload-time = "2026-05-23T04:19:36.539Z" },
-    { url = "https://files.pythonhosted.org/packages/04/50/449f5044d76d9de18cf6a9f4b1c9386a74f41b4e2da5312df245d9dd23ef/claude_agent_sdk-0.2.87-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:5ac525d9ae3481296df5639d005e12ce2b6b0427426991f35da64db30be25c6e", size = 72875504, upload-time = "2026-05-23T04:19:40.839Z" },
-    { url = "https://files.pythonhosted.org/packages/80/dd/3f9d7c491d5a98138d293192b31cc9ed792d3552b3a7e276163d7fe2d43a/claude_agent_sdk-0.2.87-py3-none-win_amd64.whl", hash = "sha256:f34973669a1efaeb1543e7b22d7b22feefd8af2fae3adfd39181635077dae432", size = 73514880, upload-time = "2026-05-23T04:19:44.65Z" },
+    { url = "https://files.pythonhosted.org/packages/94/12/a12bfeab1a7c7f96642a2a3e08272038e19bed7a8751f9e250f91b878d2e/claude_agent_sdk-0.2.89-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c344e0e4c4a8a0c4e3d84efdffdef29d467203002ab5c898af2178498c61d82d", size = 64452653, upload-time = "2026-06-03T21:43:45.993Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/26fc80a2083f8427a284a3c4e29701b6e4acd1a753bdd62555d6f4b358a6/claude_agent_sdk-0.2.89-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:f84d4f48b1f9926e24665b910013f77dfce2b0ed1dca64c3c350a383009b5dd3", size = 66513584, upload-time = "2026-06-03T21:43:51.221Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1b/88fe49274e9a1bb3b7623f04ca3a0a82358082bf0d29d42e9bc32050461d/claude_agent_sdk-0.2.89-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:be8663d990879578d101d4153dfad3a6ec38642a9d542f56de4f0a7051f8d284", size = 74080592, upload-time = "2026-06-03T21:43:57.602Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/47/56fb2e0bbf128b41edb9e15b79622cd0b41585c63f4e691287f6609af679/claude_agent_sdk-0.2.89-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:8a078e6fa06a66530bb5c58fd068a15438456f8b597bec870dd8e053a618278d", size = 74251641, upload-time = "2026-06-03T21:44:03.329Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ab/edbedca3e4599e9a3d96bd38ae3266ef2106bfc90fe9867181717c271030/claude_agent_sdk-0.2.89-py3-none-win_amd64.whl", hash = "sha256:a34ebd796f69ec2f2e41b0412b325de4a8aab042c2149079a07efddf04cc6899", size = 74869839, upload-time = "2026-06-03T21:44:09.736Z" },
 ]
 
 [[package]]
@@ -916,11 +916,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.17"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -2240,7 +2240,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.26.4"
+version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -2248,9 +2248,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/d3/90c1ee19209cb59f6ad185883fd4ccfcf72f8f0bfd549d5a8b70474611d0/typer-0.26.4.tar.gz", hash = "sha256:25b128964de66c5ea36d5ac82adc579e5e113509b17469edf9f5a4a1864ff2a9", size = 201191, upload-time = "2026-05-30T17:05:04.213Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/6d/5a525c69df4a90892135e5d490b00e9e46402491f3416d4395fcb0d0201e/typer-0.26.4-py3-none-any.whl", hash = "sha256:11bfd7b43557137e373c2b10f6967a555f9678a61ed72c808968b011d95534d6", size = 122436, upload-time = "2026-05-30T17:05:05.812Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]
@@ -2294,15 +2294,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.48.0"
+version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]
@@ -2401,13 +2401,13 @@ dev = [
 requires-dist = [
     { name = "aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=9.6.2" },
     { name = "asyncpg", specifier = ">=0.31.0" },
-    { name = "claude-agent-sdk", specifier = "==0.2.87" },
+    { name = "claude-agent-sdk", specifier = "==0.2.89" },
     { name = "cryptography", marker = "extra == 'dev'", specifier = ">=48.0.0" },
     { name = "cryptography", marker = "extra == 'encryption'", specifier = ">=48.0.0" },
     { name = "fastapi", specifier = ">=0.136.3" },
     { name = "gitpython", specifier = ">=3.1.50" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "idna", specifier = ">=3.17" },
+    { name = "idna", specifier = ">=3.18" },
     { name = "kubernetes-asyncio", marker = "extra == 'k8s'", specifier = ">=35.0.1" },
     { name = "msgpack", specifier = ">=1.1.2" },
     { name = "nats-py", marker = "extra == 'dev'", specifier = ">=2.14.0" },
@@ -2443,11 +2443,11 @@ requires-dist = [
     { name = "textual", marker = "extra == 'cli'", specifier = ">=8.2.7" },
     { name = "textual", marker = "extra == 'dev'", specifier = ">=8.2.7" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=8.2.7" },
-    { name = "typer", specifier = ">=0.26.4" },
-    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.26.4" },
-    { name = "typer", marker = "extra == 'dev'", specifier = ">=0.26.4" },
+    { name = "typer", specifier = ">=0.26.7" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.26.7" },
+    { name = "typer", marker = "extra == 'dev'", specifier = ">=0.26.7" },
     { name = "urllib3", specifier = ">=2.7.0" },
-    { name = "uvicorn", specifier = ">=0.48.0" },
+    { name = "uvicorn", specifier = ">=0.49.0" },
     { name = "websockets", specifier = ">=16.0" },
     { name = "zeroconf", specifier = ">=0.149.16" },
 ]


### PR DESCRIPTION
## Summary

Ports the Forge/session work from `xteo/niuu` branch `lexi/forge-api` (author: Thor/Damien) onto `dev` — now **22 of the fork's 25 commits** (everything except their internal migration renumbering and two commits superseded by our own equivalents), reconciled with #775 and hardened with default-off flags where agreed.

### Reliability fixes (first wave)
Raw-body file upload; subscription auth (cluster charts pin api_key); PUT rename proxy; workspace-archive ownership (ghost replay); false broker-presumed-dead trio (64 MiB WS frames, restart/heartbeat error clearing).

### Resume, universal (with #775)
Context-restoring resume for Volundr-born sessions (`cli_session_id` capture → migration `000046` → resume overlay), SDK-transport resume via `ClaudeAgentOptions.resume`, initial-prompt suppression on resume, activity/usage ingestion proxies, claude-agent-sdk pinned to 0.2.96 with the diverged lockfile repaired, fresh sessions pin a new session id (no cwd history bleed).

### Second wave (this push)
- **Durable full-fidelity event log** (`session_event_log`, migration `000047`): every CLI frame captured append-only with cursor replay (`GET /sessions/{id}/log?after=`, `/log/head`); emission timestamps; human turns mirrored; gateway ingest/replay proxies with the list-passthrough fix. **No retention policy yet — operators of busy deployments should plan pruning.**
- **AskUserQuestion HITL** behind `SKULD__ASK_USER_QUESTION_ENABLED` (default **off** → classic bypassPermissions). When on, permissions route over the control protocol; AskUserQuestion blocks for a client `ask_user_answer`. Full protocol now unit-tested on both Claude transports.
- **Liveness reaper** behind `session_liveness.enabled` (default **off** — brokers heartbeat only on state changes today; false-reap caveat documented).
- **Remote-control sessions**: `skuldClaudeRemote`/`skuldCodexRemote` built-in definitions, pairing-URL scrape surfaced as `remote_control` events; the stop sweep gained a `ps` fallback (was /proc-only — silently leaked RC workers on macOS hosts); Codex stub fails fast.
- **Policy defaults**: platform default model `claude-opus-4-8`; model-aware reasoning effort (xhigh/max Claude, high Codex incl. the `modelReasoningEffort` plumbing); stop-summarization **off** (`SKULD__CHRONICLE_ON_STOP_ENABLED`); chronicle watcher **off** (`SKULD__CHRONICLE_WATCHER_ENABLED`).
- **Docs**: OpenClaw guide documents all of the above (event-log replay contract, HITL frames, every flag/switch); root `CLAUDE.md` replaced — its entire history was droppings from the prompt-clobbering bug fixed earlier in this PR.

### Still not ported (3)
`3853604f` (their migration renumbering — moot), `edac98b0` (start proxy — superseded by ours), and nothing else.

## Test Plan
- Full volundr CI matrix job: **5,728 passed, coverage 85.06%** ≥ 85% gate; ruff + format clean; helm lint clean on all three charts
- Integration tests vs real PostgreSQL with migrations 000045–000047 applied; `session_event_log` table verified created
- New unit tests: HITL control protocol end-to-end (block-until-answered) on both transports, both flag states, remote-control internals, chronicle opt-in defaults, reaper default-off, event-log gateway proxies incl. list passthrough

## Checklist
- [x] Tests pass locally
- [x] Code follows project conventions
- [x] Self-reviewed the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)