### PR TITLE
[codex] add Skuld Claude tmux interactive transport

### DIFF
--- a/charts/volundr/README.md
+++ b/charts/volundr/README.md
@@ -1,8 +1,8 @@
 # Volundr Helm Chart
 
-![Version: 0.55.0](https://img.shields.io/badge/Version-0.55.0-informational?style=flat-square)
+![Version: 0.0.0-ting.160](https://img.shields.io/badge/Version-0.0.0--ting.160-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 0.55.0](https://img.shields.io/badge/AppVersion-0.55.0-informational?style=flat-square)
+![AppVersion: 0.0.0-ting.159](https://img.shields.io/badge/AppVersion-0.0.0--ting.159-informational?style=flat-square)
 
 Helm chart for deploying **Volundr** — a self-hosted Claude Code session manager with pluggable adapters for identity, authorization, storage, secret management, and session orchestration.
 
@@ -20,7 +20,7 @@ Helm chart for deploying **Volundr** — a self-hosted Claude Code session manag
 
 ```bash
 # Add the helm repository (if using OCI registry)
-helm pull oci://ghcr.io/niuulabs/charts/volundr --version 0.55.0
+helm pull oci://ghcr.io/niuulabs/charts/volundr --version 0.0.0-ting.160
 
 # Create namespace
 kubectl create namespace volundr
@@ -602,7 +602,7 @@ Session definitions are Kubernetes custom resources that describe how session po
 | `sessionDefinitions.skuldClaude.helm.chart` | string | `"skuld"` | Chart name |
 | `sessionDefinitions.skuldClaude.helm.repo` | string | `"oci://ghcr.io/niuulabs/charts"` | Helm repository URL (supports `oci://` for OCI registries) |
 | `sessionDefinitions.skuldClaude.helm.repoName` | string | `""` | Name of HelmRepository or OCIRepository CR in cluster (for Flux) |
-| `sessionDefinitions.skuldClaude.helm.version` | string | `"0.55.0"` | Chart version constraint |
+| `sessionDefinitions.skuldClaude.helm.version` | string | `"0.1.0"` | Chart version constraint |
 | `sessionDefinitions.skuldClaude.defaults.session.model` | string | `"claude-sonnet-4-20250514"` | Default Claude model |
 | `sessionDefinitions.skuldClaude.defaults.broker.cliType` | string | `"claude"` | AI CLI backend |
 | `sessionDefinitions.skuldClaude.defaults.broker.transport` | string | `"sdk"` | CLI transport mode (`sdk` = WebSocket, `subprocess` = legacy) |
@@ -634,6 +634,49 @@ Session definitions are Kubernetes custom resources that describe how session po
 | `sessionDefinitions.skuldClaude.defaults.runtimeClassName` | string | `""` | Runtime class name for session pods (e.g., `"nvidia"`, `"kata"`, `"gvisor"`) |
 | `sessionDefinitions.skuldClaude.defaults.volundr.apiUrl` | string | `""` | Volundr API URL for session pods (auto-wired in template) |
 
+#### skuld-claude-interactive
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `sessionDefinitions.skuldClaudeInteractive.enabled` | bool | `true` | Enable skuld-claude-interactive session definition |
+| `sessionDefinitions.skuldClaudeInteractive.displayName` | string | `"Claude Code Interactive"` | Human-readable name shown in the UI |
+| `sessionDefinitions.skuldClaudeInteractive.description` | string | `"Anthropic Claude Code through a tmux-backed interactive terminal"` | Short description for the session picker |
+| `sessionDefinitions.skuldClaudeInteractive.defaultModel` | string | `"claude-sonnet-4-6"` | Default model for this definition |
+| `sessionDefinitions.skuldClaudeInteractive.labels` | list | `["session","interactive"]` | Labels for agent routing |
+| `sessionDefinitions.skuldClaudeInteractive.compatibleProviders` | list | `["anthropic"]` | Model providers this runtime accepts |
+| `sessionDefinitions.skuldClaudeInteractive.active` | bool | `true` | Whether this session definition is active |
+| `sessionDefinitions.skuldClaudeInteractive.helm.chart` | string | `"skuld"` | Chart name |
+| `sessionDefinitions.skuldClaudeInteractive.helm.repo` | string | `"oci://ghcr.io/niuulabs/charts"` | Helm repository URL (supports `oci://` for OCI registries) |
+| `sessionDefinitions.skuldClaudeInteractive.helm.repoName` | string | `""` | Name of HelmRepository or OCIRepository CR in cluster |
+| `sessionDefinitions.skuldClaudeInteractive.helm.version` | string | `"0.1.0"` | Chart version constraint |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.session.model` | string | `"claude-sonnet-4-6"` | Default Claude model |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.broker.cliType` | string | `"claude"` | AI CLI backend |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.broker.transport` | string | `"tmux-interactive"` | Interactive tmux transport for a real TTY |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.broker.transportAdapter` | string | `"skuld.transports.tmux_interactive.TmuxInteractiveTransport"` | Fully-qualified transport adapter class path |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.broker.skipPermissions` | bool | `true` | Skip tool permission prompts (`--dangerously-skip-permissions`) |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.broker.agentTeams` | bool | `false` | Enable Claude Code experimental Agent Teams |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.image.repository` | string | `"ghcr.io/niuulabs/skuld"` | Session image repository |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.image.tag` | string | `"latest"` | Session image tag |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.resources` | object | See values.yaml | Resource requests/limits for the session container |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.imagePullSecrets` | list | `["ghcr-pull-secret"]` | Image pull secrets for session pods |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.ingress.className` | string | `""` | Ingress class name for sessions |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.ingress.annotations` | object | `{}` | Controller-specific annotations for WebSocket support |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.ingress.tls.enabled` | bool | `false` | Enable TLS for session ingress |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.ingress.tls.secretName` | string | `"skuld-wildcard-tls"` | TLS wildcard secret name |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.git.credentials.secretName` | string | `"github-token"` | K8s secret name containing git credentials |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.localServices.terminal.debug` | bool | `false` | Enable terminal debug UI in session pods |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.persistence.mountPath` | string | `"/volundr/sessions"` | Mount path for session data |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.homeVolume.enabled` | bool | `true` | Enable persistent home directory in session pods |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.homeVolume.mountPath` | string | `"/volundr/home"` | Mount path for the home PVC |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.homeVolume.credentialFiles.secretName` | string | `"claude-credentials"` | K8s secret containing Claude credential files |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.homeVolume.credentialFiles.destDir` | string | `".claude"` | Subdirectory under mountPath where credential symlinks are placed |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.homeVolume.credentialFiles.secretMountPath` | string | `"/volundr/secrets/credential-files"` | Internal mount path for the credentials secret |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.envSecrets` | list | See values.yaml | Secrets injected as env vars into the broker container |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.envVars` | list | `[]` | Plain env vars injected into the broker container |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.securityContext` | object | `{"runAsNonRoot":true,"runAsUser":1000,"fsGroup":1000}` | Security context for session pods |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.runtimeClassName` | string | `""` | Runtime class name for session pods (e.g., `"nvidia"`, `"kata"`, `"gvisor"`) |
+| `sessionDefinitions.skuldClaudeInteractive.defaults.volundr.apiUrl` | string | `""` | Volundr API URL for session pods (auto-wired in template) |
+
 #### skuld-codex
 
 | Key | Type | Default | Description |
@@ -644,7 +687,7 @@ Session definitions are Kubernetes custom resources that describe how session po
 | `sessionDefinitions.skuldCodex.helm.chart` | string | `"skuld"` | Chart name |
 | `sessionDefinitions.skuldCodex.helm.repo` | string | `"oci://ghcr.io/niuulabs/charts"` | Helm repository URL |
 | `sessionDefinitions.skuldCodex.helm.repoName` | string | `""` | Name of HelmRepository or OCIRepository CR in cluster |
-| `sessionDefinitions.skuldCodex.helm.version` | string | `"0.55.0"` | Chart version constraint |
+| `sessionDefinitions.skuldCodex.helm.version` | string | `"0.1.0"` | Chart version constraint |
 | `sessionDefinitions.skuldCodex.defaults.session.model` | string | `"o4-mini"` | Default Codex model |
 | `sessionDefinitions.skuldCodex.defaults.broker.cliType` | string | `"codex"` | AI CLI backend |
 | `sessionDefinitions.skuldCodex.defaults.broker.transport` | string | `"subprocess"` | Codex always uses subprocess transport |
@@ -971,7 +1014,7 @@ podManager:
   kwargs:
     namespace: "default"
     chart_name: "skuld"
-    chart_version: "0.55.0"
+    chart_version: "0.1.0"
     source_ref_kind: "HelmRepository"
     source_ref_name: "skuld"
     timeout: "5m"

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -907,6 +907,110 @@ sessionDefinitions:
       volundr:
         apiUrl: ""
 
+  # Skuld-Claude Interactive session definition (Claude Code REPL in tmux).
+  # This runtime uses the interactive subscription path and captures tmux pane
+  # output/events instead of the Agent SDK stream-json protocol.
+  skuldClaudeInteractive:
+    # -- Enable skuld-claude-interactive session definition
+    enabled: true
+    # -- Human-readable name shown in the UI
+    displayName: "Claude Code Interactive"
+    # -- Short description for the session picker
+    description: "Anthropic Claude Code through a tmux-backed interactive terminal"
+    # -- Default model for this definition (empty = use server default)
+    defaultModel: "claude-sonnet-4-6"
+    # -- Labels for agent routing
+    labels:
+      - session
+      - interactive
+    # -- Model providers this runtime accepts
+    compatibleProviders:
+      - anthropic
+    # -- Whether this session definition is active
+    active: true
+
+    # Helm chart configuration (references the shared skuld chart)
+    helm:
+      chart: skuld
+      repo: "oci://ghcr.io/niuulabs/charts"
+      repoName: ""
+      version: "0.1.0"
+
+    defaults:
+      session:
+        # -- Default Claude model
+        model: "claude-sonnet-4-6"
+
+      broker:
+        # -- AI CLI backend: "claude" (Claude Code)
+        cliType: claude
+        # -- Interactive tmux transport (real TTY; supports built-in slash commands)
+        transport: tmux-interactive
+        # -- Fully-qualified transport adapter class path
+        transportAdapter: "skuld.transports.tmux_interactive.TmuxInteractiveTransport"
+        # -- Skip tool permission prompts (--dangerously-skip-permissions)
+        skipPermissions: true
+        # -- Enable Claude Code experimental Agent Teams
+        agentTeams: false
+
+      image:
+        repository: ghcr.io/niuulabs/skuld
+        tag: "latest"
+
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "100m"
+        limits:
+          memory: "1Gi"
+          cpu: "500m"
+
+      imagePullSecrets:
+        - ghcr-pull-secret
+
+      ingress:
+        className: ""
+        annotations: {}
+        tls:
+          enabled: false
+          secretName: "skuld-wildcard-tls"
+
+      git:
+        credentials:
+          secretName: github-token
+
+      localServices:
+        terminal:
+          debug: false
+
+      persistence:
+        mountPath: "/volundr/sessions"
+
+      homeVolume:
+        enabled: true
+        mountPath: "/volundr/home"
+        credentialFiles:
+          secretName: "claude-credentials"
+          destDir: ".claude"
+          secretMountPath: "/volundr/secrets/credential-files"
+
+      envSecrets:
+        - envVar: ANTHROPIC_API_KEY
+          secretName: anthropic-api-key
+          secretKey: api-key
+
+      envVars: []
+
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+
+      runtimeClassName: ""
+
+      volundr:
+        apiUrl: ""
+
   # Skuld-Codex session definition (OpenAI Codex)
   # Uses the merged skuld image (ships both Claude Code and Codex CLIs).
   skuldCodex:

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -931,9 +931,13 @@ sessionDefinitions:
 
     # Helm chart configuration (references the shared skuld chart)
     helm:
+      # -- Chart name
       chart: skuld
+      # -- Helm repository URL (supports oci:// for OCI registries)
       repo: "oci://ghcr.io/niuulabs/charts"
+      # -- Name of HelmRepository or OCIRepository CR in cluster
       repoName: ""
+      # -- Chart version constraint
       version: "0.1.0"
 
     defaults:
@@ -954,7 +958,9 @@ sessionDefinitions:
         agentTeams: false
 
       image:
+        # -- Session image repository
         repository: ghcr.io/niuulabs/skuld
+        # -- Session image tag
         tag: "latest"
 
       resources:
@@ -965,40 +971,56 @@ sessionDefinitions:
           memory: "1Gi"
           cpu: "500m"
 
+      # -- Image pull secrets for session pods
       imagePullSecrets:
         - ghcr-pull-secret
 
       ingress:
+        # -- Ingress class name for sessions
         className: ""
+        # -- Controller-specific annotations for WebSocket support
         annotations: {}
         tls:
+          # -- Enable TLS for session ingress
           enabled: false
+          # -- TLS wildcard secret name for session ingress
           secretName: "skuld-wildcard-tls"
 
+      # -- Git credential secret for session pods to clone repositories
       git:
         credentials:
+          # -- K8s secret name containing git credentials
           secretName: github-token
 
       localServices:
         terminal:
+          # -- Enable terminal debug UI in session pods
           debug: false
 
       persistence:
+        # -- Mount path for session data
         mountPath: "/volundr/sessions"
 
       homeVolume:
+        # -- Enable persistent home directory in session pods
         enabled: true
+        # -- Mount path for the home PVC
         mountPath: "/volundr/home"
         credentialFiles:
+          # -- Pre-existing K8s secret containing Claude credential files
           secretName: "claude-credentials"
+          # -- Subdirectory under mountPath where credential symlinks are placed
           destDir: ".claude"
+          # -- Internal mount path for the credentials secret
           secretMountPath: "/volundr/secrets/credential-files"
 
+      # Secrets injected as env vars into the skuld broker container.
       envSecrets:
         - envVar: ANTHROPIC_API_KEY
           secretName: anthropic-api-key
           secretKey: api-key
 
+      # Plain env vars injected into the skuld broker container.
       envVars: []
 
       securityContext:
@@ -1006,8 +1028,10 @@ sessionDefinitions:
         runAsUser: 1000
         fsGroup: 1000
 
+      # -- Runtime class name for session pods (e.g., "nvidia", "kata", "gvisor")
       runtimeClassName: ""
 
+      # -- Volundr API URL for session pods to report token usage
       volundr:
         apiUrl: ""
 

--- a/docs/testing/skuld-claude-interactive.md
+++ b/docs/testing/skuld-claude-interactive.md
@@ -1,0 +1,71 @@
+# Skuld Claude Interactive Test Plan
+
+`skuldClaudeInteractive` runs Claude Code as an interactive tmux session via
+`skuld.transports.tmux_interactive.TmuxInteractiveTransport`. It is intentionally
+opt-in; the existing `skuldClaude` runtime remains the SDK/stream-json default.
+
+## Automated Coverage
+
+Run the focused backend suite:
+
+```bash
+uv run pytest \
+  tests/test_skuld/test_tmux_interactive_transport.py \
+  tests/test_skuld/test_config.py::TestTransportAdapter \
+  tests/test_skuld/test_transport.py::TestTransportCapabilities \
+  tests/test_skuld/test_broker.py::TestDispatchBrowserMessage \
+  tests/test_volundr/test_session_definition_contributor.py::TestDefaultSessionDefinitions \
+  tests/test_charts/test_volundr_chart.py::TestValuesDefaults
+```
+
+Run the real tmux smoke test without Claude credentials:
+
+```bash
+uv run pytest -m integration \
+  tests/test_skuld/test_tmux_interactive_transport.py::test_real_tmux_smoke_with_fake_claude
+```
+
+The fake-runner tests validate command construction, pane discovery, pane
+capture events, paste-buffer input, key dispatch, resize dispatch, interrupt,
+capabilities, and synthetic result closure. The integration smoke uses a fake
+`claude` executable but real tmux to verify the pipe-pane/tail loop end to end.
+
+## Live Claude Smoke
+
+Prerequisites:
+
+- `tmux` is installed in the Skuld image or local runtime.
+- Claude Code is logged in through the subscription path. For local testing,
+  run `claude /status` and verify it is not using an API key unless that is the
+  intended billing mode.
+- `SKULD__CLAUDE_AUTH` is unset or set to `subscription`.
+
+Manual checks:
+
+1. Launch a session with definition `skuldClaudeInteractive`.
+2. Connect to the session WebSocket and confirm capabilities include
+   `terminal_output`, `terminal_input`, `terminal_keys`, `terminal_resize`,
+   `terminal_panes`, `slash_commands`, and `interrupt`.
+3. Send a normal chat message and verify:
+   - `terminal_input_sent` is emitted.
+   - `terminal_output` frames are persisted.
+   - a conservative `assistant` / `content_block_delta` / `result` sequence is
+     emitted after terminal output goes idle.
+4. Send `{"type":"slash_command","command":"status"}` and verify `/status`
+   runs in the interactive Claude terminal.
+5. Send `terminal_key` controls for `Up`, `Down`, `Escape`, and `C-c`; verify
+   the terminal reflects history/menu/cancel behavior.
+6. Send `terminal_resize` with a desktop and mobile-size geometry; verify tmux
+   accepts the resize and emits `terminal_resized`.
+7. If agent teams are enabled for the session, run `/agents` and verify new tmux
+   panes appear as `terminal_pane_opened` events with independent output logs.
+8. POST a sample payload to `/api/claude/hooks`; verify a `claude_hook` event is
+   appended to the session event log.
+
+## Known Fidelity Boundary
+
+This transport gives interactive-command parity, not stream-json parity. Tmux
+captures terminal bytes and Claude hooks can supply structured lifecycle events,
+but hidden model state, exact token accounting, and every SDK-level delta are
+not guaranteed. Keep SDK-based `skuldClaude` for structured automation that
+needs exact stream-json semantics.

--- a/docs/testing/skuld-claude-interactive.md
+++ b/docs/testing/skuld-claude-interactive.md
@@ -46,20 +46,27 @@ Manual checks:
 2. Connect to the session WebSocket and confirm capabilities include
    `terminal_output`, `terminal_input`, `terminal_keys`, `terminal_resize`,
    `terminal_panes`, `slash_commands`, and `interrupt`.
-3. Send a normal chat message and verify:
+3. Fetch `GET /api/slash-commands` and verify the response includes live
+   commands from Claude Code's `/` autocomplete menu, including custom
+   project/user commands and workflow commands such as `/workflows` when
+   available.
+4. Send `{"type":"discover_slash_commands","refresh":true}` over the session
+   WebSocket and verify the response is `{"type":"slash_commands", ...}`.
+5. Send `POST /api/slash-commands/send` with `{"command":"workflows"}` or send
+   `{"type":"slash_command","command":"workflows"}` over the WebSocket; verify
+   the command is injected as terminal input rather than as a chat turn.
+6. Send a normal chat message and verify:
    - `terminal_input_sent` is emitted.
    - `terminal_output` frames are persisted.
    - a conservative `assistant` / `content_block_delta` / `result` sequence is
      emitted after terminal output goes idle.
-4. Send `{"type":"slash_command","command":"status"}` and verify `/status`
-   runs in the interactive Claude terminal.
-5. Send `terminal_key` controls for `Up`, `Down`, `Escape`, and `C-c`; verify
+7. Send `terminal_key` controls for `Up`, `Down`, `Escape`, and `C-c`; verify
    the terminal reflects history/menu/cancel behavior.
-6. Send `terminal_resize` with a desktop and mobile-size geometry; verify tmux
+8. Send `terminal_resize` with a desktop and mobile-size geometry; verify tmux
    accepts the resize and emits `terminal_resized`.
-7. If agent teams are enabled for the session, run `/agents` and verify new tmux
+9. If agent teams are enabled for the session, run `/agents` and verify new tmux
    panes appear as `terminal_pane_opened` events with independent output logs.
-8. POST a sample payload to `/api/claude/hooks`; verify a `claude_hook` event is
+10. POST a sample payload to `/api/claude/hooks`; verify a `claude_hook` event is
    appended to the session event log.
 
 ## Known Fidelity Boundary

--- a/src/niuu/ports/cli/transport.py
+++ b/src/niuu/ports/cli/transport.py
@@ -77,6 +77,10 @@ class CLITransport(ABC):
     async def send_control(self, subtype: str, **kwargs: object) -> None:
         """Send a server-initiated control message."""
 
+    async def discover_slash_commands(self, *, refresh: bool = False) -> list[dict]:
+        """Return slash commands available in this transport, if discoverable."""
+        return []
+
     @property
     @abstractmethod
     def session_id(self) -> str | None:

--- a/src/niuu/ports/cli/transport.py
+++ b/src/niuu/ports/cli/transport.py
@@ -27,6 +27,11 @@ class TransportCapabilities:
     permission_requests: bool = False
     slash_commands: bool = False
     skills: bool = False
+    terminal_output: bool = False
+    terminal_input: bool = False
+    terminal_keys: bool = False
+    terminal_resize: bool = False
+    terminal_panes: bool = False
 
 
 class CLITransport(ABC):

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -3238,6 +3238,7 @@ class Broker:
         "terminal_key": "terminal_keys",
         "terminal_resize": "terminal_resize",
         "slash_command": "slash_commands",
+        "discover_slash_commands": "slash_commands",
     }
 
     async def _dispatch_browser_message(
@@ -3380,8 +3381,22 @@ class Broker:
                 await self._transport.send_control(
                     "slash_command",
                     command=data.get("command", ""),
+                    arguments=data.get("arguments", data.get("args", "")),
                     pane_id=data.get("pane_id", ""),
                 )
+
+            case "discover_slash_commands":
+                commands = await self.discover_slash_commands(
+                    refresh=bool(data.get("refresh", True))
+                )
+                if sender_ws is not None:
+                    await sender_ws.send_json(
+                        {
+                            "type": "slash_commands",
+                            "commands": commands,
+                            "count": len(commands),
+                        }
+                    )
 
             # Room: forward a directed message to a specific Ravn participant
             case "directed_message":
@@ -3551,6 +3566,57 @@ class Broker:
                 "payload": payload,
             }
         )
+
+    async def discover_slash_commands(self, *, refresh: bool = False) -> list[dict[str, Any]]:
+        """Return slash commands available through the current transport."""
+        if self._transport is None:
+            return []
+
+        commands = await self._transport.discover_slash_commands(refresh=refresh)
+        if commands:
+            return self._normalize_slash_commands(commands)
+
+        raw_commands = getattr(self._transport, "slash_commands", [])
+        if callable(raw_commands):
+            raw_commands = raw_commands()
+        return self._normalize_slash_commands(raw_commands)
+
+    @staticmethod
+    def _normalize_slash_commands(raw_commands: Any) -> list[dict[str, Any]]:
+        normalized: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        if not isinstance(raw_commands, list):
+            return normalized
+        for item in raw_commands:
+            if isinstance(item, str):
+                raw_name = item
+                description = ""
+                kind = "command"
+                source = "transport"
+            elif isinstance(item, dict):
+                raw_name = str(item.get("name") or item.get("command") or "")
+                description = str(item.get("description") or "")
+                kind = str(item.get("kind") or "command")
+                source = str(item.get("source") or "transport")
+            else:
+                continue
+            raw_name = raw_name.strip()
+            if not raw_name:
+                continue
+            name = raw_name if raw_name.startswith("/") else f"/{raw_name}"
+            if name in seen:
+                continue
+            seen.add(name)
+            normalized.append(
+                {
+                    "name": name,
+                    "command": name[1:],
+                    "description": description.strip(),
+                    "kind": kind,
+                    "source": source,
+                }
+            )
+        return normalized
 
     async def handle_human_room_message(
         self,
@@ -5439,12 +5505,53 @@ async def get_conversation_history() -> dict:
 # --- Capabilities API ---
 
 
+class _SlashCommandRequest(BaseModel):
+    """Request body for sending a slash command to the active transport."""
+
+    command: str
+    arguments: str = ""
+    pane_id: str = ""
+
+
 @app.get("/api/capabilities")
 async def get_capabilities() -> dict:
     """Return transport capabilities so the frontend knows which controls to render."""
     if not broker._transport:
         raise HTTPException(status_code=503, detail="Transport not initialized")
     return asdict(broker._transport.capabilities)
+
+
+@app.get("/api/slash-commands")
+async def get_slash_commands(refresh: bool = Query(True)) -> dict[str, Any]:
+    """Return slash commands available in the active CLI session."""
+    if not broker._transport:
+        raise HTTPException(status_code=503, detail="Transport not initialized")
+    if not broker._transport.capabilities.slash_commands:
+        raise HTTPException(status_code=501, detail="Slash commands not supported")
+    commands = await broker.discover_slash_commands(refresh=refresh)
+    return {"commands": commands, "count": len(commands)}
+
+
+@app.post("/api/slash-commands/send")
+async def send_slash_command(body: _SlashCommandRequest) -> dict[str, str]:
+    """Send a slash command to the active CLI session as terminal input."""
+    if not broker._transport:
+        raise HTTPException(status_code=503, detail="Transport not initialized")
+    if not broker._transport.capabilities.slash_commands:
+        raise HTTPException(status_code=501, detail="Slash commands not supported")
+    command = body.command.strip()
+    if not command:
+        raise HTTPException(status_code=400, detail="Command is required")
+    await broker._transport.send_control(
+        "slash_command",
+        command=command,
+        arguments=body.arguments,
+        pane_id=body.pane_id,
+    )
+    name = command.split(maxsplit=1)[0]
+    if not name.startswith("/"):
+        name = f"/{name}"
+    return {"status": "sent", "command": name}
 
 
 @app.post("/api/claude/hooks")

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -3234,6 +3234,10 @@ class Broker:
         "set_permission_mode": "set_permission_mode",
         "rewind_files": "rewind_files",
         "mcp_set_servers": "mcp_set_servers",
+        "terminal_input": "terminal_input",
+        "terminal_key": "terminal_keys",
+        "terminal_resize": "terminal_resize",
+        "slash_command": "slash_commands",
     }
 
     async def _dispatch_browser_message(
@@ -3343,6 +3347,40 @@ class Broker:
                 await self._transport.send_control(
                     "mcp_set_servers",
                     servers=servers,
+                )
+
+            # Interactive terminal transports: raw input, key presses, and
+            # resize events. These are intentionally transport controls, not
+            # chat turns, so workflows can drive slash menus/history/editing.
+            case "terminal_input":
+                await self._transport.send_control(
+                    "terminal_input",
+                    data=data.get("data", data.get("text", "")),
+                    enter=bool(data.get("enter", False)),
+                    pane_id=data.get("pane_id", ""),
+                )
+
+            case "terminal_key":
+                await self._transport.send_control(
+                    "terminal_key",
+                    key=data.get("key", ""),
+                    keys=data.get("keys", []),
+                    pane_id=data.get("pane_id", ""),
+                )
+
+            case "terminal_resize":
+                await self._transport.send_control(
+                    "terminal_resize",
+                    cols=data.get("cols", data.get("columns", 0)),
+                    rows=data.get("rows", 0),
+                    pane_id=data.get("pane_id", ""),
+                )
+
+            case "slash_command":
+                await self._transport.send_control(
+                    "slash_command",
+                    command=data.get("command", ""),
+                    pane_id=data.get("pane_id", ""),
                 )
 
             # Room: forward a directed message to a specific Ravn participant
@@ -3480,6 +3518,39 @@ class Broker:
                 await self._channels.broadcast({"type": "error", "content": str(exc)})
             except Exception:
                 logger.debug("Failed to broadcast transport error to channels", exc_info=True)
+
+    async def handle_claude_hook(self, payload: dict[str, Any]) -> None:
+        """Ingest a Claude Code hook payload into the normal event pipeline.
+
+        Interactive tmux sessions can configure Claude Code HTTP hooks to POST
+        here. The payload schema is owned by Claude Code, so we keep the raw
+        body intact and add only stable routing fields.
+        """
+        transport_hook = getattr(self._transport, "handle_claude_hook", None)
+        if callable(transport_hook):
+            try:
+                handled = await transport_hook(payload)
+            except Exception:
+                logger.warning("Transport Claude hook handler failed", exc_info=True)
+            else:
+                if handled:
+                    return
+
+        event_name = (
+            payload.get("hook_event_name")
+            or payload.get("hookEventName")
+            or payload.get("event")
+            or payload.get("hook_event")
+            or "unknown"
+        )
+        await self._handle_cli_event(
+            {
+                "type": "claude_hook",
+                "event_type": "claude.hook",
+                "hook_event_name": str(event_name),
+                "payload": payload,
+            }
+        )
 
     async def handle_human_room_message(
         self,
@@ -5374,6 +5445,13 @@ async def get_capabilities() -> dict:
     if not broker._transport:
         raise HTTPException(status_code=503, detail="Transport not initialized")
     return asdict(broker._transport.capabilities)
+
+
+@app.post("/api/claude/hooks")
+async def receive_claude_hook(payload: dict[str, Any]) -> dict[str, bool]:
+    """Receive Claude Code HTTP hook callbacks for interactive tmux sessions."""
+    await broker.handle_claude_hook(payload)
+    return {"ok": True}
 
 
 # --- Service Management API ---

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -390,6 +390,8 @@ class SkuldSettings(BaseSettings):
 
         if self.transport == "subprocess":
             self.transport_adapter = "skuld.transports.subprocess.SubprocessTransport"
+        elif self.transport == "tmux-interactive":
+            self.transport_adapter = "skuld.transports.tmux_interactive.TmuxInteractiveTransport"
 
         return self
 

--- a/src/skuld/transports/__init__.py
+++ b/src/skuld/transports/__init__.py
@@ -25,6 +25,7 @@ from skuld.transports.persistent_subprocess import (  # noqa: E402
 from skuld.transports.sdk import SDKTransport  # noqa: E402
 from skuld.transports.sdk_websocket import SdkWebSocketTransport  # noqa: E402
 from skuld.transports.subprocess import SubprocessTransport  # noqa: E402
+from skuld.transports.tmux_interactive import TmuxInteractiveTransport  # noqa: E402
 
 __all__ = [
     "CLITransport",
@@ -36,6 +37,7 @@ __all__ = [
     "SDKTransport",
     "SdkWebSocketTransport",
     "SubprocessTransport",
+    "TmuxInteractiveTransport",
     "TransportCapabilities",
     "_CODEX_TOOL_MAP",
     "_drain_stream",

--- a/src/skuld/transports/tmux_interactive.py
+++ b/src/skuld/transports/tmux_interactive.py
@@ -111,6 +111,8 @@ _OPTIONAL_HIGH_VOLUME_HOOK_EVENTS = [
     "MessageDisplay",
 ]
 
+_SLASH_COMMAND_ROW_RE = re.compile(r"^(/\S+)\s{2,}(.+?)\s*$")
+
 
 @dataclass
 class _TmuxResult:
@@ -216,6 +218,10 @@ class TmuxInteractiveTransport(CLITransport):
         self._pane_sequences: dict[str, int] = {}
         self._pane_watcher_task: asyncio.Task[None] | None = None
         self._last_result: dict | None = None
+        self._slash_commands_cache = self._normalize_slash_command_items(
+            _BUILT_IN_SLASH_COMMANDS,
+            source="static",
+        )
 
         self._turn_active = False
         self._turn_started_at = 0.0
@@ -393,14 +399,45 @@ class TmuxInteractiveTransport(CLITransport):
         if subtype in {"slash_command", "terminal_slash_command"}:
             command = self._coerce_str(kwargs.get("command"))
             if command:
-                command = command if command.startswith("/") else f"/{command}"
-                await self.send_message(command)
+                await self._send_slash_command(
+                    command,
+                    arguments=(
+                        self._coerce_str(kwargs.get("arguments"))
+                        or self._coerce_str(kwargs.get("args"))
+                    ),
+                    pane_id=self._coerce_str(kwargs.get("pane_id")),
+                )
             return
 
         if subtype in {"redirect", "steer"}:
             content = self._coerce_str(kwargs.get("content"))
             if content:
                 await self._paste_text(content, enter=True)
+
+    async def discover_slash_commands(self, *, refresh: bool = False) -> list[dict]:
+        """Discover slash commands from Claude Code's live `/` autocomplete menu."""
+        if not refresh and self._slash_commands_cache:
+            return list(self._slash_commands_cache)
+        if not self.is_alive:
+            await self.start()
+        if self._turn_active:
+            return list(self._slash_commands_cache)
+
+        async with self._send_lock:
+            if self._turn_active:
+                return list(self._slash_commands_cache)
+            commands = await self._discover_slash_commands_from_terminal()
+            if commands:
+                self._slash_commands_cache = commands
+                await self._emit(
+                    {
+                        "type": "slash_commands",
+                        "event_type": "slash.commands",
+                        "commands": commands,
+                        "source": "tmux_autocomplete",
+                    }
+                )
+            return list(self._slash_commands_cache)
 
     async def send_control_response(self, request_id: str, response: dict) -> None:
         await self._emit(
@@ -1090,6 +1127,73 @@ class TmuxInteractiveTransport(CLITransport):
             }
         )
 
+    async def _send_slash_command(
+        self,
+        command: str,
+        *,
+        arguments: str = "",
+        pane_id: str | None = None,
+    ) -> None:
+        text = command.strip()
+        if not text:
+            return
+        if not text.startswith("/"):
+            text = f"/{text}"
+        arguments = arguments.strip()
+        if arguments:
+            text = f"{text} {arguments}"
+        await self._paste_text(text, enter=True, pane_id=pane_id)
+        await self._emit(
+            {
+                "type": "slash_command_sent",
+                "event_type": "slash.command.sent",
+                "command": text.split(maxsplit=1)[0],
+                "input": text,
+                "pane_id": self._target_pane(pane_id),
+            }
+        )
+
+    async def _discover_slash_commands_from_terminal(self) -> list[dict]:
+        target = self._target_pane(None)
+        captures: list[str] = []
+        try:
+            await self._send_key_raw("Escape", pane_id=target)
+            await asyncio.sleep(0.05)
+            await self._send_key_raw("C-u", pane_id=target)
+            await asyncio.sleep(0.05)
+            await self._send_key_raw("/", pane_id=target)
+            await asyncio.sleep(0.25)
+            for _ in range(12):
+                result = await self._run_tmux(
+                    "capture-pane",
+                    "-t",
+                    target,
+                    "-p",
+                    "-S",
+                    "-200",
+                )
+                captures.append(result.stdout)
+                for _ in range(10):
+                    await self._send_key_raw("Down", pane_id=target)
+                await asyncio.sleep(0.05)
+        finally:
+            with suppress(Exception):
+                await self._send_key_raw("Escape", pane_id=target)
+                await self._send_key_raw("C-u", pane_id=target)
+
+        commands: list[dict] = []
+        seen: set[str] = set()
+        for capture in captures:
+            for item in self._parse_slash_command_menu(capture):
+                if item["name"] in seen:
+                    continue
+                seen.add(item["name"])
+                commands.append(item)
+        return commands
+
+    async def _send_key_raw(self, key: str, *, pane_id: str | None = None) -> None:
+        await self._run_tmux("send-keys", "-t", self._target_pane(pane_id), key)
+
     async def _resize_pane(self, *, cols: int, rows: int, pane_id: str | None = None) -> None:
         target = self._target_pane(pane_id)
         await self._run_tmux("resize-pane", "-t", target, "-x", str(cols), "-y", str(rows))
@@ -1201,6 +1305,86 @@ class TmuxInteractiveTransport(CLITransport):
         cleaned = cleaned.replace("\r\n", "\n").replace("\r", "\n")
         cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
         return cleaned
+
+    @classmethod
+    def _parse_slash_command_menu(cls, text: str) -> list[dict]:
+        rows = cls._normalize_terminal_rows(text)
+        commands: list[dict] = []
+        current: dict | None = None
+        for row in rows:
+            match = _SLASH_COMMAND_ROW_RE.match(row.strip())
+            if match:
+                name = match.group(1)
+                description = match.group(2).strip()
+                current = cls._normalize_slash_command_item(
+                    {
+                        "name": name,
+                        "description": description,
+                        "kind": cls._infer_slash_command_kind(description),
+                    },
+                    source="tmux_autocomplete",
+                )
+                commands.append(current)
+                continue
+            if current is None:
+                continue
+            continuation = row.strip()
+            if (
+                not continuation
+                or continuation.startswith("/")
+                or cls._is_terminal_chrome_row(continuation)
+            ):
+                continue
+            current["description"] = f"{current['description']} {continuation}".strip()
+        return commands
+
+    @classmethod
+    def _normalize_slash_command_items(
+        cls,
+        items: list[dict] | list[str],
+        *,
+        source: str,
+    ) -> list[dict]:
+        normalized: list[dict] = []
+        seen: set[str] = set()
+        for item in items:
+            command = cls._normalize_slash_command_item(item, source=source)
+            if not command or command["name"] in seen:
+                continue
+            seen.add(command["name"])
+            normalized.append(command)
+        return normalized
+
+    @classmethod
+    def _normalize_slash_command_item(cls, item: dict | str, *, source: str) -> dict:
+        if isinstance(item, str):
+            raw_name = item
+            description = ""
+            kind = "command"
+        else:
+            raw_name = cls._coerce_str(item.get("name")) or cls._coerce_str(item.get("command"))
+            description = cls._coerce_str(item.get("description"))
+            kind = cls._coerce_str(item.get("kind")) or cls._infer_slash_command_kind(description)
+        raw_name = raw_name.strip()
+        if not raw_name:
+            return {}
+        name = raw_name if raw_name.startswith("/") else f"/{raw_name}"
+        return {
+            "name": name,
+            "command": name[1:],
+            "description": description.strip(),
+            "kind": kind or "command",
+            "source": source,
+        }
+
+    @staticmethod
+    def _infer_slash_command_kind(description: str) -> str:
+        lowered = description.lower()
+        if "dynamic workflow" in lowered:
+            return "workflow"
+        if "[skill]" in lowered:
+            return "skill"
+        return "command"
 
     @classmethod
     def _normalize_terminal_rows(cls, text: str) -> list[str]:

--- a/src/skuld/transports/tmux_interactive.py
+++ b/src/skuld/transports/tmux_interactive.py
@@ -1,0 +1,1350 @@
+"""TmuxInteractiveTransport — interactive Claude Code through a real TTY.
+
+This adapter is intentionally separate from the SDK/print transports. It runs
+the interactive ``claude`` REPL in tmux so built-in slash commands, terminal
+history navigation, permission prompts, and tmux-backed agent-team panes stay
+available. Tmux output is UI bytes, not stream-json, so the transport emits raw
+terminal events and a conservative chat-shaped synthetic turn for existing
+Skuld clients.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import shlex
+import shutil
+import time
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from niuu.ports.cli import CLITransport, TransportCapabilities
+from skuld.transports.claude_env import claude_spawn_env
+from skuld.transports.mcp_config import build_claude_mcp_config
+from skuld.transports.subprocess import _DEFAULT_PERMISSION_MODE
+from skuld.transports.tool_shims import ensure_codex_tool_shims
+
+logger = logging.getLogger("skuld.transport")
+
+_ANSI_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))")
+
+_BUILT_IN_SLASH_COMMANDS = [
+    {"name": "/agents", "description": "Manage agent teams and subagents"},
+    {"name": "/compact", "description": "Compact the current conversation"},
+    {"name": "/context", "description": "Inspect context usage"},
+    {"name": "/cost", "description": "Show session cost"},
+    {"name": "/doctor", "description": "Check Claude Code health"},
+    {"name": "/exit", "description": "Exit Claude Code"},
+    {"name": "/export", "description": "Export the conversation"},
+    {"name": "/help", "description": "Show help"},
+    {"name": "/hooks", "description": "Configure hooks"},
+    {"name": "/init", "description": "Initialize project context"},
+    {"name": "/login", "description": "Authenticate Claude Code"},
+    {"name": "/logout", "description": "Sign out of Claude Code"},
+    {"name": "/mcp", "description": "Manage MCP servers"},
+    {"name": "/memory", "description": "Manage memory"},
+    {"name": "/model", "description": "Switch model"},
+    {"name": "/permissions", "description": "Manage permissions"},
+    {"name": "/resume", "description": "Resume a prior session"},
+    {"name": "/review", "description": "Review code changes"},
+    {"name": "/status", "description": "Show Claude Code status"},
+    {"name": "/terminal-setup", "description": "Configure terminal integration"},
+    {"name": "/vim", "description": "Toggle Vim mode"},
+]
+
+_KEY_ALIASES = {
+    "ctrl-c": "C-c",
+    "ctrl+d": "C-d",
+    "ctrl-d": "C-d",
+    "ctrl+r": "C-r",
+    "ctrl-r": "C-r",
+    "enter": "Enter",
+    "escape": "Escape",
+    "esc": "Escape",
+    "tab": "Tab",
+    "backspace": "BSpace",
+    "delete": "Delete",
+    "up": "Up",
+    "down": "Down",
+    "left": "Left",
+    "right": "Right",
+    "home": "Home",
+    "end": "End",
+    "pageup": "PageUp",
+    "pagedown": "PageDown",
+}
+
+_CLAUDE_HOOK_EVENTS = [
+    "SessionStart",
+    "UserPromptSubmit",
+    "UserPromptExpansion",
+    "PreToolUse",
+    "PermissionRequest",
+    "PermissionDenied",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "PostToolBatch",
+    "Notification",
+    "SubagentStart",
+    "SubagentStop",
+    "TaskCreated",
+    "TaskCompleted",
+    "TeammateIdle",
+    "PreCompact",
+    "PostCompact",
+    "Stop",
+    "StopFailure",
+    "SessionEnd",
+    "Elicitation",
+    "ElicitationResult",
+    "InstructionsLoaded",
+    "CwdChanged",
+]
+
+_OPTIONAL_HIGH_VOLUME_HOOK_EVENTS = [
+    "MessageDisplay",
+]
+
+
+@dataclass
+class _TmuxResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _PaneState:
+    pane_id: str
+    pane_index: str
+    window_name: str
+    active: bool
+    current_command: str
+    width: int
+    height: int
+    cursor_x: int
+    cursor_y: int
+    log_path: Path
+
+
+class TmuxCommandError(RuntimeError):
+    """Raised when a required tmux command fails."""
+
+
+class TmuxInteractiveTransport(CLITransport):
+    """Drive an interactive Claude Code process through tmux."""
+
+    def __init__(
+        self,
+        workspace_dir: str,
+        model: str = "",
+        session_id: str = "",
+        skip_permissions: bool = False,
+        agent_teams: bool = False,
+        system_prompt: str = "",
+        initial_prompt: str = "",
+        mcp_servers: list[dict] | None = None,
+        sdk_port: int | None = None,
+        turn_idle_timeout_s: float | None = None,
+        turn_no_output_timeout_s: float | None = None,
+        turn_max_seconds: float | None = None,
+        pane_poll_interval_s: float | None = None,
+        frame_interval_s: float | None = None,
+    ) -> None:
+        super().__init__()
+        self.workspace_dir = workspace_dir
+        self._model = model
+        self._forge_session_id = session_id or "skuld-interactive"
+        self._skip_permissions = skip_permissions
+        self._agent_teams = agent_teams
+        self._system_prompt = system_prompt
+        self._initial_prompt = initial_prompt
+        self._raw_mcp_servers = list(mcp_servers or [])
+        self._mcp_config = build_claude_mcp_config(mcp_servers or [])
+        self._sdk_port = sdk_port
+
+        self._session_name = self._safe_name(f"skuld-{self._forge_session_id}")[:80]
+        base_socket_dir = Path(
+            os.environ.get("SKULD__TMUX_SOCKET_DIR", f"/tmp/skuld-tmux-{os.getuid()}")
+        )
+        self._socket_path = base_socket_dir / f"{self._session_name}.sock"
+        self._runtime_dir = (
+            Path(self.workspace_dir) / ".skuld" / "tmux-interactive" / self._session_name
+        )
+        self._pane_log_dir = self._runtime_dir / "panes"
+        self._hook_settings_path = self._runtime_dir / "claude-hooks.settings.json"
+
+        self._turn_idle_timeout_s = self._float_env(
+            "SKULD__TMUX_TURN_IDLE_TIMEOUT_SECONDS", turn_idle_timeout_s, 3.0
+        )
+        self._turn_no_output_timeout_s = self._float_env(
+            "SKULD__TMUX_TURN_NO_OUTPUT_TIMEOUT_SECONDS", turn_no_output_timeout_s, 30.0
+        )
+        self._turn_max_seconds = self._float_env(
+            "SKULD__TMUX_TURN_MAX_SECONDS", turn_max_seconds, 3600.0
+        )
+        self._pane_poll_interval_s = self._float_env(
+            "SKULD__TMUX_PANE_POLL_INTERVAL_SECONDS", pane_poll_interval_s, 1.0
+        )
+        self._frame_interval_s = self._float_env(
+            "SKULD__TMUX_FRAME_INTERVAL_SECONDS", frame_interval_s, 0.12
+        )
+        self._emit_raw_terminal_output = self._bool_env("SKULD__TMUX_EMIT_RAW_OUTPUT", False)
+        self._hook_events_enabled = self._bool_env(
+            "SKULD__TMUX_HOOK_EVENTS_ENABLED",
+            bool(self._sdk_port),
+        )
+        self._message_display_hook_enabled = self._bool_env(
+            "SKULD__TMUX_MESSAGE_DISPLAY_HOOK_ENABLED",
+            False,
+        )
+
+        self._alive = False
+        self._initial_prompt_sent = False
+        self._lifecycle_lock = asyncio.Lock()
+        self._send_lock = asyncio.Lock()
+        self._panes: dict[str, _PaneState] = {}
+        self._tail_tasks: dict[str, asyncio.Task[None]] = {}
+        self._frame_tasks: dict[str, asyncio.Task[None]] = {}
+        self._last_frame_signature: dict[str, str] = {}
+        self._pane_sequences: dict[str, int] = {}
+        self._pane_watcher_task: asyncio.Task[None] | None = None
+        self._last_result: dict | None = None
+
+        self._turn_active = False
+        self._turn_started_at = 0.0
+        self._turn_last_output_at: float | None = None
+        self._turn_stream_started = False
+        self._turn_buffer: list[str] = []
+        self._turn_last_clean_text = ""
+        self._turn_done: asyncio.Event | None = None
+        self._turn_watchdog_task: asyncio.Task[None] | None = None
+
+    @property
+    def capabilities(self) -> TransportCapabilities:
+        return TransportCapabilities(
+            interrupt=True,
+            slash_commands=True,
+            steer=True,
+            terminal_output=True,
+            terminal_input=True,
+            terminal_keys=True,
+            terminal_resize=True,
+            terminal_panes=True,
+        )
+
+    @property
+    def session_id(self) -> str | None:
+        return self._session_name
+
+    @property
+    def last_result(self) -> dict | None:
+        return self._last_result
+
+    @property
+    def is_alive(self) -> bool:
+        return self._alive
+
+    @property
+    def is_turn_active(self) -> bool:
+        return self._turn_active
+
+    async def start(self) -> None:
+        await self._ensure_started()
+
+        if self._initial_prompt and not self._initial_prompt_sent:
+            self._initial_prompt_sent = True
+            try:
+                await self.send_message(self._initial_prompt)
+            except Exception:
+                self._initial_prompt_sent = False
+                raise
+
+    async def _ensure_started(self) -> None:
+        async with self._lifecycle_lock:
+            if not self._tmux_binary_exists():
+                raise RuntimeError("tmux is required for TmuxInteractiveTransport")
+            self._runtime_dir.mkdir(parents=True, exist_ok=True)
+            self._pane_log_dir.mkdir(parents=True, exist_ok=True)
+            self._socket_path.parent.mkdir(parents=True, exist_ok=True)
+
+            if not await self._has_session():
+                await self._create_session()
+                await self._apply_tmux_options()
+            self._alive = True
+            await self._refresh_panes(emit_events=True)
+            if self._pane_watcher_task is None or self._pane_watcher_task.done():
+                self._pane_watcher_task = asyncio.create_task(
+                    self._watch_panes(),
+                    name=f"tmux-pane-watch-{self._session_name}",
+                )
+            await self._emit_system_init()
+
+    async def stop(self) -> None:
+        async with self._lifecycle_lock:
+            self._alive = False
+            if self._pane_watcher_task is not None:
+                self._pane_watcher_task.cancel()
+                with suppress(asyncio.CancelledError, Exception):
+                    await self._pane_watcher_task
+                self._pane_watcher_task = None
+            if self._turn_watchdog_task is not None:
+                self._turn_watchdog_task.cancel()
+                with suppress(asyncio.CancelledError, Exception):
+                    await self._turn_watchdog_task
+                self._turn_watchdog_task = None
+            for task in list(self._tail_tasks.values()):
+                task.cancel()
+            for task in list(self._frame_tasks.values()):
+                task.cancel()
+            for task in list(self._tail_tasks.values()):
+                with suppress(asyncio.CancelledError, Exception):
+                    await task
+            for task in list(self._frame_tasks.values()):
+                with suppress(asyncio.CancelledError, Exception):
+                    await task
+            self._tail_tasks.clear()
+            self._frame_tasks.clear()
+            self._panes.clear()
+            if self._turn_done is not None:
+                self._turn_done.set()
+            await self._run_tmux("kill-session", "-t", self._session_name, check=False)
+
+    async def send_message(self, content: str) -> None:
+        async with self._send_lock:
+            if not self.is_alive:
+                await self._ensure_started()
+            if self._turn_active:
+                await self._finish_synthetic_turn(reason="superseded")
+            done = asyncio.Event()
+            self._turn_done = done
+            self._turn_active = True
+            self._turn_started_at = time.monotonic()
+            self._turn_last_output_at = None
+            self._turn_stream_started = False
+            self._turn_buffer = []
+            self._turn_last_clean_text = ""
+            self._turn_watchdog_task = asyncio.create_task(
+                self._watch_turn_completion(done),
+                name=f"tmux-turn-watch-{self._session_name}",
+            )
+            try:
+                await self._paste_text(content, enter=True)
+                await done.wait()
+            finally:
+                if self._turn_watchdog_task is not None:
+                    self._turn_watchdog_task.cancel()
+                    with suppress(asyncio.CancelledError, Exception):
+                        await self._turn_watchdog_task
+                    self._turn_watchdog_task = None
+                self._turn_done = None
+
+    async def interrupt(self) -> None:
+        await self.send_control("interrupt")
+
+    async def send_control(self, subtype: str, **kwargs: object) -> None:
+        if not self.is_alive:
+            await self.start()
+
+        if subtype == "interrupt":
+            await self._send_key("C-c", pane_id=self._coerce_str(kwargs.get("pane_id")))
+            if self._turn_active:
+                await self._finish_synthetic_turn(reason="interrupted", is_error=True)
+            return
+
+        if subtype in {"terminal_input", "input"}:
+            text = self._coerce_str(kwargs.get("data")) or self._coerce_str(kwargs.get("text"))
+            if text:
+                await self._paste_text(
+                    text,
+                    enter=bool(kwargs.get("enter", False)),
+                    pane_id=self._coerce_str(kwargs.get("pane_id")),
+                )
+            return
+
+        if subtype in {"terminal_key", "key"}:
+            raw_keys = kwargs.get("keys")
+            if isinstance(raw_keys, list):
+                keys = [self._normalize_key(str(key)) for key in raw_keys if str(key)]
+            else:
+                key = self._coerce_str(kwargs.get("key")) or self._coerce_str(raw_keys)
+                keys = [self._normalize_key(key)] if key else []
+            for key in keys:
+                await self._send_key(key, pane_id=self._coerce_str(kwargs.get("pane_id")))
+            return
+
+        if subtype == "terminal_resize":
+            cols = int(kwargs.get("cols") or kwargs.get("columns") or 0)
+            rows = int(kwargs.get("rows") or 0)
+            if cols > 0 and rows > 0:
+                await self._resize_pane(
+                    cols=cols,
+                    rows=rows,
+                    pane_id=self._coerce_str(kwargs.get("pane_id")),
+                )
+            return
+
+        if subtype in {"slash_command", "terminal_slash_command"}:
+            command = self._coerce_str(kwargs.get("command"))
+            if command:
+                command = command if command.startswith("/") else f"/{command}"
+                await self.send_message(command)
+            return
+
+        if subtype in {"redirect", "steer"}:
+            content = self._coerce_str(kwargs.get("content"))
+            if content:
+                await self._paste_text(content, enter=True)
+
+    async def send_control_response(self, request_id: str, response: dict) -> None:
+        await self._emit(
+            {
+                "type": "terminal_control_response_ignored",
+                "request_id": request_id,
+                "response": response,
+                "reason": "interactive terminal permission prompts are handled in the TTY",
+            }
+        )
+
+    async def handle_claude_hook(self, payload: dict[str, Any]) -> bool:
+        """Convert Claude Code hook callbacks into Skuld events.
+
+        The terminal pane remains the interactive display channel. Hooks provide
+        the semantic channel: prompt state, tool calls/results, permissions, and
+        the final assistant message for a turn.
+        """
+        event_name = self._hook_event_name(payload)
+        await self._emit(
+            {
+                "type": "claude_hook",
+                "event_type": "claude.hook",
+                "hook_event_name": event_name,
+                "payload": payload,
+                "metadata": {"source": "claude_hook"},
+            }
+        )
+
+        if event_name == "UserPromptSubmit":
+            self._mark_semantic_turn_started()
+            prompt = payload.get("prompt")
+            await self._emit(
+                {
+                    "type": "terminal_prompt_submitted",
+                    "event_type": "claude.prompt.submitted",
+                    "prompt": prompt if isinstance(prompt, str) else "",
+                    "claude_session_id": payload.get("session_id"),
+                    "transcript_path": payload.get("transcript_path"),
+                    "metadata": {"source": "claude_hook"},
+                }
+            )
+            return True
+
+        if event_name == "PreToolUse":
+            self._mark_semantic_turn_started()
+            await self._emit_tool_use_from_hook(payload)
+            return True
+
+        if event_name in {"PostToolUse", "PostToolUseFailure"}:
+            await self._emit_tool_result_from_hook(
+                payload,
+                is_error=event_name == "PostToolUseFailure",
+            )
+            return True
+
+        if event_name == "PermissionRequest":
+            await self._emit_permission_request_from_hook(payload)
+            return True
+
+        if event_name == "Stop":
+            await self._finish_hook_turn(
+                content=self._coerce_str(payload.get("last_assistant_message")),
+                reason="stop",
+            )
+            return True
+
+        if event_name == "StopFailure":
+            await self._finish_hook_turn(
+                content=(
+                    self._coerce_str(payload.get("last_assistant_message"))
+                    or self._coerce_str(payload.get("error"))
+                ),
+                reason="stop_failure",
+                is_error=True,
+            )
+            return True
+
+        return True
+
+    @staticmethod
+    def _hook_event_name(payload: dict[str, Any]) -> str:
+        event_name = (
+            payload.get("hook_event_name")
+            or payload.get("hookEventName")
+            or payload.get("event")
+            or payload.get("hook_event")
+            or "unknown"
+        )
+        return str(event_name)
+
+    def _mark_semantic_turn_started(self) -> None:
+        if self._turn_active:
+            return
+        self._turn_active = True
+        self._turn_started_at = time.monotonic()
+        self._turn_last_output_at = self._turn_started_at
+        self._turn_stream_started = False
+        self._turn_buffer = []
+        self._turn_last_clean_text = ""
+
+    async def _emit_tool_use_from_hook(self, payload: dict[str, Any]) -> None:
+        tool_name = self._coerce_str(payload.get("tool_name"))
+        if not tool_name:
+            return
+        tool_input = payload.get("tool_input")
+        tool_use_id = self._coerce_str(payload.get("tool_use_id")) or (f"hook-{uuid.uuid4().hex}")
+        await self._emit(
+            {
+                "type": "assistant",
+                "message": {
+                    "model": self._model or "interactive",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": tool_use_id,
+                            "name": tool_name,
+                            "input": tool_input if isinstance(tool_input, dict) else {},
+                        }
+                    ],
+                },
+                "metadata": {
+                    "source": "claude_hook",
+                    "hook_event_name": "PreToolUse",
+                    "claude_session_id": payload.get("session_id"),
+                    "transcript_path": payload.get("transcript_path"),
+                },
+            }
+        )
+
+    async def _emit_tool_result_from_hook(
+        self,
+        payload: dict[str, Any],
+        *,
+        is_error: bool,
+    ) -> None:
+        tool_use_id = self._coerce_str(payload.get("tool_use_id"))
+        if not tool_use_id:
+            return
+        result = payload.get("tool_response")
+        if result is None:
+            result = payload.get("error", "")
+        await self._emit(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_use_id,
+                            "content": self._stringify_hook_value(result),
+                            "is_error": is_error,
+                        }
+                    ]
+                },
+                "metadata": {
+                    "source": "claude_hook",
+                    "hook_event_name": ("PostToolUseFailure" if is_error else "PostToolUse"),
+                    "claude_session_id": payload.get("session_id"),
+                    "transcript_path": payload.get("transcript_path"),
+                },
+            }
+        )
+
+    async def _emit_permission_request_from_hook(self, payload: dict[str, Any]) -> None:
+        tool_input = payload.get("tool_input")
+        await self._emit(
+            {
+                "type": "claude_permission_request",
+                "event_type": "claude.permission.request",
+                "tool_name": payload.get("tool_name"),
+                "input": tool_input if isinstance(tool_input, dict) else {},
+                "permission_suggestions": payload.get("permission_suggestions", []),
+                "claude_session_id": payload.get("session_id"),
+                "transcript_path": payload.get("transcript_path"),
+                "metadata": {"source": "claude_hook"},
+            }
+        )
+
+    async def _finish_hook_turn(
+        self,
+        *,
+        content: str,
+        reason: str,
+        is_error: bool = False,
+    ) -> None:
+        content = content.strip()
+        if content:
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "model": self._model or "interactive",
+                        "content": [{"type": "text", "text": content}],
+                    },
+                    "metadata": {"source": "claude_hook"},
+                }
+            )
+        result = {
+            "type": "result",
+            "result": content,
+            "is_error": is_error,
+            "stop_reason": reason,
+            "modelUsage": {},
+            "metadata": {"source": "claude_hook"},
+        }
+        self._last_result = result
+        await self._emit(result)
+        self._turn_active = False
+        if self._turn_done is not None:
+            self._turn_done.set()
+
+    @staticmethod
+    def _stringify_hook_value(value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        try:
+            return json.dumps(value, ensure_ascii=False, sort_keys=True)
+        except TypeError:
+            return str(value)
+
+    async def _create_session(self) -> None:
+        env = self._spawn_env()
+        self._write_hook_settings()
+        command = self._interactive_argv()
+        logger.info("TmuxInteractiveTransport: starting %s", self._session_name)
+        await self._run_tmux(
+            "new-session",
+            "-d",
+            "-s",
+            self._session_name,
+            "-c",
+            self.workspace_dir,
+            "-n",
+            "main",
+            "-x",
+            "200",
+            "-y",
+            "50",
+            "--",
+            *command,
+            env=env,
+        )
+
+    async def _apply_tmux_options(self) -> None:
+        for args in (
+            ("set-option", "-t", self._session_name, "-g", "status", "off"),
+            ("set-option", "-t", self._session_name, "-g", "history-limit", "50000"),
+            ("set-option", "-t", self._session_name, "-g", "mouse", "on"),
+            ("set-option", "-t", self._session_name, "-g", "remain-on-exit", "on"),
+        ):
+            await self._run_tmux(*args, check=False)
+
+    def _interactive_argv(self) -> list[str]:
+        cmd = ["claude"]
+        if self._model:
+            cmd.extend(["--model", self._model])
+        if self._skip_permissions:
+            cmd.extend(["--permission-mode", _DEFAULT_PERMISSION_MODE])
+        if self._hook_events_enabled and self._sdk_port:
+            cmd.extend(["--settings", str(self._hook_settings_path)])
+        if self._system_prompt:
+            cmd.extend(["--append-system-prompt", self._system_prompt])
+        if self._mcp_config:
+            cmd.extend(["--mcp-config", self._mcp_config])
+        if self._agent_teams:
+            cmd.extend(["--teammate-mode", "tmux"])
+        return cmd
+
+    def _write_hook_settings(self) -> None:
+        if not self._hook_events_enabled or not self._sdk_port:
+            return
+
+        events = list(_CLAUDE_HOOK_EVENTS)
+        if self._message_display_hook_enabled:
+            events.extend(_OPTIONAL_HIGH_VOLUME_HOOK_EVENTS)
+        hook = {
+            "type": "http",
+            "url": f"http://127.0.0.1:{self._sdk_port}/api/claude/hooks",
+            "timeout": 5,
+        }
+        settings = {"hooks": {event: [{"matcher": "", "hooks": [hook]}] for event in events}}
+        self._hook_settings_path.parent.mkdir(parents=True, exist_ok=True)
+        self._hook_settings_path.write_text(
+            json.dumps(settings, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def _spawn_env(self) -> dict[str, str]:
+        env = claude_spawn_env()
+        env["TERM"] = env.get("TERM") or "xterm-256color"
+        if self._agent_teams:
+            env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
+        _, shim_env = ensure_codex_tool_shims(
+            self.workspace_dir,
+            mcp_servers=self._raw_mcp_servers,
+        )
+        env.update(shim_env)
+        return env
+
+    async def _emit_system_init(self) -> None:
+        await self._emit(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": self._session_name,
+                "message": {"model": self._model or "interactive"},
+                "slash_commands": list(_BUILT_IN_SLASH_COMMANDS),
+                "terminal": {
+                    "transport": "tmux_interactive",
+                    "session_name": self._session_name,
+                    "socket_path": str(self._socket_path),
+                    "hook_endpoint": (
+                        f"http://127.0.0.1:{self._sdk_port}/api/claude/hooks"
+                        if self._sdk_port
+                        else None
+                    ),
+                },
+            }
+        )
+
+    async def _watch_panes(self) -> None:
+        try:
+            while self._alive:
+                await self._refresh_panes(emit_events=True)
+                await asyncio.sleep(self._pane_poll_interval_s)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Tmux pane watcher failed", exc_info=True)
+
+    async def _refresh_panes(self, *, emit_events: bool) -> None:
+        result = await self._run_tmux(
+            "list-panes",
+            "-t",
+            self._session_name,
+            "-F",
+            (
+                "#{pane_id}\t#{pane_index}\t#{window_name}\t#{pane_active}\t"
+                "#{pane_current_command}\t#{pane_width}\t#{pane_height}\t"
+                "#{cursor_x}\t#{cursor_y}"
+            ),
+            check=False,
+        )
+        if result.returncode != 0:
+            self._alive = False
+            return
+
+        seen: set[str] = set()
+        for line in result.stdout.splitlines():
+            parts = line.split("\t")
+            if len(parts) < 5:
+                continue
+            pane_id, pane_index, window_name, pane_active, current_command = parts[:5]
+            width = self._coerce_int(parts[5] if len(parts) > 5 else None, 200)
+            height = self._coerce_int(parts[6] if len(parts) > 6 else None, 50)
+            cursor_x = self._coerce_int(parts[7] if len(parts) > 7 else None, 0)
+            cursor_y = self._coerce_int(parts[8] if len(parts) > 8 else None, 0)
+            seen.add(pane_id)
+            pane = _PaneState(
+                pane_id=pane_id,
+                pane_index=pane_index,
+                window_name=window_name,
+                active=pane_active == "1",
+                current_command=current_command,
+                width=width,
+                height=height,
+                cursor_x=cursor_x,
+                cursor_y=cursor_y,
+                log_path=self._pane_log_path(pane_id),
+            )
+            is_new = pane_id not in self._panes
+            self._panes[pane_id] = pane
+            if is_new:
+                await self._start_pipe_for_pane(pane)
+                if emit_events:
+                    await self._emit_pane_opened(pane)
+
+        for pane_id in set(self._panes) - seen:
+            pane = self._panes.pop(pane_id)
+            task = self._tail_tasks.pop(pane_id, None)
+            if task is not None:
+                task.cancel()
+            frame_task = self._frame_tasks.pop(pane_id, None)
+            if frame_task is not None:
+                frame_task.cancel()
+            self._last_frame_signature.pop(pane_id, None)
+            self._pane_sequences.pop(pane_id, None)
+            if emit_events:
+                await self._emit(
+                    {
+                        "type": "terminal_pane_closed",
+                        "pane_id": pane_id,
+                        "window_name": pane.window_name,
+                    }
+                )
+
+    async def _start_pipe_for_pane(self, pane: _PaneState) -> None:
+        pane.log_path.parent.mkdir(parents=True, exist_ok=True)
+        pane.log_path.touch(exist_ok=True)
+        await self._run_tmux("pipe-pane", "-t", pane.pane_id, check=False)
+        await self._run_tmux(
+            "pipe-pane",
+            "-t",
+            pane.pane_id,
+            f"cat >> {shlex.quote(str(pane.log_path))}",
+            check=False,
+        )
+        await self._emit_pane_frame(pane, event_type="terminal_snapshot", force=True)
+        task = asyncio.create_task(
+            self._tail_pane_log(pane),
+            name=f"tmux-pane-tail-{self._session_name}-{pane.pane_id}",
+        )
+        self._tail_tasks[pane.pane_id] = task
+
+    async def _tail_pane_log(self, pane: _PaneState) -> None:
+        try:
+            with pane.log_path.open("rb") as handle:
+                handle.seek(0, os.SEEK_END)
+                while self._alive and pane.pane_id in self._panes:
+                    chunk = handle.read(8192)
+                    if not chunk:
+                        await asyncio.sleep(0.1)
+                        continue
+                    await self._handle_pane_output(pane, chunk)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning("Pane tail failed for %s", pane.pane_id, exc_info=True)
+
+    async def _handle_pane_output(self, pane: _PaneState, chunk: bytes | str) -> None:
+        text = chunk.decode("utf-8", errors="replace") if isinstance(chunk, bytes) else chunk
+        if not text:
+            return
+        if self._turn_active:
+            self._turn_last_output_at = time.monotonic()
+        if self._emit_raw_terminal_output:
+            await self._emit(
+                {
+                    "type": "terminal_output",
+                    "event_type": "terminal.output.raw",
+                    "pane_id": pane.pane_id,
+                    "pane_index": pane.pane_index,
+                    "window_name": pane.window_name,
+                    "data": text,
+                    "encoding": "utf-8",
+                    "stream": "stdout",
+                    "raw": True,
+                    "ts": time.time(),
+                }
+            )
+        self._schedule_pane_frame(pane)
+
+    def _schedule_pane_frame(self, pane: _PaneState) -> None:
+        if pane.pane_id in self._frame_tasks and not self._frame_tasks[pane.pane_id].done():
+            return
+
+        async def _delayed_emit() -> None:
+            try:
+                await asyncio.sleep(self._frame_interval_s)
+                latest = self._panes.get(pane.pane_id, pane)
+                await self._emit_pane_frame(latest, event_type="terminal_frame")
+            finally:
+                self._frame_tasks.pop(pane.pane_id, None)
+
+        self._frame_tasks[pane.pane_id] = asyncio.create_task(
+            _delayed_emit(),
+            name=f"tmux-pane-frame-{self._session_name}-{pane.pane_id}",
+        )
+
+    async def _emit_pane_frame(
+        self,
+        pane: _PaneState,
+        *,
+        event_type: str,
+        force: bool = False,
+    ) -> dict | None:
+        frame = await self._capture_pane_frame(pane)
+        if frame is None:
+            return None
+        signature = frame["text"]
+        if not force and self._last_frame_signature.get(pane.pane_id) == signature:
+            return frame
+        self._last_frame_signature[pane.pane_id] = signature
+        await self._emit(frame | {"type": event_type})
+        if self._turn_active and pane.active and not self._hook_events_enabled:
+            await self._maybe_emit_clean_turn_delta(frame["rows"])
+        return frame
+
+    async def _capture_pane_frame(self, pane: _PaneState) -> dict | None:
+        start = f"-{max(pane.height - 1, 0)}"
+        snapshot = await self._run_tmux(
+            "capture-pane",
+            "-p",
+            "-S",
+            start,
+            "-t",
+            pane.pane_id,
+            check=False,
+        )
+        if snapshot.returncode != 0:
+            return None
+        rows = self._normalize_terminal_rows(snapshot.stdout)
+        seq = self._pane_sequences.get(pane.pane_id, 0) + 1
+        self._pane_sequences[pane.pane_id] = seq
+        return {
+            "event_type": "terminal.frame",
+            "pane_id": pane.pane_id,
+            "pane_index": pane.pane_index,
+            "window_name": pane.window_name,
+            "active": pane.active,
+            "current_command": pane.current_command,
+            "cols": pane.width,
+            "rows_count": pane.height,
+            "cursor": {"x": pane.cursor_x, "y": pane.cursor_y},
+            "rows": rows,
+            "text": "\n".join(rows).rstrip(),
+            "seq": seq,
+            "encoding": "utf-8",
+            "raw": False,
+            "ts": time.time(),
+        }
+
+    async def _emit_synthetic_delta(self, text: str) -> None:
+        self._turn_last_output_at = time.monotonic()
+        if not self._turn_stream_started:
+            self._turn_stream_started = True
+            await self._emit(
+                {
+                    "type": "assistant",
+                    "message": {
+                        "model": self._model or "interactive",
+                        "content": [],
+                    },
+                    "metadata": {"source": "tmux_interactive"},
+                }
+            )
+            await self._emit(
+                {
+                    "type": "content_block_start",
+                    "content_block": {"type": "text"},
+                    "metadata": {"source": "tmux_interactive"},
+                }
+            )
+        self._turn_buffer.append(text)
+        await self._emit(
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": text},
+                "metadata": {"source": "tmux_interactive"},
+            }
+        )
+
+    async def _maybe_emit_clean_turn_delta(self, rows: list[str]) -> None:
+        clean = self._extract_assistant_response(rows)
+        if not clean:
+            return
+        previous = self._turn_last_clean_text
+        self._turn_last_clean_text = clean
+        if clean == previous:
+            return
+        if not previous:
+            delta = clean
+        elif clean.startswith(previous):
+            delta = clean[len(previous) :]
+        else:
+            prefix_len = self._common_prefix_len(previous, clean)
+            # Terminal reflow can rewrite visible rows. Only stream the suffix
+            # when the new frame mostly preserves what the browser already saw;
+            # the final result event still replaces the message with clean text.
+            if prefix_len < max(12, int(len(previous) * 0.8)):
+                return
+            delta = clean[prefix_len:]
+        if delta:
+            await self._emit_synthetic_delta(delta)
+
+    async def _watch_turn_completion(self, done: asyncio.Event) -> None:
+        try:
+            while not done.is_set():
+                now = time.monotonic()
+                if self._hook_events_enabled:
+                    if now - self._turn_started_at >= self._turn_max_seconds:
+                        await self._finish_hook_turn(
+                            content="",
+                            reason="timeout",
+                            is_error=True,
+                        )
+                        return
+                    await asyncio.sleep(0.2)
+                    continue
+                if self._turn_last_output_at is not None:
+                    if now - self._turn_last_output_at >= self._turn_idle_timeout_s:
+                        await self._finish_synthetic_turn(reason="terminal_idle")
+                        return
+                elif now - self._turn_started_at >= self._turn_no_output_timeout_s:
+                    await self._finish_synthetic_turn(reason="no_terminal_output")
+                    return
+                if now - self._turn_started_at >= self._turn_max_seconds:
+                    await self._finish_synthetic_turn(reason="timeout", is_error=True)
+                    return
+                await asyncio.sleep(0.2)
+        except asyncio.CancelledError:
+            raise
+
+    async def _finish_synthetic_turn(self, *, reason: str, is_error: bool = False) -> None:
+        if not self._turn_active:
+            return
+        content = (await self._capture_turn_text()) or self._turn_last_clean_text
+        if not content:
+            content = "".join(self._turn_buffer).strip()
+        if self._turn_stream_started:
+            await self._emit(
+                {
+                    "type": "content_block_stop",
+                    "metadata": {"source": "tmux_interactive"},
+                }
+            )
+        result = {
+            "type": "result",
+            "result": content,
+            "is_error": is_error,
+            "stop_reason": reason,
+            "modelUsage": {},
+            "metadata": {"source": "tmux_interactive"},
+        }
+        self._last_result = result
+        await self._emit(result)
+        self._turn_active = False
+        if self._turn_done is not None:
+            self._turn_done.set()
+
+    async def _capture_turn_text(self) -> str:
+        pane = None
+        for candidate in self._panes.values():
+            if candidate.active:
+                pane = candidate
+                break
+        if pane is None and self._panes:
+            pane = next(iter(self._panes.values()))
+        if pane is None:
+            return ""
+        frame = await self._emit_pane_frame(pane, event_type="terminal_frame", force=True)
+        if not frame:
+            return ""
+        return self._extract_assistant_response(frame["rows"])
+
+    async def _paste_text(
+        self,
+        text: str,
+        *,
+        enter: bool,
+        pane_id: str | None = None,
+    ) -> None:
+        text = text.replace("\r", "")
+        target = self._target_pane(pane_id)
+        buffer_name = f"skuld-{uuid.uuid4().hex}"
+        input_path = self._runtime_dir / f"input-{uuid.uuid4().hex}.txt"
+        input_path.write_text(text, encoding="utf-8")
+        try:
+            await self._run_tmux("load-buffer", "-b", buffer_name, str(input_path))
+            await self._run_tmux("paste-buffer", "-p", "-t", target, "-b", buffer_name)
+        finally:
+            await self._run_tmux("delete-buffer", "-b", buffer_name, check=False)
+            with suppress(OSError):
+                input_path.unlink()
+        await self._emit(
+            {
+                "type": "terminal_input_sent",
+                "event_type": "terminal.input",
+                "pane_id": target,
+                "bytes": len(text.encode("utf-8")),
+                "enter": enter,
+            }
+        )
+        if enter:
+            await self._send_key("Enter", pane_id=target)
+
+    async def _send_key(self, key: str, *, pane_id: str | None = None) -> None:
+        target = self._target_pane(pane_id)
+        await self._run_tmux("send-keys", "-t", target, key)
+        await self._emit(
+            {
+                "type": "terminal_key_sent",
+                "event_type": "terminal.key",
+                "pane_id": target,
+                "key": key,
+            }
+        )
+
+    async def _resize_pane(self, *, cols: int, rows: int, pane_id: str | None = None) -> None:
+        target = self._target_pane(pane_id)
+        await self._run_tmux("resize-pane", "-t", target, "-x", str(cols), "-y", str(rows))
+        await self._emit(
+            {
+                "type": "terminal_resized",
+                "event_type": "terminal.resize",
+                "pane_id": target,
+                "cols": cols,
+                "rows": rows,
+            }
+        )
+
+    async def _emit_pane_opened(self, pane: _PaneState) -> None:
+        await self._emit(
+            {
+                "type": "terminal_pane_opened",
+                "event_type": "terminal.pane.opened",
+                "pane_id": pane.pane_id,
+                "pane_index": pane.pane_index,
+                "window_name": pane.window_name,
+                "active": pane.active,
+                "current_command": pane.current_command,
+                "log_path": str(pane.log_path),
+            }
+        )
+
+    async def _has_session(self) -> bool:
+        result = await self._run_tmux("has-session", "-t", self._session_name, check=False)
+        return result.returncode == 0
+
+    async def _run_tmux(
+        self,
+        *args: str,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> _TmuxResult:
+        cmd = [self._tmux_bin(), "-S", str(self._socket_path), *args]
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout_b, stderr_b = await process.communicate()
+        result = _TmuxResult(
+            returncode=process.returncode or 0,
+            stdout=stdout_b.decode("utf-8", errors="replace"),
+            stderr=stderr_b.decode("utf-8", errors="replace"),
+        )
+        if check and result.returncode != 0:
+            raise TmuxCommandError(
+                f"tmux {' '.join(args)} failed ({result.returncode}): {result.stderr.strip()}"
+            )
+        return result
+
+    def _target_pane(self, pane_id: str | None = None) -> str:
+        if pane_id:
+            return pane_id
+        for pane in self._panes.values():
+            if pane.active:
+                return pane.pane_id
+        if self._panes:
+            return next(iter(self._panes.values())).pane_id
+        return f"{self._session_name}:main"
+
+    def _pane_log_path(self, pane_id: str) -> Path:
+        safe = self._safe_name(pane_id.lstrip("%") or "pane")
+        return self._pane_log_dir / f"{safe}.log"
+
+    def _tmux_binary_exists(self) -> bool:
+        return shutil.which(self._tmux_bin()) is not None
+
+    @staticmethod
+    def _tmux_bin() -> str:
+        return os.environ.get("SKULD__TMUX_BIN") or "tmux"
+
+    @staticmethod
+    def _normalize_key(key: str) -> str:
+        stripped = key.strip()
+        return _KEY_ALIASES.get(stripped.lower(), stripped)
+
+    @staticmethod
+    def _safe_name(value: str) -> str:
+        safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", value.strip())
+        return safe.strip("-") or "skuld-interactive"
+
+    @staticmethod
+    def _coerce_str(value: object) -> str:
+        return value if isinstance(value, str) else ""
+
+    @staticmethod
+    def _coerce_int(value: object, default: int) -> int:
+        try:
+            return int(str(value or "").strip())
+        except ValueError:
+            return default
+
+    @staticmethod
+    def _bool_env(name: str, default: bool) -> bool:
+        raw = os.environ.get(name, "")
+        if not raw:
+            return default
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+    @staticmethod
+    def _clean_terminal_text(text: str) -> str:
+        cleaned = _ANSI_RE.sub("", text)
+        cleaned = cleaned.replace("\r\n", "\n").replace("\r", "\n")
+        cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+        return cleaned
+
+    @classmethod
+    def _normalize_terminal_rows(cls, text: str) -> list[str]:
+        cleaned = cls._clean_terminal_text(text)
+        rows = [row.rstrip() for row in cleaned.splitlines()]
+        while rows and not rows[-1].strip():
+            rows.pop()
+        return rows
+
+    @classmethod
+    def _extract_assistant_response(cls, rows: list[str]) -> str:
+        normalized = [row.rstrip() for row in rows]
+        prompt_indices = [idx for idx, row in enumerate(normalized) if cls._is_prompt_row(row)]
+        if prompt_indices:
+            prompt_idx = prompt_indices[-1]
+            if cls._is_empty_prompt_row(normalized[prompt_idx]) and len(prompt_indices) >= 2:
+                prompt_idx = prompt_indices[-2]
+            end_idx = next(
+                (
+                    idx
+                    for idx in prompt_indices
+                    if idx > prompt_idx and cls._is_empty_prompt_row(normalized[idx])
+                ),
+                len(normalized),
+            )
+            candidate_rows = normalized[prompt_idx + 1 : end_idx]
+        else:
+            candidate_rows = normalized
+
+        cleaned_rows: list[str] = []
+        for row in candidate_rows:
+            row = cls._clean_response_row(row)
+            if row is None:
+                continue
+            cleaned_rows.append(row)
+
+        while cleaned_rows and not cleaned_rows[0].strip():
+            cleaned_rows.pop(0)
+        while cleaned_rows and not cleaned_rows[-1].strip():
+            cleaned_rows.pop()
+        return cls._collapse_response_rows(cleaned_rows)
+
+    @staticmethod
+    def _is_prompt_row(row: str) -> bool:
+        return row.lstrip().startswith("❯")
+
+    @staticmethod
+    def _is_empty_prompt_row(row: str) -> bool:
+        stripped = row.strip().replace("\u00a0", " ")
+        if not stripped.startswith("❯"):
+            return False
+        return not stripped[1:].strip()
+
+    @classmethod
+    def _clean_response_row(cls, row: str) -> str | None:
+        stripped = row.strip()
+        if not stripped:
+            return ""
+        if cls._is_terminal_chrome_row(stripped):
+            return None
+        for prefix in ("●", "⏺"):
+            if stripped.startswith(prefix):
+                return stripped[len(prefix) :].lstrip()
+        # Claude Code renders continuation lines with two leading spaces. Keep
+        # meaningful indentation from code blocks, but drop one UI continuation
+        # level for prose rows.
+        if row.startswith("  ") and not row.startswith("    "):
+            return row[2:].rstrip()
+        return row.rstrip()
+
+    @staticmethod
+    def _is_terminal_chrome_row(stripped: str) -> bool:
+        if stripped in {"?", "│", "╭", "╰"}:
+            return True
+        if set(stripped) <= {"─"}:
+            return True
+        if "for shortcuts" in stripped:
+            return True
+        if "esc to interrupt" in stripped:
+            return True
+        if "Esc to cancel" in stripped:
+            return True
+        if stripped == "Bash command":
+            return True
+        if stripped == "Do you want to proceed?":
+            return True
+        if re.fullmatch(r"[1-9]\.\s+.*", stripped):
+            return True
+        if stripped.startswith("⎿ Tip:"):
+            return True
+        if stripped.startswith("⚠ ") and "/doctor" in stripped:
+            return True
+        if stripped.startswith("◉ ") and "/effort" in stripped:
+            return True
+        if re.fullmatch(r"[✻✽✶✢*·⠂⠐⠠⠄\s]+", stripped):
+            return True
+        spinner_prefixes = ("✻", "✽", "✶", "✢", "*", "·")
+        spinner_words = (
+            "Cogitated",
+            "Combobulating",
+            "Gesticulating",
+            "Incubating",
+            "Lollygagging",
+            "Synthesizing",
+            "Thinking",
+        )
+        if stripped.startswith(spinner_prefixes) and any(
+            word in stripped for word in spinner_words
+        ):
+            return True
+        if "thinking with" in stripped and "effort" in stripped:
+            return True
+        if re.search(r"(?:[↑↓]\s*)?\d+(?:\.\d+)?k?\s+tokens\b", stripped):
+            return True
+        if re.search(r"\b(?:Thought|Cogitated) for \d+s\b", stripped, re.IGNORECASE):
+            return True
+        if stripped.startswith("You're now using usage credits"):
+            return True
+        if stripped.startswith("Your session limit resets"):
+            return True
+        return False
+
+    @staticmethod
+    def _collapse_response_rows(rows: list[str]) -> str:
+        text = "\n".join(rows)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()
+
+    @staticmethod
+    def _common_prefix_len(left: str, right: str) -> int:
+        limit = min(len(left), len(right))
+        for idx in range(limit):
+            if left[idx] != right[idx]:
+                return idx
+        return limit
+
+    @staticmethod
+    def _float_env(name: str, explicit: float | None, default: float) -> float:
+        if explicit is not None:
+            return explicit
+        raw = os.environ.get(name, "")
+        if not raw:
+            return default
+        try:
+            return float(raw)
+        except ValueError:
+            return default

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -330,6 +330,28 @@ def _default_session_definitions() -> dict[str, SessionDefinitionConfig]:
                 },
             },
         ),
+        "skuldClaudeInteractive": SessionDefinitionConfig(
+            enabled=True,
+            display_name="Claude Code Interactive",
+            description=(
+                "Anthropic Claude Code through a tmux-backed interactive terminal "
+                "for subscription sessions, slash commands, and terminal controls"
+            ),
+            labels=["session", "claude", "interactive"],
+            default_model="claude-sonnet-4-6",
+            compatible_providers=["anthropic"],
+            defaults={
+                "broker": {
+                    "cliType": "claude",
+                    "transport": "tmux-interactive",
+                    "transportAdapter": (
+                        "skuld.transports.tmux_interactive.TmuxInteractiveTransport"
+                    ),
+                    "skipPermissions": True,
+                    "agentTeams": False,
+                },
+            },
+        ),
         "skuldCodex": SessionDefinitionConfig(
             enabled=True,
             display_name="OpenAI Codex",

--- a/tests/test_charts/test_volundr_chart.py
+++ b/tests/test_charts/test_volundr_chart.py
@@ -63,6 +63,13 @@ class TestValuesDefaults:
         skuld = values_yaml["sessionDefinitions"]["skuldClaude"]
         assert "session" in skuld["labels"]
 
+    def test_skuld_claude_interactive_session_definition_enabled(self, values_yaml):
+        """Test skuld-claude-interactive session definition is enabled."""
+        skuld = values_yaml["sessionDefinitions"]["skuldClaudeInteractive"]
+        assert skuld["enabled"] is True
+        assert skuld["active"] is True
+        assert "interactive" in skuld["labels"]
+
     def test_skuld_claude_defaults_session_model(self, values_yaml):
         """Test skuld-claude defaults include session model."""
         defaults = values_yaml["sessionDefinitions"]["skuldClaude"]["defaults"]
@@ -139,6 +146,16 @@ class TestValuesDefaults:
         broker = values_yaml["sessionDefinitions"]["skuldClaude"]["defaults"]["broker"]
         assert broker["transport"] == "sdk"
         assert broker["transportAdapter"] == "skuld.transports.sdk.SDKTransport"
+
+    def test_skuld_claude_interactive_broker_transport_adapter(self, values_yaml):
+        """Test skuld-claude-interactive broker uses the tmux adapter."""
+        broker = values_yaml["sessionDefinitions"]["skuldClaudeInteractive"]["defaults"]["broker"]
+        assert broker["transport"] == "tmux-interactive"
+        assert (
+            broker["transportAdapter"]
+            == "skuld.transports.tmux_interactive.TmuxInteractiveTransport"
+        )
+        assert broker["skipPermissions"] is True
 
     def test_skuld_codex_broker_cli_type(self, values_yaml):
         """Test skuld-codex broker cliType is codex-ws (WebSocket transport)."""

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -1776,6 +1776,7 @@ class TestDispatchBrowserMessage:
             "terminal_key",
             "terminal_resize",
             "slash_command",
+            "discover_slash_commands",
         ]
         for msg_type in guarded:
             sender_ws = AsyncMock()
@@ -1816,7 +1817,12 @@ class TestDispatchBrowserMessage:
             {"type": "terminal_resize", "cols": 120, "rows": 40, "pane_id": "%1"}
         )
         await test_broker._dispatch_browser_message(
-            {"type": "slash_command", "command": "compact", "pane_id": "%1"}
+            {
+                "type": "slash_command",
+                "command": "compact",
+                "arguments": "now",
+                "pane_id": "%1",
+            }
         )
 
         assert test_broker._transport.send_control.call_args_list[0].args == ("terminal_input",)
@@ -1840,8 +1846,48 @@ class TestDispatchBrowserMessage:
         assert test_broker._transport.send_control.call_args_list[3].args == ("slash_command",)
         assert test_broker._transport.send_control.call_args_list[3].kwargs == {
             "command": "compact",
+            "arguments": "now",
             "pane_id": "%1",
         }
+
+    @pytest.mark.asyncio
+    async def test_dispatch_discovers_slash_commands(self, test_broker):
+        """Browser can request slash commands over the session WebSocket."""
+        test_broker._transport.capabilities = TransportCapabilities(slash_commands=True)
+        test_broker._transport.discover_slash_commands = AsyncMock(
+            return_value=[
+                {
+                    "name": "/workflows",
+                    "command": "workflows",
+                    "description": "Browse workflows",
+                    "kind": "command",
+                    "source": "tmux_autocomplete",
+                }
+            ]
+        )
+        sender_ws = AsyncMock()
+
+        await test_broker._dispatch_browser_message(
+            {"type": "discover_slash_commands", "refresh": True},
+            sender_ws=sender_ws,
+        )
+
+        test_broker._transport.discover_slash_commands.assert_awaited_once_with(refresh=True)
+        sender_ws.send_json.assert_awaited_once_with(
+            {
+                "type": "slash_commands",
+                "commands": [
+                    {
+                        "name": "/workflows",
+                        "command": "workflows",
+                        "description": "Browse workflows",
+                        "kind": "command",
+                        "source": "tmux_autocomplete",
+                    }
+                ],
+                "count": 1,
+            }
+        )
 
     @pytest.mark.asyncio
     async def test_handle_claude_hook_normalizes_payload(self, test_broker):
@@ -2004,6 +2050,66 @@ class TestFastAPIEndpoints:
         broker._transport = None
         response = client.get("/api/capabilities")
         assert response.status_code == 503
+
+    def test_slash_commands_endpoint_returns_discovered_commands(self, client):
+        """GET /api/slash-commands returns normalized transport commands."""
+        mock_transport = MagicMock()
+        mock_transport.capabilities = TransportCapabilities(slash_commands=True)
+        mock_transport.discover_slash_commands = AsyncMock(
+            return_value=[
+                {
+                    "name": "/deep-research",
+                    "command": "deep-research",
+                    "description": "Deep research",
+                    "kind": "workflow",
+                    "source": "tmux_autocomplete",
+                }
+            ]
+        )
+        broker._transport = mock_transport
+
+        response = client.get("/api/slash-commands?refresh=true")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["count"] == 1
+        assert data["commands"][0]["name"] == "/deep-research"
+        assert data["commands"][0]["kind"] == "workflow"
+        mock_transport.discover_slash_commands.assert_awaited_once_with(refresh=True)
+        broker._transport = None
+
+    def test_send_slash_command_endpoint_uses_transport_control(self, client):
+        """POST /api/slash-commands/send sends a terminal slash command."""
+        mock_transport = MagicMock()
+        mock_transport.capabilities = TransportCapabilities(slash_commands=True)
+        mock_transport.send_control = AsyncMock()
+        broker._transport = mock_transport
+
+        response = client.post(
+            "/api/slash-commands/send",
+            json={"command": "workflows", "arguments": "--all", "pane_id": "%1"},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "sent", "command": "/workflows"}
+        mock_transport.send_control.assert_awaited_once_with(
+            "slash_command",
+            command="workflows",
+            arguments="--all",
+            pane_id="%1",
+        )
+        broker._transport = None
+
+    def test_slash_commands_endpoint_501_when_unsupported(self, client):
+        """Slash command APIs report unsupported transports clearly."""
+        mock_transport = MagicMock()
+        mock_transport.capabilities = TransportCapabilities()
+        broker._transport = mock_transport
+
+        response = client.get("/api/slash-commands")
+
+        assert response.status_code == 501
+        broker._transport = None
 
     def test_logs_endpoint_level_filter(self, client):
         _log_buffer.clear()

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -1772,6 +1772,10 @@ class TestDispatchBrowserMessage:
             "set_permission_mode",
             "rewind_files",
             "mcp_set_servers",
+            "terminal_input",
+            "terminal_key",
+            "terminal_resize",
+            "slash_command",
         ]
         for msg_type in guarded:
             sender_ws = AsyncMock()
@@ -1791,6 +1795,86 @@ class TestDispatchBrowserMessage:
         await test_broker._dispatch_browser_message({"type": "interrupt"})
 
         test_broker._transport.send_control.assert_called_once_with("interrupt")
+
+    @pytest.mark.asyncio
+    async def test_dispatch_terminal_controls(self, test_broker):
+        """Interactive terminal controls pass through when the transport supports them."""
+        test_broker._transport.capabilities = TransportCapabilities(
+            terminal_input=True,
+            terminal_keys=True,
+            terminal_resize=True,
+            slash_commands=True,
+        )
+
+        await test_broker._dispatch_browser_message(
+            {"type": "terminal_input", "data": "/help", "enter": True, "pane_id": "%1"}
+        )
+        await test_broker._dispatch_browser_message(
+            {"type": "terminal_key", "key": "Up", "pane_id": "%1"}
+        )
+        await test_broker._dispatch_browser_message(
+            {"type": "terminal_resize", "cols": 120, "rows": 40, "pane_id": "%1"}
+        )
+        await test_broker._dispatch_browser_message(
+            {"type": "slash_command", "command": "compact", "pane_id": "%1"}
+        )
+
+        assert test_broker._transport.send_control.call_args_list[0].args == ("terminal_input",)
+        assert test_broker._transport.send_control.call_args_list[0].kwargs == {
+            "data": "/help",
+            "enter": True,
+            "pane_id": "%1",
+        }
+        assert test_broker._transport.send_control.call_args_list[1].args == ("terminal_key",)
+        assert test_broker._transport.send_control.call_args_list[1].kwargs == {
+            "key": "Up",
+            "keys": [],
+            "pane_id": "%1",
+        }
+        assert test_broker._transport.send_control.call_args_list[2].args == ("terminal_resize",)
+        assert test_broker._transport.send_control.call_args_list[2].kwargs == {
+            "cols": 120,
+            "rows": 40,
+            "pane_id": "%1",
+        }
+        assert test_broker._transport.send_control.call_args_list[3].args == ("slash_command",)
+        assert test_broker._transport.send_control.call_args_list[3].kwargs == {
+            "command": "compact",
+            "pane_id": "%1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_handle_claude_hook_normalizes_payload(self, test_broker):
+        """Claude HTTP hooks are routed into the normal CLI event pipeline."""
+        test_broker._transport = None
+        test_broker._handle_cli_event = AsyncMock()
+
+        await test_broker.handle_claude_hook(
+            {"hook_event_name": "PostToolUse", "tool_name": "Read"}
+        )
+
+        test_broker._handle_cli_event.assert_awaited_once_with(
+            {
+                "type": "claude_hook",
+                "event_type": "claude.hook",
+                "hook_event_name": "PostToolUse",
+                "payload": {"hook_event_name": "PostToolUse", "tool_name": "Read"},
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_claude_hook_delegates_to_transport_handler(self, test_broker):
+        """Interactive transports can convert hook payloads before broker fallback."""
+        transport = MagicMock()
+        transport.handle_claude_hook = AsyncMock(return_value=True)
+        test_broker._transport = transport
+        test_broker._handle_cli_event = AsyncMock()
+
+        payload = {"hook_event_name": "Stop", "last_assistant_message": "done"}
+        await test_broker.handle_claude_hook(payload)
+
+        transport.handle_claude_hook.assert_awaited_once_with(payload)
+        test_broker._handle_cli_event.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_dispatch_guard_no_sender_ws_still_blocks(self, test_broker):

--- a/tests/test_skuld/test_config.py
+++ b/tests/test_skuld/test_config.py
@@ -295,6 +295,13 @@ class TestTransportAdapter:
         s = SkuldSettings()
         assert s.transport_adapter == "skuld.transports.subprocess.SubprocessTransport"
 
+    def test_transport_tmux_interactive_resolves(self, monkeypatch):
+        """transport=tmux-interactive maps to TmuxInteractiveTransport."""
+        monkeypatch.setenv("SKULD__TRANSPORT", "tmux-interactive")
+
+        s = SkuldSettings()
+        assert s.transport_adapter == "skuld.transports.tmux_interactive.TmuxInteractiveTransport"
+
     def test_explicit_transport_adapter_takes_precedence(self, monkeypatch):
         """Explicit transport_adapter overrides legacy fields."""
         monkeypatch.setenv("SKULD__CLI_TYPE", "codex")

--- a/tests/test_skuld/test_tmux_interactive_transport.py
+++ b/tests/test_skuld/test_tmux_interactive_transport.py
@@ -34,6 +34,7 @@ class FakeTmuxInteractiveTransport(TmuxInteractiveTransport):
             **kwargs,
         )
         self.commands: list[tuple[tuple[str, ...], dict[str, str] | None]] = []
+        self.loaded_buffers: list[str] = []
         self.session_exists = False
         self.capture_stdout = ""
         self.pane_lines = ["%1\t0\tmain\t1\tclaude\t200\t50\t2\t47"]
@@ -56,6 +57,9 @@ class FakeTmuxInteractiveTransport(TmuxInteractiveTransport):
             return _TmuxResult(0)
         if command == "list-panes":
             return _TmuxResult(0, "\n".join(self.pane_lines) + "\n")
+        if command == "load-buffer":
+            self.loaded_buffers.append(Path(args[-1]).read_text(encoding="utf-8"))
+            return _TmuxResult(0)
         if command == "capture-pane":
             return _TmuxResult(0, self.capture_stdout)
         return _TmuxResult(0)
@@ -196,6 +200,61 @@ async def test_terminal_input_strips_carriage_returns(tmp_path: Path) -> None:
     assert not input_path.exists()
     input_event = next(event for event in events if event["type"] == "terminal_input_sent")
     assert input_event["bytes"] == len(b"first\nsecond")
+
+
+@pytest.mark.asyncio
+async def test_slash_command_control_pastes_terminal_input_without_chat_turn(
+    tmp_path: Path,
+) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path))
+    events = await _collect_events(transport)
+    await transport.start()
+
+    await transport.send_control(
+        "slash_command",
+        command="workflows",
+        arguments="--all",
+        pane_id="%1",
+    )
+    await transport.stop()
+
+    assert "/workflows --all" in transport.loaded_buffers
+    assert ("send-keys", "-t", "%1", "Enter") in [args for args, _ in transport.commands]
+    assert any(event["type"] == "slash_command_sent" for event in events)
+    assert not any(event["type"] == "assistant" for event in events)
+    assert not any(event["type"] == "result" for event in events)
+
+
+@pytest.mark.asyncio
+async def test_discover_slash_commands_scrapes_terminal_menu(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path))
+    events = await _collect_events(transport)
+    transport.capture_stdout = "\n".join(
+        [
+            "❯ /",
+            "────────────────",
+            "/deep-research                [dynamic workflow] Deep research harness",
+            "                              with wrapped details",
+            "/workflows                    Browse running and completed workflows",
+            "/compact                      Free up context",
+        ]
+    )
+    await transport.start()
+
+    commands = await transport.discover_slash_commands(refresh=True)
+    await transport.stop()
+
+    assert {(command["name"], command["kind"], command["source"]) for command in commands} >= {
+        ("/deep-research", "workflow", "tmux_autocomplete"),
+        ("/workflows", "command", "tmux_autocomplete"),
+        ("/compact", "command", "tmux_autocomplete"),
+    }
+    deep_research = next(command for command in commands if command["name"] == "/deep-research")
+    assert "wrapped details" in deep_research["description"]
+    sent_keys = [args for args, _ in transport.commands if args and args[0] == "send-keys"]
+    assert ("send-keys", "-t", "%1", "/") in sent_keys
+    assert ("send-keys", "-t", "%1", "Down") in sent_keys
+    assert any(event["type"] == "slash_commands" for event in events)
 
 
 @pytest.mark.asyncio

--- a/tests/test_skuld/test_tmux_interactive_transport.py
+++ b/tests/test_skuld/test_tmux_interactive_transport.py
@@ -1,0 +1,407 @@
+"""Tests for the tmux-backed interactive Claude transport."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from skuld.transports.tmux_interactive import (
+    TmuxInteractiveTransport,
+    _TmuxResult,
+)
+
+
+class FakeTmuxInteractiveTransport(TmuxInteractiveTransport):
+    """Tmux transport with an in-memory command runner for deterministic tests."""
+
+    def __init__(self, workspace_dir: str, **kwargs: Any) -> None:
+        super().__init__(
+            workspace_dir=workspace_dir,
+            session_id="test-session",
+            model="claude-sonnet-4-6",
+            turn_idle_timeout_s=0.05,
+            turn_no_output_timeout_s=0.2,
+            pane_poll_interval_s=999,
+            frame_interval_s=0.01,
+            **kwargs,
+        )
+        self.commands: list[tuple[tuple[str, ...], dict[str, str] | None]] = []
+        self.session_exists = False
+        self.capture_stdout = ""
+        self.pane_lines = ["%1\t0\tmain\t1\tclaude\t200\t50\t2\t47"]
+
+    def _tmux_binary_exists(self) -> bool:
+        return True
+
+    async def _run_tmux(
+        self,
+        *args: str,
+        check: bool = True,
+        env: dict[str, str] | None = None,
+    ) -> _TmuxResult:
+        self.commands.append((args, env))
+        command = args[0] if args else ""
+        if command == "has-session":
+            return _TmuxResult(0 if self.session_exists else 1)
+        if command == "new-session":
+            self.session_exists = True
+            return _TmuxResult(0)
+        if command == "list-panes":
+            return _TmuxResult(0, "\n".join(self.pane_lines) + "\n")
+        if command == "capture-pane":
+            return _TmuxResult(0, self.capture_stdout)
+        return _TmuxResult(0)
+
+
+async def _collect_events(
+    transport: TmuxInteractiveTransport,
+) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+
+    async def on_event(event: dict[str, Any]) -> None:
+        events.append(event)
+
+    transport.on_event(on_event)
+    return events
+
+
+async def _wait_until(predicate: Callable[[], bool], timeout: float = 1.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError("condition was not met before timeout")
+
+
+def _command_names(transport: FakeTmuxInteractiveTransport) -> list[str]:
+    return [command[0][0] for command in transport.commands if command[0]]
+
+
+@pytest.mark.asyncio
+async def test_start_creates_session_emits_init_and_pane(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path), sdk_port=8081)
+    events = await _collect_events(transport)
+
+    await transport.start()
+    await transport.stop()
+
+    names = _command_names(transport)
+    assert "new-session" in names
+    new_session = next(args for args, _ in transport.commands if args[0] == "new-session")
+    assert "-c" in new_session
+    assert str(tmp_path) in new_session
+    assert "--" in new_session
+    argv = new_session[new_session.index("--") + 1 :]
+    assert argv[:2] == ("claude", "--model")
+    assert argv[2] == "claude-sonnet-4-6"
+    assert "--settings" in argv
+    settings_path = Path(argv[argv.index("--settings") + 1])
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert "Stop" in settings["hooks"]
+    assert "PreToolUse" in settings["hooks"]
+    assert "MessageDisplay" not in settings["hooks"]
+
+    event_types = [event["type"] for event in events]
+    assert "terminal_pane_opened" in event_types
+    init = next(event for event in events if event["type"] == "system")
+    assert init["subtype"] == "init"
+    assert init["terminal"]["transport"] == "tmux_interactive"
+    assert init["terminal"]["hook_endpoint"] == "http://127.0.0.1:8081/api/claude/hooks"
+    assert any(command["name"] == "/compact" for command in init["slash_commands"])
+
+
+@pytest.mark.asyncio
+async def test_send_message_pastes_text_and_synthesizes_chat_turn(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path))
+    events = await _collect_events(transport)
+    await transport.start()
+
+    send_task = asyncio.create_task(transport.send_message("hello Claude"))
+    await _wait_until(lambda: any(args[0] == "paste-buffer" for args, _ in transport.commands))
+    transport.capture_stdout = "\n".join(
+        [
+            "❯ hello Claude",
+            "",
+            "✶ Gesticulating...",
+            "● Claude says hi",
+            "  with clean spacing",
+            "",
+            "❯ ",
+        ]
+    )
+    await transport._handle_pane_output(  # noqa: SLF001 - direct event simulation
+        transport._panes["%1"],  # noqa: SLF001
+        b"\x1b[32mClaude says hi\x1b[0m\r\n",
+    )
+    await send_task
+    await transport.stop()
+
+    command_names = _command_names(transport)
+    assert "load-buffer" in command_names
+    assert "paste-buffer" in command_names
+    assert ("send-keys", "-t", "%1", "Enter") in [args for args, _ in transport.commands]
+
+    event_types = [event["type"] for event in events]
+    assert "terminal_frame" in event_types
+    assert "terminal_output" not in event_types
+    assert "assistant" in event_types
+    assert "content_block_delta" in event_types
+    result = next(event for event in events if event["type"] == "result")
+    assert result["stop_reason"] == "terminal_idle"
+    assert result["result"] == "Claude says hi\nwith clean spacing"
+
+
+@pytest.mark.asyncio
+async def test_terminal_controls_send_keys_input_and_resize(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path))
+    events = await _collect_events(transport)
+    await transport.start()
+
+    await transport.send_control("terminal_key", key="Up")
+    await transport.send_control("terminal_input", data="/help", enter=True)
+    await transport.send_control("terminal_resize", cols=120, rows=40)
+    await transport.stop()
+
+    commands = [args for args, _ in transport.commands]
+    assert ("send-keys", "-t", "%1", "Up") in commands
+    assert ("send-keys", "-t", "%1", "Enter") in commands
+    assert ("resize-pane", "-t", "%1", "-x", "120", "-y", "40") in commands
+
+    event_types = [event["type"] for event in events]
+    assert "terminal_key_sent" in event_types
+    assert "terminal_input_sent" in event_types
+    assert "terminal_resized" in event_types
+
+
+@pytest.mark.asyncio
+async def test_terminal_input_strips_carriage_returns(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path))
+    events = await _collect_events(transport)
+    await transport.start()
+
+    await transport.send_control("terminal_input", data="first\r\nsecond\r", enter=False)
+    await transport.stop()
+
+    load_buffer = next(args for args, _ in transport.commands if args[0] == "load-buffer")
+    input_path = Path(load_buffer[-1])
+    assert not input_path.exists()
+    input_event = next(event for event in events if event["type"] == "terminal_input_sent")
+    assert input_event["bytes"] == len(b"first\nsecond")
+
+
+@pytest.mark.asyncio
+async def test_refresh_panes_emits_new_agent_team_pane(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path))
+    events = await _collect_events(transport)
+    await transport.start()
+
+    transport.pane_lines.append("%2\t1\tagent-1\t0\tclaude\t100\t40\t0\t0")
+    await transport._refresh_panes(emit_events=True)  # noqa: SLF001 - direct pane simulation
+    await transport.stop()
+
+    opened = [event for event in events if event["type"] == "terminal_pane_opened"]
+    assert {event["pane_id"] for event in opened} == {"%1", "%2"}
+    assert any(event["window_name"] == "agent-1" for event in opened)
+    pipe_targets = [
+        args[2]
+        for args, _ in transport.commands
+        if len(args) >= 3 and args[0] == "pipe-pane" and args[1] == "-t"
+    ]
+    assert "%2" in pipe_targets
+
+
+@pytest.mark.asyncio
+async def test_interrupt_finishes_active_turn(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path))
+    events = await _collect_events(transport)
+    await transport.start()
+
+    send_task = asyncio.create_task(transport.send_message("long task"))
+    await _wait_until(lambda: transport.is_turn_active)
+    await transport.send_control("interrupt")
+    await send_task
+    await transport.stop()
+
+    assert ("send-keys", "-t", "%1", "C-c") in [args for args, _ in transport.commands]
+    result = next(event for event in events if event["type"] == "result")
+    assert result["is_error"] is True
+    assert result["stop_reason"] == "interrupted"
+
+
+def test_capabilities_advertise_interactive_terminal_controls(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path))
+    caps = transport.capabilities
+
+    assert caps.interrupt is True
+    assert caps.slash_commands is True
+    assert caps.steer is True
+    assert caps.terminal_output is True
+    assert caps.terminal_input is True
+    assert caps.terminal_keys is True
+    assert caps.terminal_resize is True
+    assert caps.terminal_panes is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_real_tmux_smoke_with_fake_claude(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise real tmux plumbing without requiring Claude credentials."""
+    if shutil.which("tmux") is None:
+        pytest.skip("tmux is not installed")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    fake_claude = bin_dir / "claude"
+    fake_claude.write_text(
+        """#!/usr/bin/env bash
+printf 'Fake Claude ready\\n'
+while IFS= read -r line; do
+  printf 'assistant: %s\\n' "$line"
+done
+""",
+        encoding="utf-8",
+    )
+    fake_claude.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ.get('PATH', '')}")
+
+    transport = TmuxInteractiveTransport(
+        workspace_dir=str(tmp_path),
+        session_id=f"fake-{uuid.uuid4().hex}",
+        turn_idle_timeout_s=0.1,
+        turn_no_output_timeout_s=1.0,
+        pane_poll_interval_s=30.0,
+    )
+    events = await _collect_events(transport)
+
+    await transport.start()
+    await transport.send_message("ping")
+    await transport.stop()
+
+    terminal_frames = [
+        "\n".join(event.get("rows", [])) for event in events if event["type"] == "terminal_frame"
+    ]
+    results = [event for event in events if event["type"] == "result"]
+    assert any("assistant: ping" in frame for frame in terminal_frames)
+    assert results
+    assert "assistant: ping" in results[-1]["result"]
+
+
+def test_extract_assistant_response_filters_claude_terminal_chrome() -> None:
+    rows = [
+        " ▐▛███▜▌   Claude Code v2.1.172",
+        "❯ I want to learn about you, tell me 5 words about your dream",
+        "✶ Gesticulating...",
+        "⎿ Tip: Use /feedback to help us improve!",
+        "● Five words about my dream:",
+        "",
+        "  Code, clarity, curiosity, craft, connection.",
+        "* Lollygagging… (4s · ↓ 167 tokens)",
+        "✻ Cogitated for 4s",
+        "◉ xhigh · /effort",
+        "❯ ",
+        "? for shortcuts · ← for agents",
+    ]
+
+    assert (
+        TmuxInteractiveTransport._extract_assistant_response(rows)  # noqa: SLF001
+        == "Five words about my dream:\n\nCode, clarity, curiosity, craft, connection."
+    )
+
+
+@pytest.mark.asyncio
+async def test_claude_stop_hook_emits_semantic_result(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path), sdk_port=8081)
+    events = await _collect_events(transport)
+
+    handled = await transport.handle_claude_hook(
+        {
+            "hook_event_name": "Stop",
+            "session_id": "claude-session",
+            "transcript_path": "/tmp/transcript.jsonl",
+            "last_assistant_message": "Structured final answer.",
+        }
+    )
+
+    assert handled is True
+    assert [event["type"] for event in events] == [
+        "claude_hook",
+        "assistant",
+        "result",
+    ]
+    assert events[1]["message"]["content"] == [{"type": "text", "text": "Structured final answer."}]
+    assert events[2]["result"] == "Structured final answer."
+    assert events[2]["metadata"]["source"] == "claude_hook"
+
+
+@pytest.mark.asyncio
+async def test_claude_tool_hooks_emit_sdk_shaped_tool_events(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path), sdk_port=8081)
+    events = await _collect_events(transport)
+
+    await transport.handle_claude_hook(
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "tool-1",
+            "tool_input": {"command": "npm test"},
+        }
+    )
+    await transport.handle_claude_hook(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_use_id": "tool-1",
+            "tool_response": {"stdout": "ok", "stderr": "", "interrupted": False},
+        }
+    )
+
+    assistant = next(event for event in events if event["type"] == "assistant")
+    result = next(event for event in events if event["type"] == "user")
+    assert assistant["message"]["content"][0] == {
+        "type": "tool_use",
+        "id": "tool-1",
+        "name": "Bash",
+        "input": {"command": "npm test"},
+    }
+    assert result["message"]["content"][0]["type"] == "tool_result"
+    assert result["message"]["content"][0]["tool_use_id"] == "tool-1"
+
+
+@pytest.mark.asyncio
+async def test_hook_enabled_turn_waits_for_stop_not_terminal_idle(tmp_path: Path) -> None:
+    transport = FakeTmuxInteractiveTransport(str(tmp_path), sdk_port=8081)
+    events = await _collect_events(transport)
+    await transport.start()
+
+    send_task = asyncio.create_task(transport.send_message("hello"))
+    await _wait_until(lambda: transport.is_turn_active)
+    await transport._handle_pane_output(  # noqa: SLF001
+        transport._panes["%1"],  # noqa: SLF001
+        b"terminal redraw\n",
+    )
+    await asyncio.sleep(0.08)
+    assert not send_task.done()
+
+    await transport.handle_claude_hook(
+        {
+            "hook_event_name": "Stop",
+            "last_assistant_message": "done from hook",
+        }
+    )
+    await send_task
+    await transport.stop()
+
+    assert any(
+        event["type"] == "result" and event["result"] == "done from hook" for event in events
+    )

--- a/tests/test_skuld/test_transport.py
+++ b/tests/test_skuld/test_transport.py
@@ -43,6 +43,11 @@ class TestTransportCapabilities:
         assert caps.permission_requests is False
         assert caps.slash_commands is False
         assert caps.skills is False
+        assert caps.terminal_output is False
+        assert caps.terminal_input is False
+        assert caps.terminal_keys is False
+        assert caps.terminal_resize is False
+        assert caps.terminal_panes is False
 
     def test_subprocess_transport_capabilities(self, tmp_path):
         """SubprocessTransport has session_resume=True, rest False."""
@@ -61,6 +66,11 @@ class TestTransportCapabilities:
         assert caps.permission_requests is False
         assert caps.slash_commands is False
         assert caps.skills is False
+        assert caps.terminal_output is False
+        assert caps.terminal_input is False
+        assert caps.terminal_keys is False
+        assert caps.terminal_resize is False
+        assert caps.terminal_panes is False
 
     def test_sdk_websocket_transport_capabilities(self, tmp_path):
         """SdkWebSocketTransport has all capabilities True."""
@@ -83,6 +93,11 @@ class TestTransportCapabilities:
         assert caps.permission_requests is True
         assert caps.slash_commands is True
         assert caps.skills is True
+        assert caps.terminal_output is False
+        assert caps.terminal_input is False
+        assert caps.terminal_keys is False
+        assert caps.terminal_resize is False
+        assert caps.terminal_panes is False
 
     def test_codex_subprocess_transport_capabilities(self, tmp_path):
         """CodexSubprocessTransport has all capabilities False."""
@@ -101,6 +116,11 @@ class TestTransportCapabilities:
         assert caps.permission_requests is False
         assert caps.slash_commands is False
         assert caps.skills is False
+        assert caps.terminal_output is False
+        assert caps.terminal_input is False
+        assert caps.terminal_keys is False
+        assert caps.terminal_resize is False
+        assert caps.terminal_panes is False
 
     def test_capabilities_is_frozen(self):
         """TransportCapabilities is immutable (frozen dataclass)."""

--- a/tests/test_volundr/test_session_definition_contributor.py
+++ b/tests/test_volundr/test_session_definition_contributor.py
@@ -151,6 +151,7 @@ class TestDefaultSessionDefinitions:
     def test_returns_three_definitions(self):
         defs = _default_session_definitions()
         assert "skuldClaude" in defs
+        assert "skuldClaudeInteractive" in defs
         assert "skuldCodex" in defs
         assert "skuldOpenCode" in defs
 
@@ -164,6 +165,18 @@ class TestDefaultSessionDefinitions:
         assert claude.defaults["broker"]["cliType"] == "claude"
         assert claude.defaults["broker"]["transport"] == "sdk"
         assert claude.defaults["broker"]["transportAdapter"] == "skuld.transports.sdk.SDKTransport"
+
+    def test_claude_interactive_defaults(self):
+        interactive = _default_session_definitions()["skuldClaudeInteractive"]
+        assert interactive.display_name == "Claude Code Interactive"
+        assert interactive.default_model == "claude-sonnet-4-6"
+        assert interactive.defaults["broker"]["cliType"] == "claude"
+        assert interactive.defaults["broker"]["transport"] == "tmux-interactive"
+        assert (
+            interactive.defaults["broker"]["transportAdapter"]
+            == "skuld.transports.tmux_interactive.TmuxInteractiveTransport"
+        )
+        assert interactive.defaults["broker"]["skipPermissions"] is True
 
     def test_codex_defaults(self):
         codex = _default_session_definitions()["skuldCodex"]

--- a/web-next/packages/plugin-volundr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.ts
@@ -990,6 +990,14 @@ const SEED_SESSION_DEFINITIONS: SessionDefinition[] = [
     compatibleProviders: ['anthropic'],
   },
   {
+    key: 'skuldClaudeInteractive',
+    displayName: 'Claude Code Interactive',
+    description: 'Claude Code running in a tmux-backed interactive terminal.',
+    labels: ['anthropic', 'coding', 'interactive'],
+    defaultModel: 'claude-sonnet-4-6',
+    compatibleProviders: ['anthropic'],
+  },
+  {
     key: 'skuldCodex',
     displayName: 'Codex',
     description: 'OpenAI Codex-powered coding agent for autonomous tasks.',

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.helpers.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.helpers.test.ts
@@ -81,11 +81,14 @@ describe('LaunchWizard helpers', () => {
     expect(getDefinitionRune('skuld-codex')).toBe('ᚲ');
     expect(getDefinitionRune('unknown')).toBe('ᚠ');
     expect(deriveCliTool('skuld-gemini')).toBe('gemini');
+    expect(deriveCliTool('skuld-claude-interactive')).toBe('claude');
     expect(deriveCliTool('codex')).toBe('codex');
     expect(deriveCliTool('skuld-custom')).toBe('custom');
     expect(deriveCliTool(' bespoke-tool ')).toBe('bespoke-tool');
     expect(normalizeDefinitionKey(' skuld-opencode ')).toBe('skuldOpenCode');
+    expect(normalizeDefinitionKey('skuld-claude-interactive')).toBe('skuldClaudeInteractive');
     expect(normalizeDefinitionKey('custom-tool')).toBe('custom-tool');
+    expect(definitionToTaskType('skuldClaudeInteractive')).toBe('skuld-claude-interactive');
     expect(definitionToTaskType('skuldOpenCode')).toBe('skuld-opencode');
     expect(definitionToTaskType('raw-task')).toBe('raw-task');
   });

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.steps.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.steps.test.tsx
@@ -399,7 +399,7 @@ describe('LaunchWizard step components', () => {
     });
     expect(onApplyPreset).toHaveBeenCalledWith(PRESET.id);
 
-    fireEvent.click(screen.getByTestId('cli-option-codex'));
+    fireEvent.click(screen.getByTestId('runtime-option-skuld-codex'));
     expect(update).toHaveBeenCalledWith({ definition: 'skuld-codex', model: 'gpt-test' });
 
     fireEvent.click(screen.getByText('show advanced'));

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.test.tsx
@@ -110,8 +110,9 @@ describe('LaunchWizard', () => {
   it('shows runtime step with CLI options', async () => {
     wrap();
     await advanceToRuntime();
-    expect(screen.getByTestId('cli-option-claude')).toBeInTheDocument();
-    expect(screen.getByTestId('cli-option-codex')).toBeInTheDocument();
+    expect(screen.getByTestId('runtime-option-skuldClaude')).toBeInTheDocument();
+    expect(screen.getByTestId('runtime-option-skuldClaudeInteractive')).toBeInTheDocument();
+    expect(screen.getByTestId('runtime-option-skuldCodex')).toBeInTheDocument();
   });
 
   it('shows confirm step with review rows', async () => {

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
@@ -86,11 +86,13 @@ const STEP_LABELS: Record<string, string> = {
 /** Map definition keys to runes for visual branding. */
 const DEFINITION_RUNES: Record<string, string> = {
   skuldClaude: '\u16D7',
+  skuldClaudeInteractive: '\u16D7',
   skuldCodex: '\u16B2',
   skuldGemini: '\u16C7',
   skuldAider: '\u16A8',
   skuldOpenCode: '\u16A0',
   'skuld-claude': '\u16D7',
+  'skuld-claude-interactive': '\u16D7',
   'skuld-codex': '\u16B2',
   'skuld-gemini': '\u16C7',
   'skuld-aider': '\u16A8',
@@ -107,6 +109,14 @@ const FALLBACK_SESSION_DEFINITIONS: SessionDefinition[] = [
     displayName: 'Claude Code',
     description: '',
     labels: [],
+    defaultModel: '',
+    compatibleProviders: ['anthropic'],
+  },
+  {
+    key: 'skuldClaudeInteractive',
+    displayName: 'Claude Code Interactive',
+    description: '',
+    labels: ['interactive'],
     defaultModel: '',
     compatibleProviders: ['anthropic'],
   },
@@ -149,6 +159,7 @@ export function normalizeDefinitionKey(definitionKey: string): string {
     aider: 'skuldAider',
     opencode: 'skuldOpenCode',
     'skuld-claude': 'skuldClaude',
+    'skuld-claude-interactive': 'skuldClaudeInteractive',
     'skuld-codex': 'skuldCodex',
     'skuld-gemini': 'skuldGemini',
     'skuld-aider': 'skuldAider',
@@ -162,6 +173,7 @@ export function deriveCliTool(definitionKey: string): string {
   const normalized = normalizeDefinitionKey(definitionKey);
   const cliToolMap: Record<string, string> = {
     skuldClaude: 'claude',
+    skuldClaudeInteractive: 'claude',
     skuldCodex: 'codex',
     skuldGemini: 'gemini',
     skuldAider: 'aider',
@@ -176,6 +188,7 @@ export function definitionToTaskType(definitionKey: string): string {
   const normalized = normalizeDefinitionKey(definitionKey);
   const taskTypeMap: Record<string, string> = {
     skuldClaude: 'skuld-claude',
+    skuldClaudeInteractive: 'skuld-claude-interactive',
     skuldCodex: 'skuld-codex',
     skuldGemini: 'skuld-gemini',
     skuldAider: 'skuld-aider',

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
@@ -1224,7 +1224,7 @@ export function RuntimeStep({
                   }
                   update(patch);
                 }}
-                data-testid={`cli-option-${deriveCliTool(def.key)}`}
+                data-testid={`runtime-option-${def.key}`}
                 title={def.description || undefined}
               >
                 <span className="niuu:font-mono niuu:text-base">{getDefinitionRune(def.key)}</span>

--- a/web-next/packages/plugin-volundr/src/ui/hooks/useSkuldChat.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/hooks/useSkuldChat.test.tsx
@@ -1865,6 +1865,12 @@ page_path: council/demo/opinion-b.md
       set_model: true,
       set_thinking_tokens: true,
       rewind_files: true,
+      slash_commands: false,
+      terminal_input: false,
+      terminal_keys: false,
+      terminal_output: false,
+      terminal_panes: false,
+      terminal_resize: false,
     });
     expect(result.current.messages.slice(1).map((message) => message.content)).toEqual([
       'Session initialized · claude-sonnet-4-6',

--- a/web-next/packages/plugin-volundr/src/ui/hooks/useSkuldChat.ts
+++ b/web-next/packages/plugin-volundr/src/ui/hooks/useSkuldChat.ts
@@ -1029,6 +1029,12 @@ export function useSkuldChat(
               set_model: caps.set_model === true,
               set_thinking_tokens: caps.set_thinking_tokens === true,
               rewind_files: caps.rewind_files === true,
+              slash_commands: caps.slash_commands === true,
+              terminal_output: caps.terminal_output === true,
+              terminal_input: caps.terminal_input === true,
+              terminal_keys: caps.terminal_keys === true,
+              terminal_resize: caps.terminal_resize === true,
+              terminal_panes: caps.terminal_panes === true,
             });
             break;
           }

--- a/web-next/packages/ui/src/chat/types.ts
+++ b/web-next/packages/ui/src/chat/types.ts
@@ -141,4 +141,10 @@ export interface SessionCapabilities {
   set_model?: boolean;
   set_thinking_tokens?: boolean;
   rewind_files?: boolean;
+  slash_commands?: boolean;
+  terminal_output?: boolean;
+  terminal_input?: boolean;
+  terminal_keys?: boolean;
+  terminal_resize?: boolean;
+  terminal_panes?: boolean;
 }


### PR DESCRIPTION
## Summary

- add a tmux-backed Claude Code interactive transport for Skuld sessions
- expose terminal controls, pane events, Claude hook ingestion, and slash-command discovery/send through the broker
- add the `skuldClaudeInteractive` Volundr session definition and UI capability plumbing
- update the Volundr chart README/default comments for the interactive session definition
- make LaunchWizard runtime option test ids unique per session definition now that multiple runtimes can share the same CLI

## Notes

This intentionally cherry-picks only the two feature commits from `xteo/feature/skuld-claude-tmux-interactive` onto current `dev`; it does not merge the larger divergent fork history.

`charts/volundr` is still a live chart: `charts/niuu` depends on it as the Volundr subchart, and CI/release workflows still package or install it directly.

## Validation

- `uv run ruff check src/niuu/ports/cli/transport.py src/skuld/broker.py src/skuld/config.py src/skuld/transports/__init__.py src/skuld/transports/tmux_interactive.py src/volundr/config.py tests/test_charts/test_volundr_chart.py tests/test_skuld/test_broker.py tests/test_skuld/test_config.py tests/test_skuld/test_tmux_interactive_transport.py tests/test_skuld/test_transport.py tests/test_volundr/test_session_definition_contributor.py`
- `uv run ruff format --check src/niuu/ports/cli/transport.py src/skuld/broker.py src/skuld/config.py src/skuld/transports/__init__.py src/skuld/transports/tmux_interactive.py src/volundr/config.py tests/test_charts/test_volundr_chart.py tests/test_skuld/test_broker.py tests/test_skuld/test_config.py tests/test_skuld/test_tmux_interactive_transport.py tests/test_skuld/test_transport.py tests/test_volundr/test_session_definition_contributor.py`
- `uv run pytest tests/test_skuld/test_tmux_interactive_transport.py tests/test_skuld/test_config.py::TestTransportAdapter tests/test_skuld/test_transport.py::TestTransportCapabilities tests/test_skuld/test_broker.py::TestDispatchBrowserMessage tests/test_volundr/test_session_definition_contributor.py::TestDefaultSessionDefinitions tests/test_charts/test_volundr_chart.py::TestValuesDefaults`
- `uv run pytest tests/test_skuld/test_broker.py::TestFastAPIEndpoints`
- `uv run pytest tests/test_charts/test_volundr_chart.py::TestValuesDefaults`
- `helm lint charts/volundr -f charts/volundr/ci-values.yaml`
- `helm template volundr charts/volundr -f charts/volundr/ci-values.yaml`
- `pnpm vitest run packages/plugin-volundr/src/ui/LaunchWizard.helpers.test.ts packages/plugin-volundr/src/ui/hooks/useSkuldChat.test.tsx`
- `pnpm vitest run packages/plugin-volundr/src/ui/LaunchWizard.test.tsx packages/plugin-volundr/src/ui/LaunchWizard.steps.test.tsx`
- `pnpm --filter @niuulabs/plugin-volundr typecheck && pnpm --filter @niuulabs/ui typecheck`
- `pnpm --filter @niuulabs/plugin-volundr typecheck`
- `git diff --check`

## Follow-up

- The real tmux smoke test was skipped locally because `tmux` is not installed on this Mac host. The Skuld container image does install `tmux`.
