### PR TITLE
[codex] Implement NIU-1077 Momentum attention selection

### DIFF
--- a/src/ravn/adapters/resident_signal.py
+++ b/src/ravn/adapters/resident_signal.py
@@ -6,7 +6,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from ravn.ports.mimir import MimirPort
-from ravn.ports.resident_signal import ResidentSignalSourcePort
+from ravn.ports.resident_signal import (
+    ResidentSignalCandidateSourcePort,
+    ResidentSignalSourcePort,
+)
 from ravn.resident_inbox.models import (
     _INBOX_SIGNAL_PREFIX,
     ResidentInboxClassification,
@@ -41,7 +44,10 @@ class MarkdownResidentSignalSource(ResidentSignalSourcePort):
         )
 
 
-class MimirResidentInboxSignalSource(ResidentSignalSourcePort):
+class MimirResidentInboxSignalSource(
+    ResidentSignalSourcePort,
+    ResidentSignalCandidateSourcePort,
+):
     """Loads stored resident inbox signals from Mimir."""
 
     def __init__(
@@ -66,6 +72,27 @@ class MimirResidentInboxSignalSource(ResidentSignalSourcePort):
             if signal.id == text:
                 return signal
         raise FileNotFoundError(text)
+
+    async def list_candidates(
+        self,
+        *,
+        limit: int,
+        status: str = "",
+        classification: str = "",
+    ) -> list[tuple[str, ResidentInboxSignal]]:
+        items: list[tuple[str, ResidentInboxSignal]] = []
+        for ref in await self._signal_refs():
+            signal = await self._read_signal_page(ref)
+            if signal is None:
+                continue
+            if status and signal.status != status:
+                continue
+            if classification and signal.classification != classification:
+                continue
+            items.append((ref, signal))
+            if len(items) >= limit:
+                break
+        return items
 
     async def _signal_refs(self) -> list[str]:
         pages = await self._mimir.list_pages(prefix=self._signal_prefix)

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -4976,6 +4976,26 @@ def momentum_reflect_cmd(
     asyncio.run(_run_momentum_reflect(settings, target_ref, outcome, note, actor))
 
 
+@momentum_app.command("attend")
+def momentum_attend_cmd(
+    limit: int = typer.Option(5, "--limit", "-n", min=1, help="Candidate signal limit."),
+    status: str = typer.Option("new", "--status", help="Candidate inbox status filter."),
+    classification: str = typer.Option(
+        "",
+        "--classification",
+        help="Optional candidate classification filter.",
+    ),
+    config: str = typer.Option("", "--config", "-c", help="Path to ravn config YAML."),
+) -> None:
+    """Select which resident inbox signal deserves Momentum attention."""
+    if config:
+        os.environ["RAVN_CONFIG"] = config
+
+    settings = Settings()
+    _configure_logging(settings)
+    asyncio.run(_run_momentum_attend(settings, limit, status, classification))
+
+
 async def _run_momentum_extract(settings: Settings, path: str) -> None:
     from ravn.adapters.resident_signal import MarkdownResidentSignalSource
 
@@ -5020,6 +5040,46 @@ async def _run_momentum_reflect(
     typer.echo(f"reflection_ref:  {result.reflection_ref}")
     typer.echo(f"current_state_ref: {result.current_state_ref}")
     typer.echo(f"state_patch_ref:   {result.state_patch_ref}")
+
+
+async def _run_momentum_attend(
+    settings: Settings,
+    limit: int,
+    status: str,
+    classification: str,
+) -> None:
+    from ravn.momentum import (
+        MomentumAttentionWorker,
+        MomentumExtractionWorker,
+        MomentumPipeline,
+    )
+
+    source = _build_resident_inbox_signal_source(settings)
+    candidates = await source.list_candidates(
+        limit=limit + 1,
+        status=status.strip(),
+        classification=classification.strip(),
+    )
+    if not candidates:
+        typer.echo("No resident signal candidates found.", err=True)
+        raise typer.Exit(1)
+
+    workspace = _resolve_workspace(settings)
+    state = await _build_resident_state(settings, workspace)
+    llm = _build_llm(settings)
+    model = settings.effective_model()
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(llm, model=model),
+        attention_worker=MomentumAttentionWorker(llm, model=model),
+        state=state,
+    ).attend(candidates, limit=limit)
+    decision = result.decision
+    typer.echo(f"attention_ref: {result.decision_ref}")
+    typer.echo(f"selected_signal_id: {decision.selected_signal_id or '-'}")
+    typer.echo(f"selected_signal_ref: {decision.selected_signal_ref or '-'}")
+    typer.echo(f"attention_tier: {decision.attention_tier}")
+    typer.echo(f"recommended_next_action: {decision.recommended_next_action}")
+    typer.echo(f"confidence: {decision.confidence}")
 
 
 def _print_momentum_result(result: Any) -> None:

--- a/src/ravn/momentum/__init__.py
+++ b/src/ravn/momentum/__init__.py
@@ -1,13 +1,20 @@
 """Momentum Packet proof pipeline."""
 
 from ravn.momentum.pipeline import (
+    MomentumAttentionResult,
     MomentumPipeline,
     MomentumPipelineResult,
     MomentumReflectionResult,
 )
-from ravn.momentum.worker import MomentumExtractionWorker, MomentumReflectionWorker
+from ravn.momentum.worker import (
+    MomentumAttentionWorker,
+    MomentumExtractionWorker,
+    MomentumReflectionWorker,
+)
 
 __all__ = [
+    "MomentumAttentionResult",
+    "MomentumAttentionWorker",
     "MomentumExtractionWorker",
     "MomentumPipeline",
     "MomentumPipelineResult",

--- a/src/ravn/momentum/models.py
+++ b/src/ravn/momentum/models.py
@@ -16,6 +16,12 @@ ArtifactKind = Literal[
 ProvenanceStatus = Literal["verified", "unverified"]
 AttentionTier = Literal["silent", "ambient", "present", "urgent"]
 NextAction = Literal["write_momentum_packet", "update_understanding_only", "ask_human"]
+AttentionNextAction = Literal[
+    "extract_selected_signal",
+    "ask_human",
+    "update_understanding_only",
+    "no_action",
+]
 DispositionOutcome = Literal["accepted", "dismissed", "wrong", "deferred", "acted"]
 MomentumTensionStatus = Literal["pending", "open", "confirmed", "changed", "resolved"]
 
@@ -240,6 +246,41 @@ class MomentumResidentState(BaseModel):
     source_refs: list[str] = Field(default_factory=list)
     compaction: dict[str, int] = Field(default_factory=dict)
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class MomentumAttentionDecisionDraft(BaseModel):
+    selected_signal_id: str | None = None
+    selected_signal_ref: str | None = None
+    no_attention_needed: bool = False
+    selected_tension_ids: list[str] = Field(default_factory=list)
+    attention_tier: AttentionTier = "ambient"
+    rationale: str = Field(min_length=1)
+    why_now: str = Field(min_length=1)
+    evidence_refs: list[str] = Field(default_factory=list)
+    signal_refs: list[str] = Field(default_factory=list)
+    recommended_next_action: AttentionNextAction
+    confidence: float = Field(ge=0, le=1)
+    source_refs: list[str] = Field(default_factory=list)
+
+    @field_validator("source_refs")
+    @classmethod
+    def _must_have_source_refs(cls, value: list[str]) -> list[str]:
+        if not value:
+            raise ValueError("attention decision must cite source refs")
+        return value
+
+
+class MomentumAttentionDecision(MomentumAttentionDecisionDraft):
+    decision_id: str = Field(min_length=1)
+    validation_status: Literal["valid"] = "valid"
+    created_at: datetime
+    current_state_ref: str | None = None
+    current_state_present: bool = False
+    candidate_count: int = Field(ge=0)
+    candidate_limit: int = Field(ge=1)
+    candidates_truncated: int = Field(ge=0)
+    procedure_name: str = Field(min_length=1)
+    model_name: str = Field(min_length=1)
 
 
 class MomentumReflectionDraft(BaseModel):

--- a/src/ravn/momentum/pipeline.py
+++ b/src/ravn/momentum/pipeline.py
@@ -13,6 +13,8 @@ from ravn.momentum.models import (
     DispositionOutcome,
     MomentumArtifact,
     MomentumArtifactDraft,
+    MomentumAttentionDecision,
+    MomentumAttentionDecisionDraft,
     MomentumExtraction,
     MomentumExtractionDraft,
     MomentumExtractionRun,
@@ -25,6 +27,7 @@ from ravn.momentum.models import (
 )
 from ravn.momentum.render import (
     render_artifact,
+    render_attention_decision,
     render_disposition,
     render_judgment,
     render_packet,
@@ -43,7 +46,11 @@ from ravn.momentum.state import (
     render_momentum_state,
     render_state_patch,
 )
-from ravn.momentum.worker import MomentumExtractionWorker, MomentumReflectionWorker
+from ravn.momentum.worker import (
+    MomentumAttentionWorker,
+    MomentumExtractionWorker,
+    MomentumReflectionWorker,
+)
 from ravn.ports.momentum_state_compactor import MomentumStateCompactorPort
 from ravn.resident_continuation import _slug
 from ravn.resident_inbox.models import ResidentInboxSignal
@@ -75,12 +82,19 @@ class MomentumReflectionResult:
     state_patch_ref: str
 
 
+@dataclass(frozen=True)
+class MomentumAttentionResult:
+    decision: MomentumAttentionDecision
+    decision_ref: str
+
+
 class MomentumPipeline:
     def __init__(
         self,
         *,
         worker: MomentumExtractionWorker,
         reflection_worker: MomentumReflectionWorker | None = None,
+        attention_worker: MomentumAttentionWorker | None = None,
         state: ResidentStatePort,
         state_compactor: MomentumStateCompactorPort | None = None,
         now: datetime | None = None,
@@ -88,10 +102,55 @@ class MomentumPipeline:
     ) -> None:
         self._worker = worker
         self._reflection_worker = reflection_worker
+        self._attention_worker = attention_worker
         self._state = state
         self._state_compactor = state_compactor or BoundedMomentumStateCompactor()
         self._now = now
         self._run_id = run_id
+
+    async def attend(
+        self,
+        candidates: list[tuple[str, ResidentInboxSignal]],
+        *,
+        limit: int,
+    ) -> MomentumAttentionResult:
+        if self._attention_worker is None:
+            raise ValueError("Momentum attention worker is required")
+        if limit < 1:
+            raise ValueError("candidate limit must be at least 1")
+        if not candidates:
+            raise ValueError("no resident signal candidates found")
+
+        created_at = self._now or datetime.now(UTC)
+        bounded = candidates[:limit]
+        truncated = max(0, len(candidates) - len(bounded))
+        memory = await self._state.recall(
+            "Niuu Momentum Engine attention and resident signal selection",
+            limit=5,
+        )
+        current_state, current_state_frame = await _load_current_state(self._state)
+        draft = await self._attention_worker.attend(
+            memory_frame="\n\n".join(entry.content for entry in memory),
+            current_state_frame=current_state_frame,
+            candidate_frame=_candidate_frame(bounded),
+            truncation_note=_truncation_note(len(candidates), limit, truncated),
+        )
+        decision = _materialize_attention_decision(
+            draft,
+            candidates=bounded,
+            candidate_count=len(candidates),
+            candidate_limit=limit,
+            candidates_truncated=truncated,
+            current_state_present=current_state is not None,
+            created_at=created_at,
+            procedure_name=self._attention_worker.procedure_name,
+            model_name=self._attention_worker.model,
+        )
+        ref = await self._state.write_artifact(
+            _attention_decision_ref(decision),
+            render_attention_decision(decision),
+        )
+        return MomentumAttentionResult(decision=decision, decision_ref=ref)
 
     async def extract_signal(self, signal: ResidentInboxSignal) -> MomentumPipelineResult:
         return await self._extract_text(
@@ -282,6 +341,82 @@ class MomentumPipeline:
             current_state_ref=current_state_ref,
             state_patch_ref=state_patch_ref,
         )
+
+
+def _materialize_attention_decision(
+    draft: MomentumAttentionDecisionDraft,
+    *,
+    candidates: list[tuple[str, ResidentInboxSignal]],
+    candidate_count: int,
+    candidate_limit: int,
+    candidates_truncated: int,
+    current_state_present: bool,
+    created_at: datetime,
+    procedure_name: str,
+    model_name: str,
+) -> MomentumAttentionDecision:
+    _validate_attention_decision(draft, candidates)
+    selected = draft.selected_signal_ref or draft.selected_signal_id or "none"
+    return MomentumAttentionDecision(
+        **draft.model_dump(),
+        decision_id=f"attention-{_timestamp_id(created_at)}-{_slug(selected) or 'none'}",
+        created_at=created_at,
+        current_state_ref=CURRENT_MOMENTUM_STATE_REF if current_state_present else None,
+        current_state_present=current_state_present,
+        candidate_count=candidate_count,
+        candidate_limit=candidate_limit,
+        candidates_truncated=candidates_truncated,
+        procedure_name=procedure_name,
+        model_name=model_name,
+    )
+
+
+def _validate_attention_decision(
+    draft: MomentumAttentionDecisionDraft,
+    candidates: list[tuple[str, ResidentInboxSignal]],
+) -> None:
+    candidate_refs = {ref for ref, _ in candidates}
+    candidate_ids = {signal.id for _, signal in candidates}
+    if draft.no_attention_needed:
+        if draft.selected_signal_id or draft.selected_signal_ref:
+            raise ValueError("no_attention_needed cannot select a signal")
+        return
+    if not draft.selected_signal_id and not draft.selected_signal_ref:
+        raise ValueError("attention decision must select a signal or no_attention_needed")
+    if draft.selected_signal_id and draft.selected_signal_id not in candidate_ids:
+        raise ValueError(f"selected signal id is not a candidate: {draft.selected_signal_id}")
+    if draft.selected_signal_ref and draft.selected_signal_ref not in candidate_refs:
+        raise ValueError(f"selected signal ref is not a candidate: {draft.selected_signal_ref}")
+
+
+def _candidate_frame(candidates: list[tuple[str, ResidentInboxSignal]]) -> str:
+    sections: list[str] = []
+    for ref, signal in candidates:
+        sections.append(
+            "### Candidate\n\n"
+            f"- ref: {ref}\n"
+            f"- id: {signal.id}\n"
+            f"- source: {signal.source}\n"
+            f"- kind: {signal.kind}\n"
+            f"- classification: {signal.classification}\n"
+            f"- status: {signal.status}\n"
+            f"- summary: {signal.summary}\n"
+            f"- evidence_refs: {', '.join(signal.evidence_refs) or '-'}\n"
+            f"- raw_ref: {signal.raw_ref or '-'}\n\n"
+            "#### Signal Markdown\n\n"
+            f"{_source_text(signal)}"
+        )
+    return "\n\n---\n\n".join(sections)
+
+
+def _truncation_note(candidate_count: int, limit: int, truncated: int) -> str:
+    if not truncated:
+        return f"{candidate_count} candidate(s) included; limit {limit}; none truncated."
+    return f"{candidate_count} candidate(s) available; limit {limit}; {truncated} truncated."
+
+
+def _attention_decision_ref(decision: MomentumAttentionDecision) -> str:
+    return f"resident/continuation/momentum/attention/{decision.decision_id}.md"
 
 
 @dataclass(frozen=True)

--- a/src/ravn/momentum/pipeline.py
+++ b/src/ravn/momentum/pipeline.py
@@ -377,7 +377,10 @@ def _validate_attention_decision(
 ) -> None:
     candidate_refs = {ref for ref, _ in candidates}
     candidate_ids = {signal.id for _, signal in candidates}
+    candidate_pairs = {(ref, signal.id) for ref, signal in candidates}
     if draft.no_attention_needed:
+        if draft.recommended_next_action != "no_action":
+            raise ValueError("no_attention_needed requires no_action")
         if draft.selected_signal_id or draft.selected_signal_ref:
             raise ValueError("no_attention_needed cannot select a signal")
         return
@@ -387,6 +390,12 @@ def _validate_attention_decision(
         raise ValueError(f"selected signal id is not a candidate: {draft.selected_signal_id}")
     if draft.selected_signal_ref and draft.selected_signal_ref not in candidate_refs:
         raise ValueError(f"selected signal ref is not a candidate: {draft.selected_signal_ref}")
+    if (
+        draft.selected_signal_id
+        and draft.selected_signal_ref
+        and (draft.selected_signal_ref, draft.selected_signal_id) not in candidate_pairs
+    ):
+        raise ValueError("selected signal id/ref do not refer to the same candidate")
 
 
 def _candidate_frame(candidates: list[tuple[str, ResidentInboxSignal]]) -> str:

--- a/src/ravn/momentum/render.py
+++ b/src/ravn/momentum/render.py
@@ -11,6 +11,7 @@ from ravn.domain.valkyrie_contracts import (
 )
 from ravn.momentum.models import (
     MomentumArtifact,
+    MomentumAttentionDecision,
     MomentumExtractionRun,
     MomentumJudgment,
     MomentumJudgmentDisposition,
@@ -155,6 +156,42 @@ def render_disposition(disposition: MomentumJudgmentDisposition) -> str:
         f"- created_at: {disposition.created_at.isoformat()}\n\n"
         "## Note\n\n"
         f"{disposition.note}\n"
+    )
+
+
+def render_attention_decision(decision: MomentumAttentionDecision) -> str:
+    selected = decision.selected_signal_ref or decision.selected_signal_id or "-"
+    return (
+        f"# Momentum Attention Decision {decision.decision_id}\n\n"
+        f"- decision_id: {decision.decision_id}\n"
+        f"- selected_signal_id: {decision.selected_signal_id or '-'}\n"
+        f"- selected_signal_ref: {decision.selected_signal_ref or '-'}\n"
+        f"- no_attention_needed: {str(decision.no_attention_needed).lower()}\n"
+        f"- selected: {selected}\n"
+        f"- validation_status: {decision.validation_status}\n"
+        f"- attention_tier: {decision.attention_tier}\n"
+        f"- recommended_next_action: {decision.recommended_next_action}\n"
+        f"- confidence: {decision.confidence}\n"
+        f"- current_state_ref: {decision.current_state_ref or '-'}\n"
+        f"- current_state_present: {str(decision.current_state_present).lower()}\n"
+        f"- candidate_count: {decision.candidate_count}\n"
+        f"- candidate_limit: {decision.candidate_limit}\n"
+        f"- candidates_truncated: {decision.candidates_truncated}\n"
+        f"- procedure: {decision.procedure_name}\n"
+        f"- model: {decision.model_name}\n"
+        f"- created_at: {decision.created_at.isoformat()}\n\n"
+        "## Rationale\n\n"
+        f"{decision.rationale}\n\n"
+        "## Why Attention Now\n\n"
+        f"{decision.why_now}\n\n"
+        "## Selected Tensions\n\n"
+        f"{_bullets_text(decision.selected_tension_ids)}\n\n"
+        "## Evidence Refs\n\n"
+        f"{_bullets_text(decision.evidence_refs)}\n\n"
+        "## Signal Refs\n\n"
+        f"{_bullets_text(decision.signal_refs)}\n\n"
+        "## Source Refs\n\n"
+        f"{_bullets_text(decision.source_refs)}\n"
     )
 
 

--- a/src/ravn/momentum/worker.py
+++ b/src/ravn/momentum/worker.py
@@ -6,6 +6,7 @@ import json
 import re
 
 from ravn.momentum.models import (
+    MomentumAttentionDecisionDraft,
     MomentumExtractionDraft,
     MomentumJudgmentDisposition,
     MomentumReflectionDraft,
@@ -14,6 +15,7 @@ from ravn.ports.llm import LLMPort
 
 PROCEDURE_NAME = "ravn.momentum.extract.v1"
 REFLECTION_PROCEDURE_NAME = "ravn.momentum.reflect.v1"
+ATTENTION_PROCEDURE_NAME = "ravn.momentum.attend.v1"
 
 SYSTEM_PROMPT = """You extract the living shape of an idea into typed artifacts.
 
@@ -222,6 +224,81 @@ class MomentumReflectionWorker:
         return MomentumReflectionDraft.model_validate_json(_json_payload(response.content))
 
 
+ATTENTION_SYSTEM_PROMPT = """You select Momentum attention from current resident state
+and candidate signals.
+
+Return only JSON matching this shape:
+{
+  "selected_signal_id": "signal id or null",
+  "selected_signal_ref": "signal ref or null",
+  "no_attention_needed": false,
+  "selected_tension_ids": ["current-state tension id"],
+  "attention_tier": "silent|ambient|present|urgent",
+  "rationale": "...",
+  "why_now": "...",
+  "evidence_refs": ["candidate signal ref/id or current-state ref"],
+  "signal_refs": ["candidate signal ref/id"],
+  "recommended_next_action": "extract_selected_signal",
+  "confidence": 0.82,
+  "source_refs": ["candidate signal ref/id or current-state ref"]
+}
+
+Select based on current Momentum state and open tensions, not simply newest,
+loudest, or most detailed. If nothing deserves attention now, set
+no_attention_needed true, selected_signal_id/ref null, recommended_next_action
+no_action, and explain why.
+
+Allowed recommended_next_action values: extract_selected_signal, ask_human,
+update_understanding_only, no_action.
+"""
+
+
+class MomentumAttentionWorker:
+    """Typed attention selection over current state and candidate signals."""
+
+    def __init__(
+        self,
+        llm: LLMPort,
+        *,
+        model: str,
+        procedure_name: str = ATTENTION_PROCEDURE_NAME,
+        max_tokens: int = 3000,
+    ) -> None:
+        self._llm = llm
+        self.model = model
+        self.procedure_name = procedure_name
+        self._max_tokens = max_tokens
+
+    async def attend(
+        self,
+        *,
+        memory_frame: str,
+        current_state_frame: str,
+        candidate_frame: str,
+        truncation_note: str,
+    ) -> MomentumAttentionDecisionDraft:
+        response = await self._llm.generate(
+            [
+                {
+                    "role": "user",
+                    "content": _attention_input_frame(
+                        memory_frame=memory_frame,
+                        current_state_frame=current_state_frame,
+                        candidate_frame=candidate_frame,
+                        truncation_note=truncation_note,
+                    ),
+                }
+            ],
+            tools=[],
+            system=ATTENTION_SYSTEM_PROMPT,
+            model=self.model,
+            max_tokens=self._max_tokens,
+        )
+        return MomentumAttentionDecisionDraft.model_validate_json(
+            _json_payload(response.content)
+        )
+
+
 def _input_frame(markdown: str, *, memory_frame: str, current_state_frame: str) -> str:
     return (
         "## Existing resident memory frame\n\n"
@@ -230,6 +307,25 @@ def _input_frame(markdown: str, *, memory_frame: str, current_state_frame: str) 
         f"{current_state_frame or '(none)'}\n\n"
         "## Resident signal markdown\n\n"
         f"{markdown}"
+    )
+
+
+def _attention_input_frame(
+    *,
+    memory_frame: str,
+    current_state_frame: str,
+    candidate_frame: str,
+    truncation_note: str,
+) -> str:
+    return (
+        "## Existing resident memory frame\n\n"
+        f"{memory_frame or '(none)'}\n\n"
+        "## Current Momentum state\n\n"
+        f"{current_state_frame or '(none)'}\n\n"
+        "## Candidate resident signals\n\n"
+        f"{candidate_frame or '(none)'}\n\n"
+        "## Candidate frame bounds\n\n"
+        f"{truncation_note or 'No candidate truncation.'}"
     )
 
 

--- a/src/ravn/ports/resident_signal.py
+++ b/src/ravn/ports/resident_signal.py
@@ -11,3 +11,15 @@ class ResidentSignalSourcePort(Protocol):
     """Loads canonical resident signal envelopes from one concrete source."""
 
     async def load_signal(self, ref_or_id: str) -> ResidentInboxSignal: ...
+
+
+class ResidentSignalCandidateSourcePort(Protocol):
+    """Lists normalized resident signals for attention consideration."""
+
+    async def list_candidates(
+        self,
+        *,
+        limit: int,
+        status: str = "",
+        classification: str = "",
+    ) -> list[tuple[str, ResidentInboxSignal]]: ...

--- a/tests/test_ravn/fixtures/momentum_attention_current_state.md
+++ b/tests/test_ravn/fixtures/momentum_attention_current_state.md
@@ -1,0 +1,84 @@
+# Current Momentum Resident State
+
+- updated_at: 2026-06-28T10:00:00+00:00
+
+## Current Beliefs
+
+- Reflected Momentum state should guide the next signal selected for extraction.
+
+## Constraints
+
+- Attention selection must prefer signals that address current open tensions.
+
+## Corrections
+
+- none
+
+## Open Tensions
+
+- Carry reflected state into attention selection
+  - id: tension-carry-reflected-state-into-attention
+  - status: open
+  - summary: Prove the next selected resident signal is chosen because it addresses current Momentum state, not because an operator manually picked it.
+  - evidence_refs: resident/continuation/momentum/runs/proof/reflections/reflection-proof.md
+  - source_refs: resident/continuation/momentum/state/patches/patch-proof.md
+
+## Stale Assumptions Or Unknowns
+
+- none
+
+## Recent Lessons
+
+- Current-state handoff is only useful if future attention can see and apply it.
+
+## Candidate Reflexes (candidate-only)
+
+- none
+
+## Candidate Capability Gaps (candidate-only)
+
+- none
+
+## Source Refs
+
+- resident/continuation/momentum/state/patches/patch-proof.md
+
+## State Data
+
+```json
+{
+  "beliefs": [
+    "Reflected Momentum state should guide the next signal selected for extraction."
+  ],
+  "constraints": [
+    "Attention selection must prefer signals that address current open tensions."
+  ],
+  "corrections": [],
+  "open_tensions": [
+    {
+      "tension_id": "tension-carry-reflected-state-into-attention",
+      "title": "Carry reflected state into attention selection",
+      "summary": "Prove the next selected resident signal is chosen because it addresses current Momentum state, not because an operator manually picked it.",
+      "status": "open",
+      "evidence_refs": [
+        "resident/continuation/momentum/runs/proof/reflections/reflection-proof.md"
+      ],
+      "source_refs": [
+        "resident/continuation/momentum/state/patches/patch-proof.md"
+      ],
+      "updated_at": "2026-06-28T10:00:00Z"
+    }
+  ],
+  "stale_assumptions": [],
+  "recent_lessons": [
+    "Current-state handoff is only useful if future attention can see and apply it."
+  ],
+  "candidate_reflexes": [],
+  "candidate_capability_gaps": [],
+  "source_refs": [
+    "resident/continuation/momentum/state/patches/patch-proof.md"
+  ],
+  "compaction": {},
+  "updated_at": "2026-06-28T10:00:00Z"
+}
+```

--- a/tests/test_ravn/fixtures/momentum_attention_signal_distractor.md
+++ b/tests/test_ravn/fixtures/momentum_attention_signal_distractor.md
@@ -1,0 +1,44 @@
+# Resident Inbox Signal: Unrelated shell preference reminder
+
+- id: sig-attention-distractor
+- source: proof:fixture
+- kind: operator.directed_message
+- classification: preference
+- confidence: 0.70
+- status: new
+- target_objective_id: 
+- observed_at: 2026-06-28T10:04:00Z
+- created_at: 2026-06-28T10:04:00+00:00
+- processed_at: 
+
+## Summary
+
+Unrelated shell preference reminder.
+
+## Reason
+
+Fixture distractor for NIU-1077 attention proof.
+
+<resident-inbox-signal-json>
+{
+  "classification": "preference",
+  "confidence": 0.7,
+  "created_at": "2026-06-28T10:04:00+00:00",
+  "evidence_refs": [
+    "proof:distractor"
+  ],
+  "id": "sig-attention-distractor",
+  "kind": "operator.directed_message",
+  "observed_at": "2026-06-28T10:04:00Z",
+  "payload": {
+    "content": "# Preference Note\n\nWhen editing shell snippets later, prefer concise zsh examples. This does not address the Momentum current-state attention tension."
+  },
+  "processed_at": "",
+  "raw_ref": "proof:signal:distractor",
+  "reason": "Fixture distractor for NIU-1077 attention proof.",
+  "source": "proof:fixture",
+  "status": "new",
+  "summary": "Unrelated shell preference reminder.",
+  "target_objective_id": ""
+}
+</resident-inbox-signal-json>

--- a/tests/test_ravn/fixtures/momentum_attention_signal_relevant.md
+++ b/tests/test_ravn/fixtures/momentum_attention_signal_relevant.md
@@ -1,0 +1,44 @@
+# Resident Inbox Signal: Follow-up proves current Momentum state steers attention
+
+- id: sig-attention-current-state-relevant
+- source: proof:fixture
+- kind: operator.directed_message
+- classification: idea
+- confidence: 0.90
+- status: new
+- target_objective_id: 
+- observed_at: 2026-06-28T10:05:00Z
+- created_at: 2026-06-28T10:05:00+00:00
+- processed_at: 
+
+## Summary
+
+Follow-up proves current Momentum state steers attention.
+
+## Reason
+
+Fixture for NIU-1077 attention proof.
+
+<resident-inbox-signal-json>
+{
+  "classification": "idea",
+  "confidence": 0.9,
+  "created_at": "2026-06-28T10:05:00+00:00",
+  "evidence_refs": [
+    "proof:current-state-attention"
+  ],
+  "id": "sig-attention-current-state-relevant",
+  "kind": "operator.directed_message",
+  "observed_at": "2026-06-28T10:05:00Z",
+  "payload": {
+    "content": "# Attention Proof Signal\n\nThis signal directly addresses the open Momentum tension: prove the next selected resident signal is chosen because it addresses current Momentum state, not because an operator manually picked it.\n\nExpected next step: extract this selected signal through the normal Momentum inbox path after attention selects it."
+  },
+  "processed_at": "",
+  "raw_ref": "proof:signal:current-state-attention",
+  "reason": "Fixture for NIU-1077 attention proof.",
+  "source": "proof:fixture",
+  "status": "new",
+  "summary": "Follow-up proves current Momentum state steers attention.",
+  "target_objective_id": ""
+}
+</resident-inbox-signal-json>

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -625,6 +625,40 @@ async def test_momentum_attention_without_current_state_records_absence(
 
 
 @pytest.mark.asyncio
+async def test_momentum_attention_valid_no_attention_decision_persists(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    llm = FakeLLM(
+        _attention_payload(
+            selected_id=None,
+            selected_ref=None,
+            no_attention_needed=True,
+        )
+    )
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        attention_worker=MomentumAttentionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 13, tzinfo=UTC),
+    ).attend(
+        [
+            (
+                "resident/inbox/signals/sig-quiet.md",
+                _candidate("sig-quiet", "Routine status", "Nothing changed."),
+            )
+        ],
+        limit=5,
+    )
+
+    artifact = await state.read_artifact(result.decision_ref)
+    assert result.decision.no_attention_needed is True
+    assert result.decision.recommended_next_action == "no_action"
+    assert "recommended_next_action: no_action" in artifact.content
+
+
+@pytest.mark.asyncio
 async def test_momentum_attention_rejects_unknown_selected_signal(tmp_path: Path) -> None:
     state = LocalResidentState(tmp_path / "state")
     payload = _attention_payload(
@@ -642,6 +676,67 @@ async def test_momentum_attention_rejects_unknown_selected_signal(tmp_path: Path
                 (
                     "resident/inbox/signals/sig-known.md",
                     _candidate("sig-known", "Known signal", "Known content."),
+                )
+            ],
+            limit=5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_momentum_attention_rejects_mismatched_selected_id_ref(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    payload = _attention_payload(
+        selected_id="sig-one",
+        selected_ref="resident/inbox/signals/sig-two.md",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="selected signal id/ref do not refer to the same candidate",
+    ):
+        await MomentumPipeline(
+            worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+            attention_worker=MomentumAttentionWorker(FakeLLM(payload), model="fake-model"),
+            state=state,
+        ).attend(
+            [
+                (
+                    "resident/inbox/signals/sig-one.md",
+                    _candidate("sig-one", "First signal", "First content."),
+                ),
+                (
+                    "resident/inbox/signals/sig-two.md",
+                    _candidate("sig-two", "Second signal", "Second content."),
+                ),
+            ],
+            limit=5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_momentum_attention_rejects_no_attention_with_extract_action(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    payload = _attention_payload(
+        selected_id=None,
+        selected_ref=None,
+        no_attention_needed=True,
+    )
+    payload["recommended_next_action"] = "extract_selected_signal"
+
+    with pytest.raises(ValueError, match="no_attention_needed requires no_action"):
+        await MomentumPipeline(
+            worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+            attention_worker=MomentumAttentionWorker(FakeLLM(payload), model="fake-model"),
+            state=state,
+        ).attend(
+            [
+                (
+                    "resident/inbox/signals/sig-quiet.md",
+                    _candidate("sig-quiet", "Routine status", "Nothing changed."),
                 )
             ],
             limit=5,
@@ -678,6 +773,41 @@ async def test_momentum_attention_records_candidate_truncation(tmp_path: Path) -
     assert result.decision.candidates_truncated == 1
     artifact = await state.read_artifact(result.decision_ref)
     assert "candidates_truncated: 1" in artifact.content
+
+
+@pytest.mark.asyncio
+async def test_momentum_attention_valid_selected_signal_decision_persists(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        attention_worker=MomentumAttentionWorker(
+            FakeLLM(
+                _attention_payload(
+                    selected_id="sig-relevant",
+                    selected_ref="resident/inbox/signals/sig-relevant.md",
+                )
+            ),
+            model="fake-model",
+        ),
+        state=state,
+        now=datetime(2026, 6, 27, 13, tzinfo=UTC),
+    ).attend(
+        [
+            (
+                "resident/inbox/signals/sig-relevant.md",
+                _candidate("sig-relevant", "Relevant signal", "Relevant content."),
+            )
+        ],
+        limit=5,
+    )
+
+    artifact = await state.read_artifact(result.decision_ref)
+    assert result.decision.selected_signal_id == "sig-relevant"
+    assert result.decision.selected_signal_ref == "resident/inbox/signals/sig-relevant.md"
+    assert "selected_signal_id: sig-relevant" in artifact.content
 
 
 @pytest.mark.asyncio

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -23,7 +23,12 @@ from ravn.domain.valkyrie_contracts import (
     VALKYRIE_JUDGMENT_PROPOSED,
     validate_valkyrie_outcome,
 )
-from ravn.momentum import MomentumExtractionWorker, MomentumPipeline, MomentumReflectionWorker
+from ravn.momentum import (
+    MomentumAttentionWorker,
+    MomentumExtractionWorker,
+    MomentumPipeline,
+    MomentumReflectionWorker,
+)
 from ravn.momentum.models import MomentumStatePatch, MomentumStateTension
 from ravn.momentum.render import judgment_event_payload
 from ravn.momentum.state import (
@@ -95,8 +100,80 @@ class RecordingStateCompactor:
         )
 
 
+class StaticCandidateSource:
+    def __init__(self, candidates: list[tuple[str, ResidentInboxSignal]]) -> None:
+        self.candidates = candidates
+        self.calls: list[dict] = []
+
+    async def list_candidates(
+        self,
+        *,
+        limit: int,
+        status: str = "",
+        classification: str = "",
+    ) -> list[tuple[str, ResidentInboxSignal]]:
+        self.calls.append(
+            {"limit": limit, "status": status, "classification": classification}
+        )
+        items = [
+            item
+            for item in self.candidates
+            if (not status or item[1].status == status)
+            and (not classification or item[1].classification == classification)
+        ]
+        return items[:limit]
+
+
 async def _markdown_signal(path: Path) -> ResidentInboxSignal:
     return await MarkdownResidentSignalSource().load_signal(str(path))
+
+
+def _candidate(signal_id: str, summary: str, content: str) -> ResidentInboxSignal:
+    return ResidentInboxSignal(
+        id=signal_id,
+        source="test:resident",
+        kind="operator.directed_message",
+        summary=summary,
+        payload={"content": content},
+        raw_ref=f"resident/inbox/signals/{signal_id}.md",
+        classification=ResidentInboxClassification.IDEA.value,
+        evidence_refs=(f"evidence:{signal_id}",),
+        created_at=datetime(2026, 6, 27, 12, tzinfo=UTC),
+    )
+
+
+def _attention_payload(
+    *,
+    selected_id: str | None = "sig-relevant",
+    selected_ref: str | None = "resident/inbox/signals/sig-relevant.md",
+    no_attention_needed: bool = False,
+) -> dict:
+    return {
+        "selected_signal_id": selected_id,
+        "selected_signal_ref": selected_ref,
+        "no_attention_needed": no_attention_needed,
+        "selected_tension_ids": (
+            [] if no_attention_needed else ["tension-carry-reflected-state"]
+        ),
+        "attention_tier": "present",
+        "rationale": (
+            "The selected signal directly answers the current open tension."
+            if not no_attention_needed
+            else "No candidate matches the current resident state strongly enough."
+        ),
+        "why_now": (
+            "The current state names this tension as open and the signal supplies evidence."
+            if not no_attention_needed
+            else "The candidates do not change current Momentum understanding."
+        ),
+        "evidence_refs": ["resident/continuation/momentum/state/current.md"],
+        "signal_refs": [selected_ref or selected_id or "none"],
+        "recommended_next_action": (
+            "no_action" if no_attention_needed else "extract_selected_signal"
+        ),
+        "confidence": 0.82,
+        "source_refs": ["resident/continuation/momentum/state/current.md"],
+    }
 
 
 @pytest.mark.asyncio
@@ -134,6 +211,31 @@ async def test_mimir_resident_inbox_signal_source_loads_signal_by_id_and_ref(tmp
     assert by_id.raw_ref == ref
     assert by_ref.id == "sig-source"
     assert by_ref.raw_ref == ref
+
+
+@pytest.mark.asyncio
+async def test_mimir_resident_inbox_signal_source_lists_attention_candidates(
+    tmp_path: Path,
+) -> None:
+    mimir = MarkdownMimirAdapter(root=tmp_path / "mimir")
+    inbox = MimirResidentInbox(mimir)
+    idea = _candidate("sig-idea", "Momentum idea", "Idea content.")
+    risk = _candidate("sig-risk", "Momentum risk", "Risk content.").with_updates(
+        classification=ResidentInboxClassification.RISK.value
+    )
+    await inbox.write_signal(idea)
+    await inbox.write_signal(risk)
+
+    candidates = await MimirResidentInboxSignalSource(mimir).list_candidates(
+        limit=5,
+        status="new",
+        classification=ResidentInboxClassification.RISK.value,
+    )
+
+    assert [(ref.endswith("-sig-risk.md"), signal.id) for ref, signal in candidates] == [
+        (True, "sig-risk")
+    ]
+    assert candidates[0][0].endswith("-sig-risk.md")
 
 
 @pytest.mark.asyncio
@@ -429,6 +531,153 @@ async def test_momentum_pipeline_uses_injected_state_compactor(tmp_path: Path):
     current = await state.read_artifact(result.current_state_ref)
     assert compactor.calls == 1
     assert "compactor touched state" in current.content
+
+
+@pytest.mark.asyncio
+async def test_momentum_attention_reads_current_state_and_persists_decision(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    current = empty_momentum_state(updated_at=datetime(2026, 6, 27, 12, tzinfo=UTC))
+    current = current.model_copy(
+        update={
+            "open_tensions": [
+                MomentumStateTension(
+                    tension_id="tension-carry-reflected-state",
+                    title="Carry reflected state",
+                    summary="Future attention should prefer signals that resolve reflected state.",
+                    status="open",
+                )
+            ]
+        }
+    )
+    await state.write_artifact(CURRENT_MOMENTUM_STATE_REF, render_momentum_state(current))
+    candidates = [
+        (
+            "resident/inbox/signals/sig-distractor.md",
+            _candidate("sig-distractor", "Unrelated shell preference", "Use fish later."),
+        ),
+        (
+            "resident/inbox/signals/sig-relevant.md",
+            _candidate(
+                "sig-relevant",
+                "Evidence about reflected state handoff",
+                "The reflected Momentum state is visible in the next signal.",
+            ),
+        ),
+    ]
+    llm = FakeLLM(_attention_payload())
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        attention_worker=MomentumAttentionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 13, tzinfo=UTC),
+    ).attend(candidates, limit=5)
+
+    assert result.decision_ref.startswith("resident/continuation/momentum/attention/")
+    assert result.decision.selected_signal_id == "sig-relevant"
+    assert result.decision.current_state_present is True
+    assert "Carry reflected state" in llm.calls[0]["messages"][0]["content"]
+    assert "sig-distractor" in llm.calls[0]["messages"][0]["content"]
+    assert "sig-relevant" in llm.calls[0]["messages"][0]["content"]
+    artifact = await state.read_artifact(result.decision_ref)
+    assert "## Rationale" in artifact.content
+    assert "selected_signal_id: sig-relevant" in artifact.content
+    assert "validation_status: valid" in artifact.content
+    assert "current_state_ref: resident/continuation/momentum/state/current.md" in artifact.content
+
+
+@pytest.mark.asyncio
+async def test_momentum_attention_without_current_state_records_absence(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    llm = FakeLLM(
+        _attention_payload(
+            selected_id=None,
+            selected_ref=None,
+            no_attention_needed=True,
+        )
+    )
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        attention_worker=MomentumAttentionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 13, tzinfo=UTC),
+    ).attend(
+        [
+            (
+                "resident/inbox/signals/sig-quiet.md",
+                _candidate("sig-quiet", "Routine status", "Nothing changed."),
+            )
+        ],
+        limit=5,
+    )
+
+    assert result.decision.no_attention_needed is True
+    assert result.decision.current_state_present is False
+    assert "## Current Momentum state\n\n(none)" in llm.calls[0]["messages"][0]["content"]
+    artifact = await state.read_artifact(result.decision_ref)
+    assert "current_state_present: false" in artifact.content
+    assert "no_attention_needed: true" in artifact.content
+
+
+@pytest.mark.asyncio
+async def test_momentum_attention_rejects_unknown_selected_signal(tmp_path: Path) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    payload = _attention_payload(
+        selected_id="sig-missing",
+        selected_ref="resident/inbox/signals/sig-missing.md",
+    )
+
+    with pytest.raises(ValueError, match="selected signal id is not a candidate"):
+        await MomentumPipeline(
+            worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+            attention_worker=MomentumAttentionWorker(FakeLLM(payload), model="fake-model"),
+            state=state,
+        ).attend(
+            [
+                (
+                    "resident/inbox/signals/sig-known.md",
+                    _candidate("sig-known", "Known signal", "Known content."),
+                )
+            ],
+            limit=5,
+        )
+
+
+@pytest.mark.asyncio
+async def test_momentum_attention_records_candidate_truncation(tmp_path: Path) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    candidates = [
+        (
+            f"resident/inbox/signals/sig-{index}.md",
+            _candidate(f"sig-{index}", f"Signal {index}", f"Content {index}"),
+        )
+        for index in range(3)
+    ]
+    llm = FakeLLM(
+        _attention_payload(
+            selected_id="sig-1",
+            selected_ref="resident/inbox/signals/sig-1.md",
+        )
+    )
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        attention_worker=MomentumAttentionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 13, tzinfo=UTC),
+    ).attend(candidates, limit=2)
+
+    frame = llm.calls[0]["messages"][0]["content"]
+    assert "3 candidate(s) available; limit 2; 1 truncated." in frame
+    assert "sig-2" not in frame
+    assert result.decision.candidates_truncated == 1
+    artifact = await state.read_artifact(result.decision_ref)
+    assert "candidates_truncated: 1" in artifact.content
 
 
 @pytest.mark.asyncio
@@ -1106,6 +1355,59 @@ def test_momentum_inbox_cli_runs_pipeline(monkeypatch, tmp_path: Path):
     assert "judgment_ref:resident/momentum/runs/" in result.output
     assert "packet_ref:  resident/momentum/runs/" in result.output
     assert f"current_state_ref: {CURRENT_MOMENTUM_STATE_REF}" in result.output
+
+
+def test_momentum_attend_cli_prints_decision_without_executing(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    candidate_ref = "resident/inbox/signals/sig-relevant.md"
+    source = StaticCandidateSource(
+        [
+            (
+                candidate_ref,
+                _candidate(
+                    "sig-relevant",
+                    "Evidence about reflected state handoff",
+                    "The reflected state is visible.",
+                ),
+            )
+        ]
+    )
+    monkeypatch.setattr(commands, "_build_resident_inbox_signal_source", lambda _s: source)
+    monkeypatch.setattr(commands, "_build_llm", lambda _settings: FakeLLM(_attention_payload()))
+
+    async def _state(_settings, _workspace):
+        return state
+
+    monkeypatch.setattr(commands, "_build_resident_state", _state)
+
+    result = CliRunner().invoke(
+        commands.app,
+        ["momentum", "attend", "--limit", "1", "--status", "new"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "attention_ref: resident/continuation/momentum/attention/" in result.output
+    assert "selected_signal_id: sig-relevant" in result.output
+    assert f"selected_signal_ref: {candidate_ref}" in result.output
+    assert "attention_tier: present" in result.output
+    assert "recommended_next_action: extract_selected_signal" in result.output
+    assert "confidence: 0.82" in result.output
+    assert "run_ref:" not in result.output
+    assert source.calls == [{"limit": 2, "status": "new", "classification": ""}]
+    assert asyncio.run(state.list_refs("resident/momentum/runs")) == []
+
+
+def test_momentum_attend_cli_empty_candidates_fails(monkeypatch, tmp_path: Path) -> None:
+    source = StaticCandidateSource([])
+    monkeypatch.setattr(commands, "_build_resident_inbox_signal_source", lambda _s: source)
+
+    result = CliRunner().invoke(commands.app, ["momentum", "attend", "--limit", "1"])
+
+    assert result.exit_code == 1
+    assert "No resident signal candidates found." in result.output
 
 
 def test_momentum_reflect_cli_records_disposition_and_reflection(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary

- Adds normal `ravn momentum attend` attention selection for resident inbox candidates.
- Uses `ResidentSignalCandidateSourcePort` so Momentum core receives normalized candidates without importing inbox backends.
- Adds typed model-authored `MomentumAttentionDecision` artifacts under `resident/continuation/momentum/attention/`.
- Validates selected signal id/ref against the bounded candidate set and records candidate truncation.
- Does not execute the recommended action; attention only selects and explains.

## Rules Loaded

- `AGENTS.md`
- `CLAUDE.md`
- `.claude/rules/architecture.md`
- `.claude/rules/module-boundaries.md`
- `.claude/rules/dynamic-adapters.md`
- `.claude/rules/testing.md`
- `docs/developer/resident-signals.md`

Applied constraints: Momentum business logic imports ports/models, not concrete Mimir/GBrain/Codex/Claude backends; LLM decides semantic attention; deterministic code bounds candidates, validates shape, persists artifacts, and does not add scheduler/daemon/proof/eval/dogfood/autonomy runtime.

## Proof of Working

Adapter config used, secrets omitted:

```yaml
llm:
  model: codex-local
  provider:
    adapter: ravn.adapters.llm.command.CommandLLMAdapter
    kwargs:
      command: zsh
      timeout: 600
      args:
        - -lc
        - 'tmp=$(mktemp); codex exec --color never --skip-git-repo-check --sandbox read-only --output-last-message "$tmp" - >/dev/null; cat "$tmp"; rm -f "$tmp"'
resident_state:
  adapter: ravn.adapters.resident_state.mimir.LocalResidentState
  kwargs:
    root: /private/tmp/ravn-momentum-attention-proof/state/preferred
  fallback_adapter: ravn.adapters.resident_state.mimir.LocalResidentState
  fallback_kwargs:
    root: /private/tmp/ravn-momentum-attention-proof/state/fallback
mimir:
  enabled: true
  path: /private/tmp/ravn-momentum-attention-proof/mimir
```

Committed fixture inputs:

- `tests/test_ravn/fixtures/momentum_attention_current_state.md`
- `tests/test_ravn/fixtures/momentum_attention_signal_relevant.md`
- `tests/test_ravn/fixtures/momentum_attention_signal_distractor.md`

Exact proof setup and normal command:

```bash
rm -rf /private/tmp/ravn-momentum-attention-proof
mkdir -p /private/tmp/ravn-momentum-attention-proof/state/preferred/resident/continuation/momentum/state /private/tmp/ravn-momentum-attention-proof/state/fallback /private/tmp/ravn-momentum-attention-proof/mimir/wiki/resident/inbox/signals
cp tests/test_ravn/fixtures/momentum_attention_current_state.md /private/tmp/ravn-momentum-attention-proof/state/preferred/resident/continuation/momentum/state/current.md
cp tests/test_ravn/fixtures/momentum_attention_signal_relevant.md /private/tmp/ravn-momentum-attention-proof/mimir/wiki/resident/inbox/signals/20260628T100500Z-sig-attention-current-state-relevant.md
cp tests/test_ravn/fixtures/momentum_attention_signal_distractor.md /private/tmp/ravn-momentum-attention-proof/mimir/wiki/resident/inbox/signals/20260628T100400Z-sig-attention-distractor.md
uv run ravn momentum attend --limit 5 --config /private/tmp/ravn-momentum-attention-codex.yaml
```

Current state ref and excerpt:

- ref: `resident/continuation/momentum/state/current.md`
- open tension: `tension-carry-reflected-state-into-attention`
- excerpt: `Prove the next selected resident signal is chosen because it addresses current Momentum state, not because an operator manually picked it.`

Candidate signals:

- `resident/inbox/signals/20260628T100500Z-sig-attention-current-state-relevant.md` / `sig-attention-current-state-relevant`: Follow-up proves current Momentum state steers attention.
- `resident/inbox/signals/20260628T100400Z-sig-attention-distractor.md` / `sig-attention-distractor`: Unrelated shell preference reminder.

Command output:

```text
attention_ref: resident/continuation/momentum/attention/attention-20260628T124405Z-resident-inbox-signals-20260628t100500z-sig-attention-current-state-relevant-md.md
selected_signal_id: sig-attention-current-state-relevant
selected_signal_ref: resident/inbox/signals/20260628T100500Z-sig-attention-current-state-relevant.md
attention_tier: present
recommended_next_action: extract_selected_signal
confidence: 0.92
```

Decision artifact evidence:

- validation status: `valid`
- candidate count: `2`
- current state present: `true`
- rationale excerpt: `Selected because it directly addresses the open Momentum tension: proving attention selection is driven by current resident state rather than manual/operator choice.`
- why-now excerpt: `The current state has exactly one open tension, and this candidate is a purpose-built follow-up for resolving or demonstrating that tension through normal Momentum inbox extraction.`

No automatic execution happened. After `attend`, the proof state contained only:

- `resident/continuation/momentum/state/current.md`
- `resident/continuation/momentum/attention/attention-20260628T124405Z-resident-inbox-signals-20260628t100500z-sig-attention-current-state-relevant-md.md`

No `resident/momentum/runs/...` extraction artifacts were created.

## Validation

```bash
uv run ruff check src/ravn/momentum src/ravn/ports/resident_signal.py src/ravn/adapters/resident_signal.py src/ravn/cli/commands.py tests/test_ravn/test_momentum_pipeline.py docs/developer/resident-signals.md
uv run pytest tests/test_ravn/test_momentum_pipeline.py tests/test_ravn/test_cli_commands.py
uv run pytest tests/test_ravn/test_resident_state.py tests/test_ravn/test_command_llm_adapter.py tests/test_ravn/test_momentum_source.py
uv run ravn momentum --help
git diff --check
make test-ravn
```

Results:

- ruff: passed
- Momentum + CLI tests: `111 passed in 1.59s`
- resident state + command LLM + Momentum source tests: `19 passed in 0.11s`
- `ravn momentum --help`: includes normal `attend` command alongside `extract`, `inbox`, `reflect`
- `git diff --check`: passed
- full Ravn coverage gate: `6131 passed, 1 skipped, 1 warning in 86.59s`; `Total coverage: 85.36%`, meeting `--cov-fail-under=85`
