### PR TITLE
[codex] Reflect Momentum handoff episodes into state

### DIFF
--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -4957,23 +4957,30 @@ def momentum_inbox_cmd(
 
 @momentum_app.command("reflect")
 def momentum_reflect_cmd(
-    target_ref: str = typer.Argument(..., help="Momentum run or judgment artifact ref."),
-    outcome: str = typer.Option(
+    target_refs: list[str] = typer.Argument(
         ...,
+        help="Momentum run, judgment, or handoff result artifact ref.",
+    ),
+    outcome: str = typer.Option(
+        "acted",
         "--outcome",
         help="Disposition: accepted, dismissed, wrong, deferred, or acted.",
     ),
-    note: str = typer.Option(..., "--note", help="What happened to this judgment."),
+    note: str = typer.Option(
+        "Reflect completed Momentum handoff episode.",
+        "--note",
+        help="What happened to this judgment or handoff episode.",
+    ),
     actor: str = typer.Option("operator", "--actor", help="Disposition actor."),
     config: str = typer.Option("", "--config", "-c", help="Path to ravn config YAML."),
 ) -> None:
-    """Record a judgment disposition and model-authored reflection."""
+    """Record model-authored Momentum reflection."""
     if config:
         os.environ["RAVN_CONFIG"] = config
 
     settings = Settings()
     _configure_logging(settings)
-    asyncio.run(_run_momentum_reflect(settings, target_ref, outcome, note, actor))
+    asyncio.run(_run_momentum_reflect(settings, target_refs, outcome, note, actor))
 
 
 @momentum_app.command("attend")
@@ -5053,7 +5060,7 @@ async def _run_momentum_inbox(settings: Settings, signal_ref_or_id: str) -> None
 
 async def _run_momentum_reflect(
     settings: Settings,
-    target_ref: str,
+    target_refs: list[str] | str,
     outcome: str,
     note: str,
     actor: str,
@@ -5073,15 +5080,73 @@ async def _run_momentum_reflect(
     state = await _build_resident_state(settings, workspace)
     llm = _build_llm(settings)
     model = settings.effective_model()
-    result = await MomentumPipeline(
+    refs = [target_refs] if isinstance(target_refs, str) else list(target_refs)
+    pipeline = MomentumPipeline(
         worker=MomentumExtractionWorker(llm, model=model),
         reflection_worker=MomentumReflectionWorker(llm, model=model),
         state=state,
-    ).reflect_judgment(target_ref, outcome=outcome, note=note, actor=actor)
+    )
+    try:
+        if _momentum_refs_are_handoffs(refs):
+            result = await pipeline.reflect_handoff_episode(
+                refs,
+                signal_source=_build_optional_resident_inbox_signal_source(settings),
+                outcome=outcome,
+                note=note,
+                actor=actor,
+            )
+        elif len(refs) == 1:
+            result = await pipeline.reflect_judgment(
+                refs[0],
+                outcome=outcome,
+                note=note,
+                actor=actor,
+            )
+        else:
+            typer.echo("Multiple reflect refs must all be handoff result refs.", err=True)
+            raise typer.Exit(1)
+    except FileNotFoundError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(1) from None
+    except ValueError as exc:
+        typer.echo(f"Cannot reflect Momentum episode: {exc}", err=True)
+        raise typer.Exit(1) from None
     typer.echo(f"disposition_ref: {result.disposition_ref}")
     typer.echo(f"reflection_ref:  {result.reflection_ref}")
     typer.echo(f"current_state_ref: {result.current_state_ref}")
     typer.echo(f"state_patch_ref:   {result.state_patch_ref}")
+    typer.echo(
+        "changed_tensions: "
+        f"{_momentum_tension_patch_summary(result.reflection.state_patch)}"
+    )
+    typer.echo(f"lesson_learned: {result.reflection.lesson_learned}")
+    typer.echo(
+        "candidate_reflexes: "
+        f"{', '.join(result.reflection.candidate_reflexes) or '-'}"
+    )
+    typer.echo(
+        "candidate_capability_gaps: "
+        f"{', '.join(result.reflection.candidate_capability_gaps) or '-'}"
+    )
+
+
+def _momentum_refs_are_handoffs(refs: list[str]) -> bool:
+    return bool(refs) and all(
+        ref.startswith("resident/continuation/momentum/handoffs/")
+        and "/traces/" not in ref
+        and "/evidence/" not in ref
+        for ref in refs
+    )
+
+
+def _momentum_tension_patch_summary(patch: Any) -> str:
+    items = [
+        *[f"changed:{item.tension_id}" for item in patch.changed_tensions],
+        *[f"resolved:{item}" for item in patch.resolved_tension_ids],
+        *[f"confirmed:{item}" for item in patch.confirmed_tension_ids],
+        *[f"opened:{item.tension_id}" for item in patch.open_tensions],
+    ]
+    return ", ".join(items) or "-"
 
 
 async def _run_momentum_attend(

--- a/src/ravn/momentum/pipeline.py
+++ b/src/ravn/momentum/pipeline.py
@@ -34,6 +34,7 @@ from ravn.momentum.models import (
 from ravn.momentum.render import (
     parse_attention_decision,
     parse_delegation_brief,
+    parse_handoff_result,
     render_artifact,
     render_attention_decision,
     render_delegation_brief,
@@ -423,6 +424,104 @@ class MomentumPipeline:
             state_patch_ref=state_patch_ref,
         )
 
+    async def reflect_handoff_episode(
+        self,
+        handoff_refs: list[str],
+        *,
+        signal_source: ResidentSignalSourcePort | None = None,
+        outcome: DispositionOutcome = "acted",
+        note: str = "Reflect completed Momentum handoff episode.",
+        actor: str = "operator",
+    ) -> MomentumReflectionResult:
+        if self._reflection_worker is None:
+            raise ValueError("Momentum reflection worker is required")
+        if not handoff_refs:
+            raise ValueError("at least one handoff result ref is required")
+
+        created_at = self._now or datetime.now(UTC)
+        context = await _load_handoff_reflection_context(
+            self._state,
+            handoff_refs,
+            signal_source,
+        )
+        base_ref = "resident/continuation/momentum/handoffs"
+        reflection_suffix = f"{_timestamp_id(created_at)}-{outcome}-{uuid4().hex[:6]}"
+        disposition = MomentumJudgmentDisposition(
+            disposition_id=f"disposition-{reflection_suffix}",
+            target_ref=", ".join(context.handoff_refs),
+            outcome=outcome,
+            actor=actor,
+            note=note,
+            created_at=created_at,
+        )
+        disposition_ref = await self._state.write_artifact(
+            f"{base_ref}/dispositions/{disposition.disposition_id}.md",
+            render_disposition(disposition),
+        )
+        memory = await self._state.recall(
+            "Niuu Momentum Engine handoff episode learning and reflections",
+            limit=5,
+        )
+        current_state, current_state_frame = await _load_current_state(self._state)
+        draft = await self._reflection_worker.reflect(
+            target_ref=disposition.target_ref,
+            target_content=context.target_content,
+            run_content=context.run_content,
+            judgment_content=context.judgment_content,
+            artifact_contents=context.artifact_contents,
+            disposition=disposition,
+            memory_frame="\n\n".join(entry.content for entry in memory),
+            current_state_frame=current_state_frame,
+            episode_context=context.episode_context,
+        )
+        reflection = MomentumReflection(
+            **draft.model_dump(),
+            reflection_id=f"reflection-{reflection_suffix}",
+            target_ref=disposition.target_ref,
+            disposition_ref=disposition_ref,
+            outcome=outcome,
+            actor=actor,
+            procedure_name=self._reflection_worker.procedure_name,
+            model_name=self._reflection_worker.model,
+            reflected_at=created_at,
+        )
+        reflection_ref = await self._state.write_artifact(
+            f"{base_ref}/reflections/{reflection.reflection_id}.md",
+            render_reflection(reflection),
+        )
+        state_patch = reflection_state_patch(
+            patch_id=f"patch-{_timestamp_id(created_at)}-{reflection.reflection_id}",
+            created_at=created_at,
+            source_refs=[
+                *context.source_refs,
+                disposition_ref,
+                reflection_ref,
+            ],
+            draft=draft.state_patch,
+            lesson_learned=reflection.lesson_learned,
+            remember_next_time=reflection.remember_next_time,
+            corrections=reflection.resident_corrections,
+            candidate_reflexes=reflection.candidate_reflexes,
+            candidate_capability_gaps=reflection.candidate_capability_gaps,
+        )
+        current_state = current_state or empty_momentum_state(updated_at=created_at)
+        updated_state = self._state_compactor.compact(
+            apply_state_patch(current_state, state_patch)
+        )
+        state_patch_ref = await _write_state_patch(self._state, state_patch)
+        current_state_ref = await self._state.write_artifact(
+            CURRENT_MOMENTUM_STATE_REF,
+            render_momentum_state(updated_state),
+        )
+        return MomentumReflectionResult(
+            disposition=disposition,
+            reflection=reflection,
+            disposition_ref=disposition_ref,
+            reflection_ref=reflection_ref,
+            current_state_ref=current_state_ref,
+            state_patch_ref=state_patch_ref,
+        )
+
     async def prepare_delegation(
         self,
         source_ref: str,
@@ -671,6 +770,17 @@ class _ReflectionContext:
 
 
 @dataclass(frozen=True)
+class _HandoffReflectionContext:
+    handoff_refs: list[str]
+    target_content: str
+    run_content: str
+    judgment_content: str
+    artifact_contents: list[str]
+    episode_context: str
+    source_refs: list[str]
+
+
+@dataclass(frozen=True)
 class _DelegationContext:
     source_ref: str
     run_ref: str | None
@@ -729,6 +839,170 @@ async def _load_reflection_context(
         judgment_content=judgment_content,
         artifact_contents=artifact_contents,
     )
+
+
+async def _load_handoff_reflection_context(
+    state: ResidentStatePort,
+    handoff_refs: list[str],
+    signal_source: ResidentSignalSourcePort | None,
+) -> _HandoffReflectionContext:
+    entries: list[ResidentMemoryEntry] = []
+    handoffs: list[MomentumHandoffResult] = []
+    for ref in handoff_refs:
+        try:
+            entry = await state.read_artifact(ref)
+        except FileNotFoundError:
+            raise FileNotFoundError(f"handoff result not found: {ref}") from None
+        result = parse_handoff_result(entry.content)
+        if result.status != "completed":
+            raise ValueError(f"handoff result is not completed: {entry.path or ref}")
+        entries.append(entry)
+        handoffs.append(result)
+
+    refs = [entry.path for entry in entries]
+    trace_sections: list[str] = []
+    brief_sections: list[str] = []
+    run_sections: list[str] = []
+    judgment_sections: list[str] = []
+    packet_sections: list[str] = []
+    attention_sections: list[str] = []
+    signal_sections: list[str] = []
+    artifact_contents: list[str] = []
+    source_refs: list[str] = []
+
+    for entry, result in zip(entries, handoffs, strict=True):
+        source_refs.append(entry.path)
+        if result.executor_trace_ref:
+            source_refs.append(result.executor_trace_ref)
+            trace_sections.append(
+                await _ref_section_or_missing(
+                    state,
+                    result.executor_trace_ref,
+                    "Executor trace unavailable",
+                )
+            )
+        else:
+            trace_sections.append("### Executor trace\n\n(missing executor_trace_ref)")
+        brief_sections.append(
+            await _ref_section_or_missing(
+                state,
+                result.source_brief_ref,
+                "Delegation brief unavailable",
+            )
+        )
+        if result.source_run_ref:
+            run_content = await _read_optional_content(state, result.source_run_ref)
+            run_sections.append(
+                _ref_section(
+                    result.source_run_ref,
+                    run_content or f"(Source run unavailable: {result.source_run_ref})",
+                )
+            )
+            packet_ref = _optional_run_field(run_content, "packet_ref")
+            if packet_ref:
+                packet_sections.append(
+                    await _ref_section_or_missing(
+                        state,
+                        packet_ref,
+                        "Source packet unavailable",
+                    )
+                )
+        if result.source_judgment_ref:
+            judgment_sections.append(
+                await _ref_section_or_missing(
+                    state,
+                    result.source_judgment_ref,
+                    "Source judgment unavailable",
+                )
+            )
+        if result.source_attention_ref:
+            attention_sections.append(
+                await _ref_section_or_missing(
+                    state,
+                    result.source_attention_ref,
+                    "Source attention decision unavailable",
+                )
+            )
+        selected_signal_ref = result.source_signal_ref or result.source_signal_id or ""
+        if selected_signal_ref:
+            signal_content = await _load_signal_for_reflection(
+                state,
+                selected_signal_ref,
+                signal_source,
+            )
+            signal_sections.append(_ref_section(selected_signal_ref, signal_content))
+        artifact_contents.extend(
+            [
+                content
+                for content in [
+                    await _ref_section_or_missing(
+                        state,
+                        ref,
+                        "Handoff evidence unavailable",
+                    )
+                    for ref in [*result.evidence_refs, *result.produced_refs]
+                ]
+                if content
+            ]
+        )
+
+    _, current_state_frame = await _load_current_state(state)
+    episode_context = (
+        "## Handoff Result Refs\n\n"
+        f"{_bullets_text(refs)}\n\n"
+        "## Executor Traces\n\n"
+        f"{_join_sections(trace_sections)}\n\n"
+        "## Delegation Briefs\n\n"
+        f"{_join_sections(brief_sections)}\n\n"
+        "## Source Attention Decisions\n\n"
+        f"{_join_sections(attention_sections)}\n\n"
+        "## Source Packets\n\n"
+        f"{_join_sections(packet_sections)}\n\n"
+        "## Selected Signals\n\n"
+        f"{_join_sections(signal_sections)}\n\n"
+        "## Current Momentum State At Reflection Time\n\n"
+        f"{current_state_frame or '(none)'}"
+    )
+    return _HandoffReflectionContext(
+        handoff_refs=refs,
+        target_content=_join_sections([entry.content for entry in entries]),
+        run_content=_join_sections(run_sections),
+        judgment_content=_join_sections(judgment_sections),
+        artifact_contents=artifact_contents,
+        episode_context=episode_context,
+        source_refs=_unique_refs(source_refs),
+    )
+
+
+async def _ref_section_or_missing(
+    state: ResidentStatePort,
+    ref: str,
+    missing_label: str,
+) -> str:
+    content = await _read_optional_content(state, ref)
+    if not content:
+        content = f"({missing_label}: {ref})"
+    return _ref_section(ref, content)
+
+
+async def _load_signal_for_reflection(
+    state: ResidentStatePort,
+    ref_or_id: str,
+    signal_source: ResidentSignalSourcePort | None,
+) -> str:
+    content = await _read_optional_content(state, ref_or_id)
+    if content:
+        return content
+    if signal_source is not None:
+        try:
+            return _source_text(await signal_source.load_signal(ref_or_id))
+        except FileNotFoundError:
+            pass
+    return f"(Selected signal unavailable: {ref_or_id})"
+
+
+def _ref_section(ref: str, content: str) -> str:
+    return f"### {ref}\n\n{content}"
 
 
 async def _load_delegation_context(
@@ -834,10 +1108,23 @@ async def _read_required_content(
 async def _read_optional_content(state: ResidentStatePort, ref: str) -> str:
     if not ref or ref == "-":
         return ""
-    try:
-        return (await state.read_artifact(ref)).content
-    except FileNotFoundError:
-        return ""
+    for candidate in _resident_ref_candidates(ref):
+        try:
+            return (await state.read_artifact(candidate)).content
+        except FileNotFoundError:
+            continue
+    return ""
+
+
+def _resident_ref_candidates(ref: str) -> list[str]:
+    candidates = [ref]
+    if ref.startswith("state/resident/"):
+        candidates.append(ref.removeprefix("state/"))
+    marker = "/state/resident/"
+    if marker in ref:
+        _, tail = ref.split(marker, 1)
+        candidates.append(f"resident/{tail}")
+    return _unique_refs(candidates)
 
 
 def _materialize_delegation_brief(
@@ -1032,6 +1319,27 @@ def _frame_section(title: str, content: str) -> list[str]:
     if not content:
         return ["", f"## {title}", "", "-"]
     return ["", f"## {title}", "", content]
+
+
+def _join_sections(contents: list[str]) -> str:
+    if not contents:
+        return "(none)"
+    return "\n\n---\n\n".join(contents)
+
+
+def _bullets_text(items: list[str]) -> str:
+    return "\n".join(f"- {item}" for item in items if item) or "- none"
+
+
+def _unique_refs(refs: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for ref in refs:
+        if not ref or ref == "-" or ref in seen:
+            continue
+        seen.add(ref)
+        result.append(ref)
+    return result
 
 
 async def _load_current_state(state: ResidentStatePort):

--- a/src/ravn/momentum/render.py
+++ b/src/ravn/momentum/render.py
@@ -295,6 +295,13 @@ def render_handoff_result(result: MomentumHandoffResult) -> str:
     )
 
 
+def parse_handoff_result(content: str) -> MomentumHandoffResult:
+    payload = _json_section(content, "Result Data")
+    if not payload:
+        raise ValueError("handoff result missing Result Data")
+    return MomentumHandoffResult.model_validate_json(payload)
+
+
 def render_handoff_turn_trace(
     *,
     result: MomentumHandoffResult,

--- a/src/ravn/momentum/worker.py
+++ b/src/ravn/momentum/worker.py
@@ -21,7 +21,8 @@ DELEGATION_PROCEDURE_NAME = "ravn.momentum.delegate.v1"
 
 SYSTEM_PROMPT = """You extract the living shape of an idea into typed artifacts.
 
-Return only JSON matching this shape:
+Return exactly one JSON object matching this shape, with no prose, markdown, or
+code fences before or after it. The response must start with { and end with }.
 {
   "artifacts": [
     {
@@ -80,11 +81,14 @@ Packet when the judgment recommends one. The judgment answers what changed in
 understanding, which tension now matters most, why it deserves attention, and
 what should happen next. Do not turn the packet into a generic ticket.
 
-Every source.excerpt must be a verbatim contiguous substring copied from the
+Every source.excerpt, including resident_patch.source, judgment.source, packet.source,
+and each artifact.source, must be a verbatim contiguous substring copied from the
 resident signal markdown. Do not paraphrase, summarize, or clean up source
-excerpts. Line ranges are useful only when they point at the cited text. If you
-are not certain about exact rendered line numbers, omit line_start and line_end;
-an exact source excerpt without line numbers is better than an inaccurate range.
+excerpts. If a source excerpt is not exact, deterministic provenance will mark
+the run unverified. Line ranges are useful only when they point at the cited
+text. If you are not certain about exact rendered line numbers, omit line_start
+and line_end; an exact source excerpt without line numbers is better than an
+inaccurate range.
 """
 
 
@@ -130,7 +134,8 @@ class MomentumExtractionWorker:
         return MomentumExtractionDraft.model_validate_json(_json_payload(response.content))
 
 
-REFLECTION_SYSTEM_PROMPT = """You reflect on a Momentum judgment after an outcome is known.
+REFLECTION_SYSTEM_PROMPT = """You reflect on a Momentum judgment or handoff episode after
+an outcome is known.
 
 Return only JSON matching this shape:
 {
@@ -166,7 +171,7 @@ Return only JSON matching this shape:
 }
 
 Semantic learning belongs to you. The deterministic system only records the
-operator disposition, applies your state_patch, and persists your reflection.
+episode disposition, applies your state_patch, and persists your reflection.
 Use state_patch to say what changed in current understanding, what should be
 remembered next time, what tensions are confirmed/resolved/changed/opened, and
 which corrections apply. Candidate reflexes and capability gaps are notes for
@@ -201,6 +206,7 @@ class MomentumReflectionWorker:
         disposition: MomentumJudgmentDisposition,
         memory_frame: str = "",
         current_state_frame: str = "",
+        episode_context: str = "",
     ) -> MomentumReflectionDraft:
         response = await self._llm.generate(
             [
@@ -215,6 +221,7 @@ class MomentumReflectionWorker:
                         disposition=disposition,
                         memory_frame=memory_frame,
                         current_state_frame=current_state_frame,
+                        episode_context=episode_context,
                     ),
                 }
             ],
@@ -433,6 +440,7 @@ def _reflection_input_frame(
     disposition: MomentumJudgmentDisposition,
     memory_frame: str,
     current_state_frame: str,
+    episode_context: str,
 ) -> str:
     return (
         "## Existing resident memory frame\n\n"
@@ -452,7 +460,9 @@ def _reflection_input_frame(
         "## Judgment artifact\n\n"
         f"{judgment_content or '(unavailable)'}\n\n"
         "## Related artifacts\n\n"
-        f"{_join_sections(artifact_contents)}"
+        f"{_join_sections(artifact_contents)}\n\n"
+        "## Episode context\n\n"
+        f"{episode_context or '(none)'}"
     )
 
 

--- a/tests/ravn/unit/test_http_mimir.py
+++ b/tests/ravn/unit/test_http_mimir.py
@@ -581,6 +581,6 @@ async def test_assign_thread_owner_raises_file_not_found_on_404(
 async def test_aclose_is_idempotent() -> None:
     adapter = HttpMimirAdapter(base_url="http://mimir.test")
     # Trigger client creation
-    _ = adapter._get_client()
+    _ = await adapter._get_client()
     await adapter.aclose()
     await adapter.aclose()  # should not raise

--- a/tests/test_ravn/test_momentum_pipeline.py
+++ b/tests/test_ravn/test_momentum_pipeline.py
@@ -47,6 +47,7 @@ from ravn.momentum.render import (
     parse_delegation_brief,
     render_attention_decision,
     render_delegation_brief,
+    render_handoff_result,
 )
 from ravn.momentum.state import (
     CURRENT_MOMENTUM_STATE_REF,
@@ -256,6 +257,32 @@ class FakeTraceExecutorAgent(FakeMomentumExecutorAgent):
         )
 
 
+class FakeWorkspacePrefixedTraceExecutorAgent(FakeTraceExecutorAgent):
+    async def run_turn(self, user_input: str) -> TurnResult:
+        self.calls.append(user_input)
+        response = json.dumps(
+            {
+                "status": "completed",
+                "summary": "unit/mock executor reported workspace-prefixed evidence",
+                "output": "unit/mock output",
+                "evidence_refs": ["state/resident/produced/unit-mock.md"],
+                "produced_refs": ["state/resident/produced/unit-mock.md"],
+                "errors": [],
+                "follow_up_recommended": "none",
+            }
+        )
+        return TurnResult(
+            response=response,
+            tool_calls=[
+                ToolCall(id="call-1", name="Read", input={"file_path": "state/ref.md"})
+            ],
+            tool_results=[
+                ToolResult(tool_call_id="call-1", content="read result", is_error=False)
+            ],
+            usage=TokenUsage(input_tokens=3, output_tokens=5),
+        )
+
+
 async def _markdown_signal(path: Path) -> ResidentInboxSignal:
     return await MarkdownResidentSignalSource().load_signal(str(path))
 
@@ -397,6 +424,25 @@ async def _seed_delegation_brief(
         now=datetime(2026, 6, 27, 15, tzinfo=UTC),
     ).prepare_delegation(run_ref)
     return result.brief_ref, result.brief
+
+
+async def _seed_handoff_result(
+    state: LocalResidentState,
+    *,
+    executor=None,
+) -> tuple[str, MomentumHandoffResult]:
+    brief_ref, _ = await _seed_delegation_brief(state)
+    result = await MomentumPipeline(
+        state=state,
+        now=datetime(2026, 6, 27, 16, tzinfo=UTC),
+    ).handoff_delegation(
+        brief_ref,
+        executor=executor or FakeTraceExecutorAgent(),
+        signal_source=StaticSignalSource(
+            [_candidate("sig-relevant", "Relevant signal", "Important living idea.")]
+        ),
+    )
+    return result.result_ref, result.result
 
 
 def test_momentum_delegation_proof_seed_script_replays_committed_fixtures(
@@ -1780,6 +1826,199 @@ async def test_momentum_handoff_leaves_sources_and_state_immutable(
     assert not any("/reflections/" in ref or "/dispositions/" in ref for ref in refs_after)
 
 
+@pytest.mark.asyncio
+async def test_handoff_episode_reflection_updates_state_from_trace_context(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    await state.write_artifact(
+        "resident/produced/unit-mock.md",
+        "Workspace-prefixed evidence body.",
+    )
+    handoff_ref, handoff = await _seed_handoff_result(
+        state,
+        executor=FakeWorkspacePrefixedTraceExecutorAgent(),
+    )
+    signal_source = StaticSignalSource(
+        [_candidate("sig-relevant", "Relevant signal", "Important living idea.")]
+    )
+    llm = FakeLLM(
+        _reflection_payload(
+            "acted",
+            state_patch={
+                "changed_tensions": [
+                    {
+                        "tension_id": "tension-attend-to-momentum-dilution",
+                        "status": "resolved",
+                        "evidence_refs": [handoff_ref, handoff.executor_trace_ref],
+                    }
+                ],
+                "recent_lessons": [
+                    "Completed handoff traces are evidence for resident learning."
+                ],
+                "candidate_reflexes": ["Candidate only: reflect after completed handoff."],
+                "candidate_capability_gaps": [
+                    "Candidate only: compare executor traces across providers."
+                ],
+            },
+        )
+    )
+
+    result = await MomentumPipeline(
+        reflection_worker=MomentumReflectionWorker(llm, model="fake-model"),
+        state=state,
+        now=datetime(2026, 6, 27, 17, tzinfo=UTC),
+    ).reflect_handoff_episode([handoff_ref], signal_source=signal_source)
+
+    prompt = llm.calls[0]["messages"][0]["content"]
+    state_patch = (await state.read_artifact(result.state_patch_ref)).content
+    current_state = (await state.read_artifact(result.current_state_ref)).content
+    assert "## Episode context" in prompt
+    assert handoff_ref in prompt
+    assert handoff.executor_trace_ref in prompt
+    assert '"name": "Read"' in prompt
+    assert "Momentum Delegation Brief" in prompt
+    assert "Momentum Attention Decision" in prompt
+    assert "Build Momentum pipeline" in prompt
+    assert "Important living idea." in prompt
+    assert "Workspace-prefixed evidence body." in prompt
+    assert signal_source.calls == ["resident/inbox/signals/sig-relevant.md"]
+    assert handoff_ref in state_patch
+    assert handoff.executor_trace_ref in state_patch
+    assert "Completed handoff traces are evidence for resident learning." in current_state
+    assert "Candidate only: reflect after completed handoff." in current_state
+    assert "Candidate only: compare executor traces across providers." in current_state
+    refs = await state.list_refs("resident/continuation/momentum")
+    assert all("/reflex" not in ref and "/capabilit" not in ref for ref in refs)
+
+
+@pytest.mark.asyncio
+async def test_future_attention_sees_handoff_episode_learning(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    handoff_ref, _ = await _seed_handoff_result(state)
+    await MomentumPipeline(
+        reflection_worker=MomentumReflectionWorker(
+            FakeLLM(
+                _reflection_payload(
+                    "acted",
+                    state_patch={
+                        "recent_lessons": [
+                            "Future attention should prefer signals with executor trace evidence."
+                        ],
+                    },
+                )
+            ),
+            model="fake-model",
+        ),
+        state=state,
+    ).reflect_handoff_episode([handoff_ref])
+    attention_llm = FakeLLM(_attention_payload())
+
+    await MomentumPipeline(
+        attention_worker=MomentumAttentionWorker(attention_llm, model="fake-model"),
+        state=state,
+    ).attend(
+        [
+            (
+                "resident/inbox/signals/sig-relevant.md",
+                _candidate("sig-relevant", "Relevant", "Trace-backed follow-up."),
+            )
+        ],
+        limit=1,
+    )
+
+    frame = attention_llm.calls[0]["messages"][0]["content"]
+    assert "Future attention should prefer signals with executor trace evidence." in frame
+
+
+@pytest.mark.asyncio
+async def test_multiple_handoff_results_can_be_reflected_together(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    first_ref, _ = await _seed_handoff_result(state)
+    second_ref, _ = await _seed_handoff_result(state)
+    llm = FakeLLM(_reflection_payload("acted"))
+
+    result = await MomentumPipeline(
+        reflection_worker=MomentumReflectionWorker(llm, model="fake-model"),
+        state=state,
+    ).reflect_handoff_episode([first_ref, second_ref])
+
+    prompt = llm.calls[0]["messages"][0]["content"]
+    assert first_ref in prompt
+    assert second_ref in prompt
+    assert first_ref in result.disposition.target_ref
+    assert second_ref in result.disposition.target_ref
+
+
+@pytest.mark.asyncio
+async def test_handoff_episode_reflection_missing_result_creates_no_patch(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+
+    with pytest.raises(FileNotFoundError, match="handoff result not found"):
+        await MomentumPipeline(
+            reflection_worker=MomentumReflectionWorker(
+                FakeLLM(_reflection_payload("acted")),
+                model="fake-model",
+            ),
+            state=state,
+        ).reflect_handoff_episode(["resident/continuation/momentum/handoffs/missing.md"])
+
+    assert await state.list_refs("resident/continuation/momentum/state/patches") == []
+
+
+@pytest.mark.asyncio
+async def test_handoff_episode_reflection_missing_trace_is_visible(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    handoff_ref, handoff = await _seed_handoff_result(state)
+    missing_trace = "resident/continuation/momentum/handoffs/traces/missing-turn.md"
+    broken_ref = await state.write_artifact(
+        "resident/continuation/momentum/handoffs/missing-trace.md",
+        render_handoff_result(handoff.model_copy(update={"executor_trace_ref": missing_trace})),
+    )
+    llm = FakeLLM(_reflection_payload("acted"))
+
+    await MomentumPipeline(
+        reflection_worker=MomentumReflectionWorker(llm, model="fake-model"),
+        state=state,
+    ).reflect_handoff_episode([broken_ref])
+
+    prompt = llm.calls[0]["messages"][0]["content"]
+    assert handoff_ref not in prompt
+    assert f"Executor trace unavailable: {missing_trace}" in prompt
+
+
+@pytest.mark.asyncio
+async def test_handoff_episode_reflection_rejects_blocked_handoff_without_patch(
+    tmp_path: Path,
+) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    handoff_ref, handoff = await _seed_handoff_result(
+        state,
+        executor=FakeMomentumExecutorAgent(status="blocked", follow_up_recommended="retry"),
+    )
+    patches_before = await state.list_refs("resident/continuation/momentum/state/patches")
+
+    with pytest.raises(ValueError, match="handoff result is not completed"):
+        await MomentumPipeline(
+            reflection_worker=MomentumReflectionWorker(
+                FakeLLM(_reflection_payload("acted")),
+                model="fake-model",
+            ),
+            state=state,
+        ).reflect_handoff_episode([handoff_ref])
+
+    assert handoff.status == "blocked"
+    assert await state.list_refs("resident/continuation/momentum/state/patches") == patches_before
+
+
 def test_momentum_core_does_not_import_concrete_delegation_implementations() -> None:
     core_files = [
         Path("src/ravn/momentum/pipeline.py"),
@@ -2918,6 +3157,67 @@ def test_momentum_reflect_cli_records_disposition_and_reflection(monkeypatch, tm
     assert "state_patch_ref:   resident/continuation/momentum/state/patches/" in result.output
     current_state = asyncio.run(state.read_artifact(CURRENT_MOMENTUM_STATE_REF))
     assert "Lesson for accepted" in current_state.content
+
+
+def test_momentum_reflect_cli_accepts_handoff_result_ref(monkeypatch, tmp_path: Path):
+    state = LocalResidentState(tmp_path / "state")
+
+    async def _seed() -> str:
+        handoff_ref, _ = await _seed_handoff_result(state)
+        return handoff_ref
+
+    handoff_ref = asyncio.run(_seed())
+    source = StaticSignalSource(
+        [_candidate("sig-relevant", "Relevant signal", "Important living idea.")]
+    )
+    monkeypatch.setattr(
+        commands,
+        "_build_llm",
+        lambda _settings: FakeLLM(_reflection_payload("acted")),
+    )
+    monkeypatch.setattr(commands, "_build_optional_resident_inbox_signal_source", lambda _s: source)
+
+    async def _state(_settings, _workspace):
+        return state
+
+    monkeypatch.setattr(commands, "_build_resident_state", _state)
+
+    result = CliRunner().invoke(commands.app, ["momentum", "reflect", handoff_ref])
+
+    assert result.exit_code == 0, result.output
+    assert "disposition_ref: resident/continuation/momentum/handoffs/dispositions/" in result.output
+    assert "reflection_ref:  resident/continuation/momentum/handoffs/reflections/" in result.output
+    assert f"current_state_ref: {CURRENT_MOMENTUM_STATE_REF}" in result.output
+    assert "state_patch_ref:   resident/continuation/momentum/state/patches/" in result.output
+    assert "lesson_learned: Lesson for acted" in result.output
+    assert "candidate_reflexes: Candidate: ask for disposition after action." in result.output
+    assert "candidate_capability_gaps: Candidate: no automatic outcome feed." in result.output
+    assert source.calls == ["resident/inbox/signals/sig-relevant.md"]
+
+
+def test_momentum_reflect_cli_invalid_handoff_ref_fails(monkeypatch, tmp_path: Path):
+    state = LocalResidentState(tmp_path / "state")
+    monkeypatch.setattr(
+        commands,
+        "_build_llm",
+        lambda _settings: FakeLLM(_reflection_payload("acted")),
+    )
+
+    async def _state(_settings, _workspace):
+        return state
+
+    monkeypatch.setattr(commands, "_build_resident_state", _state)
+
+    result = CliRunner().invoke(
+        commands.app,
+        ["momentum", "reflect", "resident/continuation/momentum/handoffs/missing.md"],
+    )
+
+    assert result.exit_code == 1
+    assert "handoff result not found" in result.output
+    assert asyncio.run(
+        state.list_refs("resident/continuation/momentum/state/patches")
+    ) == []
 
 
 def test_later_momentum_extract_cli_includes_current_state(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary

Implements NIU-1082 episode learning for completed Momentum handoff episodes by extending the normal `ravn momentum reflect` path to accept one or more handoff result refs.

What changed:
- `ravn momentum reflect <handoff-result-ref>` now reads completed `MomentumHandoffResult` artifacts, executor traces, linked brief/run/judgment/packet/attention/signal/current-state context, and produced/evidence refs.
- The existing `MomentumReflectionWorker`, reflection artifact, state patch, current-state update, and compactor path are reused. No new ports, adapters, services, executor layers, schedulers, registries, or workflow engines were added.
- Handoff episode reflection writes handoff-scoped disposition/reflection artifacts and applies the model-authored patch to current Momentum state.
- The CLI prints reflection/state refs plus changed tensions, lessons, candidate reflexes, and capability-gap candidates.
- Produced/evidence refs that come back as `state/resident/...` are resolved against the existing resident-state namespace for reflection context.

## Proof of Working

Proof type: real local LLM/executor episode-learning proof over resident current state and resident inbox signals, using normal Momentum commands, with changed future attention.

Disclosure: no attention/run/judgment/brief/handoff/trace/reflection/state-patch/learning/second-attention artifacts were seeded. The seed helper wrote only initial current state, two resident inbox signals, config, and local resident-state/Mimir directories. Unit tests use fake LLM/executor objects only at normal unit/mock boundaries; those are not presented as real proof.

Proof root: `/private/tmp/ravn-niu1082-proof-20260629T135955Z`
Executor workspace: `/private/tmp/ravn-niu1082-proof-20260629T135955Z`
Initial current state sha256: `2fa8ef4779be55fb003a270f2183135f395b1fdac0a6ebe6f0f42a668de76711`
Final current state sha256: `d050caaca2822a8922d1a76240ee4a0477367f266eadc9fda46afd7e27d85ead`

Sanitized adapter config:
```yaml
resident_state:
  adapter: ravn.adapters.resident_state.mimir.LocalResidentState
  kwargs:
    root: /private/tmp/ravn-niu1082-proof-20260629T135955Z/state
mimir:
  enabled: true
  path: /private/tmp/ravn-niu1082-proof-20260629T135955Z/mimir
permission:
  mode: workspace_write
  workspace_root: /private/tmp/ravn-niu1082-proof-20260629T135955Z
llm:
  model: claude-opus-4-8[1m]
  provider:
    adapter: ravn.adapters.llm.command.CommandLLMAdapter
    kwargs:
      command: claude
      args: [-p, --output-format, text]
momentum_executor:
  adapter: ravn.adapters.executors.cli.CliTransportExecutor
  kwargs:
    transport_adapter: skuld.transports.codex.CodexSubprocessTransport
    transport_kwargs:
      model: ''
      skip_git_repo_check: true
```

Exact commands:
```bash
uv run python tests/test_ravn/fixtures/scripts/seed_momentum_handoff_proof.py --root "/private/tmp/ravn-niu1082-proof-20260629T135955Z"
uv run ravn momentum attend --config "/private/tmp/ravn-niu1082-proof-20260629T135955Z/ravn.yaml" --limit 2
uv run ravn momentum pursue "resident/continuation/momentum/attention/attention-20260629T135956Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md" --config "/private/tmp/ravn-niu1082-proof-20260629T135955Z/ravn.yaml"
uv run ravn momentum delegate "resident/momentum/runs/momentum-20260629T140050Z-d9312f4e/run.md" --config "/private/tmp/ravn-niu1082-proof-20260629T135955Z/ravn.yaml"
uv run ravn momentum handoff "resident/continuation/momentum/delegations/delegation-20260629T140118Z-prove-the-state-driven-judgment-round-trips-through-an-executor-handoff-that-ins.md" --config "/private/tmp/ravn-niu1082-proof-20260629T135955Z/ravn.yaml"
uv run ravn momentum reflect "resident/continuation/momentum/handoffs/handoff-20260629T140325Z-prove-the-state-driven-judgment-round-trips-through-an-executor-handoff-that-ins-69133b.md" --config "/private/tmp/ravn-niu1082-proof-20260629T135955Z/ravn.yaml"
uv run ravn momentum attend --config "/private/tmp/ravn-niu1082-proof-20260629T135955Z/ravn.yaml" --limit 2
```

Key generated refs/output:
```text
initial candidates:
- resident/inbox/signals/20260628T100500Z-current-state-attention.md / sig-attention-current-state-relevant
- resident/inbox/signals/20260628T100400Z-distractor.md / sig-attention-distractor

first attention_ref: resident/continuation/momentum/attention/attention-20260629T135956Z-resident-inbox-signals-20260628t100500z-current-state-attention-md.md
selected_signal_id: sig-attention-current-state-relevant
recommended_next_action: extract_selected_signal

run_ref: resident/momentum/runs/momentum-20260629T140050Z-d9312f4e/run.md
judgment_ref: resident/momentum/runs/momentum-20260629T140050Z-d9312f4e/judgment/judgment-state-driven-signal-selected-now-prove-the-executor-handoff-round-trip.md
packet_ref: resident/momentum/runs/momentum-20260629T140050Z-d9312f4e/packet/packet-prove-state-driven-judgment-reaches-executor-handoff-evidence.md
extract_state_patch_ref: resident/continuation/momentum/state/patches/patch-20260629T140050Z-momentum-20260629T140050Z-d9312f4e-extract.md
provenance: verified

brief_ref: resident/continuation/momentum/delegations/delegation-20260629T140118Z-prove-the-state-driven-judgment-round-trips-through-an-executor-handoff-that-ins.md
handoff_recommended: true
execution_performed: false

handoff_result_ref: resident/continuation/momentum/handoffs/handoff-20260629T140325Z-prove-the-state-driven-judgment-round-trips-through-an-executor-handoff-that-ins-69133b.md
executor_label: CodexSubprocessTransport
status: completed
executor_trace_ref: resident/continuation/momentum/handoffs/traces/handoff-20260629T140325Z-prove-the-state-driven-judgment-round-trips-through-an-executor-handoff-that-ins-69133b-turn.md
produced_refs: state/resident/continuation/momentum/handoffs/evidence/evidence-codex-ravn-niu1082-20260629T140118Z.md
follow_up_recommended: reflect

reflection_ref: resident/continuation/momentum/handoffs/reflections/reflection-20260629T140326Z-acted-ddaf15.md
reflection_state_patch_ref: resident/continuation/momentum/state/patches/patch-20260629T140326Z-reflection-20260629T140326Z-acted-ddaf15.md
changed_tensions: resolved:tension-carry-reflected-state-into-attention, resolved:tension-state-driven-signal-selected-now-prove-the-executor-handoff-round-trip, confirmed:tension-state-driven-signal-selected-now-prove-the-executor-handoff-round-trip, opened:tension-delegation-brief-refs-must-resolve
lesson_learned: The handoff round-trip works, and the executor degraded gracefully when one requested ref was missing...
candidate_reflexes: candidate only, do not promote: before emitting a delegation brief, validate that each evidence_ref resolves on disk and replace any stale placeholder ref with the persisted equivalent.
candidate_capability_gaps: candidate only, do not register: a preflight ref-resolution check on delegation-brief evidence_refs so stale/placeholder paths are caught before handoff rather than surfacing as executor errors.

second_attention_ref: resident/continuation/momentum/attention/attention-20260629T140404Z-none.md
selected_signal_id: -
attention_tier: silent
recommended_next_action: no_action
confidence: 0.78
```

Current state changed through explicit patches only. The reflection patch source refs include the handoff result, executor trace, disposition, and reflection. The final state resolved the original carry-state tension and opened a new model-authored tension about delegation brief refs resolving in the executor workspace.

Second attention used the learned state. Its rationale says the old relevant signal should not be re-selected because the state→attention→executor-handoff loop is already resolved by `handoff-20260629T140325Z`, and the remaining open tension is `tension-delegation-brief-refs-must-resolve`, which neither candidate signal addresses. It therefore persisted a valid `no_attention_needed` decision.

Executor trace note: the Codex transport persisted the existing `TurnResult` trace. In this run, `tool_call_count: 0` and `tool_result_count: 0`; no fake tool calls were added. The executor still produced a real evidence file inside the proof workspace and returned it in `produced_refs`.

Side-effect checks:
```text
forbidden side-effect refs: none
reflections=1
dispositions=1
traces=1
evidence=1
state_patches=2
```
No reflex promotion, capability registration, workflow, huddle, issue creation, scheduler, daemon, or automatic loop was created.

## Validation

```text
uv run ruff check src/ravn/momentum/pipeline.py src/ravn/momentum/render.py src/ravn/momentum/worker.py src/ravn/cli/commands.py tests/test_ravn/test_momentum_pipeline.py tests/ravn/unit/test_http_mimir.py
# All checks passed!

uv run pytest tests/test_ravn/test_momentum_pipeline.py -q
# 101 passed

uv run pytest tests/test_ravn/test_cli_commands.py tests/test_ravn/test_executor_cli.py -q
# 69 passed

uv run pytest tests/test_ravn/test_resident_state.py -q
# 9 passed

uv run pytest tests/test_architecture_reuse_before_build.py -q
# 1 passed

uv run pytest tests/ravn/unit/test_http_mimir.py -q
# 34 passed

uv run ravn momentum --help
# passed

git diff --check
# passed

make test-ravn
# 6179 passed, 1 skipped, Total coverage: 85.32%
```
