### PR TITLE
NIU-1103: persist terminal streaming usage

### DIFF
--- a/src/bifrost/inbound/tracking.py
+++ b/src/bifrost/inbound/tracking.py
@@ -36,25 +36,40 @@ __all__ = ["_HEADER_QUOTA_WARNING", "_HEADER_QUOTA_REMAINING"]
 
 def _extract_usage_from_sse_line(line: str, usage: TokenUsage) -> None:
     """Parse one SSE data line and update *usage* in-place."""
-    if not line.startswith("data: "):
-        return
-    try:
-        payload = json.loads(line[6:])
-    except (json.JSONDecodeError, ValueError):
-        return
+    for raw_line in line.splitlines():
+        if not raw_line.startswith("data: "):
+            continue
+        try:
+            payload = json.loads(raw_line[6:])
+        except (json.JSONDecodeError, ValueError):
+            continue
 
-    event_type = payload.get("type", "")
+        event_type = payload.get("type", "")
 
-    if event_type == "message_start":
-        msg_usage = payload.get("message", {}).get("usage", {})
-        usage.input_tokens += msg_usage.get("input_tokens", 0)
-        usage.cache_creation_input_tokens += msg_usage.get("cache_creation_input_tokens", 0)
-        usage.cache_read_input_tokens += msg_usage.get("cache_read_input_tokens", 0)
-        usage.reasoning_tokens += msg_usage.get("reasoning_tokens", 0)
-    elif event_type == "message_delta":
-        delta_usage = payload.get("usage", {})
-        usage.output_tokens += delta_usage.get("output_tokens", 0)
-        usage.reasoning_tokens += delta_usage.get("reasoning_tokens", 0)
+        if event_type == "message_start":
+            msg_usage = payload.get("message", {}).get("usage", {})
+            usage.input_tokens += msg_usage.get("input_tokens", 0)
+            usage.cache_creation_input_tokens += msg_usage.get("cache_creation_input_tokens", 0)
+            usage.cache_read_input_tokens += msg_usage.get("cache_read_input_tokens", 0)
+            usage.reasoning_tokens += msg_usage.get("reasoning_tokens", 0)
+        elif event_type == "message_delta":
+            delta_usage = payload.get("usage", {})
+            usage.output_tokens += delta_usage.get("output_tokens", 0)
+            usage.reasoning_tokens += delta_usage.get("reasoning_tokens", 0)
+
+
+def _stream_chunk_is_terminal(chunk: str) -> bool:
+    for line in chunk.splitlines():
+        if line == "event: message_stop" or line == "data: [DONE]":
+            return True
+        if not line.startswith("data: "):
+            continue
+        try:
+            if json.loads(line[6:]).get("type") == "message_stop":
+                return True
+        except (json.JSONDecodeError, ValueError):
+            continue
+    return False
 
 
 def _log_request(log: RequestLog) -> None:
@@ -156,63 +171,72 @@ async def _stream_with_tracking(
 ) -> AsyncIterator[str]:
     """Yield SSE lines from *source* while tracking token usage."""
     usage = TokenUsage()
+    recorded = False
 
-    async for line in source:
-        _extract_usage_from_sse_line(line, usage)
-        yield line
-
-    latency_ms = (time.monotonic() - start) * 1000
-    _log_request(
-        RequestLog(
-            timestamp=datetime.now(UTC),
-            model=model,
-            usage=usage,
-            latency_ms=latency_ms,
-            stream=True,
+    async def record_usage() -> None:
+        nonlocal recorded
+        if recorded:
+            return
+        recorded = True
+        latency_ms = (time.monotonic() - start) * 1000
+        _log_request(
+            RequestLog(
+                timestamp=datetime.now(UTC),
+                model=model,
+                usage=usage,
+                latency_ms=latency_ms,
+                stream=True,
+            )
         )
-    )
 
-    cost = calculate_cost(model, usage, pricing_overrides)
-    _metrics.record_request(
-        provider=provider,
-        model=model,
-        status="200",
-        duration_seconds=latency_ms / 1000.0,
-        input_tokens=usage.input_tokens,
-        output_tokens=usage.output_tokens,
-        cache_read_tokens=usage.cache_read_input_tokens,
-        cache_write_tokens=usage.cache_creation_input_tokens,
-        cost_usd=cost,
-    )
-    await store.record(
-        UsageRecord(
-            request_id=request_id,
-            agent_id=identity.agent_id,
-            tenant_id=identity.tenant_id,
-            session_id=identity.session_id,
-            saga_id=identity.saga_id,
-            model=model,
+        cost = calculate_cost(model, usage, pricing_overrides)
+        _metrics.record_request(
             provider=provider,
+            model=model,
+            status="200",
+            duration_seconds=latency_ms / 1000.0,
             input_tokens=usage.input_tokens,
             output_tokens=usage.output_tokens,
             cache_read_tokens=usage.cache_read_input_tokens,
             cache_write_tokens=usage.cache_creation_input_tokens,
-            reasoning_tokens=usage.reasoning_tokens,
             cost_usd=cost,
-            latency_ms=latency_ms,
-            streaming=True,
-            timestamp=datetime.now(UTC),
         )
-    )
+        await store.record(
+            UsageRecord(
+                request_id=request_id,
+                agent_id=identity.agent_id,
+                tenant_id=identity.tenant_id,
+                session_id=identity.session_id,
+                saga_id=identity.saga_id,
+                model=model,
+                provider=provider,
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_read_tokens=usage.cache_read_input_tokens,
+                cache_write_tokens=usage.cache_creation_input_tokens,
+                reasoning_tokens=usage.reasoning_tokens,
+                cost_usd=cost,
+                latency_ms=latency_ms,
+                streaming=True,
+                timestamp=datetime.now(UTC),
+            )
+        )
 
-    await emit_cost_events(
-        emitter=emitter,
-        store=store,
-        identity=identity,
-        cost=cost,
-        tokens_used=usage.input_tokens + usage.output_tokens,
-        model=model,
-        agent_budget_limit=agent_budget_limit,
-        budget_warning_threshold_pct=budget_warning_threshold_pct,
-        sleipnir_publisher=sleipnir_publisher,
-    )
+        await emit_cost_events(
+            emitter=emitter,
+            store=store,
+            identity=identity,
+            cost=cost,
+            tokens_used=usage.input_tokens + usage.output_tokens,
+            model=model,
+            agent_budget_limit=agent_budget_limit,
+            budget_warning_threshold_pct=budget_warning_threshold_pct,
+            sleipnir_publisher=sleipnir_publisher,
+        )
+
+    async for line in source:
+        _extract_usage_from_sse_line(line, usage)
+        if _stream_chunk_is_terminal(line):
+            await record_usage()
+        yield line
+    await record_usage()

--- a/src/volundr/adapters/outbound/openshell_gateway.py
+++ b/src/volundr/adapters/outbound/openshell_gateway.py
@@ -46,6 +46,12 @@ from volundr.adapters.outbound.resident_container_spec import (
     image_from_values as _shared_image_from_values,
 )
 from volundr.adapters.outbound.resident_container_spec import (
+    resident_attribution_headers as _shared_resident_attribution_headers,
+)
+from volundr.adapters.outbound.resident_container_spec import (
+    resident_process_files as _shared_resident_process_files,
+)
+from volundr.adapters.outbound.resident_container_spec import (
     resident_profile_values as _shared_resident_profile_values,
 )
 from volundr.adapters.outbound.resident_container_spec import (
@@ -1212,7 +1218,7 @@ class OpenShellGatewayPodManager(
             }
             processes = self._resident_processes(runtime, values)
             for process in processes:
-                files.update(process.files)
+                files.update(_shared_resident_process_files(runtime, process.files))
             await asyncio.to_thread(
                 self._client.write_files,
                 sandbox_id=ready.id,
@@ -1340,7 +1346,7 @@ class OpenShellGatewayPodManager(
             raise RuntimeError(f"OpenShell resident process stop failed: {output.strip()}")
         files = self._resident_config_files(runtime, values)
         for process in processes:
-            files.update(process.files)
+            files.update(_shared_resident_process_files(runtime, process.files))
         await asyncio.to_thread(
             self._client.write_files,
             sandbox_id=sandbox.id,
@@ -2856,6 +2862,7 @@ def _resident_hermes_config(
             "provider": "custom:niuu",
             "base_url": base_url,
             "api_mode": "chat_completions",
+            "default_headers": _shared_resident_attribution_headers(runtime),
         },
         "custom_providers": [
             {

--- a/src/volundr/adapters/outbound/resident_container_spec.py
+++ b/src/volundr/adapters/outbound/resident_container_spec.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import shlex
 from dataclasses import dataclass
@@ -133,6 +134,46 @@ def runtime_processes_from_values(
     return tuple(processes)
 
 
+def resident_attribution_headers(runtime: ResidentRuntime) -> dict[str, str]:
+    """Headers understood by Bifrost's authenticated usage tracker."""
+    runtime_id = str(runtime.id)
+    return {
+        "X-Agent-ID": runtime_id,
+        "X-Tenant-ID": runtime.tenant_id,
+        "X-Session-ID": runtime_id,
+    }
+
+
+def resident_process_files(
+    runtime: ResidentRuntime,
+    files: dict[str, bytes],
+) -> dict[str, bytes]:
+    """Materialize engine-owned process files with runtime-specific identity."""
+    materialized = dict(files)
+    if runtime.engine is not ResidentEngine.OPENCLAW:
+        return materialized
+
+    provider_name, separator, _ = runtime.model.partition("/")
+    if not separator:
+        return materialized
+    for path, content in tuple(materialized.items()):
+        if not path.endswith("/.openclaw/openclaw.json"):
+            continue
+        try:
+            config = json.loads(content)
+            provider = config["models"]["providers"][provider_name]
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise RuntimeError(f"OpenClaw resident configuration is invalid: {path!r}") from exc
+        if not isinstance(config, dict) or not isinstance(provider, dict):
+            raise RuntimeError(f"OpenClaw resident configuration is invalid: {path!r}")
+        headers = provider.setdefault("headers", {})
+        if not isinstance(headers, dict):
+            raise RuntimeError(f"OpenClaw provider headers are invalid: {path!r}")
+        headers.update(resident_attribution_headers(runtime))
+        materialized[path] = json.dumps(config, indent=2).encode()
+    return materialized
+
+
 def materialize_resident_container(
     runtime: ResidentRuntime,
     values: dict[str, Any],
@@ -181,7 +222,7 @@ def materialize_resident_container(
             sort_keys=False,
         ).encode()
     for process in processes:
-        files.update(process.files)
+        files.update(resident_process_files(runtime, process.files))
     return ResidentContainerSpec(
         image=image,
         service_name=service_name,
@@ -414,6 +455,7 @@ def _resident_hermes_config(
             "provider": "custom:niuu",
             "base_url": base_url,
             "api_mode": "chat_completions",
+            "default_headers": resident_attribution_headers(runtime),
         },
         "custom_providers": [
             {

--- a/tests/test_adapters/test_local_resident_runtime.py
+++ b/tests/test_adapters/test_local_resident_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -110,6 +111,15 @@ def _profile(engine: ResidentEngine = ResidentEngine.RAVN) -> ResidentDeployment
                     {
                         "name": "openclaw",
                         "command": ["openclaw", "gateway", "run"],
+                        "files": {
+                            "/sandbox/workspace/.openclaw/openclaw.json": json.dumps(
+                                {
+                                    "models": {
+                                        "providers": {"niuu": {"baseUrl": "http://bifrost.test/v1"}}
+                                    }
+                                }
+                            )
+                        },
                     }
                 ],
             }
@@ -209,7 +219,9 @@ async def test_local_openclaw_uses_machine_credentials_and_device_approval(
     )
     store = MemoryCredentialStore()
     controller.set_credential_store(store)
-    runtime = _runtime(ResidentEngine.OPENCLAW)
+    runtime = _runtime(ResidentEngine.OPENCLAW).model_copy(
+        update={"model": "niuu/nvidia/nemotron-3-super"}
+    )
 
     deployed = await controller.deploy(runtime, _profile(ResidentEngine.OPENCLAW))
 
@@ -223,6 +235,16 @@ async def test_local_openclaw_uses_machine_credentials_and_device_approval(
         )
     )
     assert await store.get_value("resident", str(runtime.id), "openclaw-gateway")
+    openclaw_config = json.loads(
+        (
+            tmp_path / str(runtime.id) / "sandbox" / "workspace" / ".openclaw" / "openclaw.json"
+        ).read_text()
+    )
+    assert openclaw_config["models"]["providers"]["niuu"]["headers"] == {
+        "X-Agent-ID": str(runtime.id),
+        "X-Tenant-ID": "local",
+        "X-Session-ID": str(runtime.id),
+    }
     runtime = runtime.model_copy(update={"backend_ref": deployed.backend_ref})
     await controller.approve_resident_device(
         runtime,

--- a/tests/test_adapters/test_openshell_gateway.py
+++ b/tests/test_adapters/test_openshell_gateway.py
@@ -792,6 +792,9 @@ async def test_hermes_deploy_uses_persisted_process_only_credential_and_generic_
     assert "niuu/gpt-5.6-sol" not in hermes_config
     assert "key_env: NIUU_VOLUNDR_ACCESS_TOKEN" in hermes_config
     assert "api_key:" not in hermes_config
+    assert f"X-Agent-ID: {runtime.id}" in hermes_config
+    assert "X-Tenant-ID: tenant-1" in hermes_config
+    assert f"X-Session-ID: {runtime.id}" in hermes_config
     assert "api_server:" in hermes_config
     assert "port: 18789" in hermes_config
     assert any(

--- a/tests/test_bifrost/test_audit.py
+++ b/tests/test_bifrost/test_audit.py
@@ -14,10 +14,12 @@ import pytest
 from fastapi.testclient import TestClient
 
 from bifrost import catalog as bifrost_catalog
+from bifrost.adapters.memory_store import MemoryUsageStore
 from bifrost.app import create_app
+from bifrost.auth import AgentIdentity
 from bifrost.config import BifrostConfig, ProviderConfig, RoutingStrategy
 from bifrost.domain.models import TokenUsage
-from bifrost.inbound.tracking import _extract_usage_from_sse_line
+from bifrost.inbound.tracking import _extract_usage_from_sse_line, _stream_with_tracking
 from bifrost.ports.provider import ProviderError, ProviderPort
 from bifrost.router import ModelRouter, RouterError, _load_adapter
 from bifrost.translation.models import (
@@ -188,6 +190,48 @@ class TestExtractUsageFromSseLine:
         usage = TokenUsage()
         _extract_usage_from_sse_line("data: not-valid-json", usage)
         assert usage.input_tokens == 0
+
+    def test_multiline_event_chunk_populates_usage(self):
+        usage = TokenUsage()
+        _extract_usage_from_sse_line(
+            'event: message_start\ndata: {"type":"message_start",'
+            '"message":{"usage":{"input_tokens":42}}}\n',
+            usage,
+        )
+        assert usage.input_tokens == 42
+
+
+async def test_stream_usage_is_recorded_before_terminal_chunk_is_yielded():
+    async def source():
+        yield (
+            'event: message_start\ndata: {"type":"message_start",'
+            '"message":{"usage":{"input_tokens":12}}}\n\n'
+            'event: message_delta\ndata: {"type":"message_delta",'
+            '"usage":{"output_tokens":7}}\n\n'
+            'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+        )
+
+    store = MemoryUsageStore()
+    emitter = AsyncMock()
+    stream = _stream_with_tracking(
+        source(),
+        "nvidia/nemotron-3-super",
+        0.0,
+        AgentIdentity(agent_id="resident-1", tenant_id="tenant-1", session_id="session-1"),
+        store,
+        {},
+        "request-1",
+        emitter,
+        provider="valaskjalf-nemotron",
+    )
+
+    await anext(stream)
+
+    records = await store.query()
+    assert len(records) == 1
+    assert records[0].input_tokens == 12
+    assert records[0].output_tokens == 7
+    assert records[0].agent_id == "resident-1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- parse usage from multiline provider SSE chunks
- persist usage before terminal SSE closes the tracking generator
- preserve resident/session/tenant/provider attribution

## Verification
- `uv run pytest tests/test_bifrost/test_audit.py tests/test_bifrost/test_postgres_store.py tests/test_bifrost/test_events.py -q` (66 passed)