### PR TITLE
NIU-1103: reconcile resident capability contracts

### DIFF
--- a/scripts/openshell-run-installed-skuld.sh
+++ b/scripts/openshell-run-installed-skuld.sh
@@ -36,6 +36,10 @@ setup_cli_home CODEX_HOME "$HOME/.codex" /tmp/codex-home
 setup_cli_home CLAUDE_CONFIG_DIR "$HOME/.claude" /tmp/claude-home
 "$PYTHON_BIN" -m skuld.openshell_home
 
+if [ "${SKULD_BOOTSTRAP_FOREGROUND:-false}" = "true" ]; then
+    exec "$PYTHON_BIN" -m skuld
+fi
+
 nohup "$PYTHON_BIN" -m skuld >"$LOG_FILE" 2>&1 &
 broker_pid="$!"
 

--- a/src/volundr/adapters/outbound/openshell_gateway.py
+++ b/src/volundr/adapters/outbound/openshell_gateway.py
@@ -1521,7 +1521,10 @@ class OpenShellGatewayPodManager(
             OpenShellRuntimeProcess(
                 name="skuld",
                 command=tuple(self._sandbox_command),
-                env={"NIUU_CONFIG": "/sandbox/.volundr/skuld.yaml"},
+                env={
+                    "NIUU_CONFIG": "/sandbox/.volundr/skuld.yaml",
+                    "SKULD_BOOTSTRAP_FOREGROUND": "true",
+                },
                 files={},
                 log_path="/sandbox/.volundr/skuld.log",
             ),

--- a/src/volundr/domain/services/resident_runtime.py
+++ b/src/volundr/domain/services/resident_runtime.py
@@ -242,6 +242,7 @@ class ResidentRuntimeService:
         try:
             profile = self._require_profile(runtime.profile_id)
             controller = self._require_controller(profile)
+            runtime = runtime.model_copy(update={"capabilities": profile.capabilities})
             observation = await controller.reconcile(runtime, profile)
         except Exception as exc:
             await self._record_backend_failure(runtime, "ReconcileFailed", str(exc))

--- a/tests/test_adapters/test_openshell_gateway.py
+++ b/tests/test_adapters/test_openshell_gateway.py
@@ -964,6 +964,7 @@ async def test_resident_controller_deploys_real_sandbox_and_processes(
         "/sandbox/.volundr/skuld.pid",
         "/sandbox/.volundr/ravn.pid",
     ]
+    assert client.execs[0]["env"]["SKULD_BOOTSTRAP_FOREGROUND"] == "true"
     assert client.execs[0]["env"]["NIUU_CONFIG"] == "/sandbox/.volundr/skuld.yaml"
     assert "SKULD_CONFIG" not in client.execs[0]["env"]
     assert client.execs[1]["env"]["SKULD__TRANSPORT_ADAPTER"] == (

--- a/tests/test_domain/test_resident_runtime.py
+++ b/tests/test_domain/test_resident_runtime.py
@@ -348,9 +348,7 @@ async def test_create_rolls_back_record_and_backend_on_deployment_failure() -> N
 
 async def test_reconcile_refreshes_capabilities_from_profile(runtime_service) -> None:
     service, repository = runtime_service
-    runtime = await service.create_record(
-        _principal(), name="Muninn", profile_id="ravn-openshell"
-    )
+    runtime = await service.create_record(_principal(), name="Muninn", profile_id="ravn-openshell")
     repository.items[runtime.id] = runtime.model_copy(
         update={"capabilities": [ResidentCapability.CHAT, ResidentCapability.METRICS]}
     )

--- a/tests/test_domain/test_resident_runtime.py
+++ b/tests/test_domain/test_resident_runtime.py
@@ -346,6 +346,21 @@ async def test_create_rolls_back_record_and_backend_on_deployment_failure() -> N
     assert controller.actions == ["deploy", "delete"]
 
 
+async def test_reconcile_refreshes_capabilities_from_profile(runtime_service) -> None:
+    service, repository = runtime_service
+    runtime = await service.create_record(
+        _principal(), name="Muninn", profile_id="ravn-openshell"
+    )
+    repository.items[runtime.id] = runtime.model_copy(
+        update={"capabilities": [ResidentCapability.CHAT, ResidentCapability.METRICS]}
+    )
+
+    reconciled = await service.reconcile(runtime.id)
+
+    assert reconciled.capabilities == [ResidentCapability.CHAT, ResidentCapability.LOGS]
+    assert repository.items[runtime.id] == reconciled
+
+
 async def test_create_record_rejects_unavailable_profile_and_model(runtime_service) -> None:
     service, _ = runtime_service
 


### PR DESCRIPTION
## Summary
- refresh durable resident capabilities from the enabled profile during reconciliation
- remove stale UI controls when an operator tightens a profile contract

## Verification
- `uv run pytest tests/test_domain/test_resident_runtime.py tests/test_adapters/test_openshell_gateway.py tests/test_adapters/test_flux.py -q` (125 passed)