### PR TITLE
Default agent sessions to full access

### DIFF
--- a/charts/skuld-planner/templates/skuld-configmap.yaml
+++ b/charts/skuld-planner/templates/skuld-configmap.yaml
@@ -20,7 +20,7 @@ data:
       {{- end }}
 
     transport: {{ .Values.broker.transport | default "sdk" | quote }}
-    skip_permissions: {{ .Values.broker.skipPermissions | default false }}
+    skip_permissions: {{ .Values.broker.skipPermissions }}
     agent_teams: {{ .Values.broker.agentTeams | default false }}
     cli_type: {{ .Values.broker.cliType | default "claude" | quote }}
     host: "0.0.0.0"

--- a/charts/skuld-planner/values.yaml
+++ b/charts/skuld-planner/values.yaml
@@ -120,7 +120,7 @@ git:
 broker:
   cliType: claude
   transport: sdk
-  skipPermissions: false
+  skipPermissions: true
   agentTeams: true
 
 # Volundr API (for token usage reporting)

--- a/charts/skuld/README.md
+++ b/charts/skuld/README.md
@@ -224,7 +224,7 @@ Core Skuld broker configuration controlling which AI CLI backend to use and how 
 | `broker.maxPresentedFileBytes` | int | `52428800` | Maximum file size accepted by the present-file endpoint |
 | `broker.cliType` | string | `"claude"` | **(DEPRECATED)** AI CLI backend: `"claude"` (Claude Code) or `"codex"` (OpenAI Codex). Use `broker.transportAdapter` instead |
 | `broker.transport` | string | `"sdk"` | **(DEPRECATED)** CLI transport mode: `"sdk"` (WebSocket, default) or `"subprocess"` (legacy). Use `broker.transportAdapter` instead |
-| `broker.skipPermissions` | bool | `false` | Skip tool permission prompts (`--dangerously-skip-permissions` for Claude, `--full-auto` for Codex) |
+| `broker.skipPermissions` | bool | `true` | Skip tool permission prompts and use full access (Claude `bypassPermissions`; Codex `approvalPolicy=never` with `danger-full-access`) |
 | `broker.agentTeams` | bool | `false` | Enable Claude Code experimental Agent Teams (Claude only) |
 
 ### Volundr API

--- a/charts/skuld/templates/skuld-configmap.yaml
+++ b/charts/skuld/templates/skuld-configmap.yaml
@@ -32,7 +32,7 @@ data:
     transport_adapter: {{ .Values.broker.transportAdapter | default "skuld.transports.sdk.SDKTransport" | quote }}
     cli_binary: {{ .Values.broker.cliBinary | default "claude" | quote }}
     remote_control_permission_mode: {{ .Values.broker.remoteControlPermissionMode | default "" | quote }}
-    skip_permissions: {{ .Values.broker.skipPermissions | default false }}
+    skip_permissions: {{ .Values.broker.skipPermissions }}
     agent_teams: {{ .Values.broker.agentTeams | default false }}
     cli_type: {{ .Values.broker.cliType | default "claude" | quote }}
     host: "0.0.0.0"

--- a/charts/skuld/values.yaml
+++ b/charts/skuld/values.yaml
@@ -243,9 +243,9 @@ broker:
   remoteControlPermissionMode: ""
   # -- Maximum size, in bytes, accepted by the present-file endpoint.
   maxPresentedFileBytes: 52428800
-  # -- Skip tool permission prompts (true = --dangerously-skip-permissions for Claude,
-  # --full-auto for Codex)
-  skipPermissions: false
+  # -- Skip tool permission prompts and use full access (Claude bypassPermissions,
+  # Codex approvalPolicy=never with danger-full-access)
+  skipPermissions: true
   # -- Enable Claude Code experimental Agent Teams (Claude only)
   agentTeams: false
 

--- a/charts/volundr/README.md
+++ b/charts/volundr/README.md
@@ -606,7 +606,7 @@ Session definitions are Kubernetes custom resources that describe how session po
 | `sessionDefinitions.skuldClaude.defaults.session.model` | string | `"claude-sonnet-4-20250514"` | Default Claude model |
 | `sessionDefinitions.skuldClaude.defaults.broker.cliType` | string | `"claude"` | AI CLI backend |
 | `sessionDefinitions.skuldClaude.defaults.broker.transport` | string | `"sdk"` | CLI transport mode (`sdk` = WebSocket, `subprocess` = legacy) |
-| `sessionDefinitions.skuldClaude.defaults.broker.skipPermissions` | bool | `false` | Skip tool permission prompts (`--dangerously-skip-permissions`) |
+| `sessionDefinitions.skuldClaude.defaults.broker.skipPermissions` | bool | `true` | Skip tool permission prompts (`--dangerously-skip-permissions`) |
 | `sessionDefinitions.skuldClaude.defaults.broker.agentTeams` | bool | `false` | Enable Claude Code experimental Agent Teams |
 | `sessionDefinitions.skuldClaude.defaults.image.repository` | string | `"ghcr.io/niuulabs/skuld"` | Session image repository |
 | `sessionDefinitions.skuldClaude.defaults.image.tag` | string | `"latest"` | Session image tag |
@@ -692,7 +692,7 @@ Session definitions are Kubernetes custom resources that describe how session po
 | `sessionDefinitions.skuldCodex.defaults.broker.cliType` | string | `"codex"` | AI CLI backend |
 | `sessionDefinitions.skuldCodex.defaults.broker.transport` | string | `"subprocess"` | Codex always uses subprocess transport |
 | `sessionDefinitions.skuldCodex.defaults.broker.transportAdapter` | string | `"skuld.transports.codex.CodexSubprocessTransport"` | Fully-qualified transport adapter class path |
-| `sessionDefinitions.skuldCodex.defaults.broker.skipPermissions` | bool | `false` | Skip tool permission prompts (`--full-auto` for Codex) |
+| `sessionDefinitions.skuldCodex.defaults.broker.skipPermissions` | bool | `true` | Skip prompts and use `approvalPolicy=never` with `danger-full-access` |
 | `sessionDefinitions.skuldCodex.defaults.image.repository` | string | `"ghcr.io/niuulabs/skuld"` | Session image repository |
 | `sessionDefinitions.skuldCodex.defaults.image.tag` | string | `"latest"` | Session image tag |
 | `sessionDefinitions.skuldCodex.defaults.homeVolume.credentialFiles.secretName` | string | `"codex-credentials"` | K8s secret containing Codex credential files |

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -944,7 +944,7 @@ sessionDefinitions:
         # -- Fully-qualified transport adapter class path
         transportAdapter: "skuld.transports.sdk.SDKTransport"
         # -- Skip tool permission prompts (--dangerously-skip-permissions)
-        skipPermissions: false
+        skipPermissions: true
         # -- Enable Claude Code experimental Agent Teams
         agentTeams: false
 
@@ -1189,8 +1189,8 @@ sessionDefinitions:
         cliType: codex-ws
         # -- Fully-qualified transport adapter class path
         transportAdapter: "skuld.transports.codex_ws.CodexWebSocketTransport"
-        # -- Skip tool permission prompts (--full-auto for Codex)
-        skipPermissions: false
+        # -- Skip prompts and use approvalPolicy=never with danger-full-access
+        skipPermissions: true
         agentTeams: false
 
       image:
@@ -1289,7 +1289,7 @@ sessionDefinitions:
         # -- Fully-qualified transport adapter class path
         transportAdapter: "skuld.transports.opencode.OpenCodeHttpTransport"
         # -- Skip tool permission prompts
-        skipPermissions: false
+        skipPermissions: true
         agentTeams: false
 
       image:

--- a/src/ravn/personas/resident-codex.yaml
+++ b/src/ravn/personas/resident-codex.yaml
@@ -14,12 +14,12 @@ allowed_tools:
   - workflow
   - platform
   - ask_user
-permission_mode: workspace-write
+permission_mode: full-access
 iteration_budget: 80
 executor:
   adapter: ravn.adapters.executors.cli.CliTransportExecutor
   kwargs:
     transport_adapter: skuld.transports.codex_ws.CodexWebSocketTransport
     transport_kwargs:
-      approval_policy: on-request
-      sandbox: workspace-write
+      approval_policy: never
+      sandbox: danger-full-access

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -537,7 +537,10 @@ class SkuldSettings(BaseSettings):
     cli_type: str = Field(default="claude")  # "claude" | "codex" | "grok"
     transport: str = Field(default="sdk")  # claude only: "sdk" | "subprocess"
     transport_adapter: str = Field(default=_DEFAULT_TRANSPORT_ADAPTER)
-    skip_permissions: bool = Field(default=False)
+    skip_permissions: bool = Field(
+        default=True,
+        description="Run agent transports without interactive tool approval prompts.",
+    )
     approval_policy: str = Field(default="")
     sandbox: str = Field(default="")
     cli_binary: str = Field(

--- a/src/skuld/transports/codex.py
+++ b/src/skuld/transports/codex.py
@@ -109,12 +109,18 @@ class CodexSubprocessTransport(CLITransport):
         workspace_dir: str,
         model: str = "o4-mini",
         mcp_servers: list[dict] | None = None,
+        skip_permissions: bool = True,
+        approval_policy: str = "",
+        sandbox: str = "",
     ) -> None:
         super().__init__()
         self.workspace_dir = workspace_dir
         self._model = model
         self._mcp_overrides = build_codex_mcp_overrides(mcp_servers or [])
         self._mcp_servers = list(mcp_servers or [])
+        self._skip_permissions = skip_permissions
+        self._approval_policy = approval_policy
+        self._sandbox = sandbox
         self._process: asyncio.subprocess.Process | None = None
         self._last_result: dict | None = None
         self._pending_text: list[str] = []
@@ -146,8 +152,6 @@ class CodexSubprocessTransport(CLITransport):
         self._last_result = None
         self._pending_text = []
         codex_cli = resolve_codex_cli()
-        sandbox_mode = os.environ.get("SKULD_CODEX_SANDBOX", "").strip()
-
         cmd = [
             codex_cli,
             "exec",
@@ -155,8 +159,13 @@ class CodexSubprocessTransport(CLITransport):
             self._model,
             "--json",
         ]
-        if sandbox_mode:
-            cmd.extend(["--sandbox", sandbox_mode])
+        if self._skip_permissions:
+            cmd.append("--dangerously-bypass-approvals-and-sandbox")
+        else:
+            if self._approval_policy:
+                cmd.extend(["-c", f"approval_policy={self._approval_policy!r}"])
+            if self._sandbox:
+                cmd.extend(["--sandbox", self._sandbox])
         for key, value in self._mcp_overrides:
             cmd.extend(["-c", f"{key}={value}"])
         cmd.append(content)

--- a/tests/test_charts/test_volundr_chart.py
+++ b/tests/test_charts/test_volundr_chart.py
@@ -192,6 +192,14 @@ class TestValuesDefaults:
         broker = values_yaml["sessionDefinitions"]["skuldCodex"]["defaults"]["broker"]
         assert broker["transportAdapter"] == "skuld.transports.codex_ws.CodexWebSocketTransport"
 
+    @pytest.mark.parametrize(
+        "definition",
+        ["skuldClaude", "skuldClaudeInteractive", "skuldCodex", "skuldOpenCode"],
+    )
+    def test_agent_session_definitions_default_to_full_access(self, values_yaml, definition):
+        broker = values_yaml["sessionDefinitions"][definition]["defaults"]["broker"]
+        assert broker["skipPermissions"] is True
+
     def test_both_session_defs_use_same_image_repo(self, values_yaml):
         """Test skuld-claude and skuld-codex reference the same image repo."""
         defs = values_yaml["sessionDefinitions"]

--- a/tests/test_skuld/test_config.py
+++ b/tests/test_skuld/test_config.py
@@ -191,7 +191,7 @@ class TestSkuldSettings:
 
     def test_skip_permissions_default(self):
         s = SkuldSettings()
-        assert s.skip_permissions is False
+        assert s.skip_permissions is True
 
     def test_skip_permissions_false(self, monkeypatch):
         monkeypatch.setenv("SKULD__SKIP_PERMISSIONS", "false")

--- a/tests/test_skuld/test_transport.py
+++ b/tests/test_skuld/test_transport.py
@@ -1610,6 +1610,7 @@ class TestCodexSubprocessTransport:
             assert "--model" in call_args
             assert "o4-mini" in call_args
             assert "--sandbox" not in call_args
+            assert "--dangerously-bypass-approvals-and-sandbox" in call_args
             assert "--json" in call_args
             assert "--quiet" not in call_args
             assert "refactor the auth module" in call_args
@@ -1648,6 +1649,35 @@ class TestCodexSubprocessTransport:
             call_args = mock_exec.call_args[0]
             assert "-c" in call_args
             assert any(arg == 'mcp_servers.mimir-local.command="python3"' for arg in call_args)
+
+    @pytest.mark.asyncio
+    async def test_send_message_honors_explicit_permission_policy(self, tmp_path):
+        transport = CodexSubprocessTransport(
+            str(tmp_path),
+            skip_permissions=False,
+            approval_policy="on-request",
+            sandbox="workspace-write",
+        )
+        mock_process = MagicMock(
+            stdout=AsyncMock(read=AsyncMock(return_value=b"")),
+            stderr=None,
+            returncode=0,
+            wait=AsyncMock(return_value=0),
+        )
+        transport.on_event(AsyncMock())
+
+        with patch(
+            "skuld.transports.codex.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=mock_process,
+        ) as mock_exec:
+            await transport.send_message("inspect")
+
+        call_args = mock_exec.call_args[0]
+        assert "--dangerously-bypass-approvals-and-sandbox" not in call_args
+        assert "--sandbox" in call_args
+        assert call_args[call_args.index("--sandbox") + 1] == "workspace-write"
+        assert "approval_policy='on-request'" in call_args
 
     @pytest.mark.asyncio
     async def test_send_message_emits_text_delta_for_json_events(self, transport):


### PR DESCRIPTION
## Summary

- default Claude, Codex, OpenCode, and planner sessions to non-interactive full access
- keep explicit `skipPermissions: false` overrides working
- pass the shared policy into the legacy Codex adapter and use Codex native full-access bypass
- set the resident Codex persona to `never` approval with `danger-full-access`

## Validation

- 503 focused tests passed
- Ruff lint and formatting passed
- Helm lint passed for `skuld`, `skuld-planner`, and `volundr`
- rendered Helm values verified both default `true` and explicit override `false`