### PR TITLE
[codex] Tighten NIU-1077 attention boundary proof

### DIFF
--- a/docs/developer/resident-signals.md
+++ b/docs/developer/resident-signals.md
@@ -6,10 +6,12 @@ source-specific parsing stay outside `src/ravn/momentum/`.
 To add a source:
 
 1. Implement `ResidentSignalSourcePort.load_signal()`.
-2. Return a `ResidentInboxSignal` with source, kind, summary, payload,
+2. Implement `ResidentSignalCandidateSourcePort.list_candidates()` if the
+   source should feed Momentum attention selection.
+3. Return a `ResidentInboxSignal` with source, kind, summary, payload,
    classification, status, and evidence refs.
-3. Wire the adapter in CLI/main/config composition.
-4. Do not change Momentum semantic logic for the source.
+4. Wire the adapter in CLI/main/config composition.
+5. Do not change Momentum semantic logic for the source.
 
 The LLM decides meaning. Deterministic code loads signals, verifies provenance,
 and persists resident outputs.

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -42,7 +42,10 @@ from ravn.momentum.state import (
     empty_momentum_state,
     render_momentum_state,
 )
-from ravn.ports.resident_signal import ResidentSignalSourcePort
+from ravn.ports.resident_signal import (
+    ResidentSignalCandidateSourcePort,
+    ResidentSignalSourcePort,
+)
 from ravn.resident_inbox import (
     MimirResidentInbox,
     ResidentInboxClassification,
@@ -272,8 +275,14 @@ def test_momentum_package_does_not_import_concrete_signal_storage() -> None:
     forbidden = (
         "ravn.adapters.",
         "ravn.cli",
+        "Claude",
+        "Codex",
         "MimirResidentInbox",
         "GBrainResidentStateAdapter",
+        "GitHub",
+        "Skuld",
+        "Sleipnir",
+        "printer",
         "mimir.adapters",
     )
 
@@ -1493,7 +1502,7 @@ def test_momentum_attend_cli_prints_decision_without_executing(
 ) -> None:
     state = LocalResidentState(tmp_path / "state")
     candidate_ref = "resident/inbox/signals/sig-relevant.md"
-    source = StaticCandidateSource(
+    source: ResidentSignalCandidateSourcePort = StaticCandidateSource(
         [
             (
                 candidate_ref,


### PR DESCRIPTION
## Summary

- Documents the candidate-listing resident signal port used by Momentum attention.
- Tightens the Momentum core boundary test to cover the full NIU-1077 forbidden concrete implementation list.
- Annotates the CLI test's injected candidate source through `ResidentSignalCandidateSourcePort`.

## Why

PR #806 was already merged before this follow-up proof-boundary patch could attach to it. This keeps the diff small and preserves the NIU-1077 rule that Momentum core should not hardwire Mimir, GBrain, Claude, Codex, GitHub, Skuld, Sleipnir, or printer implementations.

## Validation

```bash
uv run ruff check docs/developer/resident-signals.md tests/test_ravn/test_momentum_pipeline.py
uv run pytest tests/test_ravn/test_momentum_pipeline.py::test_momentum_package_does_not_import_concrete_signal_storage tests/test_ravn/test_momentum_pipeline.py::test_momentum_attend_cli_prints_decision_without_executing
```

Results:

- ruff: passed
- focused pytest: `2 passed in 0.49s`

Full NIU-1077 validation already recorded on PR #806 and Linear NIU-1077:

- full Ravn coverage gate: `6131 passed, 1 skipped, 1 warning in 86.59s`
- coverage: `85.36%`
