### PR TITLE
[codex] Persist Momentum handoff executor traces

### DIFF
--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -5223,6 +5223,7 @@ async def _run_momentum_handoff(settings: Settings, brief_ref: str) -> None:
     typer.echo(f"source_attention_ref: {handoff.source_attention_ref or '-'}")
     typer.echo(f"source_signal_id: {handoff.source_signal_id or '-'}")
     typer.echo(f"source_signal_ref: {handoff.source_signal_ref or '-'}")
+    typer.echo(f"executor_trace_ref: {handoff.executor_trace_ref or '-'}")
     typer.echo(f"produced_refs: {', '.join(handoff.produced_refs) or '-'}")
     typer.echo(f"evidence_refs: {', '.join(handoff.evidence_refs) or '-'}")
     typer.echo(f"follow_up_recommended: {handoff.follow_up_recommended}")

--- a/src/ravn/momentum/models.py
+++ b/src/ravn/momentum/models.py
@@ -347,6 +347,7 @@ class MomentumHandoffResult(BaseModel):
     produced_refs: list[str] = Field(default_factory=list)
     errors: list[str] = Field(default_factory=list)
     follow_up_recommended: HandoffFollowUp = "none"
+    executor_trace_ref: str = ""
     started_at: datetime
     completed_at: datetime
     created_at: datetime

--- a/src/ravn/momentum/pipeline.py
+++ b/src/ravn/momentum/pipeline.py
@@ -39,6 +39,7 @@ from ravn.momentum.render import (
     render_delegation_brief,
     render_disposition,
     render_handoff_result,
+    render_handoff_turn_trace,
     render_judgment,
     render_packet,
     render_reflection,
@@ -483,6 +484,7 @@ class MomentumPipeline:
         )
         raw_output = ""
         structured_metadata: dict[str, object]
+        turn_result = None
         try:
             turn_result = await executor.run_turn(_handoff_prompt(input_frame))
             raw_output = turn_result.response
@@ -507,11 +509,13 @@ class MomentumPipeline:
             structured_metadata = {"execution_error": str(exc)}
 
         completed_at = self._now or datetime.now(UTC)
+        result_id = (
+            f"handoff-{_timestamp_id(completed_at)}-"
+            f"{_slug(brief.title) or brief.brief_id}-{uuid4().hex[:6]}"
+        )
+        trace_ref = _handoff_trace_ref(result_id) if turn_result is not None else ""
         result = MomentumHandoffResult(
-            result_id=(
-                f"handoff-{_timestamp_id(completed_at)}-"
-                f"{_slug(brief.title) or brief.brief_id}-{uuid4().hex[:6]}"
-            ),
+            result_id=result_id,
             source_brief_ref=entry.path or brief_ref,
             source_brief_id=brief.brief_id,
             source_run_ref=brief.source_run_ref,
@@ -530,6 +534,7 @@ class MomentumPipeline:
             produced_refs=parsed.produced_refs,
             errors=parsed.errors,
             follow_up_recommended=parsed.follow_up_recommended,  # type: ignore[arg-type]
+            executor_trace_ref=trace_ref,
             started_at=started_at,
             completed_at=completed_at,
             created_at=completed_at,
@@ -538,6 +543,11 @@ class MomentumPipeline:
                 **structured_metadata,
             },
         )
+        if turn_result is not None:
+            await self._state.write_artifact(
+                trace_ref,
+                render_handoff_turn_trace(result=result, turn=turn_result),
+            )
         result_ref = await self._state.write_artifact(
             _handoff_result_ref(result),
             render_handoff_result(result),
@@ -647,6 +657,10 @@ def _delegation_ref(brief: MomentumDelegationBrief) -> str:
 
 def _handoff_result_ref(result: MomentumHandoffResult) -> str:
     return f"resident/continuation/momentum/handoffs/{result.result_id}.md"
+
+
+def _handoff_trace_ref(result_id: str) -> str:
+    return f"resident/continuation/momentum/handoffs/traces/{result_id}-turn.md"
 
 
 @dataclass(frozen=True)

--- a/src/ravn/momentum/render.py
+++ b/src/ravn/momentum/render.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 
+from ravn.domain.models import TurnResult
 from ravn.domain.valkyrie_contracts import (
     VALKYRIE_JUDGMENT_PROPOSED,
     normalize_valkyrie_outcome,
@@ -275,6 +276,7 @@ def render_handoff_result(result: MomentumHandoffResult) -> str:
         f"- executor_context: {result.executor_context}\n"
         f"- status: {result.status}\n"
         f"- follow_up_recommended: {result.follow_up_recommended}\n"
+        f"- executor_trace_ref: {result.executor_trace_ref or '-'}\n"
         f"- started_at: {result.started_at.isoformat()}\n"
         f"- completed_at: {result.completed_at.isoformat()}\n"
         f"- created_at: {result.created_at.isoformat()}\n\n"
@@ -290,6 +292,45 @@ def render_handoff_result(result: MomentumHandoffResult) -> str:
         f"{_bullets_text(result.produced_refs)}\n\n"
         "## Errors\n\n"
         f"{_bullets_text(result.errors)}\n"
+    )
+
+
+def render_handoff_turn_trace(
+    *,
+    result: MomentumHandoffResult,
+    turn: TurnResult,
+) -> str:
+    usage = turn.usage
+    tool_calls = [
+        {"id": call.id, "name": call.name, "input": call.input}
+        for call in turn.tool_calls
+    ]
+    tool_results = [
+        {
+            "tool_call_id": item.tool_call_id,
+            "content": item.content,
+            "is_error": item.is_error,
+        }
+        for item in turn.tool_results
+    ]
+    return (
+        f"# Momentum Handoff Executor Trace {result.result_id}\n\n"
+        f"- result_id: {result.result_id}\n"
+        f"- source_brief_ref: {result.source_brief_ref}\n"
+        f"- executor_label: {result.executor_label}\n"
+        f"- tool_call_count: {len(tool_calls)}\n"
+        f"- tool_result_count: {len(tool_results)}\n"
+        f"- input_tokens: {usage.input_tokens}\n"
+        f"- output_tokens: {usage.output_tokens}\n"
+        f"- cache_read_tokens: {usage.cache_read_tokens}\n"
+        f"- cache_write_tokens: {usage.cache_write_tokens}\n"
+        f"- thinking_tokens: {usage.thinking_tokens}\n\n"
+        "## Tool Calls\n\n"
+        f"```json\n{json.dumps(tool_calls, indent=2)}\n```\n\n"
+        "## Tool Results\n\n"
+        f"```json\n{json.dumps(tool_results, indent=2)}\n```\n\n"
+        "## Response\n\n"
+        f"{turn.response or '-'}\n"
     )
 
 

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -23,7 +23,7 @@ from ravn.adapters.resident_state.gbrain import GBrainResidentStateAdapter
 from ravn.adapters.resident_state.mimir import LocalResidentState, MimirResidentState
 from ravn.cli import commands
 from ravn.config import MomentumExecutorConfig
-from ravn.domain.models import LLMResponse, StopReason, TokenUsage, TurnResult
+from ravn.domain.models import LLMResponse, StopReason, TokenUsage, ToolCall, ToolResult, TurnResult
 from ravn.domain.valkyrie_contracts import (
     VALKYRIE_JUDGMENT_PROPOSED,
     validate_valkyrie_outcome,
@@ -227,6 +227,32 @@ class FakeFencedExecutorAgent(FakeMomentumExecutorAgent):
             tool_calls=[],
             tool_results=[],
             usage=TokenUsage(input_tokens=1, output_tokens=1),
+        )
+
+
+class FakeTraceExecutorAgent(FakeMomentumExecutorAgent):
+    async def run_turn(self, user_input: str) -> TurnResult:
+        self.calls.append(user_input)
+        response = json.dumps(
+            {
+                "status": "completed",
+                "summary": "unit/mock executor reported an existing trace",
+                "output": "unit/mock output",
+                "evidence_refs": ["resident/evidence/unit-mock.md"],
+                "produced_refs": ["resident/produced/unit-mock.md"],
+                "errors": [],
+                "follow_up_recommended": "none",
+            }
+        )
+        return TurnResult(
+            response=response,
+            tool_calls=[
+                ToolCall(id="call-1", name="Read", input={"file_path": "state/ref.md"})
+            ],
+            tool_results=[
+                ToolResult(tool_call_id="call-1", content="read result", is_error=False)
+            ],
+            usage=TokenUsage(input_tokens=11, output_tokens=7, cache_read_tokens=3),
         )
 
 
@@ -1497,12 +1523,21 @@ async def test_momentum_handoff_unit_mock_persists_linked_result(
     assert result.result.status == "completed"
     assert result.result.produced_refs == ["resident/produced/unit-mock.md"]
     assert result.result.follow_up_recommended == "reflect"
+    assert result.result.executor_trace_ref.startswith(
+        "resident/continuation/momentum/handoffs/traces/"
+    )
     rendered = await state.read_artifact(result.result_ref)
     parsed = MomentumHandoffResult.model_validate_json(
         rendered.content.split("```json\n", 1)[1].split("\n```", 1)[0]
     )
     assert parsed.source_brief_ref == brief_ref
     assert parsed.source_signal_id == "sig-relevant"
+    assert parsed.executor_trace_ref == result.result.executor_trace_ref
+    trace = (await state.read_artifact(result.result.executor_trace_ref)).content
+    assert "- tool_call_count: 0" in trace
+    assert "- tool_result_count: 0" in trace
+    assert '"input_tokens":' not in trace
+    assert "unit/mock output" in trace
     assert "Source Judgment" in executor.calls[0]
     assert "Source Attention Decision" in executor.calls[0]
     assert "Selected Signal" in executor.calls[0]
@@ -1515,6 +1550,30 @@ async def test_momentum_handoff_unit_mock_persists_linked_result(
     assert "register capabilities" not in preamble
     assert "schedule follow-up loops" not in preamble
     assert "continue automatically" not in preamble
+
+
+@pytest.mark.asyncio
+async def test_momentum_handoff_persists_existing_executor_turn_trace(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    brief_ref, _ = await _seed_delegation_brief(state)
+
+    result = await MomentumPipeline(state=state).handoff_delegation(
+        brief_ref,
+        executor=FakeTraceExecutorAgent(),
+    )
+
+    trace = (await state.read_artifact(result.result.executor_trace_ref)).content
+    assert "- tool_call_count: 1" in trace
+    assert "- tool_result_count: 1" in trace
+    assert "- input_tokens: 11" in trace
+    assert "- output_tokens: 7" in trace
+    assert "- cache_read_tokens: 3" in trace
+    assert '"name": "Read"' in trace
+    assert '"file_path": "state/ref.md"' in trace
+    assert '"tool_call_id": "call-1"' in trace
+    assert '"content": "read result"' in trace
 
 
 @pytest.mark.asyncio
@@ -1656,11 +1715,14 @@ async def test_momentum_handoff_invalid_structured_executor_output_is_blocked(
     assert result.result.output == "free text is not a structured handoff result"
     assert result.result.produced_refs == []
     assert result.result.evidence_refs == []
+    assert result.result.executor_trace_ref
     assert result.result.errors
     assert result.result.raw_metadata["raw_output"] == (
         "free text is not a structured handoff result"
     )
     assert "parse_error" in result.result.raw_metadata
+    trace = (await state.read_artifact(result.result.executor_trace_ref)).content
+    assert "free text is not a structured handoff result" in trace
 
 
 @pytest.mark.asyncio
@@ -2738,6 +2800,7 @@ def test_momentum_handoff_cli_prints_result_status_and_linkage(
     )
     assert "source_signal_id: sig-relevant" in result.output
     assert "source_signal_ref: resident/inbox/signals/sig-relevant.md" in result.output
+    assert "executor_trace_ref: resident/continuation/momentum/handoffs/traces/" in result.output
     assert "produced_refs: resident/produced/unit-mock.md" in result.output
     assert "follow_up_recommended: reflect" in result.output
     assert source.calls == ["resident/inbox/signals/sig-relevant.md"]


### PR DESCRIPTION
## Summary

Follow-up to merged PR #811.

Momentum handoff now persists the existing executor `TurnResult` trace alongside each `MomentumHandoffResult`:

- `MomentumHandoffResult.executor_trace_ref` links to the trace artifact.
- The trace artifact records actual `tool_calls`, `tool_results`, and token usage from `ExecutionAgentPort.run_turn()`.
- `ravn momentum handoff` prints `executor_trace_ref`.
- No tool-use proof layer, tool catalog, allowlist, permission framework, provider registry, or second executor path was added.
- Empty tool traces remain empty; Momentum does not fake tool calls/results or require tool use.

## Proof Type

Real local integration proof with real local Codex and Claude executors through existing `ExecutorPort` / `CliTransportExecutor` / Skuld transports.

Proof root:

```text
/private/tmp/ravn-niu1080-trace-proof-20260629
```

Normal chain was run:

```bash
uv run python tests/test_ravn/fixtures/scripts/seed_momentum_handoff_proof.py --root "$PROOF"
RAVN_CONFIG="$PROOF/ravn.yaml" uv run ravn momentum attend --limit 2 --status new --config "$PROOF/ravn.yaml"
RAVN_CONFIG="$PROOF/ravn.yaml" uv run ravn momentum pursue "$ATT" --config "$PROOF/ravn.yaml"
RAVN_CONFIG="$PROOF/ravn.yaml" uv run ravn momentum delegate "$RUN" --config "$PROOF/ravn.yaml"
RAVN_CONFIG="$PROOF/ravn.yaml" SKULD_CODEX_SANDBOX=workspace-write CODEX_CLI_PATH=/Applications/Codex.app/Contents/Resources/codex uv run ravn momentum handoff "$BRIEF" --config "$PROOF/ravn.yaml"
RAVN_CONFIG="$PROOF/ravn-claude-persistent.yaml" uv run ravn momentum handoff "$BRIEF" --config "$PROOF/ravn-claude-persistent.yaml"
```

Generated refs:

```text
attention_ref: resident/continuation/momentum/attention/attention-20260629T034153Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
run_ref: resident/momentum/runs/momentum-20260629T034246Z-d9312f4e/run.md
judgment_ref: resident/momentum/runs/momentum-20260629T034246Z-d9312f4e/judgment/judgment-state-steered-attention-now-requires-a-bounded-executor-handoff.md
packet_ref: resident/momentum/runs/momentum-20260629T034246Z-d9312f4e/packet/packet-carry-state-steered-judgment-into-a-bounded-executor-handoff.md
brief_ref: resident/continuation/momentum/delegations/delegation-20260629T034323Z-carry-state-steered-judgment-into-a-bounded-executor-handoff-that-inspects-resid.md
```

Codex handoff:

```text
handoff_result_ref: resident/continuation/momentum/handoffs/handoff-20260629T034453Z-carry-state-steered-judgment-into-a-bounded-executor-handoff-that-inspects-resid-973c35.md
executor_label: CodexSubprocessTransport
status: completed
executor_trace_ref: resident/continuation/momentum/handoffs/traces/handoff-20260629T034453Z-carry-state-steered-judgment-into-a-bounded-executor-handoff-that-inspects-resid-973c35-turn.md
produced_refs: state/resident/continuation/momentum/handoffs/evidence/codex-executor-evidence-20260629T034323Z.md
tool_call_count: 0
tool_result_count: 0
```

Claude handoff:

```text
handoff_result_ref: resident/continuation/momentum/handoffs/handoff-20260629T034557Z-carry-state-steered-judgment-into-a-bounded-executor-handoff-that-inspects-resid-1539db.md
executor_label: PersistentSubprocessTransport
status: completed
executor_trace_ref: resident/continuation/momentum/handoffs/traces/handoff-20260629T034557Z-carry-state-steered-judgment-into-a-bounded-executor-handoff-that-inspects-resid-1539db-turn.md
produced_refs: state/resident/continuation/momentum/handoffs/evidence/claude-executor-evidence-20260629T034323Z.md
tool_call_count: 4
tool_result_count: 0
```

The Codex trace contains empty arrays because that is what the existing Codex `TurnResult` returned. The Claude trace contains the actual existing transport-reported tool calls, including Bash inspection calls and the bounded Write. Momentum did not add fake tool calls/results.

Side effects:

```text
patch_count: 1
handoff_result_count: 2
handoff_trace_count: 2
handoff_evidence_count: 2
forbidden_side_effect_dirs: no matches
```

## Validation

```text
uv run ruff check src/ravn/momentum/models.py src/ravn/momentum/render.py src/ravn/momentum/pipeline.py src/ravn/cli/commands.py tests/test_ravn/test_momentum_pipeline.py: passed
uv run pytest tests/test_ravn/test_momentum_pipeline.py -q: 93 passed
uv run pytest tests/test_ravn/test_cli_commands.py tests/test_ravn/test_executor_cli.py -q: 69 passed
uv run pytest tests/test_skuld/test_transport.py tests/test_skuld/test_persistent_subprocess.py tests/test_skuld/transports/test_sdk.py tests/test_skuld/test_codex_ws_transport.py -q: 317 passed
uv run pytest tests/test_architecture_reuse_before_build.py -q: 1 passed
uv run ravn momentum --help: passed
git diff --check: passed
make test-ravn: 6171 passed, 1 skipped, 1 warning; total coverage 85.31%
```
