### PR TITLE
Attach personas to session and resident launches

### DIFF
--- a/src/niuu/adapters/inbound/rest_ravn.py
+++ b/src/niuu/adapters/inbound/rest_ravn.py
@@ -50,6 +50,7 @@ from niuu.adapters.inbound.rest_volundr import (
     _request_remote,
     _resolve_target_instance,
     _strip_instance_hints,
+    _sync_persona_to_instance,
     _visible_instances,
     _with_instance,
 )
@@ -453,6 +454,13 @@ def create_ravn_router(
             str(requested_instance_id) if requested_instance_id else None,
             tags=list(target_tags) if target_tags else None,
             match=str(target_match),
+        )
+        await _sync_persona_to_instance(
+            instance,
+            request,
+            principal,
+            body.get("persona_name") or body.get("personaName"),
+            embedded_app=embedded_forge_app,
         )
         response = await _request_remote(
             instance,

--- a/src/niuu/adapters/inbound/rest_volundr.py
+++ b/src/niuu/adapters/inbound/rest_volundr.py
@@ -253,6 +253,67 @@ async def _request_remote(
     return response
 
 
+async def _sync_persona_to_instance(
+    instance: RegisteredInstance,
+    request: Request,
+    principal: Principal,
+    persona_name: object,
+    *,
+    embedded_app: ASGIApp | None,
+) -> None:
+    """Materialize the central user persona on a remote target before launch."""
+    name = str(persona_name or "").strip()
+    if not name or embedded_app is None or _uses_embedded_transport(instance):
+        return
+
+    registry = getattr(getattr(embedded_app, "state", None), "persona_registry", None)
+    if registry is None:
+        return
+    view = await registry.get_persona(principal.user_id, name)
+    if view is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Persona not found: {name}",
+        )
+
+    encoded_name = quote(name, safe="")
+    existing = await _request_remote(
+        instance,
+        request,
+        method="GET",
+        path=f"/personas/{encoded_name}",
+        remote_prefix="/api/v1",
+        embedded_app=embedded_app,
+    )
+    if existing.status_code < 400 and not view.has_override:
+        return
+    if existing.status_code not in {status.HTTP_200_OK, status.HTTP_404_NOT_FOUND}:
+        _ensure_remote_success(existing)
+
+    method = "PUT" if existing.status_code == status.HTTP_200_OK else "POST"
+    path = f"/personas/{encoded_name}" if method == "PUT" else "/personas"
+    synced = await _request_remote(
+        instance,
+        request,
+        method=method,
+        path=path,
+        remote_prefix="/api/v1",
+        json_body=view.payload,
+        embedded_app=embedded_app,
+    )
+    if synced.status_code == status.HTTP_409_CONFLICT and method == "POST":
+        synced = await _request_remote(
+            instance,
+            request,
+            method="PUT",
+            path=f"/personas/{encoded_name}",
+            remote_prefix="/api/v1",
+            json_body=view.payload,
+            embedded_app=embedded_app,
+        )
+    _ensure_remote_success(synced)
+
+
 async def _find_session_owner(
     service: InstanceService,
     principal: Principal,
@@ -799,6 +860,13 @@ def create_volundr_router(
             str(requested_instance_id) if requested_instance_id else None,
             tags=list(target_tags) if target_tags else None,
             match=str(target_match),
+        )
+        await _sync_persona_to_instance(
+            instance,
+            request,
+            principal,
+            body.get("persona_name") or body.get("personaName"),
+            embedded_app=embedded_forge_app,
         )
         response = await _request_remote(
             instance,

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -370,6 +370,11 @@ class SessionCreate(BaseModel):
         max_length=100,
         description="LLM model identifier (e.g. claude-sonnet-4-6)",
     )
+    persona_name: str = Field(
+        default="",
+        max_length=255,
+        description="Persona from the authenticated user's Ravn persona catalog",
+    )
     source: SessionSource = Field(
         default_factory=GitSource,
         description="Workspace source (git repo or local mount)",
@@ -710,6 +715,7 @@ class SessionResponse(BaseModel):
     id: UUID = Field(description="Unique session identifier")
     name: str = Field(description="Human-readable session name")
     model: str = Field(description="LLM model identifier")
+    persona_name: str = Field(default="", description="Persona attached at launch")
     source: SessionSource = Field(description="Workspace source config")
     status: SessionStatus = Field(description="Current lifecycle status")
     chat_endpoint: str | None = Field(
@@ -834,6 +840,7 @@ class SessionResponse(BaseModel):
             id=session.id,
             name=session.name,
             model=session.model,
+            persona_name=str(session.workload_config.get("persona") or ""),
             source=session.source,
             status=session.status,
             chat_endpoint=_public_session_endpoint(

--- a/src/volundr/adapters/outbound/contributors/persona.py
+++ b/src/volundr/adapters/outbound/contributors/persona.py
@@ -1,0 +1,44 @@
+"""Apply a selected Ravn persona to a Forge session."""
+
+from volundr.domain.models import Session
+from volundr.domain.ports import (
+    SessionContext,
+    SessionContribution,
+    SessionContributor,
+    SessionPersonaProvider,
+)
+
+
+class PersonaContributor(SessionContributor):
+    """Resolve the launch persona and apply its cognitive prompt."""
+
+    def __init__(
+        self,
+        *,
+        persona_provider: SessionPersonaProvider,
+        **_extra: object,
+    ) -> None:
+        self._provider = persona_provider
+
+    @property
+    def name(self) -> str:
+        return "persona"
+
+    async def contribute(
+        self,
+        session: Session,
+        context: SessionContext,
+    ) -> SessionContribution:
+        raw_name = context.workload_config.get("persona")
+        if not isinstance(raw_name, str) or not raw_name.strip():
+            return SessionContribution()
+
+        name = raw_name.strip()
+        owner_id = context.principal.user_id if context.principal else ""
+        persona = await self._provider.get(owner_id, name)
+        if persona is None:
+            raise ValueError(f"Persona not found: {name}")
+
+        if not persona.system_prompt:
+            return SessionContribution()
+        return SessionContribution(values={"session": {"systemPrompt": persona.system_prompt}})

--- a/src/volundr/adapters/outbound/session_personas.py
+++ b/src/volundr/adapters/outbound/session_personas.py
@@ -1,0 +1,21 @@
+"""Forge-facing adapter for the existing Ravn persona registry."""
+
+from typing import Any
+
+from volundr.domain.ports import SessionPersona, SessionPersonaProvider
+
+
+class RegistrySessionPersonaProvider(SessionPersonaProvider):
+    """Project Ravn registry records into Forge's narrow persona contract."""
+
+    def __init__(self, registry: Any) -> None:
+        self._registry = registry
+
+    async def get(self, owner_id: str, name: str) -> SessionPersona | None:
+        view = await self._registry.get_persona(owner_id, name)
+        if view is None:
+            return None
+        return SessionPersona(
+            name=view.config.name,
+            system_prompt=view.config.system_prompt_template,
+        )

--- a/src/volundr/composition_builders.py
+++ b/src/volundr/composition_builders.py
@@ -268,6 +268,13 @@ def _create_contributors(
         contributors.append(NotificationChannelContributor(**ports))
         logger.info("Session contributor: notification_channels (auto-wired)")
 
+    persona_provider = ports.get("persona_provider")
+    if persona_provider is not None and not _has_contributor("persona"):
+        from volundr.adapters.outbound.contributors.persona import PersonaContributor
+
+        contributors.append(PersonaContributor(persona_provider=persona_provider))
+        logger.info("Session contributor: persona (auto-wired)")
+
     contributors.append(PromptContributor())
 
     # Auto-wire RavnFlockContributor so ravn_flock workloads spawn

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -1400,6 +1400,22 @@ class SessionContext:
 
 
 @dataclass(frozen=True)
+class SessionPersona:
+    """Runtime persona fields Forge can apply without owning Ravn storage."""
+
+    name: str
+    system_prompt: str
+
+
+class SessionPersonaProvider(ABC):
+    """Resolve a persona in the launching user's catalog."""
+
+    @abstractmethod
+    async def get(self, owner_id: str, name: str) -> SessionPersona | None:
+        """Return the selected persona, or None when it does not exist."""
+
+
+@dataclass(frozen=True)
 class SessionContribution:
     """Output from a single contributor."""
 

--- a/src/volundr/domain/services/forge.py
+++ b/src/volundr/domain/services/forge.py
@@ -104,6 +104,10 @@ class ForgeService:
             tracker_issue_id=data.issue_id,
             issue_tracker_url=data.issue_url,
         )
+        workload_config = dict(data.workload_config or {})
+        persona_name = getattr(data, "persona_name", "")
+        if persona_name:
+            workload_config["persona"] = persona_name
         return await self._session_service.start_session(
             session.id,
             definition=resolved_definition,
@@ -116,7 +120,7 @@ class ForgeService:
             system_prompt=data.system_prompt,
             initial_prompt=data.initial_prompt,
             workload_type=data.workload_type,
-            workload_config=data.workload_config or None,
+            workload_config=workload_config or None,
         )
 
     def _resolve_session_definition(

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -437,6 +437,11 @@ def create_app(
 
             persona_registry = PostgresPersonaRegistry(pool)
             app.state.persona_registry = persona_registry
+            from volundr.adapters.outbound.session_personas import (
+                RegistrySessionPersonaProvider,
+            )
+
+            session_persona_provider = RegistrySessionPersonaProvider(persona_registry)
             workload_identity_service = create_workload_identity_service(settings.workload_identity)
             pod_manager = _create_pod_manager(settings)
             resident_controllers = _create_resident_controllers(settings, pod_manager)
@@ -639,6 +644,7 @@ def create_app(
                 integration_registry=integration_registry,
                 user_integration=user_integration_service,
                 resource_provider=resource_provider,
+                persona_provider=session_persona_provider,
             )
 
             session_service = SessionService(

--- a/tests/test_adapters/test_contributors/test_persona.py
+++ b/tests/test_adapters/test_contributors/test_persona.py
@@ -1,0 +1,55 @@
+"""Tests for PersonaContributor."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from volundr.adapters.outbound.contributors.persona import PersonaContributor
+from volundr.domain.models import GitSource, Principal, Session
+from volundr.domain.ports import SessionContext, SessionPersona, SessionPersonaProvider
+
+
+def _session() -> Session:
+    return Session(name="persona-session", model="gpt", source=GitSource())
+
+
+async def test_persona_contributor_applies_selected_user_persona() -> None:
+    provider = AsyncMock(spec=SessionPersonaProvider)
+    provider.get.return_value = SessionPersona(name="reviewer", system_prompt="Review carefully")
+    contributor = PersonaContributor(persona_provider=provider)
+    principal = Principal(
+        user_id="user-1",
+        email="user@example.com",
+        tenant_id="tenant-1",
+        roles=[],
+    )
+
+    result = await contributor.contribute(
+        _session(),
+        SessionContext(principal=principal, workload_config={"persona": "reviewer"}),
+    )
+
+    provider.get.assert_awaited_once_with("user-1", "reviewer")
+    assert result.values == {"session": {"systemPrompt": "Review carefully"}}
+
+
+async def test_persona_contributor_ignores_launch_without_persona() -> None:
+    provider = AsyncMock(spec=SessionPersonaProvider)
+    contributor = PersonaContributor(persona_provider=provider)
+
+    result = await contributor.contribute(_session(), SessionContext())
+
+    assert result.values == {}
+    provider.get.assert_not_awaited()
+
+
+async def test_persona_contributor_rejects_unknown_persona() -> None:
+    provider = AsyncMock(spec=SessionPersonaProvider)
+    provider.get.return_value = None
+    contributor = PersonaContributor(persona_provider=provider)
+
+    with pytest.raises(ValueError, match="Persona not found: missing"):
+        await contributor.contribute(
+            _session(),
+            SessionContext(workload_config={"persona": "missing"}),
+        )

--- a/tests/test_adapters/test_session_personas.py
+++ b/tests/test_adapters/test_session_personas.py
@@ -1,0 +1,31 @@
+"""Tests for the Forge projection of the Ravn persona registry."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from volundr.adapters.outbound.session_personas import RegistrySessionPersonaProvider
+
+
+async def test_registry_session_persona_provider_projects_runtime_fields() -> None:
+    registry = SimpleNamespace(
+        get_persona=AsyncMock(
+            return_value=SimpleNamespace(
+                config=SimpleNamespace(name="reviewer", system_prompt_template="Review carefully")
+            )
+        )
+    )
+    provider = RegistrySessionPersonaProvider(registry)
+
+    persona = await provider.get("user-1", "reviewer")
+
+    registry.get_persona.assert_awaited_once_with("user-1", "reviewer")
+    assert persona is not None
+    assert persona.name == "reviewer"
+    assert persona.system_prompt == "Review carefully"
+
+
+async def test_registry_session_persona_provider_preserves_missing_result() -> None:
+    registry = SimpleNamespace(get_persona=AsyncMock(return_value=None))
+    provider = RegistrySessionPersonaProvider(registry)
+
+    assert await provider.get("user-1", "missing") is None

--- a/tests/test_domain/test_forge_service.py
+++ b/tests/test_domain/test_forge_service.py
@@ -40,6 +40,7 @@ async def test_create_and_start_session_delegates_to_session_service() -> None:
         initial_prompt="start",
         workload_type="interactive",
         workload_config={},
+        persona_name="reviewer",
     )
 
     result = await forge.create_and_start_session(data)
@@ -58,7 +59,7 @@ async def test_create_and_start_session_delegates_to_session_service() -> None:
         system_prompt="system",
         initial_prompt="start",
         workload_type="interactive",
-        workload_config=None,
+        workload_config={"persona": "reviewer"},
     )
 
 

--- a/tests/test_main_contributors.py
+++ b/tests/test_main_contributors.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 from volundr.config import SessionContributorConfig, Settings
+from volundr.domain.ports import SessionPersonaProvider
 from volundr.main import _create_contributors
 
 
@@ -81,3 +84,15 @@ def test_create_contributors_passes_ravn_flock_init_writer_image() -> None:
     )
 
     assert ravn_flock._init_writer_image == "ghcr.io/niuulabs/skuld:writer"
+
+
+def test_create_contributors_auto_wires_persona_provider_once() -> None:
+    provider = AsyncMock(spec=SessionPersonaProvider)
+
+    contributors = _create_contributors(Settings(), persona_provider=provider)
+
+    assert [contributor.name for contributor in contributors].count("persona") == 1
+    names = [contributor.name for contributor in contributors]
+    assert names.index("persona") < max(
+        index for index, name in enumerate(names) if name == "prompt"
+    )

--- a/tests/test_niuu/test_rest_ravn.py
+++ b/tests/test_niuu/test_rest_ravn.py
@@ -605,10 +605,16 @@ def test_create_raven_uses_resident_command_timeout() -> None:
     client = _client([_instance("noatun", base_url="http://noatun")])
     response = Response(201, json={"id": "resident-id", "managed": True})
 
-    with patch(
-        "niuu.adapters.inbound.rest_ravn._request_remote",
-        new=AsyncMock(return_value=response),
-    ) as request_remote:
+    with (
+        patch(
+            "niuu.adapters.inbound.rest_ravn._request_remote",
+            new=AsyncMock(return_value=response),
+        ) as request_remote,
+        patch(
+            "niuu.adapters.inbound.rest_ravn._sync_persona_to_instance",
+            new=AsyncMock(),
+        ) as sync_persona,
+    ):
         result = client.post(
             "/api/v1/ravn/ravens",
             headers=_headers(),
@@ -616,11 +622,13 @@ def test_create_raven_uses_resident_command_timeout() -> None:
                 "instance_id": "noatun",
                 "profile_id": "ravn-openshell",
                 "name": "Muninn",
+                "persona_name": "reviewer",
             },
         )
 
     assert result.status_code == 201
     assert request_remote.await_args.kwargs["timeout"] == 900.0
+    assert sync_persona.await_args.args[3] == "reviewer"
 
 
 @respx.mock

--- a/tests/test_niuu/test_rest_volundr.py
+++ b/tests/test_niuu/test_rest_volundr.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 import respx
@@ -408,6 +410,43 @@ def test_create_session_uses_requested_instance_and_strips_instance_hints() -> N
     assert response.status_code == 201
     assert response.json()["instance_id"] == "target"
     assert route.calls.last.request.read() == b'{"workspace":"repo-a"}'
+
+
+@respx.mock
+def test_create_session_syncs_custom_persona_to_selected_target() -> None:
+    embedded = FastAPI()
+    embedded.state.persona_registry = SimpleNamespace(
+        get_persona=AsyncMock(
+            return_value=SimpleNamespace(
+                has_override=True,
+                payload={"name": "custom-reviewer", "system_prompt_template": "Review"},
+            )
+        )
+    )
+    client = _client(
+        [_instance("target", base_url="http://target", is_default=True)],
+        embedded_forge_app=embedded,
+    )
+    respx.get("http://target/api/v1/personas/custom-reviewer").mock(return_value=Response(404))
+    sync = respx.post("http://target/api/v1/personas").mock(
+        return_value=Response(201, json={"name": "custom-reviewer"})
+    )
+    launch = respx.post("http://target/api/v1/forge/sessions").mock(
+        return_value=Response(201, json={"id": "s-persona"})
+    )
+
+    response = client.post(
+        "/api/v1/forge/sessions",
+        headers=_headers(),
+        json={"name": "review-session", "persona_name": "custom-reviewer"},
+    )
+
+    assert response.status_code == 201
+    assert sync.called
+    assert launch.called
+    embedded.state.persona_registry.get_persona.assert_awaited_once_with(
+        "user-a", "custom-reviewer"
+    )
 
 
 @respx.mock

--- a/web-next/packages/domain/src/index.ts
+++ b/web-next/packages/domain/src/index.ts
@@ -15,6 +15,9 @@ export {
   type WeightedScoreParams,
   type FanInStrategy,
   type Persona,
+  type PersonaFilter,
+  type PersonaSummary,
+  type IPersonaCatalog,
 } from './persona';
 
 export {

--- a/web-next/packages/domain/src/persona.ts
+++ b/web-next/packages/domain/src/persona.ts
@@ -30,6 +30,29 @@ export const personaRoleSchema = z.enum([
 
 export type PersonaRole = z.infer<typeof personaRoleSchema>;
 
+export type PersonaFilter = 'all' | 'builtin' | 'custom';
+
+/** Compact persona projection shared by every persona picker. */
+export interface PersonaSummary {
+  name: string;
+  role: PersonaRole;
+  letter: string;
+  color: string;
+  summary: string;
+  permissionMode: string;
+  allowedTools: string[];
+  iterationBudget: number;
+  isBuiltin: boolean;
+  hasOverride: boolean;
+  producesEvent: string;
+  consumesEvents: string[];
+}
+
+/** Read-only persona catalog used across independently publishable plugins. */
+export interface IPersonaCatalog {
+  listPersonas(filter?: PersonaFilter): Promise<PersonaSummary[]>;
+}
+
 /**
  * LLM configuration attached to a Persona.
  *

--- a/web-next/packages/plugin-ravn/src/ports.ts
+++ b/web-next/packages/plugin-ravn/src/ports.ts
@@ -5,7 +5,13 @@
  * cost) or type aliases. Implementations live in src/adapters/.
  */
 
-import type { BudgetState, PersonaRole, FieldType } from '@niuulabs/domain';
+import type {
+  BudgetState,
+  FieldType,
+  IPersonaCatalog,
+  PersonaRole,
+  PersonaSummary,
+} from '@niuulabs/domain';
 import type { Ravn, ResidentDeploymentProfile } from './domain/ravn';
 import type { Session } from './domain/session';
 import type { Trigger } from './domain/trigger';
@@ -43,20 +49,7 @@ export interface PersonaFanIn {
   params: Record<string, unknown>;
 }
 
-export interface PersonaSummary {
-  name: string;
-  role: PersonaRole;
-  letter: string;
-  color: string;
-  summary: string;
-  permissionMode: string;
-  allowedTools: string[];
-  iterationBudget: number;
-  isBuiltin: boolean;
-  hasOverride: boolean;
-  producesEvent: string;
-  consumesEvents: string[];
-}
+export type { PersonaFilter, PersonaSummary } from '@niuulabs/domain';
 
 export interface PersonaDetail extends PersonaSummary {
   description: string;
@@ -99,15 +92,12 @@ export interface PersonaForkRequest {
   newName: string;
 }
 
-export type PersonaFilter = 'all' | 'builtin' | 'custom';
-
 // ---------------------------------------------------------------------------
 // Port interfaces
 // ---------------------------------------------------------------------------
 
 /** CRUD store for Persona configurations. */
-export interface IPersonaStore {
-  listPersonas(filter?: PersonaFilter): Promise<PersonaSummary[]>;
+export interface IPersonaStore extends IPersonaCatalog {
   getPersona(name: string): Promise<PersonaDetail>;
   getPersonaYaml(name: string): Promise<string>;
   createPersona(req: PersonaCreateRequest): Promise<PersonaDetail>;

--- a/web-next/packages/plugin-ravn/src/ui/ResidentDeployDialog.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/ResidentDeployDialog.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import { ResidentDeployDialog } from './ResidentDeployDialog';
+
+describe('ResidentDeployDialog', () => {
+  it('deploys with a persona selected from the shared catalog', async () => {
+    const deploy = vi.fn().mockResolvedValue({ id: 'ravn-1' });
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={client}>
+        <ServicesProvider
+          services={{
+            'ravn.residents': {
+              listProfiles: vi.fn().mockResolvedValue([
+                {
+                  id: 'nemohermes-local',
+                  displayName: 'NemoHermes',
+                  description: 'Resident Hermes runtime',
+                  backend: 'local',
+                  engine: 'hermes',
+                  instanceId: 'local',
+                  instanceName: 'Local',
+                  allowedModels: [],
+                  defaultModel: '',
+                },
+              ]),
+              deploy,
+            },
+            'ravn.personas': {
+              listPersonas: vi.fn().mockResolvedValue([{ name: 'reviewer', role: 'review' }]),
+            },
+          }}
+        >
+          <ResidentDeployDialog open onOpenChange={vi.fn()} onDeployed={vi.fn()} />
+        </ServicesProvider>
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(await screen.findByTestId('resident-name'), {
+      target: { value: 'resident-reviewer' },
+    });
+    fireEvent.change(screen.getByTestId('resident-persona'), {
+      target: { value: 'reviewer' },
+    });
+    fireEvent.click(screen.getByTestId('resident-deploy-submit'));
+
+    await waitFor(() =>
+      expect(deploy).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'resident-reviewer', personaName: 'reviewer' }),
+      ),
+    );
+  });
+});

--- a/web-next/packages/plugin-ravn/src/ui/ResidentDeployDialog.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/ResidentDeployDialog.tsx
@@ -4,6 +4,7 @@ import { Rocket } from 'lucide-react';
 import type { Ravn, ResidentDeploymentProfile } from '../domain/ravn';
 import { useDeployResident, useResidentProfiles } from './hooks/useResidentControl';
 import { ResidentModelSelect } from './ResidentModelSelect';
+import { useOptionalPersonas } from './usePersonas';
 
 interface ResidentDeployDialogProps {
   open: boolean;
@@ -25,6 +26,7 @@ export function ResidentDeployDialog({
   onDeployed,
 }: ResidentDeployDialogProps) {
   const profilesQuery = useResidentProfiles(open);
+  const personasQuery = useOptionalPersonas(open);
   const deploy = useDeployResident();
   const [instanceId, setInstanceId] = useState('');
   const [profileId, setProfileId] = useState('');
@@ -33,6 +35,11 @@ export function ResidentDeployDialog({
   const [model, setModel] = useState('');
 
   const profiles = useMemo(() => profilesQuery.data ?? [], [profilesQuery.data]);
+  const personas = useMemo(
+    () =>
+      [...(personasQuery.data ?? [])].sort((left, right) => left.name.localeCompare(right.name)),
+    [personasQuery.data],
+  );
   const targets = useMemo(() => {
     const byId = new Map<string, ResidentDeploymentProfile>();
     for (const profile of profiles) byId.set(profile.instanceId, profile);
@@ -169,12 +176,27 @@ export function ResidentDeployDialog({
 
               <label className="rv-form-field">
                 <span>Persona</span>
-                <input
-                  value={personaName}
-                  onChange={(event) => setPersonaName(event.target.value)}
-                  maxLength={255}
-                  data-testid="resident-persona"
-                />
+                {personas.length > 0 ? (
+                  <select
+                    value={personaName}
+                    onChange={(event) => setPersonaName(event.target.value)}
+                    data-testid="resident-persona"
+                  >
+                    <option value="">No persona</option>
+                    {personas.map((persona) => (
+                      <option key={persona.name} value={persona.name}>
+                        {persona.name} · {persona.role}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    value={personaName}
+                    onChange={(event) => setPersonaName(event.target.value)}
+                    maxLength={255}
+                    data-testid="resident-persona"
+                  />
+                )}
               </label>
 
               {selectedProfile && selectedProfile.allowedModels.length > 0 && (

--- a/web-next/packages/plugin-ravn/src/ui/usePersonas.ts
+++ b/web-next/packages/plugin-ravn/src/ui/usePersonas.ts
@@ -1,11 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
-import { useService } from '@niuulabs/plugin-sdk';
+import { useOptionalService, useService } from '@niuulabs/plugin-sdk';
 import type { IPersonaStore } from '../ports';
 
-export function usePersonas() {
+export function usePersonas(enabled = true) {
   const service = useService<IPersonaStore>('ravn.personas');
   return useQuery({
     queryKey: ['ravn', 'personas'],
     queryFn: () => service.listPersonas(),
+    enabled,
+  });
+}
+
+export function useOptionalPersonas(enabled = true) {
+  const service = useOptionalService<IPersonaStore>('ravn.personas');
+  return useQuery({
+    queryKey: ['ravn', 'personas'],
+    queryFn: () => service?.listPersonas() ?? Promise.resolve([]),
+    enabled: enabled && Boolean(service),
   });
 }

--- a/web-next/packages/plugin-sdk/src/ServicesProvider.test.tsx
+++ b/web-next/packages/plugin-sdk/src/ServicesProvider.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { ServicesProvider, useService } from './ServicesProvider';
+import { ServicesProvider, useOptionalService, useService } from './ServicesProvider';
 
 interface FakeService {
   say(): string;
@@ -9,6 +9,11 @@ interface FakeService {
 function Reader() {
   const svc = useService<FakeService>('fake');
   return <span data-testid="out">{svc.say()}</span>;
+}
+
+function OptionalReader() {
+  const svc = useOptionalService<FakeService>('fake');
+  return <span data-testid="optional-out">{svc?.say() ?? 'missing'}</span>;
 }
 
 describe('ServicesProvider', () => {
@@ -40,5 +45,14 @@ describe('ServicesProvider', () => {
       ),
     ).toThrow(/not registered/);
     console.error = error;
+  });
+
+  it('returns undefined for an optional unregistered service', () => {
+    render(
+      <ServicesProvider services={{}}>
+        <OptionalReader />
+      </ServicesProvider>,
+    );
+    expect(screen.getByTestId('optional-out').textContent).toBe('missing');
   });
 });

--- a/web-next/packages/plugin-sdk/src/ServicesProvider.tsx
+++ b/web-next/packages/plugin-sdk/src/ServicesProvider.tsx
@@ -24,3 +24,8 @@ export function useService<T>(key: string): T {
   }
   return service as T;
 }
+
+export function useOptionalService<T>(key: string): T | undefined {
+  const services = useContext(ServicesContext);
+  return services?.[key] as T | undefined;
+}

--- a/web-next/packages/plugin-sdk/src/index.ts
+++ b/web-next/packages/plugin-sdk/src/index.ts
@@ -5,7 +5,12 @@ export {
   type PluginTab,
 } from './PluginDescriptor';
 export { PluginCtxProvider, usePluginCtx } from './PluginCtxContext';
-export { ServicesProvider, useService, type ServicesMap } from './ServicesProvider';
+export {
+  ServicesProvider,
+  useOptionalService,
+  useService,
+  type ServicesMap,
+} from './ServicesProvider';
 export { ConfigProvider, useConfig } from './ConfigProvider';
 export { FeatureCatalogProvider, useFeatureCatalog, type FeatureCatalog } from './FeatureCatalog';
 export {

--- a/web-next/packages/plugin-volundr/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/http.test.ts
@@ -147,6 +147,7 @@ describe('__testables', () => {
     expect(
       buildStartSessionBody({
         name: 'alpha',
+        personaName: 'reviewer',
         source: { type: 'git', repo: 'r', branch: 'main' },
         model: 'sonnet',
         terminalRestricted: true,
@@ -160,6 +161,7 @@ describe('__testables', () => {
       }),
     ).toEqual({
       name: 'alpha',
+      persona_name: 'reviewer',
       source: { type: 'git', repo: 'r', branch: 'main' },
       model: 'sonnet',
       terminal_restricted: true,

--- a/web-next/packages/plugin-volundr/src/adapters/http.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/http.ts
@@ -102,6 +102,8 @@ type SessionPayload = {
   source: VolundrSession['source'];
   status: VolundrSession['status'];
   model: string;
+  personaName?: string;
+  persona_name?: string;
   lastActive?: number;
   last_active?: string;
   messageCount?: number;
@@ -429,6 +431,7 @@ function buildStartSessionBody(
 ): Record<string, unknown> {
   const body: Record<string, unknown> = {
     name: config.name,
+    persona_name: config.personaName,
     source: config.source,
     model: config.model,
     definition: config.definition,
@@ -491,6 +494,7 @@ function normalizeSession(session: SessionPayload): VolundrSession {
     source: session.source,
     status: session.status,
     model: session.model,
+    personaName: session.personaName ?? session.persona_name ?? undefined,
     lastActive: toEpochMs(session.lastActive ?? session.last_active),
     messageCount: session.messageCount ?? session.message_count ?? 0,
     tokensUsed: session.tokensUsed ?? session.tokens_used ?? 0,

--- a/web-next/packages/plugin-volundr/src/models/volundr.model.ts
+++ b/web-next/packages/plugin-volundr/src/models/volundr.model.ts
@@ -162,6 +162,7 @@ export interface VolundrSession {
   source: SessionSource;
   status: SessionStatus;
   model: string;
+  personaName?: string;
   lastActive: number;
   messageCount: number;
   tokensUsed: number;

--- a/web-next/packages/plugin-volundr/src/ports/IVolundrService.ts
+++ b/web-next/packages/plugin-volundr/src/ports/IVolundrService.ts
@@ -139,6 +139,7 @@ export interface IVolundrService {
   // Session lifecycle
   startSession(config: {
     name: string;
+    personaName?: string;
     source: SessionSource;
     model: string;
     launchSpec?: string;

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.helpers.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.helpers.test.ts
@@ -51,6 +51,7 @@ function makeForm(overrides: Partial<WizardForm> = {}): WizardForm {
     workspaceId: '',
     mountPath: '~/code/niuu',
     sessionName: '',
+    personaName: '',
     systemPrompt: '',
     initialPrompt: '',
     trackerQuery: '',
@@ -390,6 +391,7 @@ describe('LaunchWizard helpers', () => {
     ).toBe(true);
     expect(hasPresetBackedRuntime(makeForm({ envVars: [{ key: 'A', value: '1' }] }))).toBe(true);
     expect(hasPresetBackedRuntime(makeForm({ setupScripts: ['echo hi'] }))).toBe(true);
+    expect(hasPresetBackedRuntime(makeForm({ personaName: 'reviewer' }))).toBe(true);
   });
 
   it('builds preset payload variants for git, local mount, and blank flows', () => {
@@ -445,6 +447,9 @@ describe('LaunchWizard helpers', () => {
       paths: [],
     });
     expect(buildPresetPayload(makeForm(), 'saved-name').name).toBe('saved-name');
+    expect(
+      buildPresetPayload(makeForm({ personaName: 'reviewer' }), 'persona-spec').workloadConfig,
+    ).toEqual({ persona: 'reviewer' });
   });
 
   it('copies existing preset state into comparison payloads', () => {

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.test.tsx
@@ -37,6 +37,24 @@ function wrapWithServices(
           bifrost: createMockBifrostService(),
           volundr: service,
           'niuu.repos': repoService,
+          'ravn.personas': {
+            listPersonas: vi.fn().mockResolvedValue([
+              {
+                name: 'reviewer',
+                role: 'review',
+                letter: 'R',
+                color: 'blue',
+                summary: 'Reviews changes',
+                permissionMode: 'safe',
+                allowedTools: [],
+                iterationBudget: 10,
+                isBuiltin: true,
+                hasOverride: false,
+                producesEvent: '',
+                consumesEvents: [],
+              },
+            ]),
+          },
         }}
       >
         <LaunchWizard
@@ -234,6 +252,24 @@ describe('LaunchWizard', () => {
       );
     });
     expect(screen.getAllByTestId('boot-step').length).toBe(8);
+  });
+
+  it('attaches a catalog persona to the launched session', async () => {
+    const service = createMockVolundrService();
+    const startSession = vi.spyOn(service, 'startSession');
+    wrap(true, vi.fn(), service);
+    await advanceToRuntime();
+    const personaSelect = await screen.findByTestId('persona-select');
+    fireEvent.change(personaSelect, { target: { value: 'reviewer' } });
+    fireEvent.click(screen.getByTestId('wizard-next'));
+    expect(await screen.findByText('reviewer')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('wizard-next'));
+
+    await waitFor(() =>
+      expect(startSession).toHaveBeenCalledWith(
+        expect.objectContaining({ personaName: 'reviewer' }),
+      ),
+    );
   });
 
   it('launches through a Forge tag selector', async () => {

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.tsx
@@ -37,6 +37,7 @@ export function LaunchWizard(props: LaunchWizardProps) {
     manualBranches,
     models,
     navigate,
+    personas,
     presets,
     repos,
     sessionDefinitions,
@@ -79,6 +80,7 @@ export function LaunchWizard(props: LaunchWizardProps) {
               form={form}
               update={update}
               models={models}
+              personas={personas}
               workspaces={workspaces}
               targets={targets}
               credentials={credentials}

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizardAdvancedRuntime.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizardAdvancedRuntime.tsx
@@ -77,6 +77,10 @@ export function AdvancedRuntimeSection({
       if (parsed.envSecretRefs) patch.selectedCredentials = parsed.envSecretRefs;
       if (parsed.integrationIds) patch.selectedIntegrations = parsed.integrationIds;
       if (parsed.setupScripts) patch.setupScripts = parsed.setupScripts;
+      if (parsed.workloadConfig) {
+        patch.personaName =
+          typeof parsed.workloadConfig.persona === 'string' ? parsed.workloadConfig.persona : '';
+      }
       if (parsed.source !== undefined) {
         if (parsed.source === null) {
           patch.sourcetype = 'blank';

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizardRuntimeStep.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizardRuntimeStep.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import type { PersonaSummary } from '@niuulabs/domain';
 import { Field, Input, SegmentedFilter, Textarea } from '@niuulabs/ui';
 import type {
   ClusterResourceInfo,
@@ -45,6 +46,7 @@ export function RuntimeStep({
   form,
   update,
   models,
+  personas = [],
   workspaces,
   targets,
   credentials,
@@ -60,6 +62,7 @@ export function RuntimeStep({
   form: WizardForm;
   update: (patch: Partial<WizardForm>) => void;
   models: Record<string, RuntimeModelDescriptor>;
+  personas?: PersonaSummary[];
   workspaces: VolundrWorkspace[];
   targets: VolundrTarget[];
   credentials: StoredCredential[];
@@ -193,6 +196,22 @@ export function RuntimeStep({
             ))}
           </div>
           <div className="niuu:grid niuu:grid-cols-1 niuu:gap-4">
+            {personas.length > 0 ? (
+              <Field label="Persona (optional)">
+                <WizardSelect
+                  options={[
+                    { value: '', label: 'No persona' },
+                    ...personas.map((persona) => ({
+                      value: persona.name,
+                      label: `${persona.name} · ${persona.role}`,
+                    })),
+                  ]}
+                  value={form.personaName}
+                  onChange={(value) => update({ personaName: value })}
+                  testId="persona-select"
+                />
+              </Field>
+            ) : null}
             <Field label="Model">
               {modelOptions.length > 0 ? (
                 <WizardSelect

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizardSteps.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizardSteps.tsx
@@ -219,6 +219,7 @@ export function ConfirmStep({
           <ConfirmRow label="session" value={deriveSessionName(form)} />
           <ConfirmRow label="forge" value={targetLabel} />
           <ConfirmRow label="definition" value={definitionLabel} />
+          <ConfirmRow label="persona" value={form.personaName || 'not attached'} />
           <ConfirmRow label="model" value={modelLabel} />
           <ConfirmRow
             label="source"

--- a/web-next/packages/plugin-volundr/src/ui/launchWizardModel.ts
+++ b/web-next/packages/plugin-volundr/src/ui/launchWizardModel.ts
@@ -29,6 +29,7 @@ export interface WizardForm {
   workspaceId: string;
   mountPath: string;
   sessionName: string;
+  personaName: string;
   systemPrompt: string;
   initialPrompt: string;
   trackerQuery: string;
@@ -549,7 +550,7 @@ export function buildPresetRuntimePayload(
     repos: [],
     setupScripts: form.setupScripts.filter((script) => script.trim()),
     workspaceLayout: {},
-    workloadConfig: {},
+    workloadConfig: form.personaName ? { persona: form.personaName } : {},
   };
 }
 
@@ -618,13 +619,14 @@ export function buildYamlRuntimeFields(form: WizardForm) {
             },
     integrationIds: form.selectedIntegrations,
     setupScripts: form.setupScripts.filter((script) => script.trim()),
-    workloadConfig: {},
+    workloadConfig: form.personaName ? { persona: form.personaName } : {},
   };
 }
 
 export function hasPresetBackedRuntime(form: WizardForm): boolean {
   return (
     form.mcpServers.length > 0 ||
+    Boolean(form.personaName) ||
     form.envVars.some((entry) => entry.key.trim()) ||
     form.setupScripts.some((script) => script.trim())
   );

--- a/web-next/packages/plugin-volundr/src/ui/useLaunchWizard.ts
+++ b/web-next/packages/plugin-volundr/src/ui/useLaunchWizard.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import type { BifrostModel, IBifrostService } from '@niuulabs/plugin-bifrost';
-import { useService } from '@niuulabs/plugin-sdk';
+import type { IPersonaCatalog, PersonaSummary } from '@niuulabs/domain';
+import { useOptionalService, useService } from '@niuulabs/plugin-sdk';
 import type { RepoRecord } from '@niuulabs/ui';
 import type { IVolundrService } from '../ports/IVolundrService';
 import type {
@@ -56,6 +57,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
   const volundr = useService<IVolundrService>('volundr');
   const bifrost = useService<IBifrostService>('bifrost');
   const repoCatalog = useService<RepoCatalogService>('niuu.repos');
+  const personaCatalog = useOptionalService<IPersonaCatalog>('ravn.personas');
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [repos, setRepos] = useState<RepoRecord[]>([]);
@@ -69,6 +71,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
   const [targets, setTargets] = useState<VolundrTarget[]>([]);
   const [availableMcpServers, setAvailableMcpServers] = useState<McpServerConfig[]>([]);
   const [sessionDefinitions, setSessionDefinitions] = useState<SessionDefinition[]>([]);
+  const [personas, setPersonas] = useState<PersonaSummary[]>([]);
   const [trackerResults, setTrackerResults] = useState<TrackerIssue[]>([]);
   const [trackerLoading, setTrackerLoading] = useState(false);
 
@@ -81,6 +84,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
     workspaceId: '',
     mountPath: '~/code/niuu',
     sessionName: '',
+    personaName: '',
     systemPrompt: '',
     initialPrompt: '',
     trackerQuery: '',
@@ -128,6 +132,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
       volundr.getTargets().catch(() => []),
       volundr.getAvailableMcpServers().catch(() => []),
       volundr.getSessionDefinitions().catch(() => FALLBACK_SESSION_DEFINITIONS),
+      personaCatalog?.listPersonas().catch(() => []) ?? Promise.resolve([]),
     ]).then(
       ([
         nextRepos,
@@ -140,6 +145,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
         nextTargets,
         nextMcpServers,
         nextSessionDefinitions,
+        nextPersonas,
       ]) => {
         if (cancelled) return;
         setRepos(nextRepos);
@@ -154,13 +160,14 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
         setSessionDefinitions(
           nextSessionDefinitions.length > 0 ? nextSessionDefinitions : FALLBACK_SESSION_DEFINITIONS,
         );
+        setPersonas([...nextPersonas].sort((left, right) => left.name.localeCompare(right.name)));
       },
     );
 
     return () => {
       cancelled = true;
     };
-  }, [bifrost, open, repoCatalog, volundr]);
+  }, [bifrost, open, personaCatalog, repoCatalog, volundr]);
 
   useEffect(() => {
     if (!open || form.sourcetype !== 'git' || !form.repo.trim()) {
@@ -293,6 +300,8 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
         definition: normalizeDefinitionKey(preset.workloadType || `skuld-${preset.cliTool}`),
         model: preset.model ?? current.model,
         systemPrompt: preset.systemPrompt ?? '',
+        personaName:
+          typeof preset.workloadConfig.persona === 'string' ? preset.workloadConfig.persona : '',
         selectedCredentials: [...preset.envSecretRefs],
         selectedIntegrations: [...preset.integrationIds],
         mcpServers: [...preset.mcpServers],
@@ -457,6 +466,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
 
       const session = await volundr.startSession({
         name: effectiveSessionName,
+        personaName: form.personaName || undefined,
         source: buildSessionSource(form),
         model: form.model.trim(),
         launchSpec,
@@ -542,6 +552,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
     manualBranches,
     models,
     navigate,
+    personas,
     presets,
     repos,
     sessionDefinitions,


### PR DESCRIPTION
## Summary

- add shared persona catalog selection to Forge session and resident Ravn launch dialogs
- resolve selected session personas through the existing registry contributor path
- dynamically synchronize custom persona overrides to the selected remote cluster before session or resident deployment
- preserve persona selection in launch specs and expose it in session responses

## Impact

Users can attach an existing persona when creating either a normal session or a long-lived resident runtime. Built-in and custom personas follow the same target-aware deployment flow without duplicating persona configuration.

## Validation

- `make verify`: 16,895 passed, 26 skipped, 1 xfailed; 85.63% coverage
- `cd web-next && pnpm test`: full suite passed; 93.01% statements, 85.05% branches
- `cd web-next && pnpm typecheck`
- focused cross-cluster persona sync and launch UI tests