### PR TITLE
Fix user launch-spec ID creation

### DIFF
--- a/src/volundr/domain/services/launch_spec.py
+++ b/src/volundr/domain/services/launch_spec.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from volundr.domain.models import LaunchScope, LaunchSpec
 from volundr.domain.ports import LaunchSpecProvider, LaunchSpecRepository
@@ -90,6 +90,7 @@ class LaunchSpecService:
     async def create(self, spec: LaunchSpec) -> LaunchSpec:
         repo = self._require_repo()
         spec.scope = LaunchScope.USER
+        spec.id = spec.id or uuid4()
         existing = await repo.get_by_name(spec.name)
         if existing is not None:
             raise LaunchSpecDuplicateNameError(f"Launch spec already exists: {spec.name}")

--- a/tests/test_domain/test_launch_spec_service.py
+++ b/tests/test_domain/test_launch_spec_service.py
@@ -26,7 +26,7 @@ class InMemoryLaunchSpecRepository:
             self.specs[spec.id] = spec
 
     async def create(self, spec: LaunchSpec) -> LaunchSpec:
-        spec.id = spec.id or uuid4()
+        assert spec.id is not None
         self.specs[spec.id] = spec
         return spec
 


### PR DESCRIPTION
## Summary

Mint user launch-spec IDs in the domain service before passing them through the repository port. PostgreSQL requires the ID and the in-memory test adapter had been masking the missing ownership.

## Live failure

UI launch through Yggdrasil failed with `NotNullViolationError: null value in column id of volundr_launch_specs`.

## Validation

- launch-spec service and catalog component: 5 passed
- Ruff lint and formatting passed