### PR TITLE
[codex] Implement NIU-1076 Momentum current state

### DIFF
--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -5018,6 +5018,8 @@ async def _run_momentum_reflect(
     ).reflect_judgment(target_ref, outcome=outcome, note=note, actor=actor)
     typer.echo(f"disposition_ref: {result.disposition_ref}")
     typer.echo(f"reflection_ref:  {result.reflection_ref}")
+    typer.echo(f"current_state_ref: {result.current_state_ref}")
+    typer.echo(f"state_patch_ref:   {result.state_patch_ref}")
 
 
 def _print_momentum_result(result: Any) -> None:
@@ -5029,6 +5031,8 @@ def _print_momentum_result(result: Any) -> None:
     if result.extraction.packet is not None:
         typer.echo(f"packet:      {result.extraction.packet.title}")
     typer.echo(f"provenance:  {_provenance_label(result.provenance_fully_verified)}")
+    typer.echo(f"current_state_ref: {result.current_state_ref}")
+    typer.echo(f"state_patch_ref:   {result.state_patch_ref}")
 
 
 async def _run_momentum_source(settings: Settings, source: Any, ref_or_id: str) -> Any:

--- a/src/ravn/momentum/models.py
+++ b/src/ravn/momentum/models.py
@@ -211,6 +211,16 @@ class MomentumStatePatchDraft(BaseModel):
     candidate_reflexes: list[str] = Field(default_factory=list)
     candidate_capability_gaps: list[str] = Field(default_factory=list)
 
+    @field_validator("changed_tensions", mode="before")
+    @classmethod
+    def _changed_tension_ids_are_patches(cls, value: object) -> object:
+        if isinstance(value, list):
+            return [
+                {"tension_id": item} if isinstance(item, str) else item
+                for item in value
+            ]
+        return value
+
 
 class MomentumStatePatch(MomentumStatePatchDraft):
     patch_id: str = Field(min_length=1)
@@ -228,6 +238,7 @@ class MomentumResidentState(BaseModel):
     candidate_reflexes: list[str] = Field(default_factory=list)
     candidate_capability_gaps: list[str] = Field(default_factory=list)
     source_refs: list[str] = Field(default_factory=list)
+    compaction: dict[str, int] = Field(default_factory=dict)
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/src/ravn/momentum/models.py
+++ b/src/ravn/momentum/models.py
@@ -17,6 +17,7 @@ ProvenanceStatus = Literal["verified", "unverified"]
 AttentionTier = Literal["silent", "ambient", "present", "urgent"]
 NextAction = Literal["write_momentum_packet", "update_understanding_only", "ask_human"]
 DispositionOutcome = Literal["accepted", "dismissed", "wrong", "deferred", "acted"]
+MomentumTensionStatus = Literal["pending", "open", "confirmed", "changed", "resolved"]
 
 
 class SourceSpan(BaseModel):
@@ -149,6 +150,8 @@ class MomentumExtractionRun(BaseModel):
     signal_kind: Literal["resident_signal"] = "resident_signal"
     source_path: str
     source_sha256: str
+    input_state_ref: str | None = None
+    input_state_sha256: str | None = None
     procedure_name: str
     model_name: str
     created_at: datetime
@@ -176,6 +179,58 @@ class MomentumJudgmentDisposition(BaseModel):
     source: Literal["manual"] = "manual"
 
 
+class MomentumStateTension(BaseModel):
+    tension_id: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    summary: str = Field(min_length=1)
+    status: MomentumTensionStatus = "pending"
+    evidence_refs: list[str] = Field(default_factory=list)
+    source_refs: list[str] = Field(default_factory=list)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class MomentumStateTensionPatch(BaseModel):
+    tension_id: str = Field(min_length=1)
+    title: str | None = None
+    summary: str | None = None
+    status: MomentumTensionStatus | None = None
+    evidence_refs: list[str] = Field(default_factory=list)
+    source_refs: list[str] = Field(default_factory=list)
+
+
+class MomentumStatePatchDraft(BaseModel):
+    beliefs: list[str] = Field(default_factory=list)
+    constraints: list[str] = Field(default_factory=list)
+    corrections: list[str] = Field(default_factory=list)
+    open_tensions: list[MomentumStateTension] = Field(default_factory=list)
+    changed_tensions: list[MomentumStateTensionPatch] = Field(default_factory=list)
+    resolved_tension_ids: list[str] = Field(default_factory=list)
+    confirmed_tension_ids: list[str] = Field(default_factory=list)
+    stale_assumptions: list[str] = Field(default_factory=list)
+    recent_lessons: list[str] = Field(default_factory=list)
+    candidate_reflexes: list[str] = Field(default_factory=list)
+    candidate_capability_gaps: list[str] = Field(default_factory=list)
+
+
+class MomentumStatePatch(MomentumStatePatchDraft):
+    patch_id: str = Field(min_length=1)
+    created_at: datetime
+    source_refs: list[str] = Field(default_factory=list)
+
+
+class MomentumResidentState(BaseModel):
+    beliefs: list[str] = Field(default_factory=list)
+    constraints: list[str] = Field(default_factory=list)
+    corrections: list[str] = Field(default_factory=list)
+    open_tensions: list[MomentumStateTension] = Field(default_factory=list)
+    stale_assumptions: list[str] = Field(default_factory=list)
+    recent_lessons: list[str] = Field(default_factory=list)
+    candidate_reflexes: list[str] = Field(default_factory=list)
+    candidate_capability_gaps: list[str] = Field(default_factory=list)
+    source_refs: list[str] = Field(default_factory=list)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
 class MomentumReflectionDraft(BaseModel):
     changed_understanding: str = Field(min_length=1)
     lesson_learned: str = Field(min_length=1)
@@ -184,6 +239,7 @@ class MomentumReflectionDraft(BaseModel):
     resident_corrections: list[str] = Field(default_factory=list)
     candidate_reflexes: list[str] = Field(default_factory=list)
     candidate_capability_gaps: list[str] = Field(default_factory=list)
+    state_patch: MomentumStatePatchDraft = Field(default_factory=MomentumStatePatchDraft)
 
     @field_validator("remember_next_time")
     @classmethod

--- a/src/ravn/momentum/pipeline.py
+++ b/src/ravn/momentum/pipeline.py
@@ -32,6 +32,16 @@ from ravn.momentum.render import (
     render_run,
 )
 from ravn.momentum.source import SourceDocument
+from ravn.momentum.state import (
+    CURRENT_MOMENTUM_STATE_REF,
+    apply_state_patch,
+    empty_momentum_state,
+    extraction_state_patch,
+    parse_momentum_state,
+    reflection_state_patch,
+    render_momentum_state,
+    render_state_patch,
+)
 from ravn.momentum.worker import MomentumExtractionWorker, MomentumReflectionWorker
 from ravn.resident_continuation import _slug
 from ravn.resident_inbox.models import ResidentInboxSignal
@@ -45,6 +55,8 @@ class MomentumPipelineResult:
     artifact_refs: list[str]
     judgment_ref: str
     packet_ref: str | None
+    current_state_ref: str
+    state_patch_ref: str
 
     @property
     def provenance_fully_verified(self) -> bool:
@@ -57,6 +69,8 @@ class MomentumReflectionResult:
     reflection: MomentumReflection
     disposition_ref: str
     reflection_ref: str
+    current_state_ref: str
+    state_patch_ref: str
 
 
 class MomentumPipeline:
@@ -93,9 +107,16 @@ class MomentumPipeline:
             "Niuu Momentum Engine resident understanding and constraints",
             limit=5,
         )
+        current_state, current_state_frame = await _load_current_state(self._state)
+        input_state_sha = (
+            hashlib.sha256(current_state_frame.encode("utf-8")).hexdigest()
+            if current_state_frame
+            else None
+        )
         draft = await self._worker.extract(
             markdown,
             memory_frame="\n\n".join(entry.content for entry in memory),
+            current_state_frame=current_state_frame,
         )
         created_at = self._now or datetime.now(UTC)
         run_id = self._run_id or f"momentum-{created_at:%Y%m%dT%H%M%SZ}-{source_sha[:8]}"
@@ -130,16 +151,43 @@ class MomentumPipeline:
                 "artifact_refs": artifact_refs,
                 "judgment_ref": judgment_ref,
                 "packet_ref": packet_ref,
+                "input_state_ref": CURRENT_MOMENTUM_STATE_REF if current_state_frame else None,
+                "input_state_sha256": input_state_sha,
             }
         )
         run_ref = await self._state.write_artifact(_run_ref(run), render_run(run))
         extraction = extraction.model_copy(update={"run": run})
+        state_patch = extraction_state_patch(
+            patch_id=f"patch-{_timestamp_id(created_at)}-{run_id}-extract",
+            created_at=created_at,
+            belief_refs=artifact_refs,
+            judgment_title=extraction.judgment.title,
+            tension=extraction.judgment.tension_that_matters,
+            evidence_refs=[
+                ref
+                for ref in [*artifact_refs, judgment_ref, packet_ref]
+                if ref
+            ],
+            source_refs=[run_ref, judgment_ref],
+            beliefs=extraction.resident_patch.beliefs,
+            constraints=extraction.resident_patch.constraints,
+            corrections=extraction.resident_patch.corrections,
+        )
+        current_state = current_state or empty_momentum_state(updated_at=created_at)
+        updated_state = apply_state_patch(current_state, state_patch)
+        state_patch_ref = await _write_state_patch(self._state, state_patch)
+        current_state_ref = await self._state.write_artifact(
+            CURRENT_MOMENTUM_STATE_REF,
+            render_momentum_state(updated_state),
+        )
         return MomentumPipelineResult(
             extraction=extraction,
             run_ref=run_ref,
             artifact_refs=artifact_refs,
             judgment_ref=judgment_ref,
             packet_ref=packet_ref,
+            current_state_ref=current_state_ref,
+            state_patch_ref=state_patch_ref,
         )
 
     async def reflect_judgment(
@@ -174,6 +222,7 @@ class MomentumPipeline:
             "Niuu Momentum Engine judgment dispositions and reflections",
             limit=5,
         )
+        current_state, current_state_frame = await _load_current_state(self._state)
         draft = await self._reflection_worker.reflect(
             target_ref=disposition.target_ref,
             target_content=target.content,
@@ -182,6 +231,7 @@ class MomentumPipeline:
             artifact_contents=context.artifact_contents,
             disposition=disposition,
             memory_frame="\n\n".join(entry.content for entry in memory),
+            current_state_frame=current_state_frame,
         )
         reflection = MomentumReflection(
             **draft.model_dump(),
@@ -198,11 +248,31 @@ class MomentumPipeline:
             f"{base_ref}/reflections/{reflection.reflection_id}.md",
             render_reflection(reflection),
         )
+        state_patch = reflection_state_patch(
+            patch_id=f"patch-{_timestamp_id(created_at)}-{reflection.reflection_id}",
+            created_at=created_at,
+            source_refs=[disposition.target_ref, disposition_ref, reflection_ref],
+            draft=draft.state_patch,
+            lesson_learned=reflection.lesson_learned,
+            remember_next_time=reflection.remember_next_time,
+            corrections=reflection.resident_corrections,
+            candidate_reflexes=reflection.candidate_reflexes,
+            candidate_capability_gaps=reflection.candidate_capability_gaps,
+        )
+        current_state = current_state or empty_momentum_state(updated_at=created_at)
+        updated_state = apply_state_patch(current_state, state_patch)
+        state_patch_ref = await _write_state_patch(self._state, state_patch)
+        current_state_ref = await self._state.write_artifact(
+            CURRENT_MOMENTUM_STATE_REF,
+            render_momentum_state(updated_state),
+        )
         return MomentumReflectionResult(
             disposition=disposition,
             reflection=reflection,
             disposition_ref=disposition_ref,
             reflection_ref=reflection_ref,
+            current_state_ref=current_state_ref,
+            state_patch_ref=state_patch_ref,
         )
 
 
@@ -254,6 +324,21 @@ async def _read_optional_content(state: ResidentStatePort, ref: str) -> str:
         return (await state.read_artifact(ref)).content
     except FileNotFoundError:
         return ""
+
+
+async def _load_current_state(state: ResidentStatePort):
+    try:
+        entry = await state.read_artifact(CURRENT_MOMENTUM_STATE_REF)
+    except FileNotFoundError:
+        return None, ""
+    return parse_momentum_state(entry.content), entry.content
+
+
+async def _write_state_patch(state: ResidentStatePort, patch) -> str:
+    return await state.write_artifact(
+        f"resident/continuation/momentum/state/patches/{patch.patch_id}.md",
+        render_state_patch(patch),
+    )
 
 
 def _parse_field(content: str, field: str) -> str:

--- a/src/ravn/momentum/pipeline.py
+++ b/src/ravn/momentum/pipeline.py
@@ -34,6 +34,7 @@ from ravn.momentum.render import (
 from ravn.momentum.source import SourceDocument
 from ravn.momentum.state import (
     CURRENT_MOMENTUM_STATE_REF,
+    BoundedMomentumStateCompactor,
     apply_state_patch,
     empty_momentum_state,
     extraction_state_patch,
@@ -43,6 +44,7 @@ from ravn.momentum.state import (
     render_state_patch,
 )
 from ravn.momentum.worker import MomentumExtractionWorker, MomentumReflectionWorker
+from ravn.ports.momentum_state_compactor import MomentumStateCompactorPort
 from ravn.resident_continuation import _slug
 from ravn.resident_inbox.models import ResidentInboxSignal
 from ravn.resident_inbox.serialization import render_inbox_signal
@@ -80,12 +82,14 @@ class MomentumPipeline:
         worker: MomentumExtractionWorker,
         reflection_worker: MomentumReflectionWorker | None = None,
         state: ResidentStatePort,
+        state_compactor: MomentumStateCompactorPort | None = None,
         now: datetime | None = None,
         run_id: str | None = None,
     ) -> None:
         self._worker = worker
         self._reflection_worker = reflection_worker
         self._state = state
+        self._state_compactor = state_compactor or BoundedMomentumStateCompactor()
         self._now = now
         self._run_id = run_id
 
@@ -174,7 +178,9 @@ class MomentumPipeline:
             corrections=extraction.resident_patch.corrections,
         )
         current_state = current_state or empty_momentum_state(updated_at=created_at)
-        updated_state = apply_state_patch(current_state, state_patch)
+        updated_state = self._state_compactor.compact(
+            apply_state_patch(current_state, state_patch)
+        )
         state_patch_ref = await _write_state_patch(self._state, state_patch)
         current_state_ref = await self._state.write_artifact(
             CURRENT_MOMENTUM_STATE_REF,
@@ -260,7 +266,9 @@ class MomentumPipeline:
             candidate_capability_gaps=reflection.candidate_capability_gaps,
         )
         current_state = current_state or empty_momentum_state(updated_at=created_at)
-        updated_state = apply_state_patch(current_state, state_patch)
+        updated_state = self._state_compactor.compact(
+            apply_state_patch(current_state, state_patch)
+        )
         state_patch_ref = await _write_state_patch(self._state, state_patch)
         current_state_ref = await self._state.write_artifact(
             CURRENT_MOMENTUM_STATE_REF,

--- a/src/ravn/momentum/render.py
+++ b/src/ravn/momentum/render.py
@@ -184,7 +184,9 @@ def render_reflection(reflection: MomentumReflection) -> str:
         "## Candidate Reflexes\n\n"
         f"{_bullets_text(reflection.candidate_reflexes)}\n\n"
         "## Candidate Capability Gaps\n\n"
-        f"{_bullets_text(reflection.candidate_capability_gaps)}\n"
+        f"{_bullets_text(reflection.candidate_capability_gaps)}\n\n"
+        "## State Patch\n\n"
+        f"```json\n{reflection.state_patch.model_dump_json(indent=2)}\n```\n"
     )
 
 
@@ -231,6 +233,8 @@ def render_run(run: MomentumExtractionRun) -> str:
         f"- signal_kind: {run.signal_kind}\n"
         f"- source_path: {run.source_path}\n"
         f"- source_sha256: {run.source_sha256}\n"
+        f"- input_state_ref: {run.input_state_ref or '-'}\n"
+        f"- input_state_sha256: {run.input_state_sha256 or '-'}\n"
         f"- procedure: {run.procedure_name}\n"
         f"- model: {run.model_name}\n"
         f"- created_at: {run.created_at.isoformat()}\n"

--- a/src/ravn/momentum/state.py
+++ b/src/ravn/momentum/state.py
@@ -12,6 +12,7 @@ from ravn.momentum.models import (
     MomentumStateTension,
     MomentumStateTensionPatch,
 )
+from ravn.ports.momentum_state_compactor import MomentumStateCompactorPort
 from ravn.resident_continuation import _slug
 
 CURRENT_MOMENTUM_STATE_REF = "resident/continuation/momentum/state/current.md"
@@ -29,6 +30,52 @@ MAX_SOURCE_REFS = 24
 
 def empty_momentum_state(*, updated_at: datetime) -> MomentumResidentState:
     return MomentumResidentState(updated_at=updated_at)
+
+
+class BoundedMomentumStateCompactor(MomentumStateCompactorPort):
+    """Deterministic v0 compaction: dedupe, keep newest, record omissions."""
+
+    def compact(self, state: MomentumResidentState) -> MomentumResidentState:
+        compaction = dict(state.compaction)
+        beliefs, count = _keep_newest(state.beliefs, MAX_BELIEFS)
+        _record_compaction(compaction, "beliefs_truncated", count)
+        constraints, count = _keep_newest(state.constraints, MAX_CONSTRAINTS)
+        _record_compaction(compaction, "constraints_truncated", count)
+        corrections, count = _keep_newest(state.corrections, MAX_CORRECTIONS)
+        _record_compaction(compaction, "corrections_truncated", count)
+        stale_assumptions, count = _keep_newest(
+            state.stale_assumptions, MAX_STALE_ASSUMPTIONS
+        )
+        _record_compaction(compaction, "stale_assumptions_truncated", count)
+        recent_lessons, count = _keep_newest(state.recent_lessons, MAX_RECENT_LESSONS)
+        _record_compaction(compaction, "recent_lessons_truncated", count)
+        candidate_reflexes, count = _keep_newest(
+            state.candidate_reflexes, MAX_CANDIDATE_REFLEXES
+        )
+        _record_compaction(compaction, "candidate_reflexes_truncated", count)
+        candidate_capability_gaps, count = _keep_newest(
+            state.candidate_capability_gaps, MAX_CANDIDATE_CAPABILITY_GAPS
+        )
+        _record_compaction(compaction, "candidate_capability_gaps_truncated", count)
+        source_refs, count = _keep_newest(state.source_refs, MAX_SOURCE_REFS)
+        _record_compaction(compaction, "source_refs_truncated", count)
+        open_tensions = sorted(state.open_tensions, key=lambda item: item.updated_at)
+        open_tensions, count = _keep_newest(open_tensions, MAX_OPEN_TENSIONS)
+        _record_compaction(compaction, "open_tensions_truncated", count)
+        return state.model_copy(
+            update={
+                "beliefs": beliefs,
+                "constraints": constraints,
+                "corrections": corrections,
+                "open_tensions": open_tensions,
+                "stale_assumptions": stale_assumptions,
+                "recent_lessons": recent_lessons,
+                "candidate_reflexes": candidate_reflexes,
+                "candidate_capability_gaps": candidate_capability_gaps,
+                "source_refs": source_refs,
+                "compaction": compaction,
+            }
+        )
 
 
 def extraction_state_patch(
@@ -140,7 +187,7 @@ def apply_state_patch(
                 update={"status": "resolved", "updated_at": patch.created_at}
             )
 
-    state = MomentumResidentState(
+    return MomentumResidentState(
         beliefs=_unique_recent([*current.beliefs, *patch.beliefs]),
         constraints=_unique_recent([*current.constraints, *patch.constraints]),
         corrections=_unique_recent([*current.corrections, *patch.corrections]),
@@ -159,7 +206,6 @@ def apply_state_patch(
         compaction=current.compaction,
         updated_at=patch.created_at,
     )
-    return _compact_state(state)
 
 
 def parse_momentum_state(content: str) -> MomentumResidentState:
@@ -249,49 +295,6 @@ def _tension_text(tensions: list[MomentumStateTension | MomentumStateTensionPatc
 
 def _bullets_text(items: list[str]) -> str:
     return "\n".join(f"- {item}" for item in items if item) or "- none"
-
-
-def _compact_state(state: MomentumResidentState) -> MomentumResidentState:
-    compaction = dict(state.compaction)
-    beliefs, count = _keep_newest(state.beliefs, MAX_BELIEFS)
-    _record_compaction(compaction, "beliefs_truncated", count)
-    constraints, count = _keep_newest(state.constraints, MAX_CONSTRAINTS)
-    _record_compaction(compaction, "constraints_truncated", count)
-    corrections, count = _keep_newest(state.corrections, MAX_CORRECTIONS)
-    _record_compaction(compaction, "corrections_truncated", count)
-    stale_assumptions, count = _keep_newest(
-        state.stale_assumptions, MAX_STALE_ASSUMPTIONS
-    )
-    _record_compaction(compaction, "stale_assumptions_truncated", count)
-    recent_lessons, count = _keep_newest(state.recent_lessons, MAX_RECENT_LESSONS)
-    _record_compaction(compaction, "recent_lessons_truncated", count)
-    candidate_reflexes, count = _keep_newest(
-        state.candidate_reflexes, MAX_CANDIDATE_REFLEXES
-    )
-    _record_compaction(compaction, "candidate_reflexes_truncated", count)
-    candidate_capability_gaps, count = _keep_newest(
-        state.candidate_capability_gaps, MAX_CANDIDATE_CAPABILITY_GAPS
-    )
-    _record_compaction(compaction, "candidate_capability_gaps_truncated", count)
-    source_refs, count = _keep_newest(state.source_refs, MAX_SOURCE_REFS)
-    _record_compaction(compaction, "source_refs_truncated", count)
-    open_tensions = sorted(state.open_tensions, key=lambda item: item.updated_at)
-    open_tensions, count = _keep_newest(open_tensions, MAX_OPEN_TENSIONS)
-    _record_compaction(compaction, "open_tensions_truncated", count)
-    return state.model_copy(
-        update={
-            "beliefs": beliefs,
-            "constraints": constraints,
-            "corrections": corrections,
-            "open_tensions": open_tensions,
-            "stale_assumptions": stale_assumptions,
-            "recent_lessons": recent_lessons,
-            "candidate_reflexes": candidate_reflexes,
-            "candidate_capability_gaps": candidate_capability_gaps,
-            "source_refs": source_refs,
-            "compaction": compaction,
-        }
-    )
 
 
 def _keep_newest(items: list[T], limit: int) -> tuple[list[T], int]:

--- a/src/ravn/momentum/state.py
+++ b/src/ravn/momentum/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import TypeVar
 
 from ravn.momentum.models import (
     MomentumResidentState,
@@ -14,6 +15,16 @@ from ravn.momentum.models import (
 from ravn.resident_continuation import _slug
 
 CURRENT_MOMENTUM_STATE_REF = "resident/continuation/momentum/state/current.md"
+T = TypeVar("T")
+MAX_BELIEFS = 12
+MAX_CONSTRAINTS = 12
+MAX_CORRECTIONS = 12
+MAX_OPEN_TENSIONS = 8
+MAX_STALE_ASSUMPTIONS = 8
+MAX_RECENT_LESSONS = 12
+MAX_CANDIDATE_REFLEXES = 8
+MAX_CANDIDATE_CAPABILITY_GAPS = 8
+MAX_SOURCE_REFS = 24
 
 
 def empty_momentum_state(*, updated_at: datetime) -> MomentumResidentState:
@@ -129,20 +140,26 @@ def apply_state_patch(
                 update={"status": "resolved", "updated_at": patch.created_at}
             )
 
-    return MomentumResidentState(
-        beliefs=_unique([*current.beliefs, *patch.beliefs]),
-        constraints=_unique([*current.constraints, *patch.constraints]),
-        corrections=_unique([*current.corrections, *patch.corrections]),
+    state = MomentumResidentState(
+        beliefs=_unique_recent([*current.beliefs, *patch.beliefs]),
+        constraints=_unique_recent([*current.constraints, *patch.constraints]),
+        corrections=_unique_recent([*current.corrections, *patch.corrections]),
         open_tensions=list(tensions.values()),
-        stale_assumptions=_unique([*current.stale_assumptions, *patch.stale_assumptions]),
-        recent_lessons=_unique([*current.recent_lessons, *patch.recent_lessons]),
-        candidate_reflexes=_unique([*current.candidate_reflexes, *patch.candidate_reflexes]),
-        candidate_capability_gaps=_unique(
+        stale_assumptions=_unique_recent(
+            [*current.stale_assumptions, *patch.stale_assumptions]
+        ),
+        recent_lessons=_unique_recent([*current.recent_lessons, *patch.recent_lessons]),
+        candidate_reflexes=_unique_recent(
+            [*current.candidate_reflexes, *patch.candidate_reflexes]
+        ),
+        candidate_capability_gaps=_unique_recent(
             [*current.candidate_capability_gaps, *patch.candidate_capability_gaps]
         ),
-        source_refs=_unique([*current.source_refs, *patch.source_refs]),
+        source_refs=_unique_recent([*current.source_refs, *patch.source_refs]),
+        compaction=current.compaction,
         updated_at=patch.created_at,
     )
+    return _compact_state(state)
 
 
 def parse_momentum_state(content: str) -> MomentumResidentState:
@@ -173,6 +190,7 @@ def render_momentum_state(state: MomentumResidentState) -> str:
         f"{_bullets_text(state.candidate_reflexes)}\n\n"
         "## Candidate Capability Gaps (candidate-only)\n\n"
         f"{_bullets_text(state.candidate_capability_gaps)}\n\n"
+        f"{_compaction_section(state)}"
         "## Source Refs\n\n"
         f"{_bullets_text(state.source_refs)}\n\n"
         "## State Data\n\n"
@@ -233,6 +251,70 @@ def _bullets_text(items: list[str]) -> str:
     return "\n".join(f"- {item}" for item in items if item) or "- none"
 
 
+def _compact_state(state: MomentumResidentState) -> MomentumResidentState:
+    compaction = dict(state.compaction)
+    beliefs, count = _keep_newest(state.beliefs, MAX_BELIEFS)
+    _record_compaction(compaction, "beliefs_truncated", count)
+    constraints, count = _keep_newest(state.constraints, MAX_CONSTRAINTS)
+    _record_compaction(compaction, "constraints_truncated", count)
+    corrections, count = _keep_newest(state.corrections, MAX_CORRECTIONS)
+    _record_compaction(compaction, "corrections_truncated", count)
+    stale_assumptions, count = _keep_newest(
+        state.stale_assumptions, MAX_STALE_ASSUMPTIONS
+    )
+    _record_compaction(compaction, "stale_assumptions_truncated", count)
+    recent_lessons, count = _keep_newest(state.recent_lessons, MAX_RECENT_LESSONS)
+    _record_compaction(compaction, "recent_lessons_truncated", count)
+    candidate_reflexes, count = _keep_newest(
+        state.candidate_reflexes, MAX_CANDIDATE_REFLEXES
+    )
+    _record_compaction(compaction, "candidate_reflexes_truncated", count)
+    candidate_capability_gaps, count = _keep_newest(
+        state.candidate_capability_gaps, MAX_CANDIDATE_CAPABILITY_GAPS
+    )
+    _record_compaction(compaction, "candidate_capability_gaps_truncated", count)
+    source_refs, count = _keep_newest(state.source_refs, MAX_SOURCE_REFS)
+    _record_compaction(compaction, "source_refs_truncated", count)
+    open_tensions = sorted(state.open_tensions, key=lambda item: item.updated_at)
+    open_tensions, count = _keep_newest(open_tensions, MAX_OPEN_TENSIONS)
+    _record_compaction(compaction, "open_tensions_truncated", count)
+    return state.model_copy(
+        update={
+            "beliefs": beliefs,
+            "constraints": constraints,
+            "corrections": corrections,
+            "open_tensions": open_tensions,
+            "stale_assumptions": stale_assumptions,
+            "recent_lessons": recent_lessons,
+            "candidate_reflexes": candidate_reflexes,
+            "candidate_capability_gaps": candidate_capability_gaps,
+            "source_refs": source_refs,
+            "compaction": compaction,
+        }
+    )
+
+
+def _keep_newest(items: list[T], limit: int) -> tuple[list[T], int]:
+    if len(items) <= limit:
+        return items, 0
+    return items[-limit:], len(items) - limit
+
+
+def _record_compaction(compaction: dict[str, int], key: str, count: int) -> None:
+    if count:
+        compaction[key] = compaction.get(key, 0) + count
+
+
+def _compaction_section(state: MomentumResidentState) -> str:
+    if not state.compaction:
+        return ""
+    lines = ["## State Compaction", ""]
+    for key, count in state.compaction.items():
+        entry_word = "entry" if count == 1 else "entries"
+        lines.append(f"- {key}: {count} older {entry_word} omitted")
+    return "\n".join(lines) + "\n\n"
+
+
 def _unique(items: list[str]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
@@ -243,3 +325,7 @@ def _unique(items: list[str]) -> list[str]:
         seen.add(value)
         result.append(value)
     return result
+
+
+def _unique_recent(items: list[str]) -> list[str]:
+    return list(reversed(_unique(list(reversed(items)))))

--- a/src/ravn/momentum/state.py
+++ b/src/ravn/momentum/state.py
@@ -1,0 +1,245 @@
+"""Current Momentum resident state helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from ravn.momentum.models import (
+    MomentumResidentState,
+    MomentumStatePatch,
+    MomentumStatePatchDraft,
+    MomentumStateTension,
+    MomentumStateTensionPatch,
+)
+from ravn.resident_continuation import _slug
+
+CURRENT_MOMENTUM_STATE_REF = "resident/continuation/momentum/state/current.md"
+
+
+def empty_momentum_state(*, updated_at: datetime) -> MomentumResidentState:
+    return MomentumResidentState(updated_at=updated_at)
+
+
+def extraction_state_patch(
+    *,
+    patch_id: str,
+    created_at: datetime,
+    belief_refs: list[str],
+    judgment_title: str,
+    tension: str,
+    evidence_refs: list[str],
+    source_refs: list[str],
+    beliefs: list[str],
+    constraints: list[str],
+    corrections: list[str],
+) -> MomentumStatePatch:
+    tension_id = f"tension-{_slug(judgment_title) or _slug(tension) or patch_id}"
+    return MomentumStatePatch(
+        patch_id=patch_id,
+        created_at=created_at,
+        source_refs=_unique([*source_refs, *belief_refs]),
+        beliefs=beliefs,
+        constraints=constraints,
+        corrections=corrections,
+        open_tensions=[
+            MomentumStateTension(
+                tension_id=tension_id,
+                title=judgment_title,
+                summary=tension,
+                status="pending",
+                evidence_refs=_unique(evidence_refs),
+                source_refs=_unique(source_refs),
+                updated_at=created_at,
+            )
+        ],
+    )
+
+
+def reflection_state_patch(
+    *,
+    patch_id: str,
+    created_at: datetime,
+    source_refs: list[str],
+    draft: MomentumStatePatchDraft,
+    lesson_learned: str,
+    remember_next_time: list[str],
+    corrections: list[str],
+    candidate_reflexes: list[str],
+    candidate_capability_gaps: list[str],
+) -> MomentumStatePatch:
+    data = draft.model_dump()
+    data.pop("corrections", None)
+    data.pop("recent_lessons", None)
+    data.pop("candidate_reflexes", None)
+    data.pop("candidate_capability_gaps", None)
+    return MomentumStatePatch(
+        **data,
+        patch_id=patch_id,
+        created_at=created_at,
+        source_refs=_unique(source_refs),
+        corrections=_unique([*draft.corrections, *corrections]),
+        recent_lessons=_unique([*draft.recent_lessons, lesson_learned, *remember_next_time]),
+        candidate_reflexes=_unique([*draft.candidate_reflexes, *candidate_reflexes]),
+        candidate_capability_gaps=_unique(
+            [*draft.candidate_capability_gaps, *candidate_capability_gaps]
+        ),
+    )
+
+
+def apply_state_patch(
+    current: MomentumResidentState,
+    patch: MomentumStatePatch,
+) -> MomentumResidentState:
+    tensions = {item.tension_id: item for item in current.open_tensions}
+    for item in patch.open_tensions:
+        tensions[item.tension_id] = item.model_copy(
+            update={"source_refs": _unique([*item.source_refs, *patch.source_refs])}
+        )
+    for item in patch.changed_tensions:
+        existing = tensions.get(item.tension_id)
+        if existing is None and (item.title is None or item.summary is None):
+            continue
+        title = item.title or (existing.title if existing else item.tension_id)
+        summary = item.summary or (existing.summary if existing else "-")
+        tensions[item.tension_id] = MomentumStateTension(
+            tension_id=item.tension_id,
+            title=title,
+            summary=summary,
+            status=item.status or "changed",
+            evidence_refs=_unique(
+                [*(existing.evidence_refs if existing else []), *item.evidence_refs]
+            ),
+            source_refs=_unique(
+                [
+                    *(existing.source_refs if existing else []),
+                    *item.source_refs,
+                    *patch.source_refs,
+                ]
+            ),
+            updated_at=patch.created_at,
+        )
+    for tension_id in patch.confirmed_tension_ids:
+        if tension_id in tensions:
+            tensions[tension_id] = tensions[tension_id].model_copy(
+                update={"status": "confirmed", "updated_at": patch.created_at}
+            )
+    for tension_id in patch.resolved_tension_ids:
+        if tension_id in tensions:
+            tensions[tension_id] = tensions[tension_id].model_copy(
+                update={"status": "resolved", "updated_at": patch.created_at}
+            )
+
+    return MomentumResidentState(
+        beliefs=_unique([*current.beliefs, *patch.beliefs]),
+        constraints=_unique([*current.constraints, *patch.constraints]),
+        corrections=_unique([*current.corrections, *patch.corrections]),
+        open_tensions=list(tensions.values()),
+        stale_assumptions=_unique([*current.stale_assumptions, *patch.stale_assumptions]),
+        recent_lessons=_unique([*current.recent_lessons, *patch.recent_lessons]),
+        candidate_reflexes=_unique([*current.candidate_reflexes, *patch.candidate_reflexes]),
+        candidate_capability_gaps=_unique(
+            [*current.candidate_capability_gaps, *patch.candidate_capability_gaps]
+        ),
+        source_refs=_unique([*current.source_refs, *patch.source_refs]),
+        updated_at=patch.created_at,
+    )
+
+
+def parse_momentum_state(content: str) -> MomentumResidentState:
+    marker = "## State Data"
+    if marker not in content:
+        raise ValueError("Momentum state artifact is missing State Data")
+    payload = content.split(marker, 1)[1].split("```json", 1)[1].split("```", 1)[0]
+    return MomentumResidentState.model_validate_json(payload)
+
+
+def render_momentum_state(state: MomentumResidentState) -> str:
+    return (
+        "# Current Momentum Resident State\n\n"
+        f"- updated_at: {state.updated_at.isoformat()}\n\n"
+        "## Current Beliefs\n\n"
+        f"{_bullets_text(state.beliefs)}\n\n"
+        "## Constraints\n\n"
+        f"{_bullets_text(state.constraints)}\n\n"
+        "## Corrections\n\n"
+        f"{_bullets_text(state.corrections)}\n\n"
+        "## Open Tensions\n\n"
+        f"{_tension_text(state.open_tensions)}\n\n"
+        "## Stale Assumptions Or Unknowns\n\n"
+        f"{_bullets_text(state.stale_assumptions)}\n\n"
+        "## Recent Lessons\n\n"
+        f"{_bullets_text(state.recent_lessons)}\n\n"
+        "## Candidate Reflexes (candidate-only)\n\n"
+        f"{_bullets_text(state.candidate_reflexes)}\n\n"
+        "## Candidate Capability Gaps (candidate-only)\n\n"
+        f"{_bullets_text(state.candidate_capability_gaps)}\n\n"
+        "## Source Refs\n\n"
+        f"{_bullets_text(state.source_refs)}\n\n"
+        "## State Data\n\n"
+        f"```json\n{state.model_dump_json(indent=2)}\n```\n"
+    )
+
+
+def render_state_patch(patch: MomentumStatePatch) -> str:
+    return (
+        f"# Momentum State Patch {patch.patch_id}\n\n"
+        f"- patch_id: {patch.patch_id}\n"
+        f"- created_at: {patch.created_at.isoformat()}\n\n"
+        "## Source Refs\n\n"
+        f"{_bullets_text(patch.source_refs)}\n\n"
+        "## Added Beliefs\n\n"
+        f"{_bullets_text(patch.beliefs)}\n\n"
+        "## Added Constraints\n\n"
+        f"{_bullets_text(patch.constraints)}\n\n"
+        "## Added Corrections\n\n"
+        f"{_bullets_text(patch.corrections)}\n\n"
+        "## Open Or Changed Tensions\n\n"
+        f"{_tension_text([*patch.open_tensions, *patch.changed_tensions])}\n\n"
+        "## Resolved Tensions\n\n"
+        f"{_bullets_text(patch.resolved_tension_ids)}\n\n"
+        "## Confirmed Tensions\n\n"
+        f"{_bullets_text(patch.confirmed_tension_ids)}\n\n"
+        "## Recent Lessons\n\n"
+        f"{_bullets_text(patch.recent_lessons)}\n\n"
+        "## Candidate Reflexes (candidate-only)\n\n"
+        f"{_bullets_text(patch.candidate_reflexes)}\n\n"
+        "## Candidate Capability Gaps (candidate-only)\n\n"
+        f"{_bullets_text(patch.candidate_capability_gaps)}\n\n"
+        "## Patch Data\n\n"
+        f"```json\n{patch.model_dump_json(indent=2)}\n```\n"
+    )
+
+
+def _tension_text(tensions: list[MomentumStateTension | MomentumStateTensionPatch]) -> str:
+    if not tensions:
+        return "- none"
+    lines: list[str] = []
+    for tension in tensions:
+        title = tension.title or tension.tension_id
+        summary = tension.summary or "-"
+        status = tension.status or "changed"
+        lines.extend(
+            [
+                f"- {title}",
+                f"  - id: {tension.tension_id}",
+                f"  - status: {status}",
+                f"  - summary: {summary}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _bullets_text(items: list[str]) -> str:
+    return "\n".join(f"- {item}" for item in items if item) or "- none"
+
+
+def _unique(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        value = item.strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        result.append(value)
+    return result

--- a/src/ravn/momentum/worker.py
+++ b/src/ravn/momentum/worker.py
@@ -100,12 +100,22 @@ class MomentumExtractionWorker:
         self.procedure_name = procedure_name
         self._max_tokens = max_tokens
 
-    async def extract(self, markdown: str, *, memory_frame: str = "") -> MomentumExtractionDraft:
+    async def extract(
+        self,
+        markdown: str,
+        *,
+        memory_frame: str = "",
+        current_state_frame: str = "",
+    ) -> MomentumExtractionDraft:
         response = await self._llm.generate(
             [
                 {
                     "role": "user",
-                    "content": _input_frame(markdown, memory_frame=memory_frame),
+                    "content": _input_frame(
+                        markdown,
+                        memory_frame=memory_frame,
+                        current_state_frame=current_state_frame,
+                    ),
                 }
             ],
             tools=[],
@@ -126,13 +136,37 @@ Return only JSON matching this shape:
   "remember_next_time": ["..."],
   "resident_corrections": ["..."],
   "candidate_reflexes": ["candidate only, do not promote"],
-  "candidate_capability_gaps": ["candidate only, do not register"]
+  "candidate_capability_gaps": ["candidate only, do not register"],
+  "state_patch": {
+    "beliefs": ["..."],
+    "constraints": ["..."],
+    "corrections": ["..."],
+    "open_tensions": [
+      {
+        "tension_id": "stable-explicit-id",
+        "title": "...",
+        "summary": "...",
+        "status": "pending|open|confirmed|changed|resolved",
+        "evidence_refs": ["..."],
+        "source_refs": ["..."]
+      }
+    ],
+    "changed_tensions": [],
+    "resolved_tension_ids": ["..."],
+    "confirmed_tension_ids": ["..."],
+    "stale_assumptions": ["..."],
+    "recent_lessons": ["..."],
+    "candidate_reflexes": ["candidate only, do not promote"],
+    "candidate_capability_gaps": ["candidate only, do not register"]
+  }
 }
 
 Semantic learning belongs to you. The deterministic system only records the
-operator disposition and persists your reflection. Candidate reflexes and
-capability gaps are notes for later review; do not describe them as promoted,
-executed, registered, or applied.
+operator disposition, applies your state_patch, and persists your reflection.
+Use state_patch to say what changed in current understanding, what should be
+remembered next time, what tensions are confirmed/resolved/changed/opened, and
+which corrections apply. Candidate reflexes and capability gaps are notes for
+later review; do not describe them as promoted, executed, registered, or applied.
 """
 
 
@@ -162,6 +196,7 @@ class MomentumReflectionWorker:
         artifact_contents: list[str],
         disposition: MomentumJudgmentDisposition,
         memory_frame: str = "",
+        current_state_frame: str = "",
     ) -> MomentumReflectionDraft:
         response = await self._llm.generate(
             [
@@ -175,6 +210,7 @@ class MomentumReflectionWorker:
                         artifact_contents=artifact_contents,
                         disposition=disposition,
                         memory_frame=memory_frame,
+                        current_state_frame=current_state_frame,
                     ),
                 }
             ],
@@ -186,10 +222,12 @@ class MomentumReflectionWorker:
         return MomentumReflectionDraft.model_validate_json(_json_payload(response.content))
 
 
-def _input_frame(markdown: str, *, memory_frame: str) -> str:
+def _input_frame(markdown: str, *, memory_frame: str, current_state_frame: str) -> str:
     return (
         "## Existing resident memory frame\n\n"
         f"{memory_frame or '(none)'}\n\n"
+        "## Current Momentum state\n\n"
+        f"{current_state_frame or '(none)'}\n\n"
         "## Resident signal markdown\n\n"
         f"{markdown}"
     )
@@ -204,10 +242,13 @@ def _reflection_input_frame(
     artifact_contents: list[str],
     disposition: MomentumJudgmentDisposition,
     memory_frame: str,
+    current_state_frame: str,
 ) -> str:
     return (
         "## Existing resident memory frame\n\n"
         f"{memory_frame or '(none)'}\n\n"
+        "## Current Momentum state\n\n"
+        f"{current_state_frame or '(none)'}\n\n"
         "## Disposition\n\n"
         f"- target_ref: {target_ref}\n"
         f"- outcome: {disposition.outcome}\n"

--- a/src/ravn/ports/momentum_state_compactor.py
+++ b/src/ravn/ports/momentum_state_compactor.py
@@ -1,0 +1,13 @@
+"""Momentum current-state compaction port."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ravn.momentum.models import MomentumResidentState
+
+
+class MomentumStateCompactorPort(Protocol):
+    """Compacts current Momentum state for prompt-sized reuse."""
+
+    def compact(self, state: MomentumResidentState) -> MomentumResidentState: ...

--- a/tests/test_ravn/fixtures/momentum_state_signal_1.md
+++ b/tests/test_ravn/fixtures/momentum_state_signal_1.md
@@ -1,0 +1,16 @@
+# Momentum current-state proof signal 1
+
+We are implementing NIU-1076. Momentum now has historical artifacts, but future
+extract runs still need a compact current resident understanding.
+
+The important tension: if a reflection teaches Niuu that context dilution is
+the active failure mode, the next extraction must receive that consolidated
+state deterministically instead of relying on fuzzy recall.
+
+Constraints:
+
+- Use normal `ravn momentum extract` and `ravn momentum reflect`.
+- Persist through selected resident state.
+- Keep provider details inside adapter config.
+- Candidate reflexes and capability gaps remain candidate-only.
+- Do not add dogfood, eval, proof, scheduler, daemon, autonomy, or wrapper lanes.

--- a/tests/test_ravn/fixtures/momentum_state_signal_2.md
+++ b/tests/test_ravn/fixtures/momentum_state_signal_2.md
@@ -1,0 +1,10 @@
+# Momentum current-state proof signal 2
+
+This is the follow-up signal after reflection.
+
+The useful question is whether Momentum now sees the resident state's compact
+understanding from the prior accepted judgment. The second extraction should
+carry forward the open tension and lesson about avoiding context dilution
+without creating any special proof path.
+
+Keep the packet small and treat capability ideas as candidate-only notes.

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -29,7 +29,10 @@ from ravn.momentum.render import judgment_event_payload
 from ravn.momentum.state import (
     CURRENT_MOMENTUM_STATE_REF,
     MAX_BELIEFS,
+    MAX_CANDIDATE_CAPABILITY_GAPS,
+    MAX_CANDIDATE_REFLEXES,
     MAX_OPEN_TENSIONS,
+    BoundedMomentumStateCompactor,
     apply_state_patch,
     empty_momentum_state,
     render_momentum_state,
@@ -79,6 +82,17 @@ class RecordingGBrainState(GBrainResidentStateAdapter):
 
     async def _put_page_gbrain(self, ref, title, content) -> None:
         self.put_pages.append((ref, title, content))
+
+
+class RecordingStateCompactor:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def compact(self, state):
+        self.calls += 1
+        return state.model_copy(
+            update={"beliefs": [*state.beliefs, "compactor touched state"]}
+        )
 
 
 async def _markdown_signal(path: Path) -> ResidentInboxSignal:
@@ -358,6 +372,12 @@ def test_current_momentum_state_compacts_old_entries() -> None:
         patch_id="patch-compact",
         created_at=created_at,
         beliefs=[f"belief {index}" for index in range(MAX_BELIEFS + 2)],
+        candidate_reflexes=[
+            f"Candidate: reflex {index}" for index in range(MAX_CANDIDATE_REFLEXES + 1)
+        ],
+        candidate_capability_gaps=[
+            f"Candidate: gap {index}" for index in range(MAX_CANDIDATE_CAPABILITY_GAPS + 1)
+        ],
         open_tensions=[
             MomentumStateTension(
                 tension_id=f"tension-{index}",
@@ -369,7 +389,9 @@ def test_current_momentum_state_compacts_old_entries() -> None:
         ],
     )
 
-    state = apply_state_patch(empty_momentum_state(updated_at=created_at), patch)
+    state = BoundedMomentumStateCompactor().compact(
+        apply_state_patch(empty_momentum_state(updated_at=created_at), patch)
+    )
     rendered = render_momentum_state(state)
 
     assert state.beliefs == [f"belief {index}" for index in range(2, MAX_BELIEFS + 2)]
@@ -378,9 +400,35 @@ def test_current_momentum_state_compacts_old_entries() -> None:
     ]
     assert "belief 0" not in rendered
     assert "tension-0" not in rendered
+    assert "Candidate Reflexes (candidate-only)" in rendered
+    assert "Candidate Capability Gaps (candidate-only)" in rendered
+    assert "Candidate: reflex 0" not in rendered
+    assert "Candidate: gap 0" not in rendered
     assert "## State Compaction" in rendered
     assert "- beliefs_truncated: 2 older entries omitted" in rendered
     assert "- open_tensions_truncated: 1 older entry omitted" in rendered
+    assert "- candidate_reflexes_truncated: 1 older entry omitted" in rendered
+    assert "- candidate_capability_gaps_truncated: 1 older entry omitted" in rendered
+
+
+@pytest.mark.asyncio
+async def test_momentum_pipeline_uses_injected_state_compactor(tmp_path: Path):
+    source = tmp_path / "notes.md"
+    source.write_text("# Notes\n\nImportant living idea.", encoding="utf-8")
+    state = LocalResidentState(tmp_path / "state")
+    compactor = RecordingStateCompactor()
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        state=state,
+        state_compactor=compactor,
+        now=datetime(2026, 6, 27, 12, tzinfo=UTC),
+        run_id="inject-compactor",
+    ).extract_signal(await _markdown_signal(source))
+
+    current = await state.read_artifact(result.current_state_ref)
+    assert compactor.calls == 1
+    assert "compactor touched state" in current.content
 
 
 @pytest.mark.asyncio

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -24,8 +24,16 @@ from ravn.domain.valkyrie_contracts import (
     validate_valkyrie_outcome,
 )
 from ravn.momentum import MomentumExtractionWorker, MomentumPipeline, MomentumReflectionWorker
+from ravn.momentum.models import MomentumStatePatch, MomentumStateTension
 from ravn.momentum.render import judgment_event_payload
-from ravn.momentum.state import CURRENT_MOMENTUM_STATE_REF
+from ravn.momentum.state import (
+    CURRENT_MOMENTUM_STATE_REF,
+    MAX_BELIEFS,
+    MAX_OPEN_TENSIONS,
+    apply_state_patch,
+    empty_momentum_state,
+    render_momentum_state,
+)
 from ravn.ports.resident_signal import ResidentSignalSourcePort
 from ravn.resident_inbox import (
     MimirResidentInbox,
@@ -342,6 +350,37 @@ async def test_current_momentum_state_is_included_on_later_runs(tmp_path: Path):
     assert "Signal compression is diluting resident understanding." in frame
     assert f"- input_state_ref: {CURRENT_MOMENTUM_STATE_REF}" in run.content
     assert "- input_state_sha256: -" not in run.content
+
+
+def test_current_momentum_state_compacts_old_entries() -> None:
+    created_at = datetime(2026, 6, 27, 12, tzinfo=UTC)
+    patch = MomentumStatePatch(
+        patch_id="patch-compact",
+        created_at=created_at,
+        beliefs=[f"belief {index}" for index in range(MAX_BELIEFS + 2)],
+        open_tensions=[
+            MomentumStateTension(
+                tension_id=f"tension-{index}",
+                title=f"Tension {index}",
+                summary=f"Summary {index}",
+                updated_at=datetime(2026, 6, 27, 12, index, tzinfo=UTC),
+            )
+            for index in range(MAX_OPEN_TENSIONS + 1)
+        ],
+    )
+
+    state = apply_state_patch(empty_momentum_state(updated_at=created_at), patch)
+    rendered = render_momentum_state(state)
+
+    assert state.beliefs == [f"belief {index}" for index in range(2, MAX_BELIEFS + 2)]
+    assert [item.tension_id for item in state.open_tensions] == [
+        f"tension-{index}" for index in range(1, MAX_OPEN_TENSIONS + 1)
+    ]
+    assert "belief 0" not in rendered
+    assert "tension-0" not in rendered
+    assert "## State Compaction" in rendered
+    assert "- beliefs_truncated: 2 older entries omitted" in rendered
+    assert "- open_tensions_truncated: 1 older entry omitted" in rendered
 
 
 @pytest.mark.asyncio
@@ -743,6 +782,44 @@ async def test_reflection_state_patch_can_change_existing_tension_with_partial_u
         state=state,
         now=datetime(2026, 6, 27, 12, tzinfo=UTC),
         run_id="partial-change",
+    )
+    extraction = await pipeline.extract_signal(await _markdown_signal(source))
+
+    result = await pipeline.reflect_judgment(
+        extraction.judgment_ref,
+        outcome="accepted",
+        note="The judgment helped.",
+    )
+
+    current_state = await state.read_artifact(result.current_state_ref)
+    assert "- status: changed" in current_state.content
+    assert "Signal compression is diluting resident understanding." in current_state.content
+
+
+@pytest.mark.asyncio
+async def test_reflection_state_patch_can_change_tension_with_id_shorthand(
+    tmp_path: Path,
+):
+    source = tmp_path / "notes.md"
+    source.write_text("# Messy notes\n\nImportant living idea.", encoding="utf-8")
+    state = LocalResidentState(tmp_path / "state")
+    llm = FakeLLM(
+        [
+            _payload(),
+            _reflection_payload(
+                "accepted",
+                state_patch={
+                    "changed_tensions": ["tension-attend-to-momentum-dilution"],
+                },
+            ),
+        ]
+    )
+    pipeline = MomentumPipeline(
+        worker=MomentumExtractionWorker(llm, model="fake-model"),
+        reflection_worker=MomentumReflectionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 12, tzinfo=UTC),
+        run_id="id-change",
     )
     extraction = await pipeline.extract_signal(await _markdown_signal(source))
 

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -25,6 +25,7 @@ from ravn.domain.valkyrie_contracts import (
 )
 from ravn.momentum import MomentumExtractionWorker, MomentumPipeline, MomentumReflectionWorker
 from ravn.momentum.render import judgment_event_payload
+from ravn.momentum.state import CURRENT_MOMENTUM_STATE_REF
 from ravn.ports.resident_signal import ResidentSignalSourcePort
 from ravn.resident_inbox import (
     MimirResidentInbox,
@@ -201,6 +202,13 @@ async def test_momentum_pipeline_persists_typed_artifacts_with_selected_state(tm
     assert "- event_type: valkyrie.judgment.proposed" in judgment
     assert "## Tension That Matters" in judgment
     assert "Signal compression is diluting resident understanding." in judgment
+    current_state = (tmp_path / "state" / CURRENT_MOMENTUM_STATE_REF).read_text(
+        encoding="utf-8"
+    )
+    state_patch = (tmp_path / "state" / result.state_patch_ref).read_text(encoding="utf-8")
+    assert "Signal compression is diluting resident understanding." in current_state
+    assert "- status: pending" in current_state
+    assert result.judgment_ref in state_patch
 
 
 @pytest.mark.asyncio
@@ -276,6 +284,64 @@ async def test_judgment_payload_validates_against_valkyrie_contract(tmp_path: Pa
     judgment_payload = judgment_event_payload(result.extraction.judgment)
     assert judgment_payload["tier"] == "silent"
     assert validate_valkyrie_outcome(VALKYRIE_JUDGMENT_PROPOSED, judgment_payload) == []
+
+
+@pytest.mark.asyncio
+async def test_current_momentum_state_is_absent_on_first_run_then_persisted(
+    tmp_path: Path,
+):
+    source = tmp_path / "notes.md"
+    source.write_text("# Notes\n\nImportant living idea.", encoding="utf-8")
+    state = LocalResidentState(tmp_path / "state")
+    llm = FakeLLM(_payload())
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 12, tzinfo=UTC),
+        run_id="state-first",
+    ).extract_signal(await _markdown_signal(source))
+
+    frame = llm.calls[0]["messages"][0]["content"]
+    assert "## Current Momentum state\n\n(none)" in frame
+    current = await state.read_artifact(result.current_state_ref)
+    run = await state.read_artifact(result.run_ref)
+    assert result.current_state_ref == CURRENT_MOMENTUM_STATE_REF
+    assert "- input_state_ref: -" in run.content
+    assert "- input_state_sha256: -" in run.content
+    assert "## Open Tensions" in current.content
+    assert "Signal compression is diluting resident understanding." in current.content
+    assert "tension-attend-to-momentum-dilution" in current.content
+
+
+@pytest.mark.asyncio
+async def test_current_momentum_state_is_included_on_later_runs(tmp_path: Path):
+    source = tmp_path / "notes.md"
+    source.write_text("# Notes\n\nImportant living idea.", encoding="utf-8")
+    state = LocalResidentState(tmp_path / "state")
+
+    await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 12, tzinfo=UTC),
+        run_id="state-before",
+    ).extract_signal(await _markdown_signal(source))
+    next_llm = FakeLLM(_payload())
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(next_llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 12, 1, tzinfo=UTC),
+        run_id="state-after",
+    ).extract_signal(await _markdown_signal(source))
+
+    frame = next_llm.calls[0]["messages"][0]["content"]
+    run = await state.read_artifact(result.run_ref)
+    assert "## Current Momentum state" in frame
+    assert "# Current Momentum Resident State" in frame
+    assert "Signal compression is diluting resident understanding." in frame
+    assert f"- input_state_ref: {CURRENT_MOMENTUM_STATE_REF}" in run.content
+    assert "- input_state_sha256: -" not in run.content
 
 
 @pytest.mark.asyncio
@@ -443,8 +509,13 @@ async def test_judgment_disposition_produces_persisted_reflection(
     assert result.reflection.outcome == outcome
     disposition = await state.read_artifact(result.disposition_ref)
     reflection = await state.read_artifact(result.reflection_ref)
+    current_state = await state.read_artifact(result.current_state_ref)
+    state_patch = await state.read_artifact(result.state_patch_ref)
     assert f"- outcome: {outcome}" in disposition.content
     assert f"Lesson for {outcome}" in reflection.content
+    assert f"Lesson for {outcome}" in current_state.content
+    assert result.disposition_ref in state_patch.content
+    assert result.reflection_ref in state_patch.content
     assert "Original Judgment Useful" in reflection.content
 
 
@@ -503,7 +574,9 @@ async def test_wrong_disposition_persists_model_authored_correction(tmp_path: Pa
     )
 
     reflection = await state.read_artifact(result.reflection_ref)
+    current_state = await state.read_artifact(result.current_state_ref)
     assert correction in reflection.content
+    assert correction in current_state.content
     assert correction not in llm.calls[1]["messages"][0]["content"]
 
 
@@ -588,12 +661,135 @@ async def test_reflex_and_capability_gap_outputs_remain_candidates(tmp_path: Pat
     )
 
     reflection = await state.read_artifact(result.reflection_ref)
+    current_state = await state.read_artifact(result.current_state_ref)
     refs = await state.list_refs("resident/continuation/momentum")
     assert "- candidate_reflex_status: candidate_only" in reflection.content
     assert "- candidate_capability_gap_status: candidate_only" in reflection.content
     assert "Candidate Reflexes" in reflection.content
     assert "Candidate Capability Gaps" in reflection.content
+    assert "Candidate Reflexes (candidate-only)" in current_state.content
+    assert "Candidate Capability Gaps (candidate-only)" in current_state.content
+    assert "Candidate: ask for disposition after action." in current_state.content
+    assert "Candidate: no automatic outcome feed." in current_state.content
     assert all("/reflex" not in ref and "/capabilit" not in ref for ref in refs)
+
+
+@pytest.mark.asyncio
+async def test_reflection_state_patch_can_confirm_tension(tmp_path: Path):
+    source = tmp_path / "notes.md"
+    source.write_text("# Messy notes\n\nImportant living idea.", encoding="utf-8")
+    state = LocalResidentState(tmp_path / "state")
+    llm = FakeLLM(
+        [
+            _payload(),
+            _reflection_payload(
+                "accepted",
+                state_patch={
+                    "confirmed_tension_ids": ["tension-attend-to-momentum-dilution"],
+                    "recent_lessons": ["Confirmed state patch lesson."],
+                },
+            ),
+        ]
+    )
+    pipeline = MomentumPipeline(
+        worker=MomentumExtractionWorker(llm, model="fake-model"),
+        reflection_worker=MomentumReflectionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 12, tzinfo=UTC),
+        run_id="confirm-tension",
+    )
+    extraction = await pipeline.extract_signal(await _markdown_signal(source))
+
+    result = await pipeline.reflect_judgment(
+        extraction.judgment_ref,
+        outcome="accepted",
+        note="The judgment helped.",
+    )
+
+    current_state = await state.read_artifact(result.current_state_ref)
+    reflection_frame = llm.calls[1]["messages"][0]["content"]
+    assert "## Current Momentum state" in reflection_frame
+    assert "Signal compression is diluting resident understanding." in reflection_frame
+    assert "- status: confirmed" in current_state.content
+    assert "Confirmed state patch lesson." in current_state.content
+
+
+@pytest.mark.asyncio
+async def test_reflection_state_patch_can_change_existing_tension_with_partial_update(
+    tmp_path: Path,
+):
+    source = tmp_path / "notes.md"
+    source.write_text("# Messy notes\n\nImportant living idea.", encoding="utf-8")
+    state = LocalResidentState(tmp_path / "state")
+    llm = FakeLLM(
+        [
+            _payload(),
+            _reflection_payload(
+                "accepted",
+                state_patch={
+                    "changed_tensions": [
+                        {
+                            "tension_id": "tension-attend-to-momentum-dilution",
+                            "status": "changed",
+                        }
+                    ],
+                },
+            ),
+        ]
+    )
+    pipeline = MomentumPipeline(
+        worker=MomentumExtractionWorker(llm, model="fake-model"),
+        reflection_worker=MomentumReflectionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 12, tzinfo=UTC),
+        run_id="partial-change",
+    )
+    extraction = await pipeline.extract_signal(await _markdown_signal(source))
+
+    result = await pipeline.reflect_judgment(
+        extraction.judgment_ref,
+        outcome="accepted",
+        note="The judgment helped.",
+    )
+
+    current_state = await state.read_artifact(result.current_state_ref)
+    assert "- status: changed" in current_state.content
+    assert "Signal compression is diluting resident understanding." in current_state.content
+
+
+@pytest.mark.asyncio
+async def test_state_updates_do_not_mutate_historical_artifacts(tmp_path: Path):
+    source = tmp_path / "notes.md"
+    source.write_text("# Messy notes\n\nImportant living idea.", encoding="utf-8")
+    state = LocalResidentState(tmp_path / "state")
+    llm = FakeLLM([_payload(), _reflection_payload("accepted"), _payload()])
+    pipeline = MomentumPipeline(
+        worker=MomentumExtractionWorker(llm, model="fake-model"),
+        reflection_worker=MomentumReflectionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 12, tzinfo=UTC),
+        run_id="immutable-history",
+    )
+    extraction = await pipeline.extract_signal(await _markdown_signal(source))
+    reflection = await pipeline.reflect_judgment(
+        extraction.judgment_ref,
+        outcome="accepted",
+        note="The judgment helped.",
+    )
+    judgment_before = (await state.read_artifact(extraction.judgment_ref)).content
+    disposition_before = (await state.read_artifact(reflection.disposition_ref)).content
+    reflection_before = (await state.read_artifact(reflection.reflection_ref)).content
+
+    await MomentumPipeline(
+        worker=MomentumExtractionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 12, 1, tzinfo=UTC),
+        run_id="immutable-history-next",
+    ).extract_signal(await _markdown_signal(source))
+
+    assert (await state.read_artifact(extraction.judgment_ref)).content == judgment_before
+    assert (await state.read_artifact(reflection.disposition_ref)).content == disposition_before
+    assert (await state.read_artifact(reflection.reflection_ref)).content == reflection_before
 
 
 @pytest.mark.asyncio
@@ -731,8 +927,10 @@ def test_momentum_extract_cli_runs_pipeline(monkeypatch, tmp_path: Path):
 
     monkeypatch.setattr(commands, "_build_llm", lambda _settings: FakeLLM(_payload()))
 
+    state = LocalResidentState(tmp_path / "state")
+
     async def _state(_settings, _workspace):
-        return LocalResidentState(tmp_path / "state")
+        return state
 
     monkeypatch.setattr(commands, "_build_resident_state", _state)
 
@@ -747,6 +945,10 @@ def test_momentum_extract_cli_runs_pipeline(monkeypatch, tmp_path: Path):
         in result.output
     )
     assert "provenance:  verified" in result.output
+    assert f"current_state_ref: {CURRENT_MOMENTUM_STATE_REF}" in result.output
+    assert "state_patch_ref:   resident/continuation/momentum/state/patches/" in result.output
+    current_state = asyncio.run(state.read_artifact(CURRENT_MOMENTUM_STATE_REF))
+    assert "Signal compression is diluting resident understanding." in current_state.content
 
 
 def test_momentum_inbox_cli_runs_pipeline(monkeypatch, tmp_path: Path):
@@ -778,6 +980,7 @@ def test_momentum_inbox_cli_runs_pipeline(monkeypatch, tmp_path: Path):
     assert result.exit_code == 0, result.output
     assert "judgment_ref:resident/momentum/runs/" in result.output
     assert "packet_ref:  resident/momentum/runs/" in result.output
+    assert f"current_state_ref: {CURRENT_MOMENTUM_STATE_REF}" in result.output
 
 
 def test_momentum_reflect_cli_records_disposition_and_reflection(monkeypatch, tmp_path: Path):
@@ -818,6 +1021,48 @@ def test_momentum_reflect_cli_records_disposition_and_reflection(monkeypatch, tm
     assert result.exit_code == 0, result.output
     assert "disposition_ref: resident/continuation/momentum/runs/cli-reflect/" in result.output
     assert "reflection_ref:  resident/continuation/momentum/runs/cli-reflect/" in result.output
+    assert f"current_state_ref: {CURRENT_MOMENTUM_STATE_REF}" in result.output
+    assert "state_patch_ref:   resident/continuation/momentum/state/patches/" in result.output
+    current_state = asyncio.run(state.read_artifact(CURRENT_MOMENTUM_STATE_REF))
+    assert "Lesson for accepted" in current_state.content
+
+
+def test_later_momentum_extract_cli_includes_current_state(monkeypatch, tmp_path: Path):
+    source = tmp_path / "notes.md"
+    source.write_text("# Messy notes\n\nImportant living idea.", encoding="utf-8")
+    state = LocalResidentState(tmp_path / "state")
+    first_llm = FakeLLM([_payload(), _reflection_payload("accepted")])
+
+    async def _seed() -> None:
+        pipeline = MomentumPipeline(
+            worker=MomentumExtractionWorker(first_llm, model="fake-model"),
+            reflection_worker=MomentumReflectionWorker(first_llm, model="fake-model"),
+            state=state,
+            now=datetime(2026, 6, 27, 12, tzinfo=UTC),
+            run_id="cli-current-state",
+        )
+        extraction = await pipeline.extract_signal(await _markdown_signal(source))
+        await pipeline.reflect_judgment(
+            extraction.judgment_ref,
+            outcome="accepted",
+            note="The judgment helped.",
+        )
+
+    asyncio.run(_seed())
+    next_llm = FakeLLM(_payload())
+    monkeypatch.setattr(commands, "_build_llm", lambda _settings: next_llm)
+
+    async def _state(_settings, _workspace):
+        return state
+
+    monkeypatch.setattr(commands, "_build_resident_state", _state)
+
+    result = CliRunner().invoke(commands.app, ["momentum", "extract", str(source)])
+
+    assert result.exit_code == 0, result.output
+    frame = next_llm.calls[0]["messages"][0]["content"]
+    assert "## Current Momentum state" in frame
+    assert "Lesson for accepted" in frame
 
 
 def test_momentum_reflect_cli_rejects_invalid_outcome(monkeypatch, tmp_path: Path):
@@ -946,8 +1191,9 @@ def _reflection_payload(
     outcome: str = "accepted",
     *,
     correction: str = "Remember to compare the judgment with the outcome.",
+    state_patch: dict | None = None,
 ) -> dict:
-    return {
+    payload = {
         "changed_understanding": f"The {outcome} outcome updates resident memory.",
         "lesson_learned": f"Lesson for {outcome}",
         "original_judgment_useful": outcome != "wrong",
@@ -956,6 +1202,9 @@ def _reflection_payload(
         "candidate_reflexes": ["Candidate: ask for disposition after action."],
         "candidate_capability_gaps": ["Candidate: no automatic outcome feed."],
     }
+    if state_patch is not None:
+        payload["state_patch"] = state_patch
+    return payload
 
 
 def _vision_payload() -> dict:


### PR DESCRIPTION
## Summary

- Adds typed current Momentum resident state at `resident/continuation/momentum/state/current.md`.
- Includes current Momentum state in normal extract and reflect worker input frames.
- Persists extraction/reflection state patches under `resident/continuation/momentum/state/patches/`.
- Preserves the real proof signals as committed fixtures and bounds current-state growth behind `MomentumStateCompactorPort` with default cap-based compaction.
- Keeps candidate reflexes and capability gaps candidate-only; no new proof/eval/dogfood command or wrapper lane.

## Rules Loaded

- `AGENTS.md`
- `CLAUDE.md`
- `.claude/rules/architecture.md`
- `.claude/rules/module-boundaries.md`
- `.claude/rules/dynamic-adapters.md`
- `.claude/rules/testing.md`

Applied constraints: use existing ports/adapters and selected resident state, keep provider details in dynamic adapter config, do not add new architecture layers, no scheduler/daemon/autonomy/proof lane, keep historical artifacts immutable, and run/report relevant tests.

## Proof of Working

Adapter config used, secrets omitted:

```yaml
llm:
  model: codex-local
  provider:
    adapter: ravn.adapters.llm.command.CommandLLMAdapter
    kwargs:
      command: zsh
      timeout: 600
      args:
        - -lc
        - 'tmp=$(mktemp); codex exec --color never --skip-git-repo-check --sandbox read-only --output-last-message "$tmp" - >/dev/null; cat "$tmp"; rm -f "$tmp"'
resident_state:
  adapter: ravn.adapters.resident_state.mimir.LocalResidentState
  kwargs:
    root: /private/tmp/ravn-momentum-state-proof-niu1076-polish/preferred
  fallback_adapter: ravn.adapters.resident_state.mimir.LocalResidentState
  fallback_kwargs:
    root: /private/tmp/ravn-momentum-state-proof-niu1076-polish/fallback
```

Committed input signals:

- `tests/test_ravn/fixtures/momentum_state_signal_1.md`
- `tests/test_ravn/fixtures/momentum_state_signal_2.md`

Exact normal commands:

```bash
uv run ravn momentum extract tests/test_ravn/fixtures/momentum_state_signal_1.md --config /private/tmp/ravn-momentum-state-codex-805-polish.yaml
uv run ravn momentum reflect resident/momentum/runs/momentum-20260628T015441Z-a1da463e/judgment/judgment-carry-reflected-state-into-the-next-extraction.md --outcome accepted --note "The judgment correctly identifies deterministic current-state handoff as the tension to carry into future extractions." --config /private/tmp/ravn-momentum-state-codex-805-polish.yaml
uv run ravn momentum extract tests/test_ravn/fixtures/momentum_state_signal_2.md --config /private/tmp/ravn-momentum-state-codex-805-polish.yaml
```

Refs:

- first run ref: `resident/momentum/runs/momentum-20260628T015441Z-a1da463e/run.md`
- first judgment ref: `resident/momentum/runs/momentum-20260628T015441Z-a1da463e/judgment/judgment-carry-reflected-state-into-the-next-extraction.md`
- disposition ref: `resident/continuation/momentum/runs/momentum-20260628T015441Z-a1da463e/dispositions/disposition-20260628T015556Z-accepted-1165b1.md`
- reflection ref: `resident/continuation/momentum/runs/momentum-20260628T015441Z-a1da463e/reflections/reflection-20260628T015556Z-accepted-1165b1.md`
- current state ref: `resident/continuation/momentum/state/current.md`
- state patch ref: `resident/continuation/momentum/state/patches/patch-20260628T015556Z-reflection-20260628T015556Z-accepted-1165b1.md`
- second run ref: `resident/momentum/runs/momentum-20260628T015707Z-a0ba1a73/run.md`

State after first extraction:

```text
## Open Tensions

- Carry reflected state into the next extraction
  - id: tension-carry-reflected-state-into-the-next-extraction
  - status: pending
```

State after reflection:

```text
## Open Tensions

- Carry reflected state into the next extraction
  - id: tension-carry-reflected-state-into-the-next-extraction
  - status: confirmed

## Recent Lessons

- Accepted Momentum judgments should update current resident understanding, not just leave historical artifacts behind.
- When a Momentum judgment identifies context dilution as the failure mode, the useful next memory state is a compact, deterministic handoff constraint carried into extraction inputs.
```

Evidence that the second extraction received current state:

```text
# Resident Signal Momentum Run momentum-20260628T015707Z-a0ba1a73

- source_path: tests/test_ravn/fixtures/momentum_state_signal_2.md
- input_state_ref: resident/continuation/momentum/state/current.md
- input_state_sha256: a0380293b6fc650573b9c6b1452b801589aae403bd2a75a6442bdef1183a8424
- provenance_fully_verified: true
```

The second judgment carried the prior lesson forward:

```text
The follow-up signal confirms the next useful Momentum action is not discovering a new idea, but proving the accepted resident understanding is now present in normal extraction context.
```

State compaction proof:

- `MomentumStateCompactorPort` is the replaceable current-state compaction boundary.
- `BoundedMomentumStateCompactor` preserves deterministic v0 behavior: dedupe, keep newest, enforce caps, and record omissions in `state.compaction`.
- `test_current_momentum_state_compacts_old_entries` proves older beliefs/tensions/candidate entries are omitted, newest entries remain, candidate reflexes and capability gaps stay candidate-only, and rendered Markdown includes `## State Compaction`.
- `test_momentum_pipeline_uses_injected_state_compactor` proves `MomentumPipeline` uses an injected compactor.
- Real proof remains valid: normal `extract`/`reflect` input/output behavior is unchanged; this commit only moved compaction behind the replaceable boundary.

Provenance / validation:

- First extraction: `provenance: verified`
- Second extraction: `provenance: verified`
- Judgment payload validation: passed during `render_judgment`; invalid Valkyrie payloads raise before artifact persistence, and `test_judgment_payload_validates_against_valkyrie_contract` passes.

## Validation

```bash
uv run ruff check src/ravn/momentum src/ravn/cli/commands.py src/ravn/adapters/llm/command.py src/ravn/adapters/process_runner.py tests/test_ravn/test_momentum_pipeline.py tests/test_ravn/test_cli_commands.py tests/test_ravn/test_command_llm_adapter.py tests/test_ravn/test_resident_state.py tests/test_ravn/test_resident_letheo.py
uv run pytest tests/test_ravn/test_command_llm_adapter.py tests/test_ravn/test_momentum_pipeline.py tests/test_ravn/test_momentum_source.py tests/test_ravn/test_cli_commands.py tests/test_ravn/test_resident_state.py tests/test_ravn/test_resident_letheo.py
uv run ruff check src/ravn/momentum src/ravn/ports/momentum_state_compactor.py tests/test_ravn/test_momentum_pipeline.py
uv run pytest tests/test_ravn/test_momentum_pipeline.py
make test-ravn
uv run ravn momentum --help
git diff --check
```

Results:

- ruff: passed
- pytest subset: `124 passed in 1.46s`
- focused Momentum pytest after port refactor: `42 passed in 0.62s`
- full Ravn coverage gate: `6120 passed, 1 skipped, 1 warning in 86.66s`; `Total coverage: 85.35%`, meeting `--cov-fail-under=85`
- `ravn momentum --help`: only normal `extract`, `inbox`, and `reflect` commands are present
- `git diff --check`: passed
