### PR TITLE
NIU-1103: preserve resident streaming token usage

### DIFF
--- a/src/bifrost/adapters/ollama.py
+++ b/src/bifrost/adapters/ollama.py
@@ -42,4 +42,5 @@ class OllamaAdapter(OpenAICompatAdapter):
     def _prepare_payload(self, payload: dict) -> dict:
         """Remove fields that some Ollama versions do not support."""
         payload.pop("top_p", None)
+        payload.pop("stream_options", None)
         return payload

--- a/src/bifrost/adapters/openai_compat.py
+++ b/src/bifrost/adapters/openai_compat.py
@@ -75,6 +75,7 @@ class OpenAICompatAdapter(ProviderPort):
     async def stream(self, request: AnthropicRequest, model: str) -> AsyncIterator[str]:
         payload = anthropic_to_openai(request, model)
         payload["stream"] = True
+        payload["stream_options"] = {"include_usage": True}
         payload = self._prepare_payload(payload)
 
         message_id = f"msg_{uuid.uuid4().hex[:24]}"

--- a/src/bifrost/inbound/tracking.py
+++ b/src/bifrost/inbound/tracking.py
@@ -54,6 +54,7 @@ def _extract_usage_from_sse_line(line: str, usage: TokenUsage) -> None:
             usage.reasoning_tokens += msg_usage.get("reasoning_tokens", 0)
         elif event_type == "message_delta":
             delta_usage = payload.get("usage", {})
+            usage.input_tokens += delta_usage.get("input_tokens", 0)
             usage.output_tokens += delta_usage.get("output_tokens", 0)
             usage.reasoning_tokens += delta_usage.get("reasoning_tokens", 0)
 

--- a/src/bifrost/translation/streaming.py
+++ b/src/bifrost/translation/streaming.py
@@ -36,6 +36,7 @@ async def openai_stream_to_anthropic(
     emitted_start = False
     emitted_block_start = False
     block_index = 0
+    input_tokens = 0
     output_tokens = 0  # Updated from upstream usage if available.
     stop_reason = "end_turn"
     tool_call_accumulator: dict[str, dict] = {}  # index → partial tool call
@@ -72,6 +73,11 @@ async def openai_stream_to_anthropic(
                 },
             )
             yield _sse_event("ping", {"type": "ping"})
+
+        usage = chunk.get("usage")
+        if usage and isinstance(usage, dict):
+            input_tokens = usage.get("prompt_tokens", input_tokens)
+            output_tokens = usage.get("completion_tokens", output_tokens)
 
         choices = chunk.get("choices", [])
         if not choices:
@@ -121,11 +127,6 @@ async def openai_stream_to_anthropic(
                 acc["name"] = fn["name"]
             if fn.get("arguments"):
                 acc["arguments"] += fn["arguments"]
-
-        # Extract usage from the upstream chunk if available.
-        usage = chunk.get("usage")
-        if usage and isinstance(usage, dict):
-            output_tokens = usage.get("completion_tokens", output_tokens)
 
         if finish_reason:
             stop_reason = FINISH_REASON_MAP.get(finish_reason, "end_turn")
@@ -204,7 +205,10 @@ async def openai_stream_to_anthropic(
         {
             "type": "message_delta",
             "delta": {"stop_reason": stop_reason, "stop_sequence": None},
-            "usage": {"output_tokens": output_tokens},
+            "usage": {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            },
         },
     )
     yield _sse_event("message_stop", {"type": "message_stop"})

--- a/tests/test_bifrost/test_audit.py
+++ b/tests/test_bifrost/test_audit.py
@@ -175,6 +175,13 @@ class TestExtractUsageFromSseLine:
         _extract_usage_from_sse_line(line, usage)
         assert usage.output_tokens == 17
 
+    def test_message_delta_populates_translated_openai_usage(self):
+        usage = TokenUsage()
+        line = 'data: {"type":"message_delta","usage":{"input_tokens":19,"output_tokens":4}}'
+        _extract_usage_from_sse_line(line, usage)
+        assert usage.input_tokens == 19
+        assert usage.output_tokens == 4
+
     def test_unknown_event_type_is_a_no_op(self):
         usage = TokenUsage()
         _extract_usage_from_sse_line('data: {"type":"content_block_start"}', usage)

--- a/tests/test_bifrost/test_providers.py
+++ b/tests/test_bifrost/test_providers.py
@@ -428,6 +428,21 @@ class TestOpenAICompatAdapterStreaming:
         chunks = []
         async for chunk in adapter.stream(_simple_request(), "gpt-4o"):
             chunks.append(chunk)
+        payload = json.loads(respx.calls[0].request.content)
+        assert payload["stream_options"] == {"include_usage": True}
         # Should contain at least a message_start event.
         all_text = "".join(chunks)
         assert "message_start" in all_text
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_ollama_stream_omits_unsupported_stream_options(self):
+        route = respx.post("http://localhost:11434/v1/chat/completions").mock(
+            return_value=Response(200, text="data: [DONE]\n\n")
+        )
+        adapter = OllamaAdapter()
+
+        async for _ in adapter.stream(_simple_request(), "llama3.1:8b"):
+            pass
+
+        assert "stream_options" not in json.loads(route.calls[0].request.content)

--- a/tests/test_bifrost/test_streaming.py
+++ b/tests/test_bifrost/test_streaming.py
@@ -115,6 +115,27 @@ class TestOpenAIStreamToAnthropic:
         assert msg_delta["delta"]["stop_reason"] == "max_tokens"
 
     @pytest.mark.asyncio
+    async def test_usage_only_terminal_chunk_is_preserved(self):
+        events = await self._run(
+            _chunk("ok", finish="stop"),
+            _sse(
+                {
+                    "id": "c1",
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 17,
+                        "completion_tokens": 3,
+                        "total_tokens": 20,
+                    },
+                }
+            ),
+            "data: [DONE]",
+        )
+
+        msg_delta = next(e for e in events if e.get("type") == "message_delta")
+        assert msg_delta["usage"] == {"input_tokens": 17, "output_tokens": 3}
+
+    @pytest.mark.asyncio
     async def test_message_start_has_message_id(self):
         events = await self._run(
             _chunk("x", finish="stop"),


### PR DESCRIPTION
## Summary

- request standard OpenAI streaming usage from compatible providers
- preserve usage-only terminal chunks through the canonical Anthropic stream
- record both prompt and completion tokens for attributed resident requests
- keep unsupported stream options away from Ollama

## Validation

- `58 passed` across Bifrost provider, streaming, and audit suites
- live UI proof identified the issue with an attributed `0/0` record before this fix
