### PR TITLE
[codex] Implement NIU-1078 Momentum attention pursuit

### DIFF
--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -4919,7 +4919,7 @@ def evolve_main() -> None:
 
 momentum_app = typer.Typer(
     name="momentum",
-    help="Momentum Packet proof utilities.",
+    help="Momentum Packet commands.",
     add_completion=False,
 )
 app.add_typer(momentum_app, name="momentum")
@@ -4994,6 +4994,20 @@ def momentum_attend_cmd(
     settings = Settings()
     _configure_logging(settings)
     asyncio.run(_run_momentum_attend(settings, limit, status, classification))
+
+
+@momentum_app.command("pursue")
+def momentum_pursue_cmd(
+    attention_ref: str = typer.Argument(..., help="Momentum attention decision ref."),
+    config: str = typer.Option("", "--config", "-c", help="Path to ravn config YAML."),
+) -> None:
+    """Pursue an attention decision into a linked Momentum judgment run."""
+    if config:
+        os.environ["RAVN_CONFIG"] = config
+
+    settings = Settings()
+    _configure_logging(settings)
+    asyncio.run(_run_momentum_pursue(settings, attention_ref))
 
 
 async def _run_momentum_extract(settings: Settings, path: str) -> None:
@@ -5080,6 +5094,37 @@ async def _run_momentum_attend(
     typer.echo(f"attention_tier: {decision.attention_tier}")
     typer.echo(f"recommended_next_action: {decision.recommended_next_action}")
     typer.echo(f"confidence: {decision.confidence}")
+
+
+async def _run_momentum_pursue(settings: Settings, attention_ref: str) -> None:
+    from ravn.momentum import MomentumExtractionWorker, MomentumPipeline
+
+    source = _build_resident_inbox_signal_source(settings)
+    workspace = _resolve_workspace(settings)
+    state = await _build_resident_state(settings, workspace)
+    llm = _build_llm(settings)
+    try:
+        result = await MomentumPipeline(
+            worker=MomentumExtractionWorker(llm, model=settings.effective_model()),
+            state=state,
+        ).pursue_attention(attention_ref, signal_source=source)
+    except FileNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from None
+    except ValueError as exc:
+        typer.echo(f"Cannot pursue attention decision: {exc}", err=True)
+        raise typer.Exit(1) from None
+
+    run = result.extraction.run
+    typer.echo(f"attention_ref: {run.attention_ref or attention_ref}")
+    typer.echo(f"selected_signal_id: {run.selected_signal_id or '-'}")
+    typer.echo(f"selected_signal_ref: {run.selected_signal_ref or '-'}")
+    typer.echo(f"run_ref: {result.run_ref}")
+    typer.echo(f"judgment_ref: {result.judgment_ref}")
+    typer.echo(f"packet_ref: {result.packet_ref or '-'}")
+    typer.echo(f"current_state_ref: {result.current_state_ref}")
+    typer.echo(f"state_patch_ref: {result.state_patch_ref}")
+    typer.echo(f"provenance: {_provenance_label(result.provenance_fully_verified)}")
 
 
 def _print_momentum_result(result: Any) -> None:

--- a/src/ravn/momentum/__init__.py
+++ b/src/ravn/momentum/__init__.py
@@ -1,4 +1,4 @@
-"""Momentum Packet proof pipeline."""
+"""Momentum Packet pipeline."""
 
 from ravn.momentum.pipeline import (
     MomentumAttentionResult,

--- a/src/ravn/momentum/models.py
+++ b/src/ravn/momentum/models.py
@@ -165,6 +165,10 @@ class MomentumExtractionRun(BaseModel):
     artifact_refs: list[str]
     judgment_ref: str
     packet_ref: str | None = None
+    attention_ref: str | None = None
+    attention_decision_id: str | None = None
+    selected_signal_id: str | None = None
+    selected_signal_ref: str | None = None
 
 
 class MomentumExtraction(BaseModel):
@@ -272,7 +276,7 @@ class MomentumAttentionDecisionDraft(BaseModel):
 
 class MomentumAttentionDecision(MomentumAttentionDecisionDraft):
     decision_id: str = Field(min_length=1)
-    validation_status: Literal["valid"] = "valid"
+    validation_status: Literal["valid", "invalid"] = "valid"
     created_at: datetime
     current_state_ref: str | None = None
     current_state_present: bool = False

--- a/src/ravn/momentum/pipeline.py
+++ b/src/ravn/momentum/pipeline.py
@@ -26,6 +26,7 @@ from ravn.momentum.models import (
     ResidentUnderstandingPatch,
 )
 from ravn.momentum.render import (
+    parse_attention_decision,
     render_artifact,
     render_attention_decision,
     render_disposition,
@@ -52,6 +53,7 @@ from ravn.momentum.worker import (
     MomentumReflectionWorker,
 )
 from ravn.ports.momentum_state_compactor import MomentumStateCompactorPort
+from ravn.ports.resident_signal import ResidentSignalSourcePort
 from ravn.resident_continuation import _slug
 from ravn.resident_inbox.models import ResidentInboxSignal
 from ravn.resident_inbox.serialization import render_inbox_signal
@@ -158,11 +160,45 @@ class MomentumPipeline:
             source_path=signal.raw_ref or signal.id,
         )
 
+    async def pursue_attention(
+        self,
+        attention_ref: str,
+        *,
+        signal_source: ResidentSignalSourcePort,
+    ) -> MomentumPipelineResult:
+        try:
+            entry = await self._state.read_artifact(attention_ref)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"attention decision not found: {attention_ref}") from None
+        decision = parse_attention_decision(entry.content)
+        _validate_pursuable_attention_decision(decision)
+
+        selected = decision.selected_signal_ref or decision.selected_signal_id
+        if selected is None:
+            raise ValueError("attention decision did not select a signal")
+
+        try:
+            signal = await signal_source.load_signal(selected)
+        except FileNotFoundError:
+            raise ValueError(f"selected signal not found: {selected}") from None
+        return await self._extract_text(
+            _source_text(signal),
+            source_path=signal.raw_ref or signal.id,
+            attention_ref=entry.path or attention_ref,
+            attention_decision_id=decision.decision_id,
+            selected_signal_id=decision.selected_signal_id,
+            selected_signal_ref=decision.selected_signal_ref,
+        )
+
     async def _extract_text(
         self,
         markdown: str,
         *,
         source_path: str = "<memory>",
+        attention_ref: str | None = None,
+        attention_decision_id: str | None = None,
+        selected_signal_id: str | None = None,
+        selected_signal_ref: str | None = None,
     ) -> MomentumPipelineResult:
         source_sha = hashlib.sha256(markdown.encode("utf-8")).hexdigest()
         source_doc = SourceDocument(markdown)
@@ -216,6 +252,10 @@ class MomentumPipeline:
                 "packet_ref": packet_ref,
                 "input_state_ref": CURRENT_MOMENTUM_STATE_REF if current_state_frame else None,
                 "input_state_sha256": input_state_sha,
+                "attention_ref": attention_ref,
+                "attention_decision_id": attention_decision_id,
+                "selected_signal_id": selected_signal_id,
+                "selected_signal_ref": selected_signal_ref,
             }
         )
         run_ref = await self._state.write_artifact(_run_ref(run), render_run(run))
@@ -396,6 +436,17 @@ def _validate_attention_decision(
         and (draft.selected_signal_ref, draft.selected_signal_id) not in candidate_pairs
     ):
         raise ValueError("selected signal id/ref do not refer to the same candidate")
+
+
+def _validate_pursuable_attention_decision(decision: MomentumAttentionDecision) -> None:
+    if decision.validation_status != "valid":
+        raise ValueError("attention decision is not valid")
+    if decision.no_attention_needed:
+        raise ValueError("attention decision says no attention is needed")
+    if not decision.selected_signal_id and not decision.selected_signal_ref:
+        raise ValueError("attention decision did not select a signal")
+    if decision.recommended_next_action != "extract_selected_signal":
+        raise ValueError("attention decision does not recommend extracting the selected signal")
 
 
 def _candidate_frame(candidates: list[tuple[str, ResidentInboxSignal]]) -> str:

--- a/src/ravn/momentum/render.py
+++ b/src/ravn/momentum/render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 
 from ravn.domain.valkyrie_contracts import (
     VALKYRIE_JUDGMENT_PROPOSED,
@@ -195,6 +196,33 @@ def render_attention_decision(decision: MomentumAttentionDecision) -> str:
     )
 
 
+def parse_attention_decision(content: str) -> MomentumAttentionDecision:
+    return MomentumAttentionDecision(
+        decision_id=_field(content, "decision_id"),
+        selected_signal_id=_optional_field(content, "selected_signal_id"),
+        selected_signal_ref=_optional_field(content, "selected_signal_ref"),
+        no_attention_needed=_bool_field(content, "no_attention_needed"),
+        selected_tension_ids=_section_bullets(content, "Selected Tensions"),
+        validation_status=_field(content, "validation_status"),
+        attention_tier=_field(content, "attention_tier"),
+        rationale=_section_text(content, "Rationale"),
+        why_now=_section_text(content, "Why Attention Now"),
+        evidence_refs=_section_bullets(content, "Evidence Refs"),
+        signal_refs=_section_bullets(content, "Signal Refs"),
+        recommended_next_action=_field(content, "recommended_next_action"),
+        confidence=float(_field(content, "confidence")),
+        source_refs=_section_bullets(content, "Source Refs"),
+        created_at=datetime.fromisoformat(_field(content, "created_at")),
+        current_state_ref=_optional_field(content, "current_state_ref"),
+        current_state_present=_bool_field(content, "current_state_present"),
+        candidate_count=int(_field(content, "candidate_count")),
+        candidate_limit=int(_field(content, "candidate_limit")),
+        candidates_truncated=int(_field(content, "candidates_truncated")),
+        procedure_name=_field(content, "procedure"),
+        model_name=_field(content, "model"),
+    )
+
+
 def render_reflection(reflection: MomentumReflection) -> str:
     return (
         "# Momentum Judgment Reflection\n\n"
@@ -277,10 +305,61 @@ def render_run(run: MomentumExtractionRun) -> str:
         f"- created_at: {run.created_at.isoformat()}\n"
         f"- provenance_fully_verified: {str(run.provenance_fully_verified).lower()}\n"
         f"- judgment_ref: {run.judgment_ref}\n"
-        f"- packet_ref: {run.packet_ref or '-'}\n\n"
+        f"- packet_ref: {run.packet_ref or '-'}\n"
+        f"- attention_ref: {run.attention_ref or '-'}\n"
+        f"- attention_decision_id: {run.attention_decision_id or '-'}\n"
+        f"- selected_signal_id: {run.selected_signal_id or '-'}\n"
+        f"- selected_signal_ref: {run.selected_signal_ref or '-'}\n\n"
         "## Artifact Refs\n\n"
         f"{_bullets_text(run.artifact_refs)}\n"
     )
+
+
+def _field(content: str, field: str) -> str:
+    prefix = f"- {field}:"
+    for line in content.splitlines():
+        if line.startswith(prefix):
+            return line.removeprefix(prefix).strip()
+    raise ValueError(f"attention decision missing field: {field}")
+
+
+def _optional_field(content: str, field: str) -> str | None:
+    value = _field(content, field)
+    if not value or value == "-":
+        return None
+    return value
+
+
+def _bool_field(content: str, field: str) -> bool:
+    value = _field(content, field).lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ValueError(f"attention decision field is not a boolean: {field}")
+
+
+def _section_text(content: str, title: str) -> str:
+    marker = f"## {title}"
+    if marker not in content:
+        raise ValueError(f"attention decision missing section: {title}")
+    _, tail = content.split(marker, 1)
+    body = tail.split("\n## ", 1)[0].strip()
+    if not body:
+        raise ValueError(f"attention decision section is empty: {title}")
+    return body
+
+
+def _section_bullets(content: str, title: str) -> list[str]:
+    items: list[str] = []
+    for line in _section_text(content, title).splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        item = stripped.removeprefix("- ").strip()
+        if item and item != "none":
+            items.append(item)
+    return items
 
 
 def _bullets(items: list[str]) -> list[str]:

--- a/src/ravn/momentum/render.py
+++ b/src/ravn/momentum/render.py
@@ -181,6 +181,8 @@ def render_attention_decision(decision: MomentumAttentionDecision) -> str:
         f"- procedure: {decision.procedure_name}\n"
         f"- model: {decision.model_name}\n"
         f"- created_at: {decision.created_at.isoformat()}\n\n"
+        "## Decision Data\n\n"
+        f"```json\n{decision.model_dump_json(indent=2)}\n```\n\n"
         "## Rationale\n\n"
         f"{decision.rationale}\n\n"
         "## Why Attention Now\n\n"
@@ -197,6 +199,13 @@ def render_attention_decision(decision: MomentumAttentionDecision) -> str:
 
 
 def parse_attention_decision(content: str) -> MomentumAttentionDecision:
+    payload = _json_section(content, "Decision Data")
+    if payload:
+        return MomentumAttentionDecision.model_validate_json(payload)
+    return _parse_attention_decision_markdown(content)
+
+
+def _parse_attention_decision_markdown(content: str) -> MomentumAttentionDecision:
     return MomentumAttentionDecision(
         decision_id=_field(content, "decision_id"),
         selected_signal_id=_optional_field(content, "selected_signal_id"),
@@ -221,6 +230,15 @@ def parse_attention_decision(content: str) -> MomentumAttentionDecision:
         procedure_name=_field(content, "procedure"),
         model_name=_field(content, "model"),
     )
+
+
+def _json_section(content: str, title: str) -> str:
+    body = _section_body(content, title)
+    if not body.startswith("```json"):
+        return ""
+    _, tail = body.split("\n", 1)
+    payload, _, _ = tail.partition("\n```")
+    return payload.strip()
 
 
 def render_reflection(reflection: MomentumReflection) -> str:
@@ -340,14 +358,18 @@ def _bool_field(content: str, field: str) -> bool:
 
 
 def _section_text(content: str, title: str) -> str:
-    marker = f"## {title}"
-    if marker not in content:
-        raise ValueError(f"attention decision missing section: {title}")
-    _, tail = content.split(marker, 1)
-    body = tail.split("\n## ", 1)[0].strip()
+    body = _section_body(content, title)
     if not body:
         raise ValueError(f"attention decision section is empty: {title}")
     return body
+
+
+def _section_body(content: str, title: str) -> str:
+    marker = f"## {title}"
+    if marker not in content:
+        return ""
+    _, tail = content.split(marker, 1)
+    return tail.split("\n## ", 1)[0].strip()
 
 
 def _section_bullets(content: str, title: str) -> list[str]:

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -895,6 +895,34 @@ async def test_momentum_pursues_attention_decision_into_linked_run(
 
 
 @pytest.mark.asyncio
+async def test_momentum_pursuit_parses_attention_decision_data_block(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    content = render_attention_decision(_attention_decision()).replace(
+        "- recommended_next_action: extract_selected_signal",
+        "- recommended_next_action: ask_human",
+        1,
+    )
+    attention_ref = await state.write_artifact(
+        "resident/continuation/momentum/attention/attention-test.md",
+        content,
+    )
+    signal = _candidate("sig-relevant", "Relevant signal", "Important living idea.")
+    source = StaticSignalSource([signal])
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 14, tzinfo=UTC),
+        run_id="pursue-decision-data",
+    ).pursue_attention(attention_ref, signal_source=source)
+
+    assert source.calls == ["resident/inbox/signals/sig-relevant.md"]
+    assert result.extraction.run.attention_decision_id == "attention-test"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("updates", "match"),
     [

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -29,8 +29,12 @@ from ravn.momentum import (
     MomentumPipeline,
     MomentumReflectionWorker,
 )
-from ravn.momentum.models import MomentumStatePatch, MomentumStateTension
-from ravn.momentum.render import judgment_event_payload
+from ravn.momentum.models import (
+    MomentumAttentionDecision,
+    MomentumStatePatch,
+    MomentumStateTension,
+)
+from ravn.momentum.render import judgment_event_payload, render_attention_decision
 from ravn.momentum.state import (
     CURRENT_MOMENTUM_STATE_REF,
     MAX_BELIEFS,
@@ -127,6 +131,19 @@ class StaticCandidateSource:
         return items[:limit]
 
 
+class StaticSignalSource:
+    def __init__(self, signals: list[ResidentInboxSignal]) -> None:
+        self.signals = signals
+        self.calls: list[str] = []
+
+    async def load_signal(self, ref_or_id: str) -> ResidentInboxSignal:
+        self.calls.append(ref_or_id)
+        for signal in self.signals:
+            if ref_or_id in {signal.id, signal.raw_ref}:
+                return signal
+        raise FileNotFoundError(ref_or_id)
+
+
 async def _markdown_signal(path: Path) -> ResidentInboxSignal:
     return await MarkdownResidentSignalSource().load_signal(str(path))
 
@@ -177,6 +194,24 @@ def _attention_payload(
         "confidence": 0.82,
         "source_refs": ["resident/continuation/momentum/state/current.md"],
     }
+
+
+def _attention_decision(**updates) -> MomentumAttentionDecision:
+    payload = _attention_payload()
+    payload.update({k: v for k, v in updates.items() if k != "validation_status"})
+    return MomentumAttentionDecision(
+        **payload,
+        decision_id="attention-test",
+        validation_status=updates.get("validation_status", "valid"),
+        created_at=datetime(2026, 6, 27, 13, tzinfo=UTC),
+        current_state_ref=CURRENT_MOMENTUM_STATE_REF,
+        current_state_present=True,
+        candidate_count=1,
+        candidate_limit=1,
+        candidates_truncated=0,
+        procedure_name="momentum_attention_v1",
+        model_name="fake-model",
+    )
 
 
 @pytest.mark.asyncio
@@ -817,6 +852,118 @@ async def test_momentum_attention_valid_selected_signal_decision_persists(
     assert result.decision.selected_signal_id == "sig-relevant"
     assert result.decision.selected_signal_ref == "resident/inbox/signals/sig-relevant.md"
     assert "selected_signal_id: sig-relevant" in artifact.content
+
+
+@pytest.mark.asyncio
+async def test_momentum_pursues_attention_decision_into_linked_run(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    attention_ref = await state.write_artifact(
+        "resident/continuation/momentum/attention/attention-test.md",
+        render_attention_decision(_attention_decision()),
+    )
+    attention_before = (await state.read_artifact(attention_ref)).content
+    signal = _candidate("sig-relevant", "Relevant signal", "Important living idea.")
+    source = StaticSignalSource([signal])
+
+    result = await MomentumPipeline(
+        worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 14, tzinfo=UTC),
+        run_id="pursue-linked",
+    ).pursue_attention(attention_ref, signal_source=source)
+
+    run = result.extraction.run
+    assert source.calls == ["resident/inbox/signals/sig-relevant.md"]
+    assert run.attention_ref == attention_ref
+    assert run.attention_decision_id == "attention-test"
+    assert run.selected_signal_id == "sig-relevant"
+    assert run.selected_signal_ref == "resident/inbox/signals/sig-relevant.md"
+    assert result.provenance_fully_verified is True
+
+    run_content = (await state.read_artifact(result.run_ref)).content
+    assert f"attention_ref: {attention_ref}" in run_content
+    assert "attention_decision_id: attention-test" in run_content
+    assert "selected_signal_id: sig-relevant" in run_content
+    assert "selected_signal_ref: resident/inbox/signals/sig-relevant.md" in run_content
+    assert (await state.read_artifact(attention_ref)).content == attention_before
+
+    refs = await state.list_refs()
+    assert not any("/reflections/" in ref for ref in refs)
+    assert not any("delegation" in ref or "execution" in ref for ref in refs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("updates", "match"),
+    [
+        (
+            {
+                "selected_signal_id": None,
+                "selected_signal_ref": None,
+                "no_attention_needed": True,
+                "recommended_next_action": "no_action",
+                "selected_tension_ids": [],
+                "signal_refs": ["none"],
+            },
+            "no attention is needed",
+        ),
+        (
+            {"recommended_next_action": "ask_human"},
+            "does not recommend extracting",
+        ),
+        (
+            {"selected_signal_id": None, "selected_signal_ref": None},
+            "did not select a signal",
+        ),
+        (
+            {"validation_status": "invalid"},
+            "not valid",
+        ),
+    ],
+)
+async def test_momentum_rejects_non_pursuable_attention_decisions(
+    tmp_path: Path,
+    updates: dict,
+    match: str,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    attention_ref = await state.write_artifact(
+        "resident/continuation/momentum/attention/attention-test.md",
+        render_attention_decision(_attention_decision(**updates)),
+    )
+    source = StaticSignalSource([_candidate("sig-relevant", "Relevant", "content")])
+
+    with pytest.raises(ValueError, match=match):
+        await MomentumPipeline(
+            worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+            state=state,
+        ).pursue_attention(attention_ref, signal_source=source)
+
+    assert source.calls == []
+    assert await state.list_refs("resident/momentum/runs") == []
+
+
+@pytest.mark.asyncio
+async def test_momentum_pursuit_missing_selected_signal_creates_no_run(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    attention_ref = await state.write_artifact(
+        "resident/continuation/momentum/attention/attention-test.md",
+        render_attention_decision(_attention_decision()),
+    )
+    source = StaticSignalSource([])
+
+    with pytest.raises(ValueError, match="selected signal not found"):
+        await MomentumPipeline(
+            worker=MomentumExtractionWorker(FakeLLM(_payload()), model="fake-model"),
+            state=state,
+        ).pursue_attention(attention_ref, signal_source=source)
+
+    assert source.calls == ["resident/inbox/signals/sig-relevant.md"]
+    assert await state.list_refs("resident/momentum/runs") == []
 
 
 @pytest.mark.asyncio
@@ -1547,6 +1694,108 @@ def test_momentum_attend_cli_empty_candidates_fails(monkeypatch, tmp_path: Path)
 
     assert result.exit_code == 1
     assert "No resident signal candidates found." in result.output
+
+
+def test_momentum_pursue_cli_prints_linked_run(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    attention_ref = asyncio.run(
+        state.write_artifact(
+            "resident/continuation/momentum/attention/attention-test.md",
+            render_attention_decision(_attention_decision()),
+        )
+    )
+    source = StaticSignalSource(
+        [_candidate("sig-relevant", "Relevant signal", "Important living idea.")]
+    )
+    monkeypatch.setattr(commands, "_build_resident_inbox_signal_source", lambda _s: source)
+    monkeypatch.setattr(commands, "_build_llm", lambda _settings: FakeLLM(_payload()))
+
+    async def _state(_settings, _workspace):
+        return state
+
+    monkeypatch.setattr(commands, "_build_resident_state", _state)
+
+    result = CliRunner().invoke(commands.app, ["momentum", "pursue", attention_ref])
+
+    assert result.exit_code == 0, result.output
+    assert f"attention_ref: {attention_ref}" in result.output
+    assert "selected_signal_id: sig-relevant" in result.output
+    assert "selected_signal_ref: resident/inbox/signals/sig-relevant.md" in result.output
+    assert "run_ref: resident/momentum/runs/" in result.output
+    assert "judgment_ref: resident/momentum/runs/" in result.output
+    assert "packet_ref: resident/momentum/runs/" in result.output
+    assert f"current_state_ref: {CURRENT_MOMENTUM_STATE_REF}" in result.output
+    assert "state_patch_ref: resident/continuation/momentum/state/patches/" in result.output
+    assert "provenance: verified" in result.output
+    assert source.calls == ["resident/inbox/signals/sig-relevant.md"]
+
+
+def test_momentum_pursue_cli_invalid_attention_ref_fails(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    monkeypatch.setattr(
+        commands,
+        "_build_resident_inbox_signal_source",
+        lambda _s: StaticSignalSource([]),
+    )
+    monkeypatch.setattr(commands, "_build_llm", lambda _settings: FakeLLM(_payload()))
+
+    async def _state(_settings, _workspace):
+        return state
+
+    monkeypatch.setattr(commands, "_build_resident_state", _state)
+
+    result = CliRunner().invoke(
+        commands.app,
+        ["momentum", "pursue", "resident/continuation/momentum/attention/missing.md"],
+    )
+
+    assert result.exit_code == 1
+    assert "attention decision not found" in result.output
+
+
+def test_momentum_pursue_cli_non_pursuable_decision_fails(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    attention_ref = asyncio.run(
+        state.write_artifact(
+            "resident/continuation/momentum/attention/attention-test.md",
+            render_attention_decision(
+                _attention_decision(
+                    selected_signal_id=None,
+                    selected_signal_ref=None,
+                    no_attention_needed=True,
+                    recommended_next_action="no_action",
+                    selected_tension_ids=[],
+                    signal_refs=["none"],
+                )
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        commands,
+        "_build_resident_inbox_signal_source",
+        lambda _s: StaticSignalSource([]),
+    )
+    monkeypatch.setattr(commands, "_build_llm", lambda _settings: FakeLLM(_payload()))
+
+    async def _state(_settings, _workspace):
+        return state
+
+    monkeypatch.setattr(commands, "_build_resident_state", _state)
+
+    result = CliRunner().invoke(commands.app, ["momentum", "pursue", attention_ref])
+
+    assert result.exit_code == 1
+    assert "Cannot pursue attention decision: attention decision says no attention" in result.output
+    assert asyncio.run(state.list_refs("resident/momentum/runs")) == []
 
 
 def test_momentum_reflect_cli_records_disposition_and_reflection(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary

Implements NIU-1078 as a normal Momentum bridge from a persisted attention decision into the existing extraction/judgment path.

- Adds `ravn momentum pursue <attention-ref>`.
- Persists attention decisions with both human-readable Markdown and a structured `## Decision Data` JSON block containing the full typed `MomentumAttentionDecision`.
- Parses `Decision Data` first, with the old Markdown parser kept as a fallback for older artifacts.
- Validates that decisions are pursuable before loading the selected signal or creating extraction artifacts.
- Loads selected signals through `ResidentSignalSourcePort`, runs existing Momentum extraction, and records attention linkage on `MomentumExtractionRun`.

No scheduler, daemon, loop, registry, manager, proof command, execution path, delegation path, or fake autonomy was added.

## Proof of Working

Instruction/rule files loaded before code changes:

- `AGENTS.md`
- `CLAUDE.md`
- `.claude/rules/architecture.md`
- `.claude/rules/module-boundaries.md`
- `.claude/rules/dynamic-adapters.md`
- `.claude/rules/testing.md`
- `.claude/rules/code-style.md`
- `docs/developer/resident-signals.md`

Committed fixtures used:

- `tests/test_ravn/fixtures/momentum_attention_current_state.md`
- `tests/test_ravn/fixtures/momentum_attention_signal_relevant.md`
- `tests/test_ravn/fixtures/momentum_attention_signal_distractor.md`

Temporary proof config, secrets omitted:

```yaml
llm:
  model: llama3.1:8b
  provider:
    adapter: ravn.adapters.llm.command.CommandLLMAdapter
    kwargs:
      command: /Users/jozefvaneenbergen/git/niuu/software/volundr/.venv/bin/python
      args:
        - /private/tmp/ravn-niu1078-proof/ollama-llm.py
mimir:
  enabled: true
  path: /private/tmp/ravn-niu1078-proof-verified2/mimir
resident_state:
  adapter: ravn.adapters.resident_state.mimir.LocalResidentState
  kwargs:
    root: /private/tmp/ravn-niu1078-proof-verified2/state
```

Exact commands:

```bash
ollama serve
uv run --extra dev python /private/tmp/ravn-niu1078-proof-verified2/seed.py
uv run --extra dev ravn momentum attend --config /private/tmp/ravn-niu1078-proof-verified2/ravn.yaml --limit 5 --status new
rg -n "Decision Data|recommended_next_action|selected_signal_id|validation_status" /private/tmp/ravn-niu1078-proof-verified2/state/resident/continuation/momentum/attention/attention-20260628T162928Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
shasum -a 256 /private/tmp/ravn-niu1078-proof-verified2/state/resident/continuation/momentum/attention/attention-20260628T162928Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
uv run --extra dev ravn momentum pursue --config /private/tmp/ravn-niu1078-proof-verified2/ravn.yaml resident/continuation/momentum/attention/attention-20260628T162928Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
shasum -a 256 /private/tmp/ravn-niu1078-proof-verified2/state/resident/continuation/momentum/attention/attention-20260628T162928Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
find /private/tmp/ravn-niu1078-proof-verified2/state -type f | rg 'reflection|delegation|execution|disposition|capabilit'
```

Seed output:

```text
current_state_ref: resident/continuation/momentum/state/current.md
candidate_ref: resident/inbox/signals/20260628T100500Z-current-state-attention.md
candidate_id: sig-attention-current-state-relevant
candidate_summary: Follow-up proves current Momentum state steers attention.
candidate_ref: resident/inbox/signals/20260628T100400Z-distractor.md
candidate_id: sig-attention-distractor
candidate_summary: Unrelated shell preference reminder.
```

Current-state excerpt before attend:

```text
- Carry reflected state into attention selection
  - id: tension-carry-reflected-state-into-attention
  - status: open
  - summary: Prove the next selected resident signal is chosen because it addresses current Momentum state, not because an operator manually picked it.
```

Normal `attend` output:

```text
attention_ref: resident/continuation/momentum/attention/attention-20260628T162928Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
selected_signal_id: sig-attention-current-state-relevant
selected_signal_ref: resident/inbox/signals/20260628T100500Z-current-state-attention.md
attention_tier: present
recommended_next_action: extract_selected_signal
confidence: 0.82
```

Attention decision excerpt, including structural data:

```text
- selected_signal_id: sig-attention-current-state-relevant
- validation_status: valid
- recommended_next_action: extract_selected_signal
## Decision Data
  "selected_signal_id": "sig-attention-current-state-relevant",
  "recommended_next_action": "extract_selected_signal",
  "validation_status": "valid",
```

Normal `pursue` output:

```text
attention_ref: resident/continuation/momentum/attention/attention-20260628T162928Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
selected_signal_id: sig-attention-current-state-relevant
selected_signal_ref: resident/inbox/signals/20260628T100500Z-current-state-attention.md
run_ref: resident/momentum/runs/momentum-20260628T163021Z-5f66bd5d/run.md
judgment_ref: resident/momentum/runs/momentum-20260628T163021Z-5f66bd5d/judgment/judgment-momentum-judgment.md
packet_ref: -
current_state_ref: resident/continuation/momentum/state/current.md
state_patch_ref: resident/continuation/momentum/state/patches/patch-20260628T163021Z-momentum-20260628T163021Z-5f66bd5d-extract.md
provenance: verified
```

Run excerpt showing attention linkage:

```text
- procedure: ravn.momentum.extract.v1
- model: llama3.1:8b
- provenance_fully_verified: true
- judgment_ref: resident/momentum/runs/momentum-20260628T163021Z-5f66bd5d/judgment/judgment-momentum-judgment.md
- packet_ref: -
- attention_ref: resident/continuation/momentum/attention/attention-20260628T162928Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
- attention_decision_id: attention-20260628T162928Z-resident-inbox-signals-20260628t100500z-current-state-attention-md
- selected_signal_id: sig-attention-current-state-relevant
- selected_signal_ref: resident/inbox/signals/20260628T100500Z-current-state-attention.md
```

Judgment/provenance excerpt:

```text
- extraction_run_id: momentum-20260628T163021Z-5f66bd5d
- procedure: ravn.momentum.extract.v1
- model: llama3.1:8b
- source_path: proof:signal:current-state-attention
- recommended_next_action: update_understanding_only
- provenance_status: verified
- provenance_reason: excerpt found in source document
```

Artifact provenance check:

```text
artifacts/resident-understanding...md: - provenance_status: verified
judgment/judgment-momentum-judgment.md: - provenance_status: verified
artifacts/durable_insight...md: - provenance_status: verified
```

Attention immutability check:

```text
before: 42a64f147012b371f356fe0f2583afd16799e332e8c1c90fabf8d4bcd2046566
after:  42a64f147012b371f356fe0f2583afd16799e332e8c1c90fabf8d4bcd2046566
```

No reflection/delegation/execution happened automatically. The final proof store contained only the attention artifact, current state, one state patch, one Momentum run, two artifacts, and one judgment. The negative `rg 'reflection|delegation|execution|disposition|capabilit'` check returned no matches.

## Validation

```bash
uv run --extra dev pytest -q tests/test_ravn/test_momentum_pipeline.py -k 'pursue or attention or momentum_attend_cli'
# 21 passed, 42 deselected

uv run --extra dev pytest -q tests/test_ravn/test_momentum_pipeline.py
# 63 passed

uv run ruff check src/ravn/momentum/render.py tests/test_ravn/test_momentum_pipeline.py
# All checks passed

git diff --check
# passed
```

Earlier full-suite validation on this PR branch:

```bash
make test-ravn
# 6140 passed, 1 skipped, 1 warning; coverage 85.38%
```
