### PR TITLE
Add OpenShell runtime adapter

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -64,6 +64,38 @@ pod_manager:
     chat_path: /session
     code_path: /
 
+# Local OpenShell runtime (opt-in; also available via ./start-dev --openshell):
+# pod_manager:
+#   adapter: "volundr.adapters.outbound.openshell.OpenShellPodManager"
+#   kwargs:
+#     # Empty = use the active OpenShell CLI gateway. Set this for a container gateway.
+#     gateway_url: ""
+#     gateway_name: local
+#     openshell_binary: "openshell"
+#     sandbox_image: "ghcr.io/niuulabs/skuld:0.2.0"
+#     workspaces_dir: "~/.niuu/workspaces"
+#     state_file: "~/.niuu/openshell-forge-state.json"
+#     sdk_port_start: 9200
+#     forward_mode: "service"
+#     require_broker_ready: true
+#     broker_health_path: "/health"
+#     # Docker proof path for a local image rebuilt from this checkout:
+#     # sandbox_image: "volundr-skuld:openshell-local"
+#     # sandbox_command: "/usr/local/bin/openshell-run-installed-skuld"
+#     # Optional local-only CLI auth mounts for Codex/Claude OAuth state.
+#     # Prefer OPENAI_API_KEY / ANTHROPIC_API_KEY env passthrough in automation.
+#     # sandbox_mounts: "~/.codex:/home/sandbox/.codex,~/.claude:/home/sandbox/.claude"
+#     # VM/upload proof path for running Skuld from this checkout:
+#     # sandbox_image: "mcr.microsoft.com/devcontainers/python:3.12-bookworm"
+#     # mount_workspace: false
+#     # upload_workspace: true
+#     # upload_workspace_target: "/sandbox/workspace"
+#     # sandbox_workspace: "/sandbox/workspace/volundr"
+#     # command_timeout: 1200
+#     # policy_file: "/local/path/openshell-dev-bootstrap-policy.yaml"
+#     # sandbox_command: "/bin/sh /sandbox/openshell-run-skuld-from-workspace.sh"
+#     # sandbox_uploads: "/local/path/openshell-run-skuld-from-workspace.sh:/sandbox"
+
 # Forge profiles (argument templates for workload instantiation)
 # Profiles define the base set of values assembled into session specs.
 profiles:

--- a/containers/skuld/Dockerfile
+++ b/containers/skuld/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     git \
+    iproute2 \
     jq \
     tmux \
     vim \
@@ -96,7 +97,9 @@ RUN cd /opt/npm-bootstrap \
 # Create app user with UID 1000 (matches helm chart runAsUser)
 RUN existing=$(getent passwd 1000 | cut -d: -f1) && \
     [ -n "$existing" ] && userdel -r "$existing" || true && \
-    useradd -m -s /bin/bash -u 1000 skuld
+    useradd -m -s /bin/bash -u 1000 skuld && \
+    groupadd -r sandbox && \
+    useradd -m -s /bin/bash -g sandbox sandbox
 
 # Copy the pre-built venv from builder.
 ENV VIRTUAL_ENV=/opt/venv
@@ -110,6 +113,11 @@ RUN chmod +x /app/entrypoint.sh
 # Copy svc CLI tool
 COPY containers/skuld/svc /usr/local/bin/svc
 RUN chmod +x /usr/local/bin/svc
+
+# OpenShell local Docker proof bootstrap: starts the installed broker and exits
+# after its health endpoint is ready, leaving the sandbox resident.
+COPY scripts/openshell-run-installed-skuld.sh /usr/local/bin/openshell-run-installed-skuld
+RUN chmod +x /usr/local/bin/openshell-run-installed-skuld
 
 # Set working directory
 WORKDIR /app

--- a/containers/skuld/entrypoint.sh
+++ b/containers/skuld/entrypoint.sh
@@ -8,6 +8,10 @@ echo "==== Skuld Entrypoint ===="
 echo "Session ID: ${SESSION_ID:-unknown}"
 echo "Workspace: ${WORKSPACE_DIR:-/volundr/sessions/${SESSION_ID}/workspace}"
 
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
 # Set defaults
 export SESSION_ID="${SESSION_ID:-unknown}"
 export WORKSPACE_DIR="${WORKSPACE_DIR:-/volundr/sessions/${SESSION_ID}/workspace}"

--- a/docs/openshell-runtime-integration.md
+++ b/docs/openshell-runtime-integration.md
@@ -1,22 +1,24 @@
 # NVIDIA OpenShell as a Forge Session Runtime
 
-Status: **proposal — not implemented**. Research notes and integration path for
-running Forge sessions inside NVIDIA OpenShell sandboxes as an alternative to
-the current mini-mode local-process runtime.
+Status: **local adapter implemented**. Volundr can select
+`OpenShellPodManager` through the existing dynamic `pod_manager.adapter`
+configuration and create one OpenShell sandbox per Forge session. The current
+implementation uses the OpenShell CLI as a narrow boundary because the local
+gateway API is not yet documented as a stable public SDK.
 
 ## What OpenShell is
 
 [NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) is an open-source
 (Apache-2.0, Rust) sandboxed runtime for autonomous AI agents. Alpha software —
-v0.0.76 as of 2026-07, self-described "proof-of-life, single-player mode".
+v0.0.78 as of 2026-07, self-described "proof-of-life, single-player mode".
 
 Components:
 
-- **Gateway** — control plane (local daemon on `:18080`, or in-cluster via
+- **Gateway** — control plane (package-managed local service, or in-cluster via
   Helm). Owns sandbox lifecycle, policy delivery, credential mapping,
   inference routing. Driven via the `openshell` CLI (gRPC/HTTP under the
-  hood; **no public API docs, no Python SDK** — the CLI with `-o json` is the
-  stable programmatic surface today).
+  hood; **no public API docs, no Python SDK** — the CLI is the stable
+  programmatic surface today, using JSON output where supported).
 - **Sandbox + supervisor** — each sandbox runs a supervisor as PID 1 that
   dials *outbound* to the gateway, then launches the agent as a restricted
   child process. No inbound reachability needed from gateway to sandbox.
@@ -43,16 +45,17 @@ Agents supported unmodified: Claude Code (full policy coverage), OpenCode
 CLI surface relevant to us:
 
 ```bash
-openshell gateway add http://127.0.0.1:18080 --local --name local
+openshell status
+openshell gateway add http://127.0.0.1:17670 --local --name local
 openshell sandbox create --name forge-<id> --from <image> \
   --cpu 2 --memory 4Gi --env K=V --label session=<id> \
   --driver-config-json '{"docker":{"mounts":[{"type":"bind","source":"...","target":"/sandbox/work"}]}}' \
   -- <command>
 openshell sandbox list -o json          # lifecycle: Provisioning → Ready → Error → Deleting
-openshell sandbox get forge-<id> -o json
+openshell sandbox get forge-<id>
 openshell policy set forge-<id> --policy policy.yaml   # dynamic sections hot-reload
 openshell sandbox exec -n forge-<id> --tty -- bash
-openshell forward start <port> forge-<id>              # host port → sandbox port
+openshell forward service forge-<id> --target-port <port> --local 127.0.0.1:<port>
 openshell service expose forge-<id> <port>
 openshell sandbox upload / download                    # workspace-scoped file transfer
 openshell logs forge-<id> --source sandbox
@@ -100,11 +103,11 @@ A fourth `PodManager` adapter. Per session, it:
 2. `openshell sandbox create --name forge-<session_id> --from <skuld image>
    --label session=<id> ... -- skuld` with the workspace bind-mounted (or
    volume-mounted) at the workspace path,
-3. `openshell forward start <sdk_port> forge-<session_id>` (or
-   `service expose`) so the niuu host can reach Skuld's WebSocket exactly as
-   it does today via `/s/{session_id}/session`,
+3. `openshell forward service forge-<session_id> --target-port <sdk_port>`
+   so the niuu host can reach Skuld's WebSocket exactly as it does today via
+   `/s/{session_id}/session`,
 4. maps `status()`/`wait_for_ready()` onto
-   `openshell sandbox get -o json` lifecycle phases
+   `openshell sandbox list -o json` lifecycle phases
    (Provisioning → Ready → Error → Deleting),
 5. `stop()` → `openshell sandbox delete`.
 
@@ -120,7 +123,7 @@ niuu host :8080 ──ws──► forwarded port ──► [OpenShell sandbox]
                                                  └─ claude / codex / opencode CLI
                                              egress ──► policy proxy ──► allowlisted hosts
                                              LLM calls ► inference.local ──► bifrost
-[openshell gateway :18080] ◄──outbound──── supervisor control session
+[openshell gateway] ◄──outbound──── supervisor control session
 ```
 
 Wiring follows `.claude/rules/dynamic-adapters.md` — no new mode enum, just
@@ -128,8 +131,8 @@ config:
 
 ```yaml
 pod_manager:
-  adapter: "volundr.adapters.outbound.openshell_pod_manager.OpenShellPodManager"
-  gateway_url: "http://127.0.0.1:18080"
+  adapter: "volundr.adapters.outbound.openshell.OpenShellPodManager"
+  gateway_url: ""                 # empty = use active OpenShell CLI gateway
   sandbox_image: "ghcr.io/niuulabs/skuld:<tag>"
   workspaces_dir: "~/.niuu/workspaces"
   mount_mode: "bind"            # bind | volume | upload
@@ -187,7 +190,7 @@ default.
 
 ### Phase 0 — spike (no code)
 
-Manual validation on macOS + Linux; kills the proposal cheaply if any fail:
+Manual validation on macOS + Linux; keeps the runtime cheap to disprove:
 
 1. Install (`uv tool install openshell`), gateway up, Docker driver,
    `enable_bind_mounts = true`.
@@ -208,17 +211,240 @@ Manual validation on macOS + Linux; kills the proposal cheaply if any fail:
 7. macOS specifics: Docker Desktop vs `podman machine` vs libkrun MicroVM;
    bind-mount I/O throughput across the VM boundary.
 
+## Local developer workflow
+
+OpenShell mode is opt-in. Mini mode remains the default for dependency-free
+local development.
+
+1. Start the OpenShell gateway locally and make sure the Docker/Podman driver
+   allows bind mounts for `~/.niuu/workspaces`.
+
+   The Docker driver proof used OpenShell 0.0.78 with a local plaintext
+   gateway config shaped like this:
+
+   ```toml
+   [openshell]
+   version = 1
+
+   [openshell.gateway]
+   bind_address = "127.0.0.1:17670"
+   log_level = "info"
+   compute_drivers = ["docker"]
+   disable_tls = true
+   enable_loopback_service_http = true
+
+   [openshell.gateway.auth]
+   allow_unauthenticated_users = true
+
+   [openshell.gateway.gateway_jwt]
+   signing_key_path = "/tmp/openshell/tls/jwt/signing.pem"
+   public_key_path = "/tmp/openshell/tls/jwt/public.pem"
+   kid_path = "/tmp/openshell/tls/jwt/kid"
+   gateway_id = "openshell-docker-dev"
+   ttl_secs = 0
+
+   [openshell.drivers.docker]
+   enable_bind_mounts = true
+   ```
+
+   For the macOS MicroVM driver, the host also needs `e2fsprogs` so
+   `mkfs.ext4` exists at the Homebrew keg path expected by OpenShell:
+
+   ```bash
+   brew install e2fsprogs
+   ```
+
+2. Start Volundr with the OpenShell PodManager:
+
+   ```bash
+   ./start-dev --openshell
+   ```
+
+   This sets the CLI config mode to `openshell`, exports:
+
+   ```yaml
+   pod_manager:
+     adapter: "volundr.adapters.outbound.openshell.OpenShellPodManager"
+     kwargs:
+       gateway_url: ""     # empty = use active OpenShell CLI gateway
+       gateway_name: local
+       openshell_binary: "openshell"
+       sandbox_image: "ghcr.io/niuulabs/skuld:0.2.0"
+       workspaces_dir: "~/.niuu/workspaces"
+       state_file: "~/.niuu/openshell-forge-state.json"
+       sdk_port_start: 9200
+       forward_mode: service
+   ```
+
+   For a local image rebuilt from this checkout, the Docker proof command is:
+
+   ```bash
+   docker build -f containers/skuld/Dockerfile -t volundr-skuld:openshell-local .
+
+   NIUU_SERVER__HOST=127.0.0.1 \
+   NIUU_POD_MANAGER__SANDBOX_IMAGE=volundr-skuld:openshell-local \
+   NIUU_POD_MANAGER__SANDBOX_COMMAND=/usr/local/bin/openshell-run-installed-skuld \
+   NIUU_POD_MANAGER__FORWARD_MODE=service \
+     ./start-dev --openshell
+   ```
+
+   The local image can use either API-key credentials inherited from the
+   platform process (`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`) or local CLI OAuth
+   state. CLI state is opt-in because it mounts local auth files into the
+   sandbox:
+
+   ```bash
+   NIUU_POD_MANAGER__SANDBOX_MOUNTS="$HOME/.codex:/home/sandbox/.codex,$HOME/.claude:/home/sandbox/.claude" \
+     ./start-dev --openshell
+   ```
+
+   For the macOS VM driver, or when validating this checkout before publishing
+   a new Skuld image, use OpenShell's upload path instead of a bind mount:
+
+   ```bash
+   NIUU_POD_MANAGER__SANDBOX_IMAGE=mcr.microsoft.com/devcontainers/python:3.12-bookworm \
+   NIUU_POD_MANAGER__MOUNT_WORKSPACE=false \
+   NIUU_POD_MANAGER__UPLOAD_WORKSPACE=true \
+   NIUU_POD_MANAGER__UPLOAD_WORKSPACE_TARGET=/sandbox/workspace \
+   NIUU_POD_MANAGER__SANDBOX_WORKSPACE=/sandbox/workspace/volundr \
+   NIUU_POD_MANAGER__COMMAND_TIMEOUT=1200 \
+   NIUU_POD_MANAGER__POLICY_FILE="$PWD/scripts/openshell-dev-bootstrap-policy.yaml" \
+   NIUU_POD_MANAGER__SANDBOX_COMMAND="/bin/sh /sandbox/workspace/volundr/scripts/openshell-run-skuld-from-workspace.sh" \
+     ./start-dev --openshell
+   ```
+
+   `scripts/openshell-run-skuld-from-workspace.sh` installs the uploaded repo
+   into a sandbox-local venv, installs the existing Codex/Claude npm tool
+   bundle when npm is available, starts Skuld in the background, and returns
+   only after Skuld's `/health` endpoint answers.
+
+   During local development, if that bootstrap script is not committed yet,
+   upload it explicitly and run it from a stable sandbox path:
+
+   ```bash
+   NIUU_POD_MANAGER__UPLOAD_WORKSPACE_TARGET=/sandbox/workspace \
+   NIUU_POD_MANAGER__SANDBOX_WORKSPACE=/sandbox/workspace/volundr \
+   NIUU_POD_MANAGER__SANDBOX_UPLOADS="$PWD/scripts/openshell-run-skuld-from-workspace.sh:/sandbox" \
+   NIUU_POD_MANAGER__SANDBOX_COMMAND="/bin/sh /sandbox/openshell-run-skuld-from-workspace.sh" \
+     ./start-dev --openshell
+   ```
+
+   OpenShell uploads directories into the destination directory using the
+   source basename. The example above therefore uploads the checkout to
+   `/sandbox/workspace/volundr` and sets Skuld's workspace path to that child.
+   On the local Docker driver, bind mounts are exposed through OpenShell's
+   `fakeowner` mount and may be read-only; use upload mode when the CLI needs
+   to write runtime state such as `.skuld-tools` or `.skuld`.
+
+3. Create one Claude-backed and one Codex-backed Forge session through the
+   ordinary Volundr API/UI launch flow:
+
+   - Claude: use `standard-claude` or any launch spec whose session definition
+     resolves to `broker.cliType: claude`.
+   - Codex: use `standard-codex` or any launch spec whose session definition
+     resolves to `broker.cliType: codex` / `codex-ws`.
+
+   Volundr still creates the session. The OpenShell adapter creates
+   `forge-<session_id>`, bind-mounts the workspace at `/sandbox/workspace`,
+   starts Skuld inside the sandbox, and forwards the Skuld port back to the
+   Volundr `/s/<session_id>/session` proxy endpoint.
+
+4. Inspect local sandboxes:
+
+   ```bash
+   openshell status
+   openshell sandbox list -o json
+   openshell sandbox get forge-<session_id>
+   openshell logs forge-<session_id> --source sandbox
+   ```
+
+5. Stop the stack and any OpenShell sandboxes tracked by this dev run:
+
+   ```bash
+   ./stop-dev
+   ```
+
+### Local proof notes
+
+The local adapter was exercised successfully on 2026-07-08 against OpenShell
+0.0.78 on macOS with a manually started plaintext Docker gateway. The gateway
+had sandbox JWT auth configured and `enable_bind_mounts = true` under
+`[openshell.drivers.docker]`.
+
+The proof used a locally rebuilt Skuld image:
+
+```bash
+docker build -f containers/skuld/Dockerfile -t volundr-skuld:openshell-local .
+```
+
+That image contains the OpenShell compatibility pieces the published
+`ghcr.io/niuulabs/skuld:0.2.0` image did not yet have during the spike:
+`iproute2`, a `sandbox` user/group, command-aware entrypoint behavior, and
+`/usr/local/bin/openshell-run-installed-skuld`.
+
+This smoke created one Codex-backed and one Claude-backed Forge session through
+the ordinary Volundr API:
+
+```bash
+NIUU_SERVER__HOST=127.0.0.1 \
+NIUU_POD_MANAGER__SANDBOX_IMAGE=volundr-skuld:openshell-local \
+NIUU_POD_MANAGER__SANDBOX_COMMAND=/usr/local/bin/openshell-run-installed-skuld \
+NIUU_POD_MANAGER__FORWARD_MODE=service \
+  scripts/openshell-volundr-smoke.sh --cleanup
+```
+
+Result:
+
+```text
+Codex session running:
+  session_id: 6d9e9152-810b-481a-9703-9a38a27fcd29
+  sandbox: forge-6d9e9152-810b-481a-9703-9a38a27fcd29
+Claude session running:
+  session_id: 7fcd1e99-67a0-476f-b159-2f6ee7fa6225
+  sandbox: forge-7fcd1e99-67a0-476f-b159-2f6ee7fa6225
+
+OpenShell Volundr smoke passed.
+```
+
+OpenShell reported both sandboxes as `Ready` with Volundr labels:
+`app.kubernetes.io/managed-by=volundr`,
+`volundr.niuu.io/session=<session_id>`, and
+`volundr.niuu.io/runtime=codex-ws|claude`. The `--cleanup` path stopped
+Volundr and removed all OpenShell sandboxes.
+
+The macOS VM/upload path was also investigated. VM sandbox creation worked
+with a base Python image after installing `e2fsprogs`, and create-time
+`policy_file` attachment works. The upload bootstrap still hit OpenShell VM
+proxy restrictions while fetching Python build dependencies, so Docker is the
+current local proof path and the rebuilt Skuld image is the shortest path to a
+VM proof after publishing.
+
 ### Phase 1 — `OpenShellPodManager` adapter
 
-- New adapter in `src/volundr/adapters/outbound/openshell_pod_manager.py`,
-  shelling out to the `openshell` CLI with `-o json` (pin the version;
-  CLI contract is the API until the gateway API is documented).
+Implemented in `src/volundr/adapters/outbound/openshell.py`:
+
+- `OpenShellClient` wraps the CLI commands: `gateway add`, `sandbox create`,
+  `sandbox get`, `forward start` / `forward service`, and `sandbox delete`.
+- `OpenShellPodManager` implements `initial_chat_endpoint`, `start`, `stop`,
+  `status`, and `wait_for_ready`.
+- `wait_for_ready` requires both OpenShell sandbox readiness and Skuld broker
+  health on the forwarded `/health` endpoint by default.
+- VM drivers can use OpenShell's `--upload` path via `upload_workspace: true`;
+  Docker/Podman remain on bind mounts by default.
+- Sandbox create can pass a custom OpenShell policy with `policy_file`.
+- Session definitions still choose the agent runtime through Skuld broker env:
+  Claude sessions set `SKULD__CLI_TYPE=claude`; Codex sessions set
+  `SKULD__CLI_TYPE=codex` / `codex-ws`.
+- State is tracked in `~/.niuu/openshell-forge-state.json` with
+  `managed_by: openshell`, separate from mini mode's local process state.
+- Unit tests use a fake OpenShell client; no Docker, Podman, or gateway is
+  required for the test suite.
+
+Remaining hardening work:
+
 - Static default policy: workspace read-write, `/usr` `/lib` `/etc`
   read-only, non-root user, network audit-mode allowlist seeded with
   Anthropic/OpenAI endpoints + niuu host + git remotes.
-- Config via the dynamic-adapter pattern (above); mini mode default
-  untouched. Tests mock the CLI boundary (no Docker in tests, per
-  `.claude/rules/database.md` spirit).
 - Session labels (`--label session=<id> user=<id>`) for reconciliation on
   restart, mirroring `state_file` recovery in `LocalProcessPodManager`.
 
@@ -259,7 +485,7 @@ Manual validation on macOS + Linux; kills the proposal cheaply if any fail:
 
 ## Risks and open questions
 
-- **Alpha software.** v0.0.76, "proof-of-life". Pin the version, wrap all CLI
+- **Alpha software.** v0.0.78, "proof-of-life". Pin the version, wrap all CLI
   parsing in one module, expect breaking changes. Do not put it in the
   default path yet.
 - **No documented gateway API / SDK.** Shelling out to the CLI is the

--- a/docs/site/operations/openshell-runtime.md
+++ b/docs/site/operations/openshell-runtime.md
@@ -1,0 +1,182 @@
+# OpenShell Runtime
+
+OpenShell mode runs each local Forge session inside an NVIDIA OpenShell
+sandbox while keeping the existing Skuld broker and Forge session protocol.
+Use it when local process mode is too permissive and a full Kubernetes cluster
+is more machinery than the job needs.
+
+## Runtime Shape
+
+```text
+Völundr session
+  -> OpenShellPodManager
+  -> OpenShell sandbox
+  -> Skuld broker
+  -> Claude, Codex, or another Skuld-managed CLI
+```
+
+This is still Skuld-on-OpenShell. Native NemoClaw, OpenClaw, Hermes, or
+DeepAgents runtimes should use their own OpenShell/NemoClaw images and remain a
+separate integration path.
+
+## Configure The Pod Manager
+
+OpenShell mode uses the same dynamic `pod_manager` adapter shape as mini and
+cluster modes:
+
+```yaml
+pod_manager:
+  adapter: "volundr.adapters.outbound.openshell.OpenShellPodManager"
+  kwargs:
+    openshell_binary: "openshell"
+    gateway_url: ""
+    gateway_name: local
+    sandbox_image: "ghcr.io/niuulabs/skuld:0.2.0"
+    workspaces_dir: "~/.niuu/workspaces"
+    state_file: "~/.niuu/openshell-forge-state.json"
+    sdk_port_start: 9200
+    forward_mode: service
+```
+
+For local development, `./start-dev --openshell` applies these defaults. Override
+individual values with `NIUU_POD_MANAGER__...` environment variables:
+
+```bash
+NIUU_POD_MANAGER__OPENSHELL_BINARY=/opt/openshell/bin/openshell \
+NIUU_POD_MANAGER__SANDBOX_IMAGE=volundr-skuld:openshell-local \
+  ./start-dev --openshell
+```
+
+## Sandbox Resources
+
+CPU and memory are OpenShell sandbox-create settings. The Völundr adapter passes
+them through to `openshell sandbox create --cpu ... --memory ...`.
+
+```yaml
+pod_manager:
+  kwargs:
+    cpu: "2"
+    memory: "4Gi"
+```
+
+Docker and Podman apply these as runtime limits. Kubernetes applies them as both
+request and limit. The OpenShell VM driver currently accepts these flags but
+does not resize the VM allocation.
+
+GPU requests are also an OpenShell sandbox-create concern, but Völundr does not
+currently expose a first-class `gpu` adapter option.
+
+## Policy Controls
+
+OpenShell policy YAML controls filesystem access, process identity, and network
+egress.
+
+Static policy sections are locked at sandbox creation:
+
+- `filesystem_policy`
+- `landlock`
+- `process`
+
+Dynamic policy sections can be hot-reloaded on a running sandbox with
+`openshell policy update` or `openshell policy set`:
+
+- `network_policies`
+
+Attach a create-time policy file through the adapter:
+
+```yaml
+pod_manager:
+  kwargs:
+    policy_file: "/etc/niuu/openshell-policy.yaml"
+```
+
+Example policy:
+
+```yaml
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only: [/usr, /lib, /etc, /var/log]
+  read_write: [/sandbox, /tmp]
+landlock:
+  compatibility: best_effort
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  github_api:
+    endpoints:
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: read-only
+    binaries:
+      - path: /usr/bin/curl
+```
+
+Network policies are per binary and per endpoint. If no policy entry matches
+the destination and calling binary, outbound traffic is denied. REST and
+WebSocket policies can enforce method/path rules instead of only host/port
+rules.
+
+## Workspace Storage And Mounts
+
+OpenShell storage behavior depends on the active compute driver.
+
+Docker and Podman support `volume`, `tmpfs`, and opt-in host `bind` mounts
+through driver config. Bind mounts require `enable_bind_mounts = true` in the
+OpenShell gateway driver config and can weaken isolation by exposing host paths
+to the sandbox.
+
+The Völundr adapter exposes the common local workflow settings:
+
+```yaml
+pod_manager:
+  kwargs:
+    mount_workspace: true
+    sandbox_mounts: "~/.codex:/home/sandbox/.codex"
+```
+
+Use upload mode when bind mounts are not available or when the sandbox needs a
+writable copy of the checkout:
+
+```yaml
+pod_manager:
+  kwargs:
+    mount_workspace: false
+    upload_workspace: true
+    upload_workspace_target: "/sandbox/workspace"
+    sandbox_workspace: "/sandbox/workspace/volundr"
+```
+
+## Managed Inference
+
+OpenShell can route sandbox LLM calls through `https://inference.local`. In that
+mode the gateway injects provider credentials and strips sandbox-supplied
+credentials before forwarding requests upstream.
+
+The current Völundr OpenShell adapter does not yet configure managed inference.
+Today it preserves the existing Skuld behavior and passes normal CLI/model
+environment into the sandbox. Managed inference through OpenShell should be a
+follow-up hardening step.
+
+## Stop And Clean Up
+
+`./stop-dev` stops the local stack and removes OpenShell sandboxes tracked in
+the local OpenShell state file:
+
+```text
+~/.niuu/openshell-forge-state.json
+```
+
+Use OpenShell directly when debugging:
+
+```bash
+openshell status
+openshell sandbox list -o json
+openshell sandbox get forge-<session-id>
+openshell logs forge-<session-id> --source sandbox
+```

--- a/docs/site/reference/configuration.md
+++ b/docs/site/reference/configuration.md
@@ -22,6 +22,63 @@ GIT__GITHUB__TOKEN=ghp_xxxx
 EVENT_PIPELINE__OTEL__ENABLED=true
 ```
 
+## Völundr pod manager
+
+Völundr launches Forge sessions through a dynamic `pod_manager` adapter. The
+`adapter` value is a fully qualified Python class name. Values under `kwargs`
+are passed to that adapter.
+
+```yaml
+pod_manager:
+  adapter: "volundr.adapters.outbound.flux.FluxPodManager"
+  kwargs:
+    namespace: volundr
+```
+
+Environment overrides use the same nested shape. For a directly started
+Völundr service, adapter kwargs live under `POD_MANAGER__KWARGS__...`:
+
+```bash
+POD_MANAGER__ADAPTER=volundr.adapters.outbound.openshell.OpenShellPodManager
+POD_MANAGER__KWARGS__SANDBOX_IMAGE=ghcr.io/niuulabs/skuld:0.2.0
+```
+
+The local `niuu platform` CLI uses the `NIUU_` prefix for its own config and
+then exports service-level settings when it starts Völundr.
+
+Local development can use mini mode, cluster mode, or OpenShell mode. OpenShell
+mode keeps the normal Skuld broker/session protocol but runs each session in an
+OpenShell sandbox:
+
+```yaml
+pod_manager:
+  adapter: "volundr.adapters.outbound.openshell.OpenShellPodManager"
+  kwargs:
+    openshell_binary: "openshell"
+    gateway_url: ""
+    gateway_name: local
+    sandbox_image: "ghcr.io/niuulabs/skuld:0.2.0"
+    cpu: "2"
+    memory: "4Gi"
+    policy_file: "/etc/niuu/openshell-policy.yaml"
+    workspaces_dir: "~/.niuu/workspaces"
+    state_file: "~/.niuu/openshell-forge-state.json"
+    forward_mode: service
+```
+
+OpenShell-specific controls are split across three layers:
+
+| Control | Where to configure it |
+| --- | --- |
+| CPU, memory, GPU | OpenShell sandbox create flags; Völundr exposes `cpu` and `memory` as adapter kwargs. |
+| Network access | OpenShell policy YAML `network_policies`; pass the create-time policy with `policy_file`. |
+| Filesystem/process access | OpenShell policy YAML `filesystem_policy`, `landlock`, and `process`; these are locked at sandbox creation. |
+| Workspace storage and mounts | OpenShell driver config; Völundr exposes workspace bind/upload settings and `sandbox_mounts`. |
+| CLI location | `openshell_binary`, or `NIUU_POD_MANAGER__OPENSHELL_BINARY` for local overrides. |
+
+See [OpenShell runtime](../operations/openshell-runtime.md) for the local
+OpenShell workflow and policy examples.
+
 ## Local stack
 
 `./start-dev` sets the local host profile and aligns service URLs so embedded services can call back into the shared platform host.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Events: reference/events.md
   - Operations:
       - Local development: operations/local-development.md
+      - OpenShell runtime: operations/openshell-runtime.md
       - Kubernetes deployment: operations/kubernetes-deployment.md
       - Production checklist: operations/production-checklist.md
       - Migrations: operations/migrations.md

--- a/scripts/openshell-dev-bootstrap-policy.yaml
+++ b/scripts/openshell-dev-bootstrap-policy.yaml
@@ -1,0 +1,72 @@
+version: 1
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /etc
+    - /proc
+    - /dev/urandom
+  read_write:
+    - /sandbox
+    - /tmp
+    - /dev/null
+landlock:
+  compatibility: best_effort
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+network_policies:
+  python_package_indexes:
+    name: python-package-indexes
+    endpoints:
+      - host: pypi.org
+        port: 443
+        enforcement: audit
+      - host: files.pythonhosted.org
+        port: 443
+        enforcement: audit
+    binaries:
+      - path: /usr/local/bin/python*
+      - path: /usr/bin/python*
+      - path: /tmp/skuld-venv/bin/python*
+      - path: /tmp/skuld-venv/bin/pip*
+  npm_registry:
+    name: npm-registry
+    endpoints:
+      - host: registry.npmjs.org
+        port: 443
+        enforcement: audit
+    binaries:
+      - path: /usr/bin/npm
+      - path: /usr/bin/node
+      - path: /usr/local/bin/npm
+      - path: /usr/local/bin/node
+  llm_endpoints:
+    name: llm-endpoints
+    endpoints:
+      - host: chatgpt.com
+        port: 443
+        protocol: websocket
+        access: read-write
+        enforcement: audit
+      - host: api.openai.com
+        port: 443
+        enforcement: audit
+      - host: api.anthropic.com
+        port: 443
+        enforcement: audit
+      - host: claude.ai
+        port: 443
+        enforcement: audit
+    binaries:
+      - path: /usr/local/bin/codex
+      - path: /usr/bin/codex
+      - path: /usr/local/bin/claude
+      - path: /usr/bin/claude
+      - path: /opt/venv/bin/python
+      - path: /opt/venv/bin/python*
+      - path: /opt/venv/lib/python*/site-packages/claude_agent_sdk/_bundled/claude
+      - path: /usr/bin/curl
+      - path: /usr/local/bin/curl

--- a/scripts/openshell-run-installed-skuld.sh
+++ b/scripts/openshell-run-installed-skuld.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eu
+
+LOG_FILE="${SKULD_BOOTSTRAP_LOG:-/tmp/skuld.log}"
+PORT="${SKULD__PORT:-8081}"
+HEALTH_URL="http://127.0.0.1:${PORT}/health"
+
+PYTHON_BIN="${SKULD_PYTHON_BIN:-/opt/venv/bin/python}"
+
+setup_cli_home() {
+    env_name="$1"
+    default_path="$2"
+    writable_path="$3"
+    current_value="$(eval "printf '%s' \"\${${env_name}:-}\"")"
+    if [ -n "$current_value" ]; then
+        mkdir -p "$current_value"
+        return
+    fi
+    if [ -d "$default_path" ]; then
+        mkdir -p "$writable_path"
+        cp -R "$default_path/." "$writable_path/" 2>/dev/null || true
+        export "${env_name}=$writable_path"
+        return
+    fi
+    mkdir -p "$default_path"
+    export "${env_name}=$default_path"
+}
+
+setup_cli_home CODEX_HOME "$HOME/.codex" /tmp/codex-home
+setup_cli_home CLAUDE_CONFIG_DIR "$HOME/.claude" /tmp/claude-home
+
+nohup "$PYTHON_BIN" -m skuld >"$LOG_FILE" 2>&1 &
+broker_pid="$!"
+
+i=0
+while [ "$i" -lt "${SKULD_BOOTSTRAP_TIMEOUT_SECONDS:-90}" ]; do
+    if ! kill -0 "$broker_pid" 2>/dev/null; then
+        tail -n 120 "$LOG_FILE" >&2 || true
+        exit 1
+    fi
+    if "$PYTHON_BIN" - "$HEALTH_URL" <<'PY'
+import sys
+import urllib.request
+
+url = sys.argv[1]
+try:
+    with urllib.request.urlopen(url, timeout=1) as response:
+        raise SystemExit(0 if response.status < 500 else 1)
+except Exception:
+    raise SystemExit(1)
+PY
+    then
+        exit 0
+    fi
+    i=$((i + 1))
+    sleep 1
+done
+
+tail -n 120 "$LOG_FILE" >&2 || true
+exit 1

--- a/scripts/openshell-run-skuld-from-workspace.sh
+++ b/scripts/openshell-run-skuld-from-workspace.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+WORKSPACE="${SKULD_BOOTSTRAP_WORKSPACE:-${SKULD__SESSION__WORKSPACE_DIR:-/sandbox/workspace}}"
+VENV="${SKULD_BOOTSTRAP_VENV:-/tmp/skuld-venv}"
+LOG_FILE="${SKULD_BOOTSTRAP_LOG:-/tmp/skuld.log}"
+PORT="${SKULD__PORT:-9200}"
+
+python3 -m venv "${VENV}"
+"${VENV}/bin/python" -m pip install --upgrade pip
+"${VENV}/bin/pip" install "${WORKSPACE}"
+
+TOOLS_DIR="${WORKSPACE}/containers/skuld/npm-tools"
+if command -v npm >/dev/null 2>&1 && [ -f "${TOOLS_DIR}/package-lock.json" ]; then
+  (cd "${TOOLS_DIR}" && npm ci --omit=dev)
+  export PATH="${TOOLS_DIR}/node_modules/.bin:${PATH}"
+fi
+
+setup_cli_home() {
+  env_name="$1"
+  default_path="$2"
+  writable_path="$3"
+  current_value="$(eval "printf '%s' \"\${${env_name}:-}\"")"
+  if [ -n "${current_value}" ]; then
+    mkdir -p "${current_value}"
+    return
+  fi
+  if [ -d "${default_path}" ]; then
+    mkdir -p "${writable_path}"
+    cp -R "${default_path}/." "${writable_path}/" 2>/dev/null || true
+    export "${env_name}=${writable_path}"
+    return
+  fi
+  mkdir -p "${default_path}"
+  export "${env_name}=${default_path}"
+}
+
+setup_cli_home CODEX_HOME "${HOME}/.codex" /tmp/codex-home
+setup_cli_home CLAUDE_CONFIG_DIR "${HOME}/.claude" /tmp/claude-home
+
+nohup "${VENV}/bin/python" -m skuld >"${LOG_FILE}" 2>&1 &
+pid="$!"
+
+i=0
+while [ "${i}" -lt "${SKULD_BOOTSTRAP_HEALTH_ATTEMPTS:-120}" ]; do
+  if ! kill -0 "${pid}" >/dev/null 2>&1; then
+    tail -n 80 "${LOG_FILE}" >&2 || true
+    exit 1
+  fi
+  if "${VENV}/bin/python" - "${PORT}" <<'PY' >/dev/null 2>&1
+import http.client
+import sys
+
+conn = http.client.HTTPConnection("127.0.0.1", int(sys.argv[1]), timeout=1)
+conn.request("GET", "/health")
+response = conn.getresponse()
+sys.exit(0 if 200 <= response.status < 500 else 1)
+PY
+  then
+    exit 0
+  fi
+  i=$((i + 1))
+  sleep 1
+done
+
+tail -n 80 "${LOG_FILE}" >&2 || true
+exit 1

--- a/scripts/openshell-volundr-smoke.sh
+++ b/scripts/openshell-volundr-smoke.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+WORKSPACE_PATH="${WORKSPACE_PATH:-${ROOT_DIR}}"
+START_STACK=1
+CLEANUP=0
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-300}"
+codex_id=""
+claude_id=""
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [--no-start] [--cleanup]
+
+Starts local-dev with the OpenShell runtime, launches one Codex and one Claude
+Volundr session, and waits until both are running.
+
+Environment:
+  BASE_URL         Volundr base URL (default: ${BASE_URL})
+  WORKSPACE_PATH  Local workspace mounted into both sessions (default: repo root)
+  TIMEOUT_SECONDS Readiness timeout per session (default: ${TIMEOUT_SECONDS})
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-start)
+      START_STACK=0
+      shift
+      ;;
+    --cleanup)
+      CLEANUP=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+cleanup() {
+  if [[ "${CLEANUP}" != "1" ]]; then
+    return 0
+  fi
+  if [[ -n "${codex_id}" ]]; then
+    curl -fsS -X POST "${BASE_URL}/api/v1/forge/sessions/${codex_id}/stop" >/dev/null || true
+  fi
+  if [[ -n "${claude_id}" ]]; then
+    curl -fsS -X POST "${BASE_URL}/api/v1/forge/sessions/${claude_id}/stop" >/dev/null || true
+  fi
+  "${ROOT_DIR}/stop-dev" || true
+}
+
+trap cleanup EXIT
+
+if ! command -v openshell >/dev/null 2>&1; then
+  echo "openshell is not on PATH. Install it first, then rerun this smoke." >&2
+  echo "Official quickstart: curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh" >&2
+  exit 1
+fi
+
+if [[ "${START_STACK}" == "1" ]]; then
+  "${ROOT_DIR}/start-dev" --openshell
+fi
+
+openshell status
+
+create_session() {
+  local definition="$1"
+  local name="$2"
+  local model="$3"
+  local payload
+
+  payload="$(
+    python3 - "${definition}" "${name}" "${model}" "${WORKSPACE_PATH}" <<'PY' \
+    | curl -fsS -X POST "${BASE_URL}/api/v1/forge/sessions" \
+      -H 'Content-Type: application/json' \
+      --data-binary @-
+import json
+import sys
+
+definition, name, model, workspace = sys.argv[1:]
+print(json.dumps({
+    "name": name,
+    "definition": definition,
+    "model": model,
+    "source": {
+        "type": "local_mount",
+        "local_path": workspace,
+    },
+    "initial_prompt": "",
+    "system_prompt": "Smoke test: start the runtime and wait for broker readiness.",
+    "workload_type": "session",
+}))
+PY
+  )"
+  if [[ -n "${payload}" ]]; then
+    printf '%s' "${payload}"
+    return 0
+  fi
+
+  wait_session_named "${name}"
+}
+
+json_get() {
+  curl -fsS "$1"
+}
+
+json_field() {
+  local payload
+  payload="$(cat)"
+  python3 - "$1" "${payload}" <<'PY'
+import json
+import sys
+
+field = sys.argv[1]
+data = json.loads(sys.argv[2] or "{}")
+value = data
+for part in field.split("."):
+    if not isinstance(value, dict):
+        value = ""
+        break
+    value = value.get(part, "")
+print(value or "")
+PY
+}
+
+wait_session_named() {
+  local name="$1"
+  local deadline=$((SECONDS + 30))
+  local payload
+
+  while (( SECONDS < deadline )); do
+    payload="$(json_get "${BASE_URL}/api/v1/forge/sessions")"
+    if python3 - "${name}" "${payload}" <<'PY'
+import json
+import sys
+
+name = sys.argv[1]
+data = json.loads(sys.argv[2] or "{}")
+items = data.get("items", data) if isinstance(data, dict) else data
+if not isinstance(items, list):
+    sys.exit(1)
+for item in items:
+    if isinstance(item, dict) and item.get("name") == name:
+        print(json.dumps(item))
+        sys.exit(0)
+sys.exit(1)
+PY
+    then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Session ${name} was not returned by list endpoint after create" >&2
+  return 1
+}
+
+wait_running() {
+  local session_id="$1"
+  local label="$2"
+  local deadline=$((SECONDS + TIMEOUT_SECONDS))
+
+  while (( SECONDS < deadline )); do
+    payload="$(json_get "${BASE_URL}/api/v1/forge/sessions/${session_id}")"
+    status="$(printf '%s' "${payload}" | json_field status)"
+    pod_name="$(printf '%s' "${payload}" | json_field pod_name)"
+    chat_endpoint="$(printf '%s' "${payload}" | json_field chat_endpoint)"
+
+    if [[ "${status}" == "running" ]]; then
+      echo "${label} session running:"
+      echo "  session_id: ${session_id}"
+      echo "  sandbox: ${pod_name}"
+      echo "  chat_endpoint: ${chat_endpoint}"
+      openshell sandbox get "${pod_name}" >/dev/null
+      return 0
+    fi
+
+    if [[ "${status}" == "failed" || "${status}" == "stopped" ]]; then
+      echo "${label} session reached terminal status: ${status}" >&2
+      printf '%s\n' "${payload}" >&2
+      return 1
+    fi
+
+    sleep 2
+  done
+
+  echo "${label} session did not become running within ${TIMEOUT_SECONDS}s" >&2
+  return 1
+}
+
+suffix="$(date +%H%M%S)"
+codex_payload="$(create_session skuldCodex "openshell-codex-${suffix}" "gpt-5.4")"
+claude_payload="$(create_session skuldClaude "openshell-claude-${suffix}" "claude-sonnet-4-6")"
+
+codex_id="$(printf '%s' "${codex_payload}" | json_field id)"
+claude_id="$(printf '%s' "${claude_payload}" | json_field id)"
+
+wait_running "${codex_id}" "Codex"
+wait_running "${claude_id}" "Claude"
+
+echo
+echo "OpenShell Volundr smoke passed."
+openshell sandbox list --selector app.kubernetes.io/managed-by=volundr -o json || true
+
+if [[ "${CLEANUP}" == "1" ]]; then
+  cleanup
+  trap - EXIT
+fi

--- a/src/cli/commands/platform.py
+++ b/src/cli/commands/platform.py
@@ -233,19 +233,19 @@ def _build_up_callback(
         workspaces_dir = str(kwargs.pop("workspaces_dir", "") or "").strip()
         effective_settings = settings
         if workspaces_dir:
-            if settings.mode != "mini":
+            if settings.mode not in {"mini", "openshell"}:
                 raise typer.BadParameter(
-                    "--workspaces-dir is only supported in mini mode",
+                    "--workspaces-dir is only supported in mini or openshell mode",
                     param_hint="workspaces-dir",
                 )
             effective_settings = settings.model_copy(deep=True)
             effective_settings.pod_manager.workspaces_dir = workspaces_dir
 
-        # In mini mode, enable local mounts and mini_mode feature flag.
-        if effective_settings.mode == "mini":
+        # Host-local runtimes need local mount support and dynamic PodManager env.
+        if effective_settings.mode in {"mini", "openshell"}:
             os.environ.setdefault("LOCAL_MOUNTS__ENABLED", "true")
             os.environ.setdefault("LOCAL_MOUNTS__MINI_MODE", "true")
-            for key, value in _resolve_mini_pod_manager_env(effective_settings).items():
+            for key, value in _resolve_local_pod_manager_env(effective_settings).items():
                 os.environ[key] = value
 
         skip_preflight: bool = bool(kwargs.pop("skip_preflight", False))
@@ -349,6 +349,7 @@ def _build_up_callback(
 
 MINI_POD_MANAGER_ADAPTER = "volundr.adapters.outbound.local_process.LocalProcessPodManager"
 CLUSTER_POD_MANAGER_ADAPTER = "volundr.adapters.outbound.direct_k8s_pod_manager.DirectK8sPodManager"
+OPENSHELL_POD_MANAGER_ADAPTER = "volundr.adapters.outbound.openshell.OpenShellPodManager"
 
 CLUSTER_POD_MANAGER_DEFAULTS: dict[str, Any] = {
     "adapter": CLUSTER_POD_MANAGER_ADAPTER,
@@ -365,9 +366,20 @@ MINI_POD_MANAGER_DEFAULTS: dict[str, Any] = {
     "claude_binary": "claude",
 }
 
+OPENSHELL_POD_MANAGER_DEFAULTS: dict[str, Any] = {
+    "adapter": OPENSHELL_POD_MANAGER_ADAPTER,
+    "gateway_url": "",
+    "gateway_name": "local",
+    "openshell_binary": "openshell",
+    "sandbox_image": "ghcr.io/niuulabs/skuld:0.2.0",
+    "workspaces_dir": "~/.niuu/workspaces",
+    "state_file": "~/.niuu/openshell-forge-state.json",
+    "sdk_port_start": 9200,
+}
 
-def _resolve_mini_pod_manager_env(settings: CLISettings) -> dict[str, str]:
-    """Build env overrides for Volundr mini-mode runtime configuration."""
+
+def _resolve_local_pod_manager_env(settings: CLISettings) -> dict[str, str]:
+    """Build env overrides for Volundr host-local runtime configuration."""
     from pathlib import Path
 
     kwargs = dict(settings.pod_manager.adapter_kwargs())
@@ -386,12 +398,15 @@ def _resolve_mini_pod_manager_env(settings: CLISettings) -> dict[str, str]:
 
 
 def _prompt_mode_selection() -> str:
-    """Prompt the user for mini or cluster mode."""
+    """Prompt the user for mini, OpenShell, or cluster mode."""
     typer.echo("Select operating mode:")
     typer.echo("  [1] mini   — local processes, no cluster needed (default)")
-    typer.echo("  [2] cluster — session pods run in k3d/k3s cluster")
+    typer.echo("  [2] openshell — local OpenShell sandboxes")
+    typer.echo("  [3] cluster — session pods run in k3d/k3s cluster")
     choice = typer.prompt("Choice", default="1", show_default=False)
-    if choice.strip() in ("2", "cluster"):
+    if choice.strip() in ("2", "openshell"):
+        return "openshell"
+    if choice.strip() in ("3", "cluster"):
         return "cluster"
     return "mini"
 
@@ -402,6 +417,11 @@ def _build_init_config(mode: str) -> dict[str, Any]:
         return {
             "mode": "cluster",
             "pod_manager": dict(CLUSTER_POD_MANAGER_DEFAULTS),
+        }
+    if mode == "openshell":
+        return {
+            "mode": "openshell",
+            "pod_manager": dict(OPENSHELL_POD_MANAGER_DEFAULTS),
         }
     return {
         "mode": "mini",
@@ -460,6 +480,16 @@ def create_platform_commands(
             typer.echo("Cluster info:")
             typer.echo(f"  Namespace: {kwargs.get('namespace', 'volundr')}")
             typer.echo(f"  Kubeconfig: {kwargs.get('kubeconfig', '~/.kube/config')}")
+            typer.echo()
+        elif settings.mode == "openshell":
+            kwargs = settings.pod_manager.adapter_kwargs()
+            typer.echo("OpenShell info:")
+            binary = kwargs.get("openshell_binary", "openshell")
+            typer.echo(f"  Binary: {binary}")
+            gateway = kwargs.get("gateway_url") or "(active openshell gateway)"
+            typer.echo(f"  Gateway: {gateway}")
+            image = kwargs.get("sandbox_image", "ghcr.io/niuulabs/skuld:0.2.0")
+            typer.echo(f"  Sandbox image: {image}")
             typer.echo()
 
         plugins = registry.plugins

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -184,7 +184,7 @@ class CLISettings(BaseSettings):
 
     mode: str = Field(
         default="mini",
-        description="Operating mode: 'mini' (local) or 'cluster'.",
+        description="Operating mode: 'mini', 'openshell', or 'cluster'.",
     )
     database: DatabaseConfig = Field(default_factory=DatabaseConfig)
     pod_manager: PodManagerConfig = Field(default_factory=PodManagerConfig)

--- a/src/volundr/adapters/outbound/openshell.py
+++ b/src/volundr/adapters/outbound/openshell.py
@@ -1,0 +1,873 @@
+"""OpenShell adapter for local Forge session runtime management.
+
+Constructor accepts plain kwargs (dynamic adapter pattern):
+    adapter: "volundr.adapters.outbound.openshell.OpenShellPodManager"
+    gateway_url: ""
+    sandbox_image: "ghcr.io/niuulabs/skuld:0.2.0"
+    workspaces_dir: "~/.niuu/workspaces"
+    state_file: "~/.niuu/openshell-forge-state.json"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import http.client
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from volundr.adapters.outbound.local_process import (
+    LocalProcessPodManager,
+    SdkPortAllocator,
+    _inject_token_into_url,
+    _local_workspace_from_repo,
+)
+from volundr.domain.models import GitSource, LocalMountSource, Session, SessionSpec, SessionStatus
+from volundr.domain.ports import PodManager, PodStartResult
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GATEWAY_URL = ""
+DEFAULT_SANDBOX_IMAGE = "ghcr.io/niuulabs/skuld:0.2.0"
+DEFAULT_WORKSPACES_DIR = "~/.niuu/workspaces"
+DEFAULT_STATE_FILE = "~/.niuu/openshell-forge-state.json"
+DEFAULT_SDK_PORT_START = 9200
+DEFAULT_SANDBOX_COMMAND = ["/opt/venv/bin/python", "-m", "skuld"]
+DEFAULT_MAX_CONCURRENT = 8
+DEFAULT_STOP_TIMEOUT = 30.0
+DEFAULT_COMMAND_TIMEOUT = 60.0
+READY_POLL_INTERVAL = 1.0
+DEFAULT_BROKER_HEALTH_PATH = "/health"
+
+
+class OpenShellState(StrEnum):
+    """Small internal state stored for OpenShell-backed sessions."""
+
+    STARTING = "starting"
+    RUNNING = "running"
+    STOPPED = "stopped"
+    FAILED = "failed"
+
+
+@dataclass
+class OpenShellSessionInfo:
+    """Persisted OpenShell sandbox metadata."""
+
+    session_id: str
+    sandbox_name: str
+    port: int | None = None
+    workspace: str = ""
+    runtime: str = ""
+    state: OpenShellState = OpenShellState.STARTING
+    error: str | None = None
+    managed_by: str = "openshell"
+    start_complete: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> OpenShellSessionInfo:
+        return OpenShellSessionInfo(
+            session_id=str(data.get("session_id") or data.get("id") or ""),
+            sandbox_name=str(data.get("sandbox_name") or data.get("name") or ""),
+            port=data.get("port"),
+            workspace=str(data.get("workspace") or data.get("workspace_dir") or ""),
+            runtime=str(data.get("runtime") or ""),
+            state=OpenShellState(str(data.get("state") or data.get("status") or "stopped")),
+            error=data.get("error"),
+            managed_by=str(data.get("managed_by") or "openshell"),
+            start_complete=_as_bool(data.get("start_complete")),
+        )
+
+
+class OpenShellClient:
+    """Tiny async boundary around the OpenShell CLI.
+
+    OpenShell's local gateway API is not documented as a stable public contract yet;
+    the CLI with JSON output is the replaceable adapter boundary for this spike.
+    """
+
+    def __init__(
+        self,
+        *,
+        binary: str = "openshell",
+        gateway_url: str = DEFAULT_GATEWAY_URL,
+        gateway_name: str = "local",
+        command_timeout: float = DEFAULT_COMMAND_TIMEOUT,
+    ):
+        self._binary = binary
+        self._gateway_url = gateway_url
+        self._gateway_name = gateway_name
+        self._command_timeout = float(command_timeout)
+        self._service_forwards: dict[tuple[str, int], asyncio.subprocess.Process] = {}
+
+    async def ensure_gateway(self) -> None:
+        if not self._gateway_url:
+            return
+        result = await self._run(
+            "gateway",
+            "add",
+            self._gateway_url,
+            "--local",
+            "--name",
+            self._gateway_name,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        stderr = result.stderr.lower()
+        if "already" in stderr or "exists" in stderr:
+            return
+        raise RuntimeError(result.stderr.strip() or "openshell gateway add failed")
+
+    async def create_sandbox(
+        self,
+        *,
+        name: str,
+        image: str,
+        command: Sequence[str],
+        env: dict[str, str],
+        labels: dict[str, str],
+        cpu: str = "",
+        memory: str = "",
+        driver_config_json: str = "",
+        uploads: Sequence[str] = (),
+        upload_no_git_ignore: bool = False,
+        policy_file: str = "",
+    ) -> dict[str, Any]:
+        args: list[str] = ["sandbox", "create", "--name", name, "--from", image]
+        if cpu:
+            args.extend(["--cpu", cpu])
+        if memory:
+            args.extend(["--memory", memory])
+        for key, value in sorted(env.items()):
+            args.extend(["--env", f"{key}={value}"])
+        for key, value in sorted(labels.items()):
+            args.extend(["--label", f"{key}={value}"])
+        if policy_file:
+            args.extend(["--policy", policy_file])
+        if driver_config_json:
+            args.extend(["--driver-config-json", driver_config_json])
+        if upload_no_git_ignore:
+            args.append("--no-git-ignore")
+        for upload in uploads:
+            args.extend(["--upload", upload])
+        args.extend(["--", *command])
+        await self._run(*args)
+        return {}
+
+    async def get_sandbox(self, name: str) -> dict[str, Any] | None:
+        sandboxes = await self.list_sandboxes()
+        for sandbox in sandboxes:
+            if not isinstance(sandbox, dict):
+                continue
+            if _sandbox_name(sandbox) == name:
+                return sandbox
+        return None
+
+    async def list_sandboxes(self, *, selector: str = "") -> list[dict[str, Any]]:
+        args = ["sandbox", "list", "-o", "json"]
+        if selector:
+            args.extend(["--selector", selector])
+        result = await self._run(*args)
+        return _loads_json_list(result.stdout)
+
+    async def delete_sandbox(self, name: str) -> bool:
+        result = await self._run("sandbox", "delete", name, check=False)
+        if result.returncode == 0:
+            return True
+        stderr = result.stderr.lower()
+        if "notfound" in stderr or "not found" in stderr or "404" in stderr:
+            return False
+        raise RuntimeError(result.stderr.strip() or f"openshell sandbox delete {name} failed")
+
+    async def forward_start(self, *, sandbox_name: str, port: int) -> None:
+        await self._run("forward", "start", str(port), sandbox_name, "-d")
+
+    async def forward_service_start(self, *, sandbox_name: str, port: int) -> None:
+        key = (sandbox_name, port)
+        existing = self._service_forwards.get(key)
+        if existing is not None and existing.returncode is None:
+            return
+        process = await asyncio.create_subprocess_exec(
+            self._binary,
+            "forward",
+            "service",
+            sandbox_name,
+            "--target-port",
+            str(port),
+            "--local",
+            f"127.0.0.1:{port}",
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        await asyncio.sleep(0.2)
+        if process.returncode is not None:
+            raise RuntimeError(f"{self._binary} forward service {sandbox_name} failed")
+        self._service_forwards[key] = process
+
+    async def forward_stop(self, *, sandbox_name: str, port: int, mode: str = "start") -> None:
+        key = (sandbox_name, port)
+        process = self._service_forwards.pop(key, None)
+        if process is not None and process.returncode is None:
+            process.terminate()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=5)
+            except TimeoutError:
+                process.kill()
+                await process.wait()
+            return
+        if mode == "start":
+            await self._run("forward", "stop", str(port), sandbox_name, check=False)
+
+    async def _run_json(self, *args: str) -> dict[str, Any]:
+        result = await self._run(*args, "-o", "json")
+        if not result.stdout.strip():
+            return {}
+        return _loads_json(result.stdout)
+
+    async def _run(self, *args: str, check: bool = True) -> _CompletedProcess:
+        process = await asyncio.create_subprocess_exec(
+            self._binary,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                self._command_timeout,
+            )
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+            raise
+        result = _CompletedProcess(
+            returncode=process.returncode or 0,
+            stdout=stdout.decode(errors="replace"),
+            stderr=stderr.decode(errors="replace"),
+        )
+        if check and result.returncode != 0:
+            raise RuntimeError(result.stderr.strip() or f"{self._binary} {' '.join(args)} failed")
+        return result
+
+
+@dataclass(frozen=True)
+class _CompletedProcess:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def _loads_json(value: str) -> dict[str, Any]:
+    raw = json.loads(value)
+    if isinstance(raw, dict):
+        return raw
+    raise RuntimeError("OpenShell returned JSON that is not an object")
+
+
+def _loads_json_list(value: str) -> list[dict[str, Any]]:
+    raw = json.loads(value)
+    if isinstance(raw, list):
+        return [item for item in raw if isinstance(item, dict)]
+    if isinstance(raw, dict):
+        for key in ("items", "sandboxes", "data"):
+            items = raw.get(key)
+            if isinstance(items, list):
+                return [item for item in items if isinstance(item, dict)]
+    raise RuntimeError("OpenShell returned JSON that is not a sandbox list")
+
+
+def _sandbox_name(sandbox: dict[str, Any]) -> str:
+    metadata = sandbox.get("metadata")
+    if isinstance(metadata, dict):
+        name = metadata.get("name")
+        if name:
+            return str(name)
+    return str(sandbox.get("name") or sandbox.get("id") or "")
+
+
+class OpenShellPodManager(PodManager):
+    """OpenShell-backed local implementation of the Volundr PodManager port."""
+
+    def __init__(
+        self,
+        *,
+        gateway_url: str = DEFAULT_GATEWAY_URL,
+        gateway_name: str = "local",
+        openshell_binary: str = "openshell",
+        sandbox_image: str = DEFAULT_SANDBOX_IMAGE,
+        sandbox_command: list[str] | str | None = None,
+        workspaces_dir: str = DEFAULT_WORKSPACES_DIR,
+        state_file: str = DEFAULT_STATE_FILE,
+        sdk_port_start: int = DEFAULT_SDK_PORT_START,
+        max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+        stop_timeout: float = DEFAULT_STOP_TIMEOUT,
+        command_timeout: float = DEFAULT_COMMAND_TIMEOUT,
+        cpu: str = "",
+        memory: str = "",
+        mount_workspace: bool = True,
+        upload_workspace: bool = False,
+        upload_workspace_target: str | None = None,
+        upload_no_git_ignore: bool = False,
+        sandbox_uploads: Sequence[str] | str | None = None,
+        sandbox_mounts: Sequence[dict[str, str] | str] | str | None = None,
+        policy_file: str = "",
+        sandbox_workspace: str = "/sandbox/workspace",
+        ensure_gateway: bool = True,
+        endpoint_exposure: str = "forward",
+        forward_mode: str = "start",
+        client: OpenShellClient | None = None,
+        require_broker_ready: bool = True,
+        broker_health_path: str = DEFAULT_BROKER_HEALTH_PATH,
+        broker_health_timeout: float = 1.0,
+        healthcheck: Callable[[int], Awaitable[bool]] | None = None,
+        **_extra: object,
+    ):
+        self._gateway_url = gateway_url.rstrip("/")
+        self._gateway_name = gateway_name
+        self._sandbox_image = sandbox_image
+        self._sandbox_command = _normalize_command(sandbox_command) or DEFAULT_SANDBOX_COMMAND
+        self._workspaces_dir = Path(str(workspaces_dir)).expanduser()
+        self._state_file = Path(str(state_file)).expanduser()
+        self._port_allocator = SdkPortAllocator(start_port=int(sdk_port_start))
+        self._max_concurrent = int(max_concurrent)
+        self._stop_timeout = float(stop_timeout)
+        self._cpu = cpu
+        self._memory = memory
+        self._mount_workspace = _as_bool(mount_workspace)
+        self._upload_workspace = _as_bool(upload_workspace)
+        self._upload_workspace_target = upload_workspace_target
+        self._upload_no_git_ignore = _as_bool(upload_no_git_ignore)
+        self._sandbox_uploads = _normalize_string_list(sandbox_uploads)
+        self._sandbox_mounts = _normalize_mounts(sandbox_mounts)
+        self._policy_file = policy_file
+        self._sandbox_workspace = sandbox_workspace
+        self._ensure_gateway = _as_bool(ensure_gateway)
+        self._endpoint_exposure = endpoint_exposure
+        self._forward_mode = forward_mode
+        self._require_broker_ready = _as_bool(require_broker_ready)
+        self._broker_health_path = broker_health_path or DEFAULT_BROKER_HEALTH_PATH
+        self._broker_health_timeout = float(broker_health_timeout)
+        self._healthcheck = healthcheck
+        self._client = client or OpenShellClient(
+            binary=openshell_binary,
+            gateway_url=gateway_url,
+            gateway_name=gateway_name,
+            command_timeout=command_timeout,
+        )
+        self._sessions: dict[str, OpenShellSessionInfo] = {}
+        self._skuld_registry: object | None = None
+        self._load_state()
+        for info in self._sessions.values():
+            if info.port is not None and info.state in (
+                OpenShellState.STARTING,
+                OpenShellState.RUNNING,
+            ):
+                self._port_allocator._allocated.add(info.port)
+
+    def set_skuld_registry(self, registry: object) -> None:
+        """Inject the local Skuld proxy registry used by ``/s/{id}`` routes."""
+        self._skuld_registry = registry
+        register = getattr(registry, "register", None)
+        if not callable(register):
+            return
+        for session_id, info in self._sessions.items():
+            if info.port is None or info.state != OpenShellState.RUNNING:
+                continue
+            register(session_id, info.port)
+
+    def initial_chat_endpoint(self, session: Session) -> str | None:
+        info = self._sessions.get(str(session.id))
+        if info and info.port:
+            return self._chat_endpoint(session.id, info.port)
+        return None
+
+    async def start(self, session: Session, spec: SessionSpec) -> PodStartResult:
+        session_id = str(session.id)
+        active = [
+            info
+            for info in self._sessions.values()
+            if info.state in (OpenShellState.STARTING, OpenShellState.RUNNING)
+        ]
+        if len(active) >= self._max_concurrent:
+            raise RuntimeError(
+                f"Max concurrent OpenShell sessions ({self._max_concurrent}) reached"
+            )
+
+        if self._ensure_gateway:
+            await self._client.ensure_gateway()
+
+        workspace = await self._provision_workspace(session, spec)
+        port = self._port_allocator.allocate()
+        sandbox_name = self._sandbox_name(session)
+        runtime = self._runtime_from_spec(spec)
+        info = OpenShellSessionInfo(
+            session_id=session_id,
+            sandbox_name=sandbox_name,
+            port=port,
+            workspace=str(workspace),
+            runtime=runtime,
+            state=OpenShellState.STARTING,
+            start_complete=False,
+        )
+        self._sessions[session_id] = info
+        self._persist_state()
+
+        env = self._build_sandbox_env(session, spec, workspace, port)
+        driver_config_json = self._driver_config_json(workspace)
+        uploads = self._uploads(workspace)
+        try:
+            await self._client.create_sandbox(
+                name=sandbox_name,
+                image=self._sandbox_image,
+                command=self._sandbox_command,
+                env=env,
+                labels={
+                    "app.kubernetes.io/managed-by": "volundr",
+                    "volundr.niuu.io/session": session_id,
+                    "volundr.niuu.io/runtime": runtime,
+                },
+                cpu=self._cpu,
+                memory=self._memory,
+                driver_config_json=driver_config_json,
+                uploads=uploads,
+                upload_no_git_ignore=self._upload_no_git_ignore,
+                policy_file=self._policy_file,
+            )
+            if self._endpoint_exposure == "forward":
+                await self._start_forward(sandbox_name=sandbox_name, port=port)
+            if await self._broker_is_ready(info):
+                info.state = OpenShellState.RUNNING
+            info.start_complete = True
+            self._persist_state()
+            self._register_skuld_port(session_id, port)
+        except Exception as exc:
+            info.state = OpenShellState.FAILED
+            info.error = str(exc)
+            self._port_allocator.release(port)
+            self._persist_state()
+            raise
+
+        return PodStartResult(
+            chat_endpoint=self._chat_endpoint(session.id, port),
+            code_endpoint=self._code_endpoint(sandbox_name, workspace),
+            pod_name=sandbox_name,
+        )
+
+    async def stop(self, session: Session) -> bool:
+        info = self._sessions.get(str(session.id))
+        if info is None:
+            return False
+        if info.port is not None and self._endpoint_exposure == "forward":
+            await self._client.forward_stop(
+                sandbox_name=info.sandbox_name,
+                port=info.port,
+                mode=self._forward_mode,
+            )
+        stopped = await asyncio.wait_for(
+            self._client.delete_sandbox(info.sandbox_name),
+            timeout=self._stop_timeout,
+        )
+        if info.port is not None:
+            self._unregister_skuld_port(str(session.id))
+            self._port_allocator.release(info.port)
+        info.state = OpenShellState.STOPPED
+        self._persist_state()
+        return stopped
+
+    async def status(self, session: Session) -> SessionStatus:
+        info = self._sessions.get(str(session.id))
+        if info is None:
+            return SessionStatus.STOPPED
+        sandbox = await self._client.get_sandbox(info.sandbox_name)
+        if sandbox is None:
+            info.state = OpenShellState.STOPPED
+            self._unregister_skuld_port(str(session.id))
+            self._persist_state()
+            return SessionStatus.STOPPED
+        status = self._map_status(sandbox)
+        if status == SessionStatus.RUNNING and not await self._broker_is_ready(info):
+            status = SessionStatus.PROVISIONING
+        if status == SessionStatus.RUNNING and not info.start_complete:
+            status = SessionStatus.PROVISIONING
+        info.state = _state_from_session_status(status)
+        if info.port is not None:
+            if info.state == OpenShellState.RUNNING:
+                self._register_skuld_port(str(session.id), info.port)
+            elif info.state in (OpenShellState.STOPPED, OpenShellState.FAILED):
+                self._unregister_skuld_port(str(session.id))
+        self._persist_state()
+        return status
+
+    async def wait_for_ready(self, session: Session, timeout: float) -> SessionStatus:
+        elapsed = 0.0
+        while elapsed < timeout:
+            status = await self.status(session)
+            if status in (SessionStatus.RUNNING, SessionStatus.FAILED, SessionStatus.STOPPED):
+                return status
+            await asyncio.sleep(READY_POLL_INTERVAL)
+            elapsed += READY_POLL_INTERVAL
+        return SessionStatus.FAILED
+
+    async def _start_forward(self, *, sandbox_name: str, port: int) -> None:
+        if self._forward_mode == "service":
+            await self._client.forward_service_start(sandbox_name=sandbox_name, port=port)
+            return
+        await self._client.forward_start(sandbox_name=sandbox_name, port=port)
+
+    def _register_skuld_port(self, session_id: str, port: int) -> None:
+        if self._skuld_registry is None:
+            return
+        register = getattr(self._skuld_registry, "register", None)
+        if callable(register):
+            register(session_id, port)
+
+    def _unregister_skuld_port(self, session_id: str) -> None:
+        if self._skuld_registry is None:
+            return
+        unregister = getattr(self._skuld_registry, "unregister", None)
+        if callable(unregister):
+            unregister(session_id)
+
+    async def _provision_workspace(self, session: Session, spec: SessionSpec) -> Path:
+        if isinstance(session.source, LocalMountSource):
+            if session.source.local_path:
+                path = Path(session.source.local_path).expanduser().resolve()
+                if not path.is_dir():
+                    raise RuntimeError(f"local path {path!r} is not a directory")
+                return path
+            if session.source.paths:
+                workspace = self._workspaces_dir / str(session.id)
+                workspace.mkdir(parents=True, exist_ok=True)
+                for mapping in session.source.paths:
+                    host = Path(mapping.host_path).expanduser()
+                    if not host.exists():
+                        continue
+                    link_name = mapping.mount_path.strip("/").replace("/", "-") or host.name
+                    link = workspace / link_name
+                    if not link.exists():
+                        link.symlink_to(host)
+                return workspace
+
+        if isinstance(session.source, GitSource) and session.source.repo:
+            local_workspace = _local_workspace_from_repo(session.source.repo)
+            if local_workspace is not None:
+                workspace = local_workspace.expanduser().resolve()
+                if not workspace.is_dir():
+                    raise RuntimeError(f"local repo path {workspace!r} is not a directory")
+                return workspace
+            workspace = self._workspaces_dir / str(session.id)
+            workspace.mkdir(parents=True, exist_ok=True)
+            if not any(workspace.iterdir()):
+                await self._clone_repo(session.source, workspace, spec)
+            return workspace
+
+        workspace = self._workspaces_dir / str(session.id)
+        workspace.mkdir(parents=True, exist_ok=True)
+        return workspace
+
+    async def _clone_repo(self, source: GitSource, workspace: Path, spec: SessionSpec) -> None:
+        token = spec.values.get("git_token", "")
+        clone_url = _inject_token_into_url(source.repo, str(token))
+        args = ["git", "clone", "--depth", "1", clone_url, str(workspace / "repo")]
+        if source.branch:
+            args[2:2] = ["--branch", source.branch]
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            error = stderr.decode(errors="replace")
+            error = re.sub(r"://[^@]+@", "://***@", error)
+            raise RuntimeError(f"Git clone failed: {error}")
+
+    def _build_sandbox_env(
+        self,
+        session: Session,
+        spec: SessionSpec,
+        workspace: Path,
+        port: int,
+    ) -> dict[str, str]:
+        env = LocalProcessPodManager._build_env(spec, workspace)
+        env["SKULD__SESSION__ID"] = str(session.id)
+        env["SKULD__SESSION__NAME"] = session.name
+        env["SKULD__SESSION__WORKSPACE_DIR"] = self._sandbox_workspace
+        env["SKULD__HOST"] = "0.0.0.0"
+        env["SKULD__PORT"] = str(port)
+        env["SKULD__PERSISTENCE_MOUNT_PATH"] = str(Path(self._sandbox_workspace).parent)
+        server_host = os.environ.get("NIUU_SERVER_HOST", "127.0.0.1")
+        server_port = os.environ.get("NIUU_SERVER_PORT", "8080")
+        env["SKULD__VOLUNDR_API_URL"] = f"http://{server_host}:{server_port}"
+        if session.owner_id:
+            env["SKULD__SESSION__OWNER_ID"] = session.owner_id
+        if session.tenant_id:
+            env["SKULD__SESSION__TENANT_ID"] = session.tenant_id
+        if session.model:
+            env["SKULD__SESSION__MODEL"] = session.model
+        sandbox_env = {key: value for key, value in env.items() if _safe_env_var(key, value)}
+        extra_env = spec.values.get("env", {})
+        if isinstance(extra_env, dict):
+            for key, value in extra_env.items():
+                key_str = str(key)
+                value_str = str(value)
+                if "\x00" not in key_str and "\x00" not in value_str:
+                    sandbox_env[key_str] = value_str
+        return sandbox_env
+
+    def _driver_config_json(self, workspace: Path) -> str:
+        mounts: list[dict[str, str]] = []
+        if self._mount_workspace:
+            mounts.append(
+                {
+                    "type": "bind",
+                    "source": str(workspace),
+                    "target": self._sandbox_workspace,
+                }
+            )
+        mounts.extend(self._sandbox_mounts)
+        if not mounts:
+            return ""
+        return json.dumps(
+            {
+                "docker": {"mounts": mounts},
+                "podman": {"mounts": mounts},
+            },
+            separators=(",", ":"),
+        )
+
+    def _uploads(self, workspace: Path) -> list[str]:
+        uploads = list(self._sandbox_uploads)
+        if not self._upload_workspace:
+            return uploads
+        target = self._upload_workspace_target or self._sandbox_workspace
+        return [f"{workspace}:{target}", *uploads]
+
+    async def _broker_is_ready(self, info: OpenShellSessionInfo) -> bool:
+        if not self._require_broker_ready or self._endpoint_exposure != "forward":
+            return True
+        if info.port is None:
+            return False
+        if self._healthcheck is not None:
+            return await self._healthcheck(info.port)
+        return await asyncio.to_thread(
+            _http_healthcheck,
+            "127.0.0.1",
+            info.port,
+            self._broker_health_path,
+            self._broker_health_timeout,
+        )
+
+    def _chat_endpoint(self, session_id: object, port: int) -> str:
+        host = os.environ.get("NIUU_SERVER_PUBLIC_HOST") or os.environ.get("NIUU_SERVER_HOST")
+        host = (host or "127.0.0.1").strip() or "127.0.0.1"
+        host = "localhost" if host == "127.0.0.1" else host
+        server_port = os.environ.get("NIUU_SERVER_PORT", "8080")
+        return f"ws://{host}:{server_port}/s/{session_id}/session"
+
+    def _code_endpoint(self, sandbox_name: str, workspace: Path) -> str:
+        if self._gateway_url:
+            return f"{self._gateway_url}/sandboxes/{sandbox_name}"
+        return f"file://{workspace}"
+
+    def _sandbox_name(self, session: Session) -> str:
+        return f"forge-{session.id}"
+
+    @staticmethod
+    def _runtime_from_spec(spec: SessionSpec) -> str:
+        broker = spec.values.get("broker", {})
+        if isinstance(broker, dict):
+            return str(broker.get("cliType") or broker.get("runtime") or "skuld")
+        return "skuld"
+
+    @staticmethod
+    def _map_status(obj: dict[str, Any]) -> SessionStatus:
+        status_obj = obj.get("status")
+        if isinstance(status_obj, dict):
+            raw_value = (
+                status_obj.get("state")
+                or status_obj.get("phase")
+                or status_obj.get("lifecycle")
+                or obj.get("state")
+                or obj.get("phase")
+                or ""
+            )
+        else:
+            raw_value = obj.get("state") or status_obj or obj.get("phase") or obj.get("lifecycle")
+        raw = str(raw_value or "").lower()
+        if raw in {"ready", "running", "active"}:
+            return SessionStatus.RUNNING
+        if raw in {"provisioning", "pending", "creating", "starting", "created"}:
+            return SessionStatus.PROVISIONING
+        if raw in {"deleting", "deleted", "stopped", "terminated", "suspended"}:
+            return SessionStatus.STOPPED
+        if raw in {"error", "failed", "failure"}:
+            return SessionStatus.FAILED
+        conditions = obj.get("conditions") or []
+        if isinstance(conditions, list):
+            for condition in conditions:
+                if not isinstance(condition, dict):
+                    continue
+                if condition.get("type") != "Ready":
+                    continue
+                if condition.get("status") is True or condition.get("status") == "True":
+                    return SessionStatus.RUNNING
+        return SessionStatus.PROVISIONING
+
+    def _persist_state(self) -> None:
+        self._state_file.parent.mkdir(parents=True, exist_ok=True)
+        data = {sid: info.to_dict() for sid, info in self._sessions.items()}
+        tmp_path = self._state_file.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        tmp_path.replace(self._state_file)
+
+    def _load_state(self) -> None:
+        if not self._state_file.exists():
+            return
+        try:
+            data = json.loads(self._state_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to load OpenShell state file: %s", exc)
+            return
+        if not isinstance(data, dict):
+            return
+        for sid, raw in data.items():
+            if not isinstance(raw, dict):
+                continue
+            info = OpenShellSessionInfo.from_dict(raw)
+            if info.session_id:
+                self._sessions[str(sid)] = info
+
+
+def _safe_env_var(key: object, value: object) -> bool:
+    if not isinstance(key, str):
+        return False
+    if not isinstance(value, str):
+        return False
+    if "\x00" in key or "\x00" in value:
+        return False
+    if key.startswith("SKULD__"):
+        return True
+    return key in {
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GIT_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+    }
+
+
+def _as_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    raw = str(value).strip().lower()
+    if raw in {"", "0", "false", "no", "off"}:
+        return False
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    return bool(value)
+
+
+def _normalize_command(command: list[str] | str | None) -> list[str] | None:
+    if command is None:
+        return None
+    if isinstance(command, list):
+        return command
+    raw = command.strip()
+    if not raw:
+        return None
+    if raw.startswith("["):
+        loaded = json.loads(raw)
+        if not isinstance(loaded, list):
+            raise ValueError("sandbox_command JSON must be a list")
+        return [str(item) for item in loaded]
+    return shlex.split(raw)
+
+
+def _normalize_string_list(value: Sequence[str] | str | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        if raw.startswith("["):
+            loaded = json.loads(raw)
+            if not isinstance(loaded, list):
+                raise ValueError("sandbox_uploads JSON must be a list")
+            return [str(item) for item in loaded]
+        return [raw]
+    return [str(item) for item in value]
+
+
+def _normalize_mounts(value: Sequence[dict[str, str] | str] | str | None) -> list[dict[str, str]]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return []
+        if raw.startswith("["):
+            loaded = json.loads(raw)
+            if not isinstance(loaded, list):
+                raise ValueError("sandbox_mounts JSON must be a list")
+            return [_mount_from_value(item) for item in loaded]
+        return [_mount_from_value(part) for part in raw.split(",") if part.strip()]
+    return [_mount_from_value(item) for item in value]
+
+
+def _mount_from_value(value: dict[str, str] | str) -> dict[str, str]:
+    if isinstance(value, dict):
+        source = str(value.get("source") or "").strip()
+        target = str(value.get("target") or "").strip()
+    else:
+        source, sep, target = str(value).partition(":")
+        if not sep:
+            raise ValueError("sandbox_mounts entries must be source:target")
+        source = source.strip()
+        target = target.strip()
+    if not source or not target:
+        raise ValueError("sandbox_mounts entries must include source and target")
+    return {
+        "type": "bind",
+        "source": str(Path(source).expanduser()),
+        "target": target,
+    }
+
+
+def _http_healthcheck(host: str, port: int, path: str, timeout: float) -> bool:
+    conn: http.client.HTTPConnection | None = None
+    try:
+        conn = http.client.HTTPConnection(host, port, timeout=timeout)
+        conn.request("GET", path)
+        response = conn.getresponse()
+        return 200 <= response.status < 500
+    except OSError:
+        return False
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def _state_from_session_status(status: SessionStatus) -> OpenShellState:
+    match status:
+        case SessionStatus.RUNNING:
+            return OpenShellState.RUNNING
+        case SessionStatus.FAILED:
+            return OpenShellState.FAILED
+        case SessionStatus.STOPPED:
+            return OpenShellState.STOPPED
+    return OpenShellState.STARTING

--- a/start-dev
+++ b/start-dev
@@ -8,6 +8,7 @@ PLATFORM_PID_FILE="${RUN_DIR}/platform.pid"
 PG_CTL="${ROOT_DIR}/build/pginstall/bin/pg_ctl"
 PG_DATA="${HOME}/.niuu/pgdata"
 PLATFORM_LOG="${LOG_DIR}/platform.log"
+RUNTIME_MODE="${RUNTIME_MODE:-mini}"
 # Auto-detect a LAN-routable IP so the platform binds to (and bakes into URLs)
 # an address that browsers on this machine *and* on the LAN can reach. Override
 # by exporting NIUU_SERVER__HOST before invoking this script.
@@ -44,12 +45,19 @@ mkdir -p "${LOG_DIR}"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0")
+Usage: $(basename "$0") [--openshell]
+
+Options:
+  --openshell  Start Volundr with the local OpenShell PodManager adapter.
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --openshell)
+      RUNTIME_MODE="openshell"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -245,7 +253,21 @@ fi
 HOST_PROFILE="full"
 export ROOT_DIR PLATFORM_LOG PLATFORM_PID_FILE UI_VARIANT HOST_PROFILE
 
-echo "Starting platform on ${NIUU_SERVER__HOST}:8080 (host-profile=${HOST_PROFILE})..."
+if [[ "${RUNTIME_MODE}" == "openshell" ]]; then
+  export NIUU_MODE="openshell"
+  export NIUU_POD_MANAGER__ADAPTER="volundr.adapters.outbound.openshell.OpenShellPodManager"
+  if [[ -n "${NIUU_POD_MANAGER__GATEWAY_URL:-}" ]]; then
+    export NIUU_POD_MANAGER__GATEWAY_URL
+  fi
+  export NIUU_POD_MANAGER__GATEWAY_NAME="${NIUU_POD_MANAGER__GATEWAY_NAME:-local}"
+  export NIUU_POD_MANAGER__SANDBOX_IMAGE="${NIUU_POD_MANAGER__SANDBOX_IMAGE:-ghcr.io/niuulabs/skuld:0.2.0}"
+  export NIUU_POD_MANAGER__WORKSPACES_DIR="${NIUU_POD_MANAGER__WORKSPACES_DIR:-${HOME}/.niuu/workspaces}"
+  export NIUU_POD_MANAGER__STATE_FILE="${NIUU_POD_MANAGER__STATE_FILE:-${HOME}/.niuu/openshell-forge-state.json}"
+  export NIUU_POD_MANAGER__SDK_PORT_START="${NIUU_POD_MANAGER__SDK_PORT_START:-9200}"
+  export NIUU_POD_MANAGER__FORWARD_MODE="${NIUU_POD_MANAGER__FORWARD_MODE:-service}"
+fi
+
+echo "Starting platform on ${NIUU_SERVER__HOST}:8080 (host-profile=${HOST_PROFILE}, runtime=${RUNTIME_MODE})..."
 python3 - <<'PY'
 import os
 import subprocess

--- a/stop-dev
+++ b/stop-dev
@@ -8,6 +8,7 @@ PG_CTL="${ROOT_DIR}/build/pginstall/bin/pg_ctl"
 PG_DATA="${HOME}/.niuu/pgdata"
 PLATFORM_PORT="8080"
 FORGE_STATE_FILE="${HOME}/.niuu/forge-state.json"
+OPENSHELL_FORGE_STATE_FILE="${HOME}/.niuu/openshell-forge-state.json"
 
 stop_pid_file() {
   local pid_file="$1"
@@ -69,7 +70,7 @@ for sid, raw in data.items():
     state = str(raw.get("state") or raw.get("status") or "").lower()
     managed_by = str(raw.get("managed_by") or "local_process")
     pid = raw.get("pid")
-    if state not in {"starting", "running"}:
+    if state not in {"starting", "running", "failed"}:
         continue
     if managed_by != "local_process":
         continue
@@ -153,6 +154,99 @@ PY
 }
 
 stop_forge_state_processes "${FORGE_STATE_FILE}"
+
+stop_openshell_sandboxes() {
+  local state_file="$1"
+
+  if [[ ! -f "${state_file}" ]]; then
+    return 0
+  fi
+
+  local records
+  if ! records="$(python3 - "${state_file}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state_file = Path(sys.argv[1])
+try:
+    data = json.loads(state_file.read_text(encoding="utf-8"))
+except Exception:
+    sys.exit(0)
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+for sid, raw in data.items():
+    if not isinstance(raw, dict):
+        continue
+    state = str(raw.get("state") or raw.get("status") or "").lower()
+    managed_by = str(raw.get("managed_by") or "openshell")
+    sandbox_name = str(raw.get("sandbox_name") or raw.get("name") or "")
+    if state not in {"starting", "running", "failed"}:
+        continue
+    if managed_by != "openshell" or not sandbox_name:
+        continue
+    print(f"{sid}\t{sandbox_name}")
+PY
+  )"; then
+    return 0
+  fi
+
+  if [[ -z "${records}" ]]; then
+    return 0
+  fi
+
+  if ! command -v openshell >/dev/null 2>&1; then
+    echo "Skipping OpenShell sandbox cleanup; openshell is not on PATH."
+    return 0
+  fi
+
+  local stopped_sids=()
+  local sid
+  local sandbox_name
+  while IFS=$'\t' read -r sid sandbox_name; do
+    [[ -n "${sid}" && -n "${sandbox_name}" ]] || continue
+    echo "Stopping OpenShell sandbox ${sandbox_name}..."
+    openshell sandbox delete "${sandbox_name}" >/dev/null 2>&1 || true
+    stopped_sids+=("${sid}")
+  done <<< "${records}"
+
+  if [[ ${#stopped_sids[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  python3 - "${state_file}" "${stopped_sids[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+state_file = Path(sys.argv[1])
+stopped = set(sys.argv[2:])
+try:
+    data = json.loads(state_file.read_text(encoding="utf-8"))
+except Exception:
+    sys.exit(0)
+
+if not isinstance(data, dict):
+    sys.exit(0)
+
+changed = False
+for sid in stopped:
+    raw = data.get(sid)
+    if not isinstance(raw, dict):
+        continue
+    raw["state"] = "stopped"
+    changed = True
+
+if changed:
+    tmp = state_file.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp.replace(state_file)
+PY
+}
+
+stop_openshell_sandboxes "${OPENSHELL_FORGE_STATE_FILE}"
 
 stop_matching_processes() {
   local pattern="$1"

--- a/tests/test_adapters/test_openshell.py
+++ b/tests/test_adapters/test_openshell.py
@@ -1,0 +1,544 @@
+"""Tests for the OpenShell PodManager adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from volundr.adapters.outbound.openshell import OpenShellClient, OpenShellPodManager
+from volundr.domain.models import (
+    LocalMountSource,
+    PodSpecAdditions,
+    Session,
+    SessionSpec,
+    SessionStatus,
+)
+
+
+class FakeOpenShellClient:
+    def __init__(self, state: str = "Ready"):
+        self.state = state
+        self.ensure_gateway_calls = 0
+        self.create_calls: list[dict] = []
+        self.forward_calls: list[dict] = []
+        self.service_forward_calls: list[dict] = []
+        self.forward_stop_calls: list[dict] = []
+        self.delete_calls: list[str] = []
+
+    async def ensure_gateway(self) -> None:
+        self.ensure_gateway_calls += 1
+
+    async def create_sandbox(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return {"state": "Provisioning"}
+
+    async def forward_start(self, **kwargs) -> None:
+        self.forward_calls.append(kwargs)
+
+    async def forward_service_start(self, **kwargs) -> None:
+        self.service_forward_calls.append(kwargs)
+
+    async def forward_stop(self, **kwargs) -> None:
+        self.forward_stop_calls.append(kwargs)
+
+    async def get_sandbox(self, name: str):
+        return {"name": name, "state": self.state}
+
+    async def delete_sandbox(self, name: str) -> bool:
+        self.delete_calls.append(name)
+        self.state = "Deleted"
+        return True
+
+
+class RecordingOpenShellClient(OpenShellClient):
+    def __init__(self):
+        super().__init__(gateway_url="")
+        self.calls: list[tuple[str, ...]] = []
+
+    async def _run(self, *args: str, check: bool = True):
+        self.calls.append(args)
+        if args[:3] == ("sandbox", "list", "-o"):
+            return _Completed(
+                returncode=0,
+                stdout='[{"name":"forge-test","state":"Ready"}]',
+                stderr="",
+            )
+        return _Completed(returncode=0, stdout="", stderr="")
+
+
+class _Completed:
+    def __init__(self, *, returncode: int, stdout: str, stderr: str):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class RecordingSkuldRegistry:
+    def __init__(self) -> None:
+        self.ports: dict[str, int] = {}
+        self.register_calls: list[tuple[str, int]] = []
+        self.unregister_calls: list[str] = []
+
+    def register(self, session_id: str, port: int) -> None:
+        self.ports[session_id] = port
+        self.register_calls.append((session_id, port))
+
+    def unregister(self, session_id: str) -> None:
+        self.ports.pop(session_id, None)
+        self.unregister_calls.append(session_id)
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    path = tmp_path / "repo"
+    path.mkdir()
+    return path
+
+
+@pytest.fixture
+def session(workspace: Path) -> Session:
+    return Session(
+        id=uuid4(),
+        name="openshell-codex",
+        model="gpt-5.4",
+        source=LocalMountSource(local_path=str(workspace)),
+    )
+
+
+def _spec(cli_type: str = "codex") -> SessionSpec:
+    return SessionSpec(
+        pod_spec=PodSpecAdditions(),
+        values={
+            "broker": {
+                "cliType": cli_type,
+                "transportAdapter": "skuld.transports.codex.CodexSubprocessTransport",
+            },
+            "env": {"EXPLICIT_SESSION_ENV": "yes"},
+        }
+    )
+
+
+def _manager(tmp_path: Path, client: FakeOpenShellClient) -> OpenShellPodManager:
+    return OpenShellPodManager(
+        client=client,
+        workspaces_dir=str(tmp_path / "workspaces"),
+        state_file=str(tmp_path / "openshell-state.json"),
+        sandbox_image="skuld:test",
+        sdk_port_start=12900,
+        require_broker_ready=False,
+    )
+
+
+class TestOpenShellPodManager:
+    async def test_start_creates_sandbox_and_returns_volundr_proxy_endpoint(
+        self,
+        tmp_path: Path,
+        session: Session,
+        workspace: Path,
+    ) -> None:
+        client = FakeOpenShellClient()
+        manager = _manager(tmp_path, client)
+
+        result = await manager.start(session, _spec("codex"))
+
+        assert client.ensure_gateway_calls == 1
+        assert len(client.create_calls) == 1
+        create = client.create_calls[0]
+        assert create["name"] == f"forge-{session.id}"
+        assert create["image"] == "skuld:test"
+        assert create["command"] == ["/opt/venv/bin/python", "-m", "skuld"]
+        assert create["labels"]["volundr.niuu.io/session"] == str(session.id)
+        assert create["labels"]["volundr.niuu.io/runtime"] == "codex"
+        assert create["env"]["SKULD__CLI_TYPE"] == "codex"
+        assert create["env"]["SKULD__SESSION__ID"] == str(session.id)
+        assert create["env"]["SKULD__SESSION__WORKSPACE_DIR"] == "/sandbox/workspace"
+        assert create["env"]["EXPLICIT_SESSION_ENV"] == "yes"
+        assert "PATH" not in create["env"]
+        assert client.forward_calls == [
+            {"sandbox_name": f"forge-{session.id}", "port": 12900}
+        ]
+        assert result.chat_endpoint == f"ws://localhost:8080/s/{session.id}/session"
+        assert result.code_endpoint == f"file://{workspace}"
+        assert result.pod_name == f"forge-{session.id}"
+
+    async def test_start_can_upload_workspace_for_vm_driver(
+        self,
+        tmp_path: Path,
+        session: Session,
+        workspace: Path,
+    ) -> None:
+        client = FakeOpenShellClient()
+        manager = OpenShellPodManager(
+            client=client,
+            workspaces_dir=str(tmp_path / "workspaces"),
+            state_file=str(tmp_path / "openshell-state.json"),
+            sandbox_image="skuld:test",
+            sandbox_command=(
+                "/bin/sh /sandbox/workspace/scripts/openshell-run-skuld-from-workspace.sh"
+            ),
+            mount_workspace="false",
+            upload_workspace="true",
+            upload_workspace_target="/sandbox/workspace",
+            upload_no_git_ignore="false",
+            sandbox_workspace="/sandbox/workspace/repo",
+            sandbox_uploads="/host/bootstrap.sh:/sandbox/bootstrap.sh",
+            policy_file="/host/policy.yaml",
+        )
+
+        await manager.start(session, _spec("codex"))
+
+        create = client.create_calls[0]
+        assert create["command"] == [
+            "/bin/sh",
+            "/sandbox/workspace/scripts/openshell-run-skuld-from-workspace.sh",
+        ]
+        assert create["env"]["SKULD__SESSION__WORKSPACE_DIR"] == "/sandbox/workspace/repo"
+        assert create["driver_config_json"] == ""
+        assert create["uploads"] == [
+            f"{workspace}:/sandbox/workspace",
+            "/host/bootstrap.sh:/sandbox/bootstrap.sh",
+        ]
+        assert create["upload_no_git_ignore"] is False
+        assert create["policy_file"] == "/host/policy.yaml"
+
+    async def test_start_can_mount_local_cli_auth_dirs_without_mounting_workspace(
+        self,
+        tmp_path: Path,
+        session: Session,
+        workspace: Path,
+    ) -> None:
+        client = FakeOpenShellClient()
+        manager = OpenShellPodManager(
+            client=client,
+            workspaces_dir=str(tmp_path / "workspaces"),
+            state_file=str(tmp_path / "openshell-state.json"),
+            sandbox_image="skuld:test",
+            mount_workspace=False,
+            upload_workspace=True,
+            upload_workspace_target="/sandbox/workspace",
+            sandbox_workspace="/sandbox/workspace/repo",
+            sandbox_mounts=[
+                f"{tmp_path}/codex:/home/sandbox/.codex",
+                {
+                    "source": str(tmp_path / "claude"),
+                    "target": "/home/sandbox/.claude",
+                },
+            ],
+        )
+
+        await manager.start(session, _spec("codex"))
+
+        create = client.create_calls[0]
+        driver_config = json.loads(create["driver_config_json"])
+        expected_mounts = [
+            {
+                "type": "bind",
+                "source": str(tmp_path / "codex"),
+                "target": "/home/sandbox/.codex",
+            },
+            {
+                "type": "bind",
+                "source": str(tmp_path / "claude"),
+                "target": "/home/sandbox/.claude",
+            },
+        ]
+        assert driver_config["docker"]["mounts"] == expected_mounts
+        assert driver_config["podman"]["mounts"] == expected_mounts
+        assert create["uploads"] == [f"{workspace}:/sandbox/workspace"]
+
+    async def test_start_can_parse_sandbox_mounts_from_json(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        client = FakeOpenShellClient()
+        manager = OpenShellPodManager(
+            client=client,
+            workspaces_dir=str(tmp_path / "workspaces"),
+            state_file=str(tmp_path / "openshell-state.json"),
+            sandbox_image="skuld:test",
+            sandbox_mounts=json.dumps(
+                [
+                    {
+                        "source": str(tmp_path / "codex"),
+                        "target": "/home/sandbox/.codex",
+                    }
+                ]
+            ),
+        )
+
+        await manager.start(session, _spec("codex"))
+
+        create = client.create_calls[0]
+        driver_config = json.loads(create["driver_config_json"])
+        assert driver_config["docker"]["mounts"][-1] == {
+            "type": "bind",
+            "source": str(tmp_path / "codex"),
+            "target": "/home/sandbox/.codex",
+        }
+
+    async def test_start_supports_claude_runtime(self, tmp_path: Path, session: Session) -> None:
+        client = FakeOpenShellClient()
+        manager = _manager(tmp_path, client)
+
+        await manager.start(session, _spec("claude"))
+
+        create = client.create_calls[0]
+        assert create["labels"]["volundr.niuu.io/runtime"] == "claude"
+        assert create["env"]["SKULD__CLI_TYPE"] == "claude"
+
+    async def test_start_can_use_service_forward_mode(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        client = FakeOpenShellClient()
+        manager = OpenShellPodManager(
+            client=client,
+            workspaces_dir=str(tmp_path / "workspaces"),
+            state_file=str(tmp_path / "openshell-state.json"),
+            sandbox_image="skuld:test",
+            sdk_port_start=12900,
+            forward_mode="service",
+            require_broker_ready=False,
+        )
+
+        await manager.start(session, _spec("codex"))
+
+        assert client.forward_calls == []
+        assert client.service_forward_calls == [
+            {"sandbox_name": f"forge-{session.id}", "port": 12900}
+        ]
+
+    async def test_status_maps_openshell_states(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        client = FakeOpenShellClient(state="Provisioning")
+        manager = _manager(tmp_path, client)
+        await manager.start(session, _spec())
+
+        assert await manager.status(session) == SessionStatus.PROVISIONING
+
+        client.state = "Ready"
+        assert await manager.status(session) == SessionStatus.RUNNING
+
+        client.state = "Error"
+        assert await manager.status(session) == SessionStatus.FAILED
+
+    async def test_status_waits_for_broker_health_after_sandbox_ready(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        client = FakeOpenShellClient(state="Ready")
+        healthy = False
+
+        async def healthcheck(_port: int) -> bool:
+            return healthy
+
+        manager = OpenShellPodManager(
+            client=client,
+            workspaces_dir=str(tmp_path / "workspaces"),
+            state_file=str(tmp_path / "openshell-state.json"),
+            sandbox_image="skuld:test",
+            sdk_port_start=12900,
+            healthcheck=healthcheck,
+        )
+        await manager.start(session, _spec())
+
+        assert await manager.status(session) == SessionStatus.PROVISIONING
+
+        healthy = True
+        assert await manager.status(session) == SessionStatus.RUNNING
+
+    async def test_status_stays_provisioning_until_start_completes(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        state_file = tmp_path / "openshell-state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    str(session.id): {
+                        "session_id": str(session.id),
+                        "sandbox_name": f"forge-{session.id}",
+                        "port": 12900,
+                        "workspace": str(tmp_path),
+                        "runtime": "codex",
+                        "state": "starting",
+                        "start_complete": False,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        manager = OpenShellPodManager(
+            client=FakeOpenShellClient(state="Ready"),
+            workspaces_dir=str(tmp_path / "workspaces"),
+            state_file=str(state_file),
+            sandbox_image="skuld:test",
+            sdk_port_start=12900,
+            require_broker_ready=False,
+        )
+
+        assert await manager.status(session) == SessionStatus.PROVISIONING
+
+    async def test_max_concurrent_counts_starting_sessions(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        client = FakeOpenShellClient(state="Ready")
+
+        async def healthcheck(_port: int) -> bool:
+            return False
+
+        manager = OpenShellPodManager(
+            client=client,
+            workspaces_dir=str(tmp_path / "workspaces"),
+            state_file=str(tmp_path / "openshell-state.json"),
+            sandbox_image="skuld:test",
+            sdk_port_start=12900,
+            max_concurrent=1,
+            healthcheck=healthcheck,
+        )
+        await manager.start(session, _spec())
+
+        second = Session(
+            id=uuid4(),
+            name="openshell-codex-2",
+            model="gpt-5.4",
+            source=session.source,
+        )
+        with pytest.raises(RuntimeError, match="Max concurrent OpenShell sessions"):
+            await manager.start(second, _spec())
+
+    async def test_stop_deletes_sandbox(self, tmp_path: Path, session: Session) -> None:
+        client = FakeOpenShellClient()
+        manager = _manager(tmp_path, client)
+        await manager.start(session, _spec())
+
+        stopped = await manager.stop(session)
+
+        assert stopped is True
+        assert client.forward_stop_calls == [
+            {
+                "sandbox_name": f"forge-{session.id}",
+                "port": 12900,
+                "mode": "start",
+            }
+        ]
+        assert client.delete_calls == [f"forge-{session.id}"]
+        assert await manager.status(session) == SessionStatus.STOPPED
+
+    async def test_initial_chat_endpoint_uses_persisted_forward_port(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        client = FakeOpenShellClient()
+        manager = _manager(tmp_path, client)
+
+        assert manager.initial_chat_endpoint(session) is None
+        await manager.start(session, _spec())
+
+        assert manager.initial_chat_endpoint(session) == (
+            f"ws://localhost:8080/s/{session.id}/session"
+        )
+
+    async def test_registers_forward_port_with_skuld_proxy_registry(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        client = FakeOpenShellClient()
+        manager = _manager(tmp_path, client)
+        registry = RecordingSkuldRegistry()
+        manager.set_skuld_registry(registry)
+
+        await manager.start(session, _spec())
+        await manager.stop(session)
+
+        assert registry.register_calls == [(str(session.id), 12900)]
+        assert registry.unregister_calls == [str(session.id)]
+
+    async def test_set_skuld_registry_rehydrates_running_sessions(
+        self,
+        tmp_path: Path,
+        session: Session,
+    ) -> None:
+        state_file = tmp_path / "openshell-state.json"
+        state_file.write_text(
+            json.dumps(
+                {
+                    str(session.id): {
+                        "session_id": str(session.id),
+                        "sandbox_name": f"forge-{session.id}",
+                        "port": 12942,
+                        "workspace": str(tmp_path),
+                        "runtime": "claude",
+                        "state": "running",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        manager = OpenShellPodManager(
+            client=FakeOpenShellClient(),
+            workspaces_dir=str(tmp_path / "workspaces"),
+            state_file=str(state_file),
+            sandbox_image="skuld:test",
+            require_broker_ready=False,
+        )
+        registry = RecordingSkuldRegistry()
+
+        manager.set_skuld_registry(registry)
+
+        assert registry.register_calls == [(str(session.id), 12942)]
+
+
+class TestOpenShellClient:
+    async def test_create_sandbox_uses_current_cli_without_json_output_flag(self) -> None:
+        client = RecordingOpenShellClient()
+
+        await client.create_sandbox(
+            name="forge-test",
+            image="skuld:test",
+            command=["python", "-m", "skuld"],
+            env={"SKULD__PORT": "9200"},
+            labels={"volundr.niuu.io/session": "abc"},
+            uploads=["/host/repo:/sandbox/workspace"],
+            upload_no_git_ignore=True,
+            policy_file="/host/policy.yaml",
+        )
+
+        call = client.calls[0]
+        assert call[:5] == ("sandbox", "create", "--name", "forge-test", "--from")
+        assert "-o" not in call
+        assert "--no-git-ignore" in call
+        policy_index = call.index("--policy")
+        assert call[policy_index + 1] == "/host/policy.yaml"
+        upload_index = call.index("--upload")
+        assert call[upload_index + 1] == "/host/repo:/sandbox/workspace"
+        assert call[-4:] == ("--", "python", "-m", "skuld")
+
+    async def test_get_sandbox_filters_json_list_by_name(self) -> None:
+        client = RecordingOpenShellClient()
+
+        sandbox = await client.get_sandbox("forge-test")
+
+        assert sandbox == {"name": "forge-test", "state": "Ready"}
+        assert client.calls == [("sandbox", "list", "-o", "json")]
+
+    async def test_forward_start_runs_in_background(self) -> None:
+        client = RecordingOpenShellClient()
+
+        await client.forward_start(sandbox_name="forge-test", port=9200)
+
+        assert client.calls == [("forward", "start", "9200", "forge-test", "-d")]

--- a/tests/test_cli/test_platform_commands.py
+++ b/tests/test_cli/test_platform_commands.py
@@ -282,6 +282,53 @@ class TestDynamicUpCallback:
         startup.assert_awaited_once()
         shutdown.assert_awaited_once_with(manager)
 
+    def test_up_callback_sets_openshell_runtime_overrides(self) -> None:
+        service_defs = {"volundr": _make_svc_def("volundr")}
+        manager = MagicMock()
+        settings = CLISettings(
+            mode="openshell",
+            pod_manager=PodManagerConfig(
+                adapter="volundr.adapters.outbound.openshell.OpenShellPodManager",
+                gateway_url="",
+                sandbox_image="skuld:test",
+                workspaces_dir="~/.niuu/workspaces",
+                sdk_port_start=9200,
+            ),
+        )
+        up_fn = _build_up_callback(service_defs, manager, settings)
+
+        fake_event = MagicMock()
+        fake_event.wait = AsyncMock(side_effect=asyncio.CancelledError())
+        startup = AsyncMock()
+        shutdown = AsyncMock()
+
+        with (
+            patch("cli.commands.platform._startup", startup),
+            patch("cli.commands.platform._shutdown", shutdown),
+            patch("cli.commands.platform.asyncio.Event", return_value=fake_event),
+            patch("cli.commands.platform.asyncio.run", side_effect=asyncio.run),
+            patch.dict("os.environ", {}, clear=True),
+        ):
+            up_fn(
+                skip_preflight=True,
+                all=False,
+                no_web=False,
+                host_profile="full",
+                mounts="",
+                volundr=True,
+            )
+
+            assert os.environ["LOCAL_MOUNTS__ENABLED"] == "true"
+            assert os.environ["LOCAL_MOUNTS__MINI_MODE"] == "true"
+            assert os.environ["POD_MANAGER__ADAPTER"] == settings.pod_manager.adapter
+            assert os.environ["POD_MANAGER__KWARGS__GATEWAY_URL"] == ""
+            assert os.environ["POD_MANAGER__KWARGS__SANDBOX_IMAGE"] == "skuld:test"
+            assert os.environ["POD_MANAGER__KWARGS__SDK_PORT_START"] == "9200"
+            assert os.environ["GIT__VALIDATE_ON_CREATE"] == "false"
+
+        startup.assert_awaited_once()
+        shutdown.assert_awaited_once_with(manager)
+
     def test_up_callback_applies_workspaces_dir_override_in_mini_mode(self) -> None:
         service_defs = {"volundr": _make_svc_def("volundr")}
         manager = MagicMock()
@@ -325,7 +372,7 @@ class TestDynamicUpCallback:
         settings = CLISettings(mode="cluster")
         up_fn = _build_up_callback(service_defs, manager, settings)
 
-        with pytest.raises(typer.BadParameter, match="only supported in mini mode"):
+        with pytest.raises(typer.BadParameter, match="only supported in mini or openshell mode"):
             up_fn(
                 skip_preflight=True,
                 all=False,
@@ -506,6 +553,13 @@ class TestBuildInitConfig:
         assert "direct_k8s" in config["pod_manager"]["adapter"]
         assert config["pod_manager"]["namespace"] == "volundr"
 
+    def test_openshell_config(self) -> None:
+        config = _build_init_config("openshell")
+        assert config["mode"] == "openshell"
+        assert "openshell.OpenShellPodManager" in config["pod_manager"]["adapter"]
+        assert config["pod_manager"]["gateway_url"] == ""
+        assert config["pod_manager"]["sdk_port_start"] == 9200
+
     def test_cluster_config_uses_pinned_image_version(self) -> None:
         """skuld_image must use a pinned version, not :latest."""
         config = _build_init_config("cluster")
@@ -616,17 +670,31 @@ class TestPromptModeSelection:
             mode = _prompt_mode_selection()
         assert mode == "mini"
 
-    def test_choice_2_returns_cluster(self) -> None:
+    def test_choice_2_returns_openshell(self) -> None:
         from unittest.mock import patch
 
         with patch("cli.commands.platform.typer.prompt", return_value="2"):
             mode = _prompt_mode_selection()
-        assert mode == "cluster"
+        assert mode == "openshell"
 
     def test_choice_cluster_string_returns_cluster(self) -> None:
         from unittest.mock import patch
 
         with patch("cli.commands.platform.typer.prompt", return_value="cluster"):
+            mode = _prompt_mode_selection()
+        assert mode == "cluster"
+
+    def test_choice_openshell_string_returns_openshell(self) -> None:
+        from unittest.mock import patch
+
+        with patch("cli.commands.platform.typer.prompt", return_value="openshell"):
+            mode = _prompt_mode_selection()
+        assert mode == "openshell"
+
+    def test_choice_cluster_number_returns_cluster(self) -> None:
+        from unittest.mock import patch
+
+        with patch("cli.commands.platform.typer.prompt", return_value="3"):
             mode = _prompt_mode_selection()
         assert mode == "cluster"
 
@@ -676,6 +744,16 @@ class TestConfigModeSwitching:
         )
         assert "DirectK8sPodManager" in settings.pod_manager.adapter
         assert settings.mode == "cluster"
+
+    def test_openshell_mode_adapter(self) -> None:
+        settings = CLISettings(
+            mode="openshell",
+            pod_manager=PodManagerConfig(
+                adapter="volundr.adapters.outbound.openshell.OpenShellPodManager",
+            ),
+        )
+        assert "OpenShellPodManager" in settings.pod_manager.adapter
+        assert settings.mode == "openshell"
 
 
 class TestPlatformStatusClusterInfo:

--- a/tests/test_containers/test_cli_runtime_images.py
+++ b/tests/test_containers/test_cli_runtime_images.py
@@ -42,3 +42,10 @@ def test_cli_runtime_images_install_vim() -> None:
     for dockerfile_path in dockerfile_paths:
         dockerfile = (REPO_ROOT / dockerfile_path).read_text()
         assert "    vim \\\n" in dockerfile
+
+
+def test_skuld_image_installs_iproute2_for_openshell_vm() -> None:
+    """OpenShell's VM driver requires an ip binary during rootfs preparation."""
+    dockerfile = (REPO_ROOT / "containers/skuld/Dockerfile").read_text()
+
+    assert "    iproute2 \\\n" in dockerfile


### PR DESCRIPTION
## Summary

Adds an OpenShell-backed Volundr PodManager so local Forge sessions can be launched as resident OpenShell sandboxes while preserving the existing Skuld broker/session flow.

## Changes

- Add OpenShellPodManager and OpenShellClient for sandbox lifecycle, forwarding, workspace mounting/upload support, local state, and readiness/status mapping.
- Add ./start-dev --openshell and stop-dev cleanup support for OpenShell-managed sessions.
- Add OpenShell smoke/bootstrap scripts and a development policy file for local proof runs.
- Update Skuld container entrypoint/bootstrap compatibility for command override and local OpenShell proof paths.
- Document configuration, including openshell_binary, sandbox image/command options, workspace paths, and proof workflows.
- Add focused adapter, CLI, and container image tests.

## Validation

- uv run pytest tests/test_adapters/test_openshell.py tests/test_cli/test_platform_commands.py tests/test_containers/test_cli_runtime_images.py -q
- bash -n scripts/openshell-run-installed-skuld.sh scripts/openshell-run-skuld-from-workspace.sh scripts/openshell-volundr-smoke.sh start-dev stop-dev containers/skuld/entrypoint.sh

## Notes

This keeps the scope to Skuld-on-OpenShell: Volundr still talks to the Skuld broker, while OpenShell replaces the local/k8s substrate for these sessions. Native NemoClaw/OpenClaw/DeepAgents runtime support should remain a separate follow-up path if needed.