### PR TITLE
feat(observatory): add principal-aware A2A agent directory

### DIFF
--- a/charts/guild/templates/configmap.yaml
+++ b/charts/guild/templates/configmap.yaml
@@ -35,6 +35,17 @@ data:
       min_pool_size: {{ .Values.database.minPoolSize | default 5 }}
       max_pool_size: {{ .Values.database.maxPoolSize | default 20 }}
 
+    observatory:
+      directory:
+        instance_id: {{ .Values.directory.instanceId | default (printf "%s-guild" .Release.Name) | quote }}
+        cluster_id: {{ .Values.global.niuu.cluster | default "unknown" | quote }}
+        card_timeout_seconds: {{ .Values.directory.cardTimeoutSeconds | default 4.0 }}
+        card_cache_ttl_seconds: {{ .Values.directory.cardCacheTtlSeconds | default 300.0 }}
+        local_max_concurrency: {{ .Values.directory.localMaxConcurrency | default 8 }}
+        guild_timeout_seconds: {{ .Values.directory.guildTimeoutSeconds | default 5.0 }}
+        guild_max_concurrency: {{ .Values.directory.guildMaxConcurrency | default 8 }}
+        signature_algorithms: {{ .Values.directory.signatureAlgorithms | toJson }}
+
     workload_identity:
       enabled: {{ .Values.workloadIdentity.enabled | default false }}
       issuer: {{ .Values.workloadIdentity.issuer | default "" | quote }}

--- a/charts/guild/templates/configmap.yaml
+++ b/charts/guild/templates/configmap.yaml
@@ -45,6 +45,7 @@ data:
         guild_timeout_seconds: {{ .Values.directory.guildTimeoutSeconds | default 5.0 }}
         guild_max_concurrency: {{ .Values.directory.guildMaxConcurrency | default 8 }}
         signature_algorithms: {{ .Values.directory.signatureAlgorithms | toJson }}
+        authenticated_card_origins: {{ .Values.directory.authenticatedCardOrigins | toJson }}
 
     workload_identity:
       enabled: {{ .Values.workloadIdentity.enabled | default false }}

--- a/charts/guild/values.yaml
+++ b/charts/guild/values.yaml
@@ -206,6 +206,22 @@ autoscaling:
 podDisruptionBudget:
   enabled: false
 
+# -- Guild-to-Observatory Agent Directory fan-out and validation settings.
+directory:
+  instanceId: ""
+  cardTimeoutSeconds: 4.0
+  cardCacheTtlSeconds: 300.0
+  localMaxConcurrency: 8
+  guildTimeoutSeconds: 5.0
+  guildMaxConcurrency: 8
+  signatureAlgorithms:
+    - ES256
+    - ES384
+    - RS256
+    - RS384
+    - PS256
+    - EdDSA
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/charts/guild/values.yaml
+++ b/charts/guild/values.yaml
@@ -221,6 +221,8 @@ directory:
     - RS384
     - PS256
     - EdDSA
+  # -- Card origins explicitly trusted to receive forwarded caller authentication.
+  authenticatedCardOrigins: []
 
 nodeSelector: {}
 tolerations: []

--- a/charts/observatory/templates/configmap.yaml
+++ b/charts/observatory/templates/configmap.yaml
@@ -45,6 +45,7 @@ data:
         guild_timeout_seconds: {{ .Values.directory.guildTimeoutSeconds | default 5.0 }}
         guild_max_concurrency: {{ .Values.directory.guildMaxConcurrency | default 8 }}
         signature_algorithms: {{ .Values.directory.signatureAlgorithms | toJson }}
+        authenticated_card_origins: {{ .Values.directory.authenticatedCardOrigins | toJson }}
       guild:
         url: {{ .Values.guild.url | default (printf "http://%s-guild" .Release.Name) | quote }}
         timeout_seconds: {{ .Values.guild.timeoutSeconds | default 10.0 }}

--- a/charts/observatory/templates/configmap.yaml
+++ b/charts/observatory/templates/configmap.yaml
@@ -36,6 +36,15 @@ data:
       max_pool_size: {{ .Values.database.maxPoolSize | default 20 }}
 
     observatory:
+      directory:
+        instance_id: {{ .Values.directory.instanceId | default (printf "%s-observatory" .Release.Name) | quote }}
+        cluster_id: {{ .Values.global.niuu.cluster | default "unknown" | quote }}
+        card_timeout_seconds: {{ .Values.directory.cardTimeoutSeconds | default 4.0 }}
+        card_cache_ttl_seconds: {{ .Values.directory.cardCacheTtlSeconds | default 300.0 }}
+        local_max_concurrency: {{ .Values.directory.localMaxConcurrency | default 8 }}
+        guild_timeout_seconds: {{ .Values.directory.guildTimeoutSeconds | default 5.0 }}
+        guild_max_concurrency: {{ .Values.directory.guildMaxConcurrency | default 8 }}
+        signature_algorithms: {{ .Values.directory.signatureAlgorithms | toJson }}
       guild:
         url: {{ .Values.guild.url | default (printf "http://%s-guild" .Release.Name) | quote }}
         timeout_seconds: {{ .Values.guild.timeoutSeconds | default 10.0 }}

--- a/charts/observatory/values.yaml
+++ b/charts/observatory/values.yaml
@@ -184,6 +184,22 @@ autoscaling:
 podDisruptionBudget:
   enabled: false
 
+# -- Principal-aware A2A Agent Directory card resolution and fan-out bounds.
+directory:
+  instanceId: ""
+  cardTimeoutSeconds: 4.0
+  cardCacheTtlSeconds: 300.0
+  localMaxConcurrency: 8
+  guildTimeoutSeconds: 5.0
+  guildMaxConcurrency: 8
+  signatureAlgorithms:
+    - ES256
+    - ES384
+    - RS256
+    - RS384
+    - PS256
+    - EdDSA
+
 nodeSelector: {}
 tolerations: []
 affinity: {}

--- a/charts/observatory/values.yaml
+++ b/charts/observatory/values.yaml
@@ -199,6 +199,8 @@ directory:
     - RS384
     - PS256
     - EdDSA
+  # -- Card origins explicitly trusted to receive forwarded caller authentication.
+  authenticatedCardOrigins: []
 
 nodeSelector: {}
 tolerations: []

--- a/docs/operator/a2a-agent-directory.md
+++ b/docs/operator/a2a-agent-directory.md
@@ -1,0 +1,94 @@
+# A2A Agent Directory
+
+The Agent Directory makes A2A-addressable entities in the existing Observatory topology
+searchable without creating a second inventory. Local Observatory instances project their
+discovery records; Guild fans out across the registered Observatory instances visible to the
+caller.
+
+## Protocol compatibility
+
+Compatibility was rechecked on 2026-07-14 against the official A2A materials. The current
+stable protocol release is 1.0.1, and `a2a-sdk` 1.1 implements the 1.0 protocol. The A2A
+discovery documentation explicitly leaves curated registries to deployments, so these REST
+directory endpoints are Niuu-specific. Agent Cards, supported interfaces, cache validators,
+and JWS signatures retain their official A2A semantics.
+
+- [A2A discovery](https://a2a-protocol.org/latest/topics/agent-discovery/)
+- [A2A specification](https://a2a-protocol.org/latest/specification/)
+- [Protocol releases](https://github.com/a2aproject/A2A/releases)
+- [Python SDK releases](https://github.com/a2aproject/a2a-python/releases)
+
+## Endpoints
+
+Local Observatory:
+
+- `GET /api/v1/observatory/agents`
+- `GET /api/v1/observatory/agents/{agentId}`
+
+Guild aggregate:
+
+- `GET /api/v1/niuu/observatory/agents`
+- `GET /api/v1/niuu/observatory/agents/{agentId}`
+
+The list routes accept repeatable `skill`, `tag`, `kind`, `status`, `environmentId`,
+`cluster`, and `instance` query parameters. Multiple values within one field are ANDed for
+skills and tags and treated as allowed alternatives for the placement/status fields.
+
+Responses contain `items`, source-scoped `warnings`, `sources`, `partial`, and `revision`.
+An unavailable or invalid source degrades the response instead of hiding healthy sources.
+Aggregate IDs are collision-safe. Identically named agents remain distinct unless both cards
+have verified signatures and the same card hash; merged entries retain every provenance
+coordinate.
+
+## Principal isolation and card safety
+
+Observatory filters discovery records by owner, tenant, Environment membership, and explicit
+visibility before fetching a card. Guild independently rechecks owner, tenant, and visibility
+after fan-out; Environment membership remains enforced by each principal-aware Observatory source.
+Authentication headers are forwarded to restricted Observatory and Agent Card endpoints.
+Missing and inaccessible detail records both return the same `404` response.
+
+Card caches are keyed by caller identity and card URL, preventing one principal's authenticated
+card from being served to another. The resolver honors `Cache-Control: max-age`, `ETag`, and
+`If-None-Match`; a configured TTL is used only when the card owner supplies no cache lifetime.
+Cards are parsed by the official SDK. Credential-bearing card URLs, malformed interfaces,
+invalid cards, and unverifiable signatures are excluded with a warning. Unsigned cards can be
+listed but cannot be merged across sources.
+
+## Publishing a workflow session
+
+Volundr is the first production discovery source. A session is addressable only when its real
+workload configuration explicitly contains an HTTP(S) Agent Card URL:
+
+```yaml
+workloadConfig:
+  a2aCardUrl: https://agent.example.com/.well-known/agent-card.json
+  a2aEndpointUrl: https://agent.example.com/a2a
+  environmentId: environment-production
+  a2aVisibility: tenant
+```
+
+Snake-case equivalents are accepted. Volundr exposes only those four allowlisted values; raw
+workload configuration and credentials are never returned. Observatory adds `a2a` and
+`a2aCard` endpoints to the session's existing topology entity, so clients associate directory
+entries through `topologyNodeId` rather than duplicating the node.
+
+## Configuration
+
+The Observatory and Guild Helm charts expose the same `directory` settings:
+
+```yaml
+directory:
+  instanceId: observatory-noatun
+  cardTimeoutSeconds: 4.0
+  cardCacheTtlSeconds: 300.0
+  localMaxConcurrency: 8
+  guildTimeoutSeconds: 5.0
+  guildMaxConcurrency: 8
+  signatureAlgorithms: [ES256, ES384, RS256, RS384, PS256, EdDSA]
+```
+
+`global.niuu.cluster` supplies the deployment cluster. Guild only queries enabled,
+principal-visible registered instances whose kind is `observatory`. Observatory discovery
+adapters remain dynamically configured under `observatory.discovery`; no seeded agents or
+special demo discovery path is used.

--- a/docs/operator/a2a-agent-directory.md
+++ b/docs/operator/a2a-agent-directory.md
@@ -11,7 +11,7 @@ Compatibility was rechecked on 2026-07-14 against the official A2A materials. Th
 stable protocol release is 1.0.1, and `a2a-sdk` 1.1 implements the 1.0 protocol. The A2A
 discovery documentation explicitly leaves curated registries to deployments, so these REST
 directory endpoints are Niuu-specific. Agent Cards, supported interfaces, cache validators,
-and JWS signatures retain their official A2A semantics.
+security declarations, and JWS signatures retain their official A2A semantics.
 
 - [A2A discovery](https://a2a-protocol.org/latest/topics/agent-discovery/)
 - [A2A specification](https://a2a-protocol.org/latest/specification/)
@@ -37,15 +37,19 @@ skills and tags and treated as allowed alternatives for the placement/status fie
 Responses contain `items`, source-scoped `warnings`, `sources`, `partial`, and `revision`.
 An unavailable or invalid source degrades the response instead of hiding healthy sources.
 Aggregate IDs are collision-safe. Identically named agents remain distinct unless both cards
-have verified signatures and the same card hash; merged entries retain every provenance
-coordinate.
+have verified signatures, the same card hash, and the same verified public-key fingerprints;
+merged entries retain every provenance coordinate.
 
 ## Principal isolation and card safety
 
 Observatory filters discovery records by owner, tenant, Environment membership, and explicit
 visibility before fetching a card. Guild independently rechecks owner, tenant, and visibility
 after fan-out; Environment membership remains enforced by each principal-aware Observatory source.
-Authentication headers are forwarded to restricted Observatory and Agent Card endpoints.
+An Environment-scoped entry without authoritative membership metadata fails closed for everyone
+except its explicit owner.
+Authentication headers are forwarded to registered Observatory instances. Agent Card endpoints
+receive caller authentication only when their origin is explicitly trusted through
+`authenticatedCardOrigins`; public and untrusted card origins receive no caller credentials.
 Missing and inaccessible detail records both return the same `404` response.
 
 Card caches are keyed by caller identity and card URL, preventing one principal's authenticated
@@ -65,7 +69,7 @@ workloadConfig:
   a2aCardUrl: https://agent.example.com/.well-known/agent-card.json
   a2aEndpointUrl: https://agent.example.com/a2a
   environmentId: environment-production
-  a2aVisibility: tenant
+  a2aVisibility: user
 ```
 
 Snake-case equivalents are accepted. Volundr exposes only those four allowlisted values; raw
@@ -86,9 +90,11 @@ directory:
   guildTimeoutSeconds: 5.0
   guildMaxConcurrency: 8
   signatureAlgorithms: [ES256, ES384, RS256, RS384, PS256, EdDSA]
+  authenticatedCardOrigins: [https://agents.internal.example]
 ```
 
 `global.niuu.cluster` supplies the deployment cluster. Guild only queries enabled,
 principal-visible registered instances whose kind is `observatory`. Observatory discovery
 adapters remain dynamically configured under `observatory.discovery`; no seeded agents or
-special demo discovery path is used.
+special demo discovery path is used. Keep `authenticatedCardOrigins` empty unless a card service
+requires caller authentication, and list only origins controlled by the deployment operator.

--- a/docs/valkyrie-realm-steward.md
+++ b/docs/valkyrie-realm-steward.md
@@ -504,6 +504,16 @@ commandments — exactly "rough frame, look around, revise."
 
 ---
 
+### 4.11 Addressable agents and capability discovery
+
+The steward must discover callable agents through the principal-aware Observatory Agent
+Directory, not from a static agent list. Directory entries project the existing topology and
+link back through `topologyNodeId`; skills and tags provide capability search, while owner,
+tenant, Environment membership, and visibility constrain what the steward may see. Cross-realm
+or cross-cluster discovery uses Guild's partial-result aggregate and retains source provenance.
+Only equivalent, signed Agent Cards may collapse into one canonical identity. Operational and
+protocol details live in [A2A Agent Directory](operator/a2a-agent-directory.md).
+
 ## 5. Data, events, config, boundaries
 
 - **Postgres** (raw SQL + asyncpg, **no ORM** — `.claude/rules/database.md`):
@@ -626,4 +636,3 @@ the whole reframe before we invest in execution and embodiment.
 - **Additive only.** Every phase composes existing primitives; nothing above requires
   rewriting ravn/ting/volundr/mimir.
 ```
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = {text = "Apache-2.0"}
 keywords = ["development-platform", "remote-coding", "ai", "kubernetes", "self-hosted"]
 requires-python = ">=3.12"
 dependencies = [
+    "a2a-sdk>=1.1.0,<2",
     "pydantic>=2.13.4",
     "pydantic-settings>=2.14.2",
     "pyyaml>=6.0.3",

--- a/route-inventory.json
+++ b/route-inventory.json
@@ -147,6 +147,14 @@
     "plugin": "observatory"
   },
   {
+    "name": "observatory-agents-api",
+    "prefixes": [
+      "/api/v1/observatory/agents"
+    ],
+    "source": "plugin",
+    "plugin": "observatory"
+  },
+  {
     "name": "observatory-events-api",
     "prefixes": [
       "/api/v1/observatory/events/stream",

--- a/src/guild/app.py
+++ b/src/guild/app.py
@@ -15,11 +15,13 @@ from niuu.adapters.inbound.rest_ravn import (
     create_ravn_session_proxy_router,
 )
 from niuu.adapters.inbound.rest_volundr import create_volundr_router
+from niuu.adapters.outbound.http_agent_directory import HttpAgentDirectoryClient
 from niuu.adapters.pat_revocation_middleware import PATRevocationMiddleware
 from niuu.adapters.postgres_instances import PostgresInstanceRepository
 from niuu.adapters.postgres_pats import PostgresPATRepository
 from niuu.cors import apply_cors_middleware
 from niuu.domain.models import InstanceKind, InstanceVisibility
+from niuu.domain.services.agent_directory import AgentDirectoryAggregationService
 from niuu.domain.services.instances import InstanceService
 from niuu.service_databases import apply_service_database_settings, database_pool
 from niuu.service_instances import seed_configured_instances
@@ -58,6 +60,13 @@ def create_app(
     """Create the Guild FastAPI application."""
     loaded_settings = apply_service_database_settings(settings or _load_settings(), "guild")
     configure_logging(loaded_settings.logging)
+    directory_cfg = loaded_settings.observatory.directory
+    agent_directory = AgentDirectoryAggregationService(
+        client=HttpAgentDirectoryClient(
+            timeout_seconds=directory_cfg.guild_timeout_seconds,
+        ),
+        max_concurrency=directory_cfg.guild_max_concurrency,
+    )
     app = FastAPI(
         title="Guild",
         description="Shared instance registry, discovery, and Forge runtime facade APIs.",
@@ -93,6 +102,7 @@ def create_app(
                 create_instances_router(
                     instance_service,
                     embedded_forge_app=embedded_forge_app,
+                    agent_directory=agent_directory,
                 )
             )
             app.include_router(

--- a/src/niuu/adapters/inbound/rest_instances.py
+++ b/src/niuu/adapters/inbound/rest_instances.py
@@ -215,26 +215,6 @@ def _forward_headers(request: Request) -> dict[str, str]:
     return headers
 
 
-def _agent_filters(
-    skill: list[str] | None,
-    tag: list[str] | None,
-    kind: list[str] | None,
-    observed_status: list[str] | None,
-    environment_id: list[str] | None,
-    cluster: list[str] | None,
-    instance: list[str] | None,
-) -> AgentDirectoryFilters:
-    return AgentDirectoryFilters(
-        skills=tuple(skill or ()),
-        tags=tuple(tag or ()),
-        kinds=tuple(kind or ()),
-        statuses=tuple(observed_status or ()),
-        environment_ids=tuple(environment_id or ()),
-        cluster_ids=tuple(cluster or ()),
-        instance_ids=tuple(instance or ()),
-    )
-
-
 def _slug(value: str) -> str:
     return "".join(ch.lower() if ch.isalnum() else "-" for ch in value).strip("-") or "service"
 
@@ -864,14 +844,14 @@ def create_instances_router(
             instances,
             principal,
             headers=_forward_headers(request),
-            filters=_agent_filters(
-                skill,
-                tag,
-                kind,
-                observed_status,
-                environment_id,
-                cluster,
-                instance,
+            filters=AgentDirectoryFilters.from_values(
+                skills=skill,
+                tags=tag,
+                kinds=kind,
+                statuses=observed_status,
+                environment_ids=environment_id,
+                cluster_ids=cluster,
+                instance_ids=instance,
             ),
         )
 

--- a/src/niuu/adapters/inbound/rest_instances.py
+++ b/src/niuu/adapters/inbound/rest_instances.py
@@ -13,12 +13,18 @@ from starlette.types import ASGIApp
 
 from niuu.adapters.inbound.auth import extract_principal
 from niuu.adapters.inbound.remote_urls import build_remote_url
+from niuu.domain.agent_directory import (
+    AgentDirectoryEntry,
+    AgentDirectoryFilters,
+    AgentDirectoryPage,
+)
 from niuu.domain.models import (
     InstanceKind,
     InstanceVisibility,
     Principal,
     RegisteredInstance,
 )
+from niuu.domain.services.agent_directory import AgentDirectoryAggregationService
 from niuu.domain.services.instances import (
     InstanceAccessError,
     InstanceService,
@@ -207,6 +213,26 @@ def _forward_headers(request: Request) -> dict[str, str]:
         if value:
             headers[name] = value
     return headers
+
+
+def _agent_filters(
+    skill: list[str] | None,
+    tag: list[str] | None,
+    kind: list[str] | None,
+    observed_status: list[str] | None,
+    environment_id: list[str] | None,
+    cluster: list[str] | None,
+    instance: list[str] | None,
+) -> AgentDirectoryFilters:
+    return AgentDirectoryFilters(
+        skills=tuple(skill or ()),
+        tags=tuple(tag or ()),
+        kinds=tuple(kind or ()),
+        statuses=tuple(observed_status or ()),
+        environment_ids=tuple(environment_id or ()),
+        cluster_ids=tuple(cluster or ()),
+        instance_ids=tuple(instance or ()),
+    )
 
 
 def _slug(value: str) -> str:
@@ -648,6 +674,7 @@ def create_instances_router(
     service: InstanceService,
     *,
     embedded_forge_app: ASGIApp | None = None,
+    agent_directory: AgentDirectoryAggregationService | None = None,
 ) -> APIRouter:
     """Create the shared instance registry router."""
     router = APIRouter(prefix="/api/v1/niuu", tags=["Shared"])
@@ -806,5 +833,76 @@ def create_instances_router(
     ) -> dict[str, Any]:
         instances = await service.list_visible(principal, enabled_only=True)
         return await _build_observatory_snapshot(instances, request=request)
+
+    @router.get(
+        "/observatory/agents",
+        response_model=AgentDirectoryPage,
+        summary="Aggregate principal-visible A2A agents across Observatory instances",
+    )
+    async def list_observatory_agents(
+        request: Request,
+        skill: list[str] | None = Query(default=None),
+        tag: list[str] | None = Query(default=None),
+        kind: list[str] | None = Query(default=None),
+        observed_status: list[str] | None = Query(default=None, alias="status"),
+        environment_id: list[str] | None = Query(default=None, alias="environmentId"),
+        cluster: list[str] | None = Query(default=None),
+        instance: list[str] | None = Query(default=None),
+        principal: Principal = Depends(extract_principal),
+    ) -> AgentDirectoryPage:
+        if agent_directory is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Agent Directory aggregation is not configured",
+            )
+        instances = await service.list_visible(
+            principal,
+            kind=InstanceKind.OBSERVATORY,
+            enabled_only=True,
+        )
+        return await agent_directory.list_agents(
+            instances,
+            principal,
+            headers=_forward_headers(request),
+            filters=_agent_filters(
+                skill,
+                tag,
+                kind,
+                observed_status,
+                environment_id,
+                cluster,
+                instance,
+            ),
+        )
+
+    @router.get(
+        "/observatory/agents/{agent_id}",
+        response_model=AgentDirectoryEntry,
+        summary="Get one principal-visible aggregate A2A agent",
+    )
+    async def get_observatory_agent(
+        request: Request,
+        agent_id: str,
+        principal: Principal = Depends(extract_principal),
+    ) -> AgentDirectoryEntry:
+        if agent_directory is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Agent Directory aggregation is not configured",
+            )
+        instances = await service.list_visible(
+            principal,
+            kind=InstanceKind.OBSERVATORY,
+            enabled_only=True,
+        )
+        entry = await agent_directory.get_agent(
+            agent_id,
+            instances,
+            principal,
+            headers=_forward_headers(request),
+        )
+        if entry is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+        return entry
 
     return router

--- a/src/niuu/adapters/outbound/http_agent_directory.py
+++ b/src/niuu/adapters/outbound/http_agent_directory.py
@@ -1,0 +1,76 @@
+"""HTTP client adapter for cluster-local Observatory Agent Directories."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+from niuu.domain.agent_directory import AgentDirectoryFilters, AgentDirectoryPage
+from niuu.domain.models import RegisteredInstance
+from niuu.ports.agent_directory import AgentDirectoryClientPort
+
+
+def _agents_url(base_url: str) -> str:
+    parsed = urlsplit(base_url.rstrip("/"))
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Observatory base URL must use http or https")
+    if parsed.username or parsed.password:
+        raise ValueError("Observatory base URL must not embed credentials")
+    path = parsed.path.rstrip("/")
+    if path.endswith("/api/v1/observatory/agents"):
+        pass
+    elif path.endswith("/api/v1/observatory"):
+        path = f"{path}/agents"
+    else:
+        path = f"{path}/api/v1/observatory/agents"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _query_params(filters: AgentDirectoryFilters) -> list[tuple[str, str]]:
+    params: list[tuple[str, str]] = []
+    for key, values in (
+        ("skill", filters.skills),
+        ("tag", filters.tags),
+        ("kind", filters.kinds),
+        ("status", filters.statuses),
+        ("environmentId", filters.environment_ids),
+        ("cluster", filters.cluster_ids),
+        ("instance", filters.instance_ids),
+    ):
+        params.extend((key, value) for value in values)
+    return params
+
+
+class HttpAgentDirectoryClient(AgentDirectoryClientPort):
+    """Call one local directory with bounded timeout and auth forwarding."""
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._timeout_seconds = timeout_seconds
+        self._transport = transport
+
+    async def list_agents(
+        self,
+        instance: RegisteredInstance,
+        *,
+        headers: Mapping[str, str],
+        filters: AgentDirectoryFilters,
+    ) -> AgentDirectoryPage:
+        async with httpx.AsyncClient(
+            timeout=self._timeout_seconds,
+            follow_redirects=False,
+            transport=self._transport,
+        ) as client:
+            response = await client.get(
+                _agents_url(instance.base_url),
+                headers=dict(headers),
+                params=_query_params(filters),
+            )
+            response.raise_for_status()
+            return AgentDirectoryPage.model_validate(response.json())

--- a/src/niuu/app.py
+++ b/src/niuu/app.py
@@ -115,6 +115,7 @@ _PLUGIN_ROUTE_DOMAINS: dict[str, str] = {
     "niuu-repos-api": "niuu",
     "niuu-shared-api": "niuu",
     "observatory-api": "observatory",
+    "observatory-agents-api": "observatory",
     "observatory-events-api": "observatory",
     "observatory-registry-api": "observatory",
     "observatory-topology-api": "observatory",

--- a/src/niuu/domain/agent_directory.py
+++ b/src/niuu/domain/agent_directory.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
 
 from niuu.domain.models import Principal
 
@@ -13,180 +14,92 @@ AgentKind = Literal["steward", "resident", "workflow-session"]
 SourceHealthStatus = Literal["healthy", "degraded", "failed"]
 
 
-class AgentInterface(BaseModel):
+class _AgentDirectoryModel(BaseModel):
+    """Directory model with one consistent snake_case/camelCase boundary."""
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
+
+
+class AgentInterface(_AgentDirectoryModel):
     """One protocol binding declared by an A2A Agent Card."""
 
-    model_config = ConfigDict(populate_by_name=True)
-
     url: str
-    protocol_binding: str = Field(
-        serialization_alias="protocolBinding",
-        validation_alias="protocolBinding",
-    )
-    protocol_version: str = Field(
-        serialization_alias="protocolVersion",
-        validation_alias="protocolVersion",
-    )
+    protocol_binding: str
+    protocol_version: str
     tenant: str = ""
 
 
-class AgentProvenance(BaseModel):
+class AgentProvenance(_AgentDirectoryModel):
     """Source coordinates retained while aggregating equivalent agents."""
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    source_agent_id: str = Field(
-        serialization_alias="sourceAgentId",
-        validation_alias="sourceAgentId",
-    )
-    source_instance_id: str = Field(
-        serialization_alias="sourceInstanceId",
-        validation_alias="sourceInstanceId",
-    )
-    cluster_id: str = Field(serialization_alias="clusterId", validation_alias="clusterId")
-    environment_id: str | None = Field(
-        default=None,
-        serialization_alias="environmentId",
-        validation_alias="environmentId",
-    )
-    topology_node_id: str = Field(
-        serialization_alias="topologyNodeId",
-        validation_alias="topologyNodeId",
-    )
+    source_agent_id: str
+    source_instance_id: str
+    cluster_id: str
+    environment_id: str | None = None
+    topology_node_id: str
 
 
-class AgentDirectoryEntry(BaseModel):
+class AgentDirectoryEntry(_AgentDirectoryModel):
     """Searchable projection of one addressable A2A agent."""
 
-    model_config = ConfigDict(populate_by_name=True)
-
     id: str
-    canonical_id: str = Field(
-        serialization_alias="canonicalId",
-        validation_alias="canonicalId",
-    )
-    source_agent_id: str = Field(
-        serialization_alias="sourceAgentId",
-        validation_alias="sourceAgentId",
-    )
-    source_instance_id: str = Field(
-        serialization_alias="sourceInstanceId",
-        validation_alias="sourceInstanceId",
-    )
-    cluster_id: str = Field(serialization_alias="clusterId", validation_alias="clusterId")
-    environment_id: str | None = Field(
-        default=None,
-        serialization_alias="environmentId",
-        validation_alias="environmentId",
-    )
-    topology_node_id: str = Field(
-        serialization_alias="topologyNodeId",
-        validation_alias="topologyNodeId",
-    )
+    canonical_id: str
+    source_agent_id: str
+    source_instance_id: str
+    cluster_id: str
+    environment_id: str | None = None
+    topology_node_id: str
     name: str
     description: str
     kind: AgentKind
-    card_url: str = Field(serialization_alias="cardUrl", validation_alias="cardUrl")
-    card_version: str = Field(
-        serialization_alias="cardVersion",
-        validation_alias="cardVersion",
-    )
-    card_hash: str = Field(serialization_alias="cardHash", validation_alias="cardHash")
-    signature_verified: bool | None = Field(
-        default=None,
-        serialization_alias="signatureVerified",
-        validation_alias="signatureVerified",
-    )
-    signature_key_ids: list[str] = Field(
-        default_factory=list,
-        serialization_alias="signatureKeyIds",
-        validation_alias="signatureKeyIds",
-    )
-    skill_ids: list[str] = Field(
-        default_factory=list,
-        serialization_alias="skillIds",
-        validation_alias="skillIds",
-    )
+    card_url: str
+    card_version: str
+    card_hash: str
+    signature_verified: bool | None = None
+    signature_key_ids: list[str] = Field(default_factory=list)
+    signature_key_fingerprints: list[str] = Field(default_factory=list)
+    skill_ids: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
-    default_input_modes: list[str] = Field(
-        default_factory=list,
-        serialization_alias="defaultInputModes",
-        validation_alias="defaultInputModes",
-    )
-    default_output_modes: list[str] = Field(
-        default_factory=list,
-        serialization_alias="defaultOutputModes",
-        validation_alias="defaultOutputModes",
-    )
-    supported_interfaces: list[AgentInterface] = Field(
-        default_factory=list,
-        serialization_alias="supportedInterfaces",
-        validation_alias="supportedInterfaces",
-    )
+    default_input_modes: list[str] = Field(default_factory=list)
+    default_output_modes: list[str] = Field(default_factory=list)
+    supported_interfaces: list[AgentInterface] = Field(default_factory=list)
     capabilities: dict[str, Any] = Field(default_factory=dict)
-    observed_status: str = Field(
-        serialization_alias="observedStatus",
-        validation_alias="observedStatus",
-    )
+    security_schemes: dict[str, Any] = Field(default_factory=dict)
+    security_requirements: list[dict[str, Any]] = Field(default_factory=list)
+    observed_status: str
     activity: str = ""
-    last_seen: str = Field(
-        default="",
-        serialization_alias="lastSeen",
-        validation_alias="lastSeen",
-    )
-    owner_id: str | None = Field(
-        default=None,
-        serialization_alias="ownerId",
-        validation_alias="ownerId",
-    )
-    tenant_id: str | None = Field(
-        default=None,
-        serialization_alias="tenantId",
-        validation_alias="tenantId",
-    )
+    last_seen: str = ""
+    owner_id: str | None = None
+    tenant_id: str | None = None
     visibility: str
     environment_member_ids: list[str] = Field(
         default_factory=list,
         exclude=True,
-        validation_alias="environmentMemberIds",
     )
     provenance: list[AgentProvenance] = Field(default_factory=list)
 
 
-class AgentDirectoryWarning(BaseModel):
+class AgentDirectoryWarning(_AgentDirectoryModel):
     """A source-scoped problem that did not invalidate the whole response."""
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    source_instance_id: str = Field(
-        serialization_alias="sourceInstanceId",
-        validation_alias="sourceInstanceId",
-    )
+    source_instance_id: str
     code: str
     message: str
-    source_agent_id: str | None = Field(
-        default=None,
-        serialization_alias="sourceAgentId",
-        validation_alias="sourceAgentId",
-    )
+    source_agent_id: str | None = None
 
 
-class AgentDirectorySourceHealth(BaseModel):
+class AgentDirectorySourceHealth(_AgentDirectoryModel):
     """Per-Observatory health included with partial aggregate results."""
 
-    model_config = ConfigDict(populate_by_name=True)
-
-    instance_id: str = Field(serialization_alias="instanceId", validation_alias="instanceId")
-    cluster_id: str = Field(serialization_alias="clusterId", validation_alias="clusterId")
+    instance_id: str
+    cluster_id: str
     status: SourceHealthStatus
     revision: str = ""
     message: str = ""
 
 
-class AgentDirectoryPage(BaseModel):
+class AgentDirectoryPage(_AgentDirectoryModel):
     """List response shared by local Observatory and Guild aggregation."""
-
-    model_config = ConfigDict(populate_by_name=True)
 
     items: list[AgentDirectoryEntry] = Field(default_factory=list)
     warnings: list[AgentDirectoryWarning] = Field(default_factory=list)
@@ -207,21 +120,62 @@ class AgentDirectoryFilters:
     cluster_ids: tuple[str, ...] = ()
     instance_ids: tuple[str, ...] = ()
 
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        skills: list[str] | None = None,
+        tags: list[str] | None = None,
+        kinds: list[str] | None = None,
+        statuses: list[str] | None = None,
+        environment_ids: list[str] | None = None,
+        cluster_ids: list[str] | None = None,
+        instance_ids: list[str] | None = None,
+    ) -> AgentDirectoryFilters:
+        """Build immutable filters from transport-level optional lists."""
+        return cls(
+            skills=tuple(skills or ()),
+            tags=tuple(tags or ()),
+            kinds=tuple(kinds or ()),
+            statuses=tuple(statuses or ()),
+            environment_ids=tuple(environment_ids or ()),
+            cluster_ids=tuple(cluster_ids or ()),
+            instance_ids=tuple(instance_ids or ()),
+        )
+
 
 def is_agent_visible(entry: AgentDirectoryEntry, principal: Principal) -> bool:
     """Apply owner, tenant, Environment membership, and explicit visibility."""
-    if entry.tenant_id and entry.tenant_id != principal.tenant_id:
+    return is_agent_scope_visible(
+        owner_id=entry.owner_id,
+        tenant_id=entry.tenant_id,
+        visibility=entry.visibility,
+        environment_member_ids=entry.environment_member_ids,
+        principal=principal,
+    )
+
+
+def is_agent_scope_visible(
+    *,
+    owner_id: str | None,
+    tenant_id: str | None,
+    visibility: str,
+    environment_member_ids: list[str],
+    principal: Principal,
+) -> bool:
+    """Evaluate visibility without constructing a complete directory entry."""
+    if tenant_id and tenant_id != principal.tenant_id:
         return False
-    if entry.environment_member_ids and principal.user_id not in entry.environment_member_ids:
+    if environment_member_ids and principal.user_id not in environment_member_ids:
         return False
 
-    visibility = entry.visibility.strip().lower()
-    if visibility in {"system", "public"}:
+    normalized_visibility = visibility.strip().lower()
+    if normalized_visibility in {"system", "public"}:
         return True
-    if visibility == "tenant":
-        return bool(entry.tenant_id) and entry.tenant_id == principal.tenant_id
-    if visibility in {"user", "private"}:
-        return bool(entry.owner_id) and entry.owner_id == principal.user_id
+    if normalized_visibility == "tenant":
+        return bool(tenant_id) and tenant_id == principal.tenant_id
+    if normalized_visibility in {"user", "private"}:
+        return bool(owner_id) and owner_id == principal.user_id
     return False
 
 

--- a/src/niuu/domain/agent_directory.py
+++ b/src/niuu/domain/agent_directory.py
@@ -1,0 +1,259 @@
+"""Shared contracts for local and Guild-backed A2A agent directories."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from niuu.domain.models import Principal
+
+AgentKind = Literal["steward", "resident", "workflow-session"]
+SourceHealthStatus = Literal["healthy", "degraded", "failed"]
+
+
+class AgentInterface(BaseModel):
+    """One protocol binding declared by an A2A Agent Card."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    url: str
+    protocol_binding: str = Field(
+        serialization_alias="protocolBinding",
+        validation_alias="protocolBinding",
+    )
+    protocol_version: str = Field(
+        serialization_alias="protocolVersion",
+        validation_alias="protocolVersion",
+    )
+    tenant: str = ""
+
+
+class AgentProvenance(BaseModel):
+    """Source coordinates retained while aggregating equivalent agents."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    source_agent_id: str = Field(
+        serialization_alias="sourceAgentId",
+        validation_alias="sourceAgentId",
+    )
+    source_instance_id: str = Field(
+        serialization_alias="sourceInstanceId",
+        validation_alias="sourceInstanceId",
+    )
+    cluster_id: str = Field(serialization_alias="clusterId", validation_alias="clusterId")
+    environment_id: str | None = Field(
+        default=None,
+        serialization_alias="environmentId",
+        validation_alias="environmentId",
+    )
+    topology_node_id: str = Field(
+        serialization_alias="topologyNodeId",
+        validation_alias="topologyNodeId",
+    )
+
+
+class AgentDirectoryEntry(BaseModel):
+    """Searchable projection of one addressable A2A agent."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    canonical_id: str = Field(
+        serialization_alias="canonicalId",
+        validation_alias="canonicalId",
+    )
+    source_agent_id: str = Field(
+        serialization_alias="sourceAgentId",
+        validation_alias="sourceAgentId",
+    )
+    source_instance_id: str = Field(
+        serialization_alias="sourceInstanceId",
+        validation_alias="sourceInstanceId",
+    )
+    cluster_id: str = Field(serialization_alias="clusterId", validation_alias="clusterId")
+    environment_id: str | None = Field(
+        default=None,
+        serialization_alias="environmentId",
+        validation_alias="environmentId",
+    )
+    topology_node_id: str = Field(
+        serialization_alias="topologyNodeId",
+        validation_alias="topologyNodeId",
+    )
+    name: str
+    description: str
+    kind: AgentKind
+    card_url: str = Field(serialization_alias="cardUrl", validation_alias="cardUrl")
+    card_version: str = Field(
+        serialization_alias="cardVersion",
+        validation_alias="cardVersion",
+    )
+    card_hash: str = Field(serialization_alias="cardHash", validation_alias="cardHash")
+    signature_verified: bool | None = Field(
+        default=None,
+        serialization_alias="signatureVerified",
+        validation_alias="signatureVerified",
+    )
+    signature_key_ids: list[str] = Field(
+        default_factory=list,
+        serialization_alias="signatureKeyIds",
+        validation_alias="signatureKeyIds",
+    )
+    skill_ids: list[str] = Field(
+        default_factory=list,
+        serialization_alias="skillIds",
+        validation_alias="skillIds",
+    )
+    tags: list[str] = Field(default_factory=list)
+    default_input_modes: list[str] = Field(
+        default_factory=list,
+        serialization_alias="defaultInputModes",
+        validation_alias="defaultInputModes",
+    )
+    default_output_modes: list[str] = Field(
+        default_factory=list,
+        serialization_alias="defaultOutputModes",
+        validation_alias="defaultOutputModes",
+    )
+    supported_interfaces: list[AgentInterface] = Field(
+        default_factory=list,
+        serialization_alias="supportedInterfaces",
+        validation_alias="supportedInterfaces",
+    )
+    capabilities: dict[str, Any] = Field(default_factory=dict)
+    observed_status: str = Field(
+        serialization_alias="observedStatus",
+        validation_alias="observedStatus",
+    )
+    activity: str = ""
+    last_seen: str = Field(
+        default="",
+        serialization_alias="lastSeen",
+        validation_alias="lastSeen",
+    )
+    owner_id: str | None = Field(
+        default=None,
+        serialization_alias="ownerId",
+        validation_alias="ownerId",
+    )
+    tenant_id: str | None = Field(
+        default=None,
+        serialization_alias="tenantId",
+        validation_alias="tenantId",
+    )
+    visibility: str
+    environment_member_ids: list[str] = Field(
+        default_factory=list,
+        exclude=True,
+        validation_alias="environmentMemberIds",
+    )
+    provenance: list[AgentProvenance] = Field(default_factory=list)
+
+
+class AgentDirectoryWarning(BaseModel):
+    """A source-scoped problem that did not invalidate the whole response."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    source_instance_id: str = Field(
+        serialization_alias="sourceInstanceId",
+        validation_alias="sourceInstanceId",
+    )
+    code: str
+    message: str
+    source_agent_id: str | None = Field(
+        default=None,
+        serialization_alias="sourceAgentId",
+        validation_alias="sourceAgentId",
+    )
+
+
+class AgentDirectorySourceHealth(BaseModel):
+    """Per-Observatory health included with partial aggregate results."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    instance_id: str = Field(serialization_alias="instanceId", validation_alias="instanceId")
+    cluster_id: str = Field(serialization_alias="clusterId", validation_alias="clusterId")
+    status: SourceHealthStatus
+    revision: str = ""
+    message: str = ""
+
+
+class AgentDirectoryPage(BaseModel):
+    """List response shared by local Observatory and Guild aggregation."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    items: list[AgentDirectoryEntry] = Field(default_factory=list)
+    warnings: list[AgentDirectoryWarning] = Field(default_factory=list)
+    sources: list[AgentDirectorySourceHealth] = Field(default_factory=list)
+    partial: bool = False
+    revision: str = ""
+
+
+@dataclass(frozen=True)
+class AgentDirectoryFilters:
+    """Transport-neutral directory filters."""
+
+    skills: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    kinds: tuple[str, ...] = ()
+    statuses: tuple[str, ...] = ()
+    environment_ids: tuple[str, ...] = ()
+    cluster_ids: tuple[str, ...] = ()
+    instance_ids: tuple[str, ...] = ()
+
+
+def is_agent_visible(entry: AgentDirectoryEntry, principal: Principal) -> bool:
+    """Apply owner, tenant, Environment membership, and explicit visibility."""
+    if entry.tenant_id and entry.tenant_id != principal.tenant_id:
+        return False
+    if entry.environment_member_ids and principal.user_id not in entry.environment_member_ids:
+        return False
+
+    visibility = entry.visibility.strip().lower()
+    if visibility in {"system", "public"}:
+        return True
+    if visibility == "tenant":
+        return bool(entry.tenant_id) and entry.tenant_id == principal.tenant_id
+    if visibility in {"user", "private"}:
+        return bool(entry.owner_id) and entry.owner_id == principal.user_id
+    return False
+
+
+def matches_agent_filters(
+    entry: AgentDirectoryEntry,
+    filters: AgentDirectoryFilters,
+) -> bool:
+    """Apply all supported local/aggregate directory filters consistently."""
+    normalized_skills = {item.casefold() for item in entry.skill_ids}
+    if filters.skills and not all(item.casefold() in normalized_skills for item in filters.skills):
+        return False
+
+    normalized_tags = {item.casefold() for item in entry.tags}
+    if filters.tags and not all(item.casefold() in normalized_tags for item in filters.tags):
+        return False
+
+    if filters.kinds and entry.kind.casefold() not in {item.casefold() for item in filters.kinds}:
+        return False
+    if filters.statuses and entry.observed_status.casefold() not in {
+        item.casefold() for item in filters.statuses
+    }:
+        return False
+    if filters.environment_ids and (entry.environment_id or "").casefold() not in {
+        item.casefold() for item in filters.environment_ids
+    }:
+        return False
+    if filters.cluster_ids and entry.cluster_id.casefold() not in {
+        item.casefold() for item in filters.cluster_ids
+    }:
+        return False
+    if filters.instance_ids and entry.source_instance_id.casefold() not in {
+        item.casefold() for item in filters.instance_ids
+    }:
+        return False
+    return True

--- a/src/niuu/domain/services/agent_directory.py
+++ b/src/niuu/domain/services/agent_directory.py
@@ -26,6 +26,13 @@ def _aggregate_id(canonical_id: str) -> str:
     return f"agent-{digest}"
 
 
+def _verified_identity(entry: AgentDirectoryEntry) -> str | None:
+    fingerprints = sorted(set(entry.signature_key_fingerprints))
+    if not entry.signature_verified or not entry.card_hash or not fingerprints:
+        return None
+    return f"signed:{entry.card_hash}:keys:{','.join(fingerprints)}"
+
+
 class AgentDirectoryAggregationService:
     """Fan out to visible Observatory instances and reconcile proven identities."""
 
@@ -81,7 +88,11 @@ class AgentDirectoryAggregationService:
                 instance.config.get("cluster") or instance.config.get("environment") or ""
             )
             if error is not None or page is None:
-                message = str(error) if error is not None else "Empty Observatory response"
+                message = (
+                    "Observatory Agent Directory request failed"
+                    if error is not None
+                    else "Observatory returned an empty Agent Directory response"
+                )
                 warnings.append(
                     AgentDirectoryWarning(
                         sourceInstanceId=instance.id,
@@ -193,10 +204,9 @@ class AgentDirectoryAggregationService:
             entries,
             key=lambda item: (item.source_instance_id, item.source_agent_id),
         ):
-            if entry.signature_verified and entry.card_hash:
-                merge_key = f"signed:{entry.card_hash}"
-            else:
-                merge_key = f"source:{entry.source_instance_id}:{entry.source_agent_id}"
+            merge_key = _verified_identity(entry) or (
+                f"source:{entry.source_instance_id}:{entry.source_agent_id}"
+            )
             current = merged.get(merge_key)
             if current is None:
                 merged[merge_key] = entry.model_copy(

--- a/src/niuu/domain/services/agent_directory.py
+++ b/src/niuu/domain/services/agent_directory.py
@@ -1,0 +1,226 @@
+"""Guild-backed aggregation service for Observatory Agent Directories."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections.abc import Mapping
+from dataclasses import replace
+
+from niuu.domain.agent_directory import (
+    AgentDirectoryEntry,
+    AgentDirectoryFilters,
+    AgentDirectoryPage,
+    AgentDirectorySourceHealth,
+    AgentDirectoryWarning,
+    AgentProvenance,
+    is_agent_visible,
+    matches_agent_filters,
+)
+from niuu.domain.models import Principal, RegisteredInstance
+from niuu.ports.agent_directory import AgentDirectoryClientPort
+
+
+def _aggregate_id(canonical_id: str) -> str:
+    digest = hashlib.sha256(canonical_id.encode("utf-8")).hexdigest()[:24]
+    return f"agent-{digest}"
+
+
+class AgentDirectoryAggregationService:
+    """Fan out to visible Observatory instances and reconcile proven identities."""
+
+    def __init__(
+        self,
+        *,
+        client: AgentDirectoryClientPort,
+        max_concurrency: int,
+    ) -> None:
+        self._client = client
+        self._max_concurrency = max_concurrency
+
+    async def list_agents(
+        self,
+        instances: list[RegisteredInstance],
+        principal: Principal,
+        *,
+        headers: Mapping[str, str],
+        filters: AgentDirectoryFilters | None = None,
+    ) -> AgentDirectoryPage:
+        """Aggregate healthy results while retaining source-scoped failures."""
+        active_filters = filters or AgentDirectoryFilters()
+        local_filters = replace(active_filters, instance_ids=())
+        selected_instances = [
+            instance
+            for instance in instances
+            if not active_filters.instance_ids
+            or instance.id.casefold() in {item.casefold() for item in active_filters.instance_ids}
+        ]
+        semaphore = asyncio.Semaphore(self._max_concurrency)
+
+        async def load(
+            instance: RegisteredInstance,
+        ) -> tuple[RegisteredInstance, AgentDirectoryPage | None, Exception | None]:
+            async with semaphore:
+                try:
+                    page = await self._client.list_agents(
+                        instance,
+                        headers=headers,
+                        filters=local_filters,
+                    )
+                except Exception as exc:
+                    return instance, None, exc
+                return instance, page, None
+
+        loaded = await asyncio.gather(*(load(instance) for instance in selected_instances))
+        warnings: list[AgentDirectoryWarning] = []
+        sources: list[AgentDirectorySourceHealth] = []
+        entries: list[AgentDirectoryEntry] = []
+
+        for instance, page, error in loaded:
+            cluster_id = str(
+                instance.config.get("cluster") or instance.config.get("environment") or ""
+            )
+            if error is not None or page is None:
+                message = str(error) if error is not None else "Empty Observatory response"
+                warnings.append(
+                    AgentDirectoryWarning(
+                        sourceInstanceId=instance.id,
+                        code="observatory-unavailable",
+                        message=message,
+                    )
+                )
+                sources.append(
+                    AgentDirectorySourceHealth(
+                        instanceId=instance.id,
+                        clusterId=cluster_id,
+                        status="failed",
+                        message=message,
+                    )
+                )
+                continue
+
+            normalized_entries = [
+                self._normalize_entry(entry, instance=instance, cluster_id=cluster_id)
+                for entry in page.items
+            ]
+            entries.extend(
+                entry
+                for entry in normalized_entries
+                if is_agent_visible(entry, principal)
+                and matches_agent_filters(entry, active_filters)
+            )
+            warnings.extend(
+                warning.model_copy(update={"source_instance_id": instance.id})
+                for warning in page.warnings
+            )
+            sources.extend(
+                source.model_copy(
+                    update={
+                        "instance_id": instance.id,
+                        "cluster_id": source.cluster_id or cluster_id,
+                        "status": (
+                            "degraded"
+                            if page.partial and source.status == "healthy"
+                            else source.status
+                        ),
+                    }
+                )
+                for source in page.sources
+            )
+            if not page.sources:
+                sources.append(
+                    AgentDirectorySourceHealth(
+                        instanceId=instance.id,
+                        clusterId=cluster_id,
+                        status="degraded" if page.partial else "healthy",
+                        revision=page.revision,
+                    )
+                )
+
+        merged = self._merge_entries(entries)
+        revision = hashlib.sha256(
+            "|".join(f"{entry.id}:{entry.card_hash}" for entry in merged).encode("utf-8")
+        ).hexdigest()
+        return AgentDirectoryPage(
+            items=merged,
+            warnings=warnings,
+            sources=sources,
+            partial=bool(warnings) or any(source.status != "healthy" for source in sources),
+            revision=revision,
+        )
+
+    async def get_agent(
+        self,
+        agent_id: str,
+        instances: list[RegisteredInstance],
+        principal: Principal,
+        *,
+        headers: Mapping[str, str],
+    ) -> AgentDirectoryEntry | None:
+        """Find one aggregate entry without revealing inaccessible local matches."""
+        page = await self.list_agents(instances, principal, headers=headers)
+        return next((entry for entry in page.items if entry.id == agent_id), None)
+
+    @staticmethod
+    def _normalize_entry(
+        entry: AgentDirectoryEntry,
+        *,
+        instance: RegisteredInstance,
+        cluster_id: str,
+    ) -> AgentDirectoryEntry:
+        resolved_cluster = entry.cluster_id or cluster_id
+        provenance = [
+            AgentProvenance(
+                sourceAgentId=entry.source_agent_id,
+                sourceInstanceId=instance.id,
+                clusterId=resolved_cluster,
+                environmentId=entry.environment_id,
+                topologyNodeId=entry.topology_node_id,
+            )
+        ]
+        return entry.model_copy(
+            update={
+                "source_instance_id": instance.id,
+                "cluster_id": resolved_cluster,
+                "provenance": provenance,
+            }
+        )
+
+    @staticmethod
+    def _merge_entries(entries: list[AgentDirectoryEntry]) -> list[AgentDirectoryEntry]:
+        merged: dict[str, AgentDirectoryEntry] = {}
+        for entry in sorted(
+            entries,
+            key=lambda item: (item.source_instance_id, item.source_agent_id),
+        ):
+            if entry.signature_verified and entry.card_hash:
+                merge_key = f"signed:{entry.card_hash}"
+            else:
+                merge_key = f"source:{entry.source_instance_id}:{entry.source_agent_id}"
+            current = merged.get(merge_key)
+            if current is None:
+                merged[merge_key] = entry.model_copy(
+                    update={
+                        "id": _aggregate_id(merge_key),
+                        "canonical_id": merge_key,
+                    }
+                )
+                continue
+
+            provenance_by_source = {
+                (item.source_instance_id, item.source_agent_id): item
+                for item in [*current.provenance, *entry.provenance]
+            }
+            merged[merge_key] = current.model_copy(
+                update={
+                    "provenance": list(provenance_by_source.values()),
+                }
+            )
+        return sorted(
+            merged.values(),
+            key=lambda entry: (
+                entry.cluster_id.casefold(),
+                entry.name.casefold(),
+                entry.source_instance_id,
+            ),
+        )

--- a/src/niuu/ports/agent_cards.py
+++ b/src/niuu/ports/agent_cards.py
@@ -1,0 +1,46 @@
+"""Port for principal-aware A2A Agent Card resolution."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from niuu.domain.agent_directory import AgentInterface
+
+
+@dataclass(frozen=True)
+class ResolvedAgentCard:
+    """Validated, searchable Agent Card fields safe for directory indexing."""
+
+    name: str
+    description: str
+    version: str
+    skills: tuple[str, ...]
+    tags: tuple[str, ...]
+    default_input_modes: tuple[str, ...]
+    default_output_modes: tuple[str, ...]
+    supported_interfaces: tuple[AgentInterface, ...]
+    capabilities: dict[str, Any] = field(default_factory=dict)
+    card_hash: str = ""
+    signature_verified: bool | None = None
+    signature_key_ids: tuple[str, ...] = ()
+
+
+class AgentCardResolutionError(RuntimeError):
+    """Raised when a card is unreachable, invalid, or has an invalid signature."""
+
+
+class AgentCardResolverPort(ABC):
+    """Resolve and validate Agent Cards without coupling services to HTTP."""
+
+    @abstractmethod
+    async def resolve(
+        self,
+        card_url: str,
+        *,
+        principal_key: str,
+        headers: Mapping[str, str],
+    ) -> ResolvedAgentCard:
+        """Resolve a card for one caller-isolated cache partition."""

--- a/src/niuu/ports/agent_cards.py
+++ b/src/niuu/ports/agent_cards.py
@@ -23,9 +23,12 @@ class ResolvedAgentCard:
     default_output_modes: tuple[str, ...]
     supported_interfaces: tuple[AgentInterface, ...]
     capabilities: dict[str, Any] = field(default_factory=dict)
+    security_schemes: dict[str, Any] = field(default_factory=dict)
+    security_requirements: tuple[dict[str, Any], ...] = ()
     card_hash: str = ""
     signature_verified: bool | None = None
     signature_key_ids: tuple[str, ...] = ()
+    signature_key_fingerprints: tuple[str, ...] = ()
 
 
 class AgentCardResolutionError(RuntimeError):

--- a/src/niuu/ports/agent_directory.py
+++ b/src/niuu/ports/agent_directory.py
@@ -1,0 +1,23 @@
+"""Outbound port for querying cluster-local Observatory Agent Directories."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+
+from niuu.domain.agent_directory import AgentDirectoryFilters, AgentDirectoryPage
+from niuu.domain.models import RegisteredInstance
+
+
+class AgentDirectoryClientPort(ABC):
+    """Query one registered Observatory while preserving caller identity."""
+
+    @abstractmethod
+    async def list_agents(
+        self,
+        instance: RegisteredInstance,
+        *,
+        headers: Mapping[str, str],
+        filters: AgentDirectoryFilters,
+    ) -> AgentDirectoryPage:
+        """Return one source's principal-filtered directory page."""

--- a/src/observatory/a2a_cards.py
+++ b/src/observatory/a2a_cards.py
@@ -17,6 +17,7 @@ import httpx
 from a2a.client.card_resolver import parse_agent_card
 from a2a.types import AgentCard
 from a2a.utils.signing import create_signature_verifier
+from cryptography.hazmat.primitives import serialization
 from google.protobuf.json_format import MessageToDict, ParseError
 from jwt.api_jwk import PyJWK
 from jwt.utils import base64url_decode
@@ -39,15 +40,53 @@ class _CardCacheEntry:
     expires_at: float
 
 
-def _validate_http_url(value: str, *, require_https: bool = False) -> str:
-    parsed = urlsplit(value)
+def _validate_http_url(
+    value: str,
+    *,
+    require_https: bool = False,
+    allow_query: bool = False,
+) -> str:
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        parsed.port
+    except ValueError as exc:
+        raise AgentCardResolutionError("Agent Card URL is invalid") from exc
     allowed_schemes = {"https"} if require_https else {"http", "https"}
-    if parsed.scheme.lower() not in allowed_schemes or not parsed.netloc:
+    if parsed.scheme.lower() not in allowed_schemes or not hostname:
         requirement = "absolute HTTPS" if require_https else "absolute HTTP(S)"
         raise AgentCardResolutionError(f"Agent Card URL must be an {requirement} URL")
     if parsed.username or parsed.password:
         raise AgentCardResolutionError("Agent Card URLs must not embed credentials")
+    if parsed.fragment or (parsed.query and not allow_query):
+        raise AgentCardResolutionError(
+            "Agent Card and signature-key URLs cannot use query strings or fragments"
+        )
     return value
+
+
+def _origin(value: str) -> str:
+    parsed = urlsplit(_validate_http_url(value))
+    port = parsed.port
+    hostname = parsed.hostname or ""
+    host = f"[{hostname}]" if ":" in hostname else hostname
+    default_port = 443 if parsed.scheme.lower() == "https" else 80
+    authority = host if port in {None, default_port} else f"{host}:{port}"
+    return f"{parsed.scheme.lower()}://{authority}"
+
+
+def _key_fingerprint(key: PyJWK) -> str:
+    """Return a stable fingerprint of verified asymmetric public-key material."""
+    try:
+        encoded = key.key.public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise AgentCardResolutionError(
+            "JWKS signature key is not an asymmetric public key"
+        ) from exc
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _cache_ttl(response: httpx.Response, default_ttl_seconds: float) -> float | None:
@@ -142,6 +181,7 @@ class HttpAgentCardResolver(AgentCardResolverPort):
         timeout_seconds: float,
         default_cache_ttl_seconds: float,
         signature_algorithms: list[str],
+        authenticated_card_origins: list[str] | None = None,
         transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._timeout_seconds = timeout_seconds
@@ -152,6 +192,9 @@ class HttpAgentCardResolver(AgentCardResolverPort):
                 f"Unsupported Agent Card signature algorithm(s): {', '.join(sorted(unsupported))}"
             )
         self._signature_algorithms = list(signature_algorithms)
+        self._authenticated_card_origins = frozenset(
+            _origin(value.strip()) for value in authenticated_card_origins or ()
+        )
         self._transport = transport
         self._cache: dict[tuple[str, str], _CardCacheEntry] = {}
         self._locks: dict[tuple[str, str], asyncio.Lock] = {}
@@ -178,7 +221,9 @@ class HttpAgentCardResolver(AgentCardResolverPort):
             if cached is not None and cached.expires_at > now:
                 return cached.card
 
-            request_headers = dict(headers)
+            request_headers = (
+                dict(headers) if _origin(card_url) in self._authenticated_card_origins else {}
+            )
             request_headers.setdefault("Accept", "application/a2a+json, application/json")
             if cached is not None and cached.etag:
                 request_headers["If-None-Match"] = cached.etag
@@ -204,7 +249,7 @@ class HttpAgentCardResolver(AgentCardResolverPort):
                     response.raise_for_status()
                     payload = response.json()
                     card = self._parse_card(payload)
-                    signature_verified, key_ids = await self._verify_signatures(
+                    signature_verified, key_ids, key_fingerprints = await self._verify_signatures(
                         card,
                         client=client,
                     )
@@ -217,6 +262,7 @@ class HttpAgentCardResolver(AgentCardResolverPort):
                 card,
                 signature_verified=signature_verified,
                 signature_key_ids=key_ids,
+                signature_key_fingerprints=key_fingerprints,
             )
             ttl = _cache_ttl(response, self._default_cache_ttl_seconds)
             if ttl is not None:
@@ -238,7 +284,7 @@ class HttpAgentCardResolver(AgentCardResolverPort):
                 f"Agent Card is missing required fields: {', '.join(missing)}"
             )
         for interface in card.supported_interfaces:
-            _validate_http_url(interface.url)
+            _validate_http_url(interface.url, allow_query=True)
             if not interface.protocol_binding.strip() or not interface.protocol_version.strip():
                 raise AgentCardResolutionError(
                     "Agent Card interfaces require protocolBinding and protocolVersion"
@@ -257,13 +303,14 @@ class HttpAgentCardResolver(AgentCardResolverPort):
         card: AgentCard,
         *,
         client: httpx.AsyncClient,
-    ) -> tuple[bool | None, tuple[str, ...]]:
+    ) -> tuple[bool | None, tuple[str, ...], tuple[str, ...]]:
         if not card.signatures:
-            return None, ()
+            return None, (), ()
 
         protected_headers = _protected_headers(card)
         keys: dict[tuple[str, str], PyJWK] = {}
         key_ids: list[str] = []
+        key_fingerprints: list[str] = []
         for header in protected_headers:
             key_id = str(header.get("kid") or "").strip()
             jwks_url = str(header.get("jku") or "").strip()
@@ -296,7 +343,12 @@ class HttpAgentCardResolver(AgentCardResolverPort):
             )
             if matching is None:
                 raise AgentCardResolutionError(f"JWKS does not contain signature key {key_id}")
-            keys[(key_id, jwks_url)] = PyJWK.from_dict(matching)
+            try:
+                key = PyJWK.from_dict(matching)
+            except Exception as exc:
+                raise AgentCardResolutionError("JWKS contains an invalid signature key") from exc
+            keys[(key_id, jwks_url)] = key
+            key_fingerprints.append(_key_fingerprint(key))
 
         verifier = create_signature_verifier(
             lambda kid, jku: keys[(str(kid or ""), str(jku or ""))],
@@ -306,7 +358,11 @@ class HttpAgentCardResolver(AgentCardResolverPort):
             verifier(card)
         except Exception as exc:
             raise AgentCardResolutionError("Agent Card signature verification failed") from exc
-        return True, tuple(dict.fromkeys(key_ids))
+        return (
+            True,
+            tuple(dict.fromkeys(key_ids)),
+            tuple(sorted(set(key_fingerprints))),
+        )
 
     @staticmethod
     def _to_resolved(
@@ -314,9 +370,12 @@ class HttpAgentCardResolver(AgentCardResolverPort):
         *,
         signature_verified: bool | None,
         signature_key_ids: tuple[str, ...],
+        signature_key_fingerprints: tuple[str, ...],
     ) -> ResolvedAgentCard:
         card_payload = MessageToDict(card)
         capabilities = card_payload.get("capabilities", {})
+        security_schemes = card_payload.get("securitySchemes", {})
+        security_requirements = card_payload.get("securityRequirements", [])
         return ResolvedAgentCard(
             name=card.name,
             description=card.description,
@@ -335,7 +394,14 @@ class HttpAgentCardResolver(AgentCardResolverPort):
                 for interface in card.supported_interfaces
             ),
             capabilities=capabilities if isinstance(capabilities, dict) else {},
+            security_schemes=(security_schemes if isinstance(security_schemes, dict) else {}),
+            security_requirements=(
+                tuple(item for item in security_requirements if isinstance(item, dict))
+                if isinstance(security_requirements, list)
+                else ()
+            ),
             card_hash=_canonical_card_hash(card),
             signature_verified=signature_verified,
             signature_key_ids=signature_key_ids,
+            signature_key_fingerprints=signature_key_fingerprints,
         )

--- a/src/observatory/a2a_cards.py
+++ b/src/observatory/a2a_cards.py
@@ -1,0 +1,341 @@
+"""HTTP adapter for resolving and validating standard A2A Agent Cards."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import time
+from collections.abc import Mapping
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+from a2a.client.card_resolver import parse_agent_card
+from a2a.types import AgentCard
+from a2a.utils.signing import create_signature_verifier
+from google.protobuf.json_format import MessageToDict, ParseError
+from jwt.api_jwk import PyJWK
+from jwt.utils import base64url_decode
+
+from niuu.domain.agent_directory import AgentInterface
+from niuu.ports.agent_cards import (
+    AgentCardResolutionError,
+    AgentCardResolverPort,
+    ResolvedAgentCard,
+)
+
+_MAX_AGE_PATTERN = re.compile(r"(?:^|,)\s*max-age=(\d+)(?:\s*(?:,|$))", re.IGNORECASE)
+_SUPPORTED_SIGNATURE_ALGORITHMS = frozenset({"ES256", "ES384", "RS256", "RS384", "PS256", "EdDSA"})
+
+
+@dataclass(frozen=True)
+class _CardCacheEntry:
+    card: ResolvedAgentCard
+    etag: str
+    expires_at: float
+
+
+def _validate_http_url(value: str, *, require_https: bool = False) -> str:
+    parsed = urlsplit(value)
+    allowed_schemes = {"https"} if require_https else {"http", "https"}
+    if parsed.scheme.lower() not in allowed_schemes or not parsed.netloc:
+        requirement = "absolute HTTPS" if require_https else "absolute HTTP(S)"
+        raise AgentCardResolutionError(f"Agent Card URL must be an {requirement} URL")
+    if parsed.username or parsed.password:
+        raise AgentCardResolutionError("Agent Card URLs must not embed credentials")
+    return value
+
+
+def _cache_ttl(response: httpx.Response, default_ttl_seconds: float) -> float | None:
+    cache_control = response.headers.get("cache-control", "").casefold()
+    directives = {item.strip().split("=", 1)[0] for item in cache_control.split(",")}
+    if "no-store" in directives:
+        return None
+    if "no-cache" in directives:
+        return 0.0
+    match = _MAX_AGE_PATTERN.search(cache_control)
+    ttl = default_ttl_seconds if match is None else float(match.group(1))
+    try:
+        age = max(float(response.headers.get("age", "0")), 0.0)
+    except ValueError:
+        age = 0.0
+    return max(ttl - age, 0.0)
+
+
+def _required_card_fields(card: AgentCard) -> list[str]:
+    missing: list[str] = []
+    if not card.name.strip():
+        missing.append("name")
+    if not card.description.strip():
+        missing.append("description")
+    if not card.version.strip():
+        missing.append("version")
+    if not card.supported_interfaces:
+        missing.append("supportedInterfaces")
+    if not card.HasField("capabilities"):
+        missing.append("capabilities")
+    if not card.default_input_modes:
+        missing.append("defaultInputModes")
+    if not card.default_output_modes:
+        missing.append("defaultOutputModes")
+    if not card.skills:
+        missing.append("skills")
+    return missing
+
+
+def _without_empty_values(value: Any) -> Any:
+    if isinstance(value, dict):
+        cleaned = {
+            key: cleaned_value
+            for key, item in value.items()
+            if (cleaned_value := _without_empty_values(item)) is not None
+        }
+        return cleaned or None
+    if isinstance(value, list):
+        cleaned = [
+            cleaned_value
+            for item in value
+            if (cleaned_value := _without_empty_values(item)) is not None
+        ]
+        return cleaned or None
+    if value == "":
+        return None
+    return value
+
+
+def _canonical_card_hash(card: AgentCard) -> str:
+    """Hash the same signature-free semantic payload used by the official SDK signer."""
+    card_payload = MessageToDict(card)
+    card_payload.pop("signatures", None)
+    canonical_payload = json.dumps(
+        _without_empty_values(card_payload),
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical_payload.encode("utf-8")).hexdigest()
+
+
+def _protected_headers(card: AgentCard) -> list[dict[str, Any]]:
+    headers: list[dict[str, Any]] = []
+    for signature in card.signatures:
+        try:
+            payload = base64url_decode(signature.protected.encode("utf-8")).decode("utf-8")
+            header = json.loads(payload)
+        except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+            raise AgentCardResolutionError("Agent Card contains an invalid JWS header") from exc
+        if not isinstance(header, dict):
+            raise AgentCardResolutionError("Agent Card contains an invalid JWS header")
+        headers.append(header)
+    return headers
+
+
+class HttpAgentCardResolver(AgentCardResolverPort):
+    """Resolve cards with caller-isolated HTTP caching and signature verification."""
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float,
+        default_cache_ttl_seconds: float,
+        signature_algorithms: list[str],
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._timeout_seconds = timeout_seconds
+        self._default_cache_ttl_seconds = default_cache_ttl_seconds
+        unsupported = set(signature_algorithms) - _SUPPORTED_SIGNATURE_ALGORITHMS
+        if unsupported:
+            raise ValueError(
+                f"Unsupported Agent Card signature algorithm(s): {', '.join(sorted(unsupported))}"
+            )
+        self._signature_algorithms = list(signature_algorithms)
+        self._transport = transport
+        self._cache: dict[tuple[str, str], _CardCacheEntry] = {}
+        self._locks: dict[tuple[str, str], asyncio.Lock] = {}
+
+    async def resolve(
+        self,
+        card_url: str,
+        *,
+        principal_key: str,
+        headers: Mapping[str, str],
+    ) -> ResolvedAgentCard:
+        """Resolve a standard card without sharing restricted cards between callers."""
+        card_url = _validate_http_url(card_url.strip())
+        cache_key = (principal_key, card_url)
+        cached = self._cache.get(cache_key)
+        now = time.monotonic()
+        if cached is not None and cached.expires_at > now:
+            return cached.card
+
+        lock = self._locks.setdefault(cache_key, asyncio.Lock())
+        async with lock:
+            cached = self._cache.get(cache_key)
+            now = time.monotonic()
+            if cached is not None and cached.expires_at > now:
+                return cached.card
+
+            request_headers = dict(headers)
+            request_headers.setdefault("Accept", "application/a2a+json, application/json")
+            if cached is not None and cached.etag:
+                request_headers["If-None-Match"] = cached.etag
+
+            try:
+                async with httpx.AsyncClient(
+                    timeout=self._timeout_seconds,
+                    follow_redirects=False,
+                    transport=self._transport,
+                ) as client:
+                    response = await client.get(card_url, headers=request_headers)
+                    if response.status_code == httpx.codes.NOT_MODIFIED and cached is not None:
+                        ttl = _cache_ttl(response, self._default_cache_ttl_seconds)
+                        if ttl is None:
+                            self._cache.pop(cache_key, None)
+                        else:
+                            self._cache[cache_key] = _CardCacheEntry(
+                                card=cached.card,
+                                etag=cached.etag,
+                                expires_at=now + ttl,
+                            )
+                        return cached.card
+                    response.raise_for_status()
+                    payload = response.json()
+                    card = self._parse_card(payload)
+                    signature_verified, key_ids = await self._verify_signatures(
+                        card,
+                        client=client,
+                    )
+            except AgentCardResolutionError:
+                raise
+            except (httpx.HTTPError, json.JSONDecodeError, ParseError, ValueError) as exc:
+                raise AgentCardResolutionError("Unable to resolve Agent Card") from exc
+
+            resolved = self._to_resolved(
+                card,
+                signature_verified=signature_verified,
+                signature_key_ids=key_ids,
+            )
+            ttl = _cache_ttl(response, self._default_cache_ttl_seconds)
+            if ttl is not None:
+                self._cache[cache_key] = _CardCacheEntry(
+                    card=resolved,
+                    etag=response.headers.get("etag", ""),
+                    expires_at=now + ttl,
+                )
+            return resolved
+
+    @staticmethod
+    def _parse_card(payload: Any) -> AgentCard:
+        if not isinstance(payload, dict):
+            raise AgentCardResolutionError("Agent Card response must be a JSON object")
+        card = parse_agent_card(deepcopy(payload))
+        missing = _required_card_fields(card)
+        if missing:
+            raise AgentCardResolutionError(
+                f"Agent Card is missing required fields: {', '.join(missing)}"
+            )
+        for interface in card.supported_interfaces:
+            _validate_http_url(interface.url)
+            if not interface.protocol_binding.strip() or not interface.protocol_version.strip():
+                raise AgentCardResolutionError(
+                    "Agent Card interfaces require protocolBinding and protocolVersion"
+                )
+        for skill in card.skills:
+            if not skill.id.strip() or not skill.name.strip() or not skill.description.strip():
+                raise AgentCardResolutionError(
+                    "Agent Card skills require id, name, and description"
+                )
+            if not skill.tags:
+                raise AgentCardResolutionError("Agent Card skills require at least one tag")
+        return card
+
+    async def _verify_signatures(
+        self,
+        card: AgentCard,
+        *,
+        client: httpx.AsyncClient,
+    ) -> tuple[bool | None, tuple[str, ...]]:
+        if not card.signatures:
+            return None, ()
+
+        protected_headers = _protected_headers(card)
+        keys: dict[tuple[str, str], PyJWK] = {}
+        key_ids: list[str] = []
+        for header in protected_headers:
+            key_id = str(header.get("kid") or "").strip()
+            jwks_url = str(header.get("jku") or "").strip()
+            algorithm = str(header.get("alg") or "").strip()
+            if not key_id or not jwks_url or not algorithm:
+                raise AgentCardResolutionError(
+                    "Signed Agent Cards require alg, kid, and jku protected headers"
+                )
+            if algorithm not in self._signature_algorithms:
+                raise AgentCardResolutionError(
+                    f"Agent Card signature algorithm is not allowed: {algorithm}"
+                )
+            _validate_http_url(jwks_url, require_https=True)
+            key_ids.append(key_id)
+            if (key_id, jwks_url) in keys:
+                continue
+            response = await client.get(jwks_url, headers={"Accept": "application/json"})
+            response.raise_for_status()
+            payload = response.json()
+            jwks = payload.get("keys") if isinstance(payload, dict) else None
+            if not isinstance(jwks, list):
+                raise AgentCardResolutionError("Agent Card signature jku did not return a JWKS")
+            matching = next(
+                (
+                    item
+                    for item in jwks
+                    if isinstance(item, dict) and str(item.get("kid") or "") == key_id
+                ),
+                None,
+            )
+            if matching is None:
+                raise AgentCardResolutionError(f"JWKS does not contain signature key {key_id}")
+            keys[(key_id, jwks_url)] = PyJWK.from_dict(matching)
+
+        verifier = create_signature_verifier(
+            lambda kid, jku: keys[(str(kid or ""), str(jku or ""))],
+            algorithms=self._signature_algorithms,
+        )
+        try:
+            verifier(card)
+        except Exception as exc:
+            raise AgentCardResolutionError("Agent Card signature verification failed") from exc
+        return True, tuple(dict.fromkeys(key_ids))
+
+    @staticmethod
+    def _to_resolved(
+        card: AgentCard,
+        *,
+        signature_verified: bool | None,
+        signature_key_ids: tuple[str, ...],
+    ) -> ResolvedAgentCard:
+        card_payload = MessageToDict(card)
+        capabilities = card_payload.get("capabilities", {})
+        return ResolvedAgentCard(
+            name=card.name,
+            description=card.description,
+            version=card.version,
+            skills=tuple(skill.id for skill in card.skills),
+            tags=tuple(dict.fromkeys(tag for skill in card.skills for tag in skill.tags)),
+            default_input_modes=tuple(card.default_input_modes),
+            default_output_modes=tuple(card.default_output_modes),
+            supported_interfaces=tuple(
+                AgentInterface(
+                    url=interface.url,
+                    protocolBinding=interface.protocol_binding,
+                    protocolVersion=interface.protocol_version,
+                    tenant=interface.tenant,
+                )
+                for interface in card.supported_interfaces
+            ),
+            capabilities=capabilities if isinstance(capabilities, dict) else {},
+            card_hash=_canonical_card_hash(card),
+            signature_verified=signature_verified,
+            signature_key_ids=signature_key_ids,
+        )

--- a/src/observatory/agent_directory.py
+++ b/src/observatory/agent_directory.py
@@ -1,0 +1,343 @@
+"""Principal-aware Agent Directory projection over Observatory discovery."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+from niuu.domain.agent_directory import (
+    AgentDirectoryEntry,
+    AgentDirectoryFilters,
+    AgentDirectoryPage,
+    AgentDirectorySourceHealth,
+    AgentDirectoryWarning,
+    AgentProvenance,
+    is_agent_visible,
+    matches_agent_filters,
+)
+from niuu.domain.models import Principal
+from niuu.ports.agent_cards import (
+    AgentCardResolutionError,
+    AgentCardResolverPort,
+    ResolvedAgentCard,
+)
+from observatory.entity_discovery import DiscoveredEntity, DiscoveryResult
+
+_AGENT_KINDS = {"steward", "resident", "workflow-session"}
+
+
+class DiscoveryResultProvider(Protocol):
+    """Port exposing unfiltered discovery source truth to the directory projection."""
+
+    async def get_discovery_result(self) -> DiscoveryResult: ...
+
+
+def _string_metadata(metadata: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _string_list_metadata(metadata: dict[str, Any], *keys: str) -> list[str]:
+    for key in keys:
+        value = metadata.get(key)
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(",") if item.strip()]
+    return []
+
+
+def _stable_agent_id(canonical_id: str) -> str:
+    digest = hashlib.sha256(canonical_id.encode("utf-8")).hexdigest()[:24]
+    return f"agent-{digest}"
+
+
+class AgentDirectoryService:
+    """Project validated A2A metadata without creating parallel topology nodes."""
+
+    def __init__(
+        self,
+        *,
+        discovery: DiscoveryResultProvider,
+        card_resolver: AgentCardResolverPort,
+        instance_id: str,
+        cluster_id: str,
+        max_concurrency: int,
+    ) -> None:
+        self._discovery = discovery
+        self._card_resolver = card_resolver
+        self._instance_id = instance_id
+        self._cluster_id = cluster_id
+        self._max_concurrency = max_concurrency
+
+    async def list_agents(
+        self,
+        principal: Principal,
+        *,
+        headers: Mapping[str, str],
+        filters: AgentDirectoryFilters | None = None,
+    ) -> AgentDirectoryPage:
+        """Return visible entries and bounded per-card warnings."""
+        active_filters = filters or AgentDirectoryFilters()
+        result = await self._discovery.get_discovery_result()
+        candidates = [
+            entity
+            for entity in result.entities
+            if entity.endpoints.get("a2aCard") and self._entity_may_match(entity, active_filters)
+        ]
+        semaphore = asyncio.Semaphore(self._max_concurrency)
+
+        async def resolve(
+            entity: DiscoveredEntity,
+        ) -> tuple[AgentDirectoryEntry | None, AgentDirectoryWarning | None]:
+            async with semaphore:
+                return await self._project_entity(
+                    entity,
+                    principal=principal,
+                    headers=headers,
+                    filters=active_filters,
+                )
+
+        resolved = await asyncio.gather(*(resolve(entity) for entity in candidates))
+        items = sorted(
+            (entry for entry, _ in resolved if entry is not None),
+            key=lambda entry: (
+                entry.cluster_id.casefold(),
+                entry.name.casefold(),
+                entry.source_agent_id,
+            ),
+        )
+        warnings = [warning for _, warning in resolved if warning is not None]
+        revision = hashlib.sha256(
+            "|".join(f"{item.id}:{item.card_hash}" for item in items).encode("utf-8")
+        ).hexdigest()
+        cluster_id = self._cluster_id or next(
+            (entity.cluster for entity in candidates if entity.cluster),
+            "",
+        )
+        return AgentDirectoryPage(
+            items=items,
+            warnings=warnings,
+            sources=[
+                AgentDirectorySourceHealth(
+                    instanceId=self._instance_id,
+                    clusterId=cluster_id,
+                    status="degraded" if warnings else "healthy",
+                    revision=revision,
+                    message=(
+                        f"{len(warnings)} Agent Card resolution warning(s)" if warnings else ""
+                    ),
+                )
+            ],
+            partial=bool(warnings),
+            revision=revision,
+        )
+
+    async def get_agent(
+        self,
+        agent_id: str,
+        principal: Principal,
+        *,
+        headers: Mapping[str, str],
+    ) -> AgentDirectoryEntry | None:
+        """Resolve a visible detail without disclosing inaccessible identifiers."""
+        page = await self.list_agents(principal, headers=headers)
+        return next(
+            (
+                entry
+                for entry in page.items
+                if agent_id
+                in {
+                    entry.id,
+                    entry.canonical_id,
+                    entry.source_agent_id,
+                    entry.topology_node_id,
+                }
+            ),
+            None,
+        )
+
+    def _entity_may_match(
+        self,
+        entity: DiscoveredEntity,
+        filters: AgentDirectoryFilters,
+    ) -> bool:
+        metadata = entity.metadata
+        kind = self._agent_kind(entity)
+        cluster_id = entity.cluster or self._cluster_id
+        environment_id = _string_metadata(metadata, "environmentId", "environment_id")
+        if filters.kinds and kind.casefold() not in {item.casefold() for item in filters.kinds}:
+            return False
+        if filters.statuses and entity.status.casefold() not in {
+            item.casefold() for item in filters.statuses
+        }:
+            return False
+        if filters.environment_ids and environment_id.casefold() not in {
+            item.casefold() for item in filters.environment_ids
+        }:
+            return False
+        if filters.cluster_ids and cluster_id.casefold() not in {
+            item.casefold() for item in filters.cluster_ids
+        }:
+            return False
+        if filters.instance_ids and self._instance_id.casefold() not in {
+            item.casefold() for item in filters.instance_ids
+        }:
+            return False
+        return True
+
+    async def _project_entity(
+        self,
+        entity: DiscoveredEntity,
+        *,
+        principal: Principal,
+        headers: Mapping[str, str],
+        filters: AgentDirectoryFilters,
+    ) -> tuple[AgentDirectoryEntry | None, AgentDirectoryWarning | None]:
+        metadata = entity.metadata
+        source_agent_id = entity.source_uid or entity.id
+        visibility = _string_metadata(metadata, "visibility", "a2aVisibility")
+        if not visibility and "volundr-session" in entity.source_kind:
+            visibility = "user"
+        entry_scope = self._scope_entry(
+            entity,
+            source_agent_id=source_agent_id,
+            visibility=visibility,
+        )
+        if not is_agent_visible(entry_scope, principal):
+            return None, None
+
+        card_url = entity.endpoints["a2aCard"]
+        principal_key = f"{principal.tenant_id}\0{principal.user_id}"
+        try:
+            card = await self._card_resolver.resolve(
+                card_url,
+                principal_key=principal_key,
+                headers=headers,
+            )
+        except AgentCardResolutionError as exc:
+            return None, AgentDirectoryWarning(
+                sourceInstanceId=self._instance_id,
+                sourceAgentId=source_agent_id,
+                code="agent-card-unavailable",
+                message=str(exc),
+            )
+
+        entry = self._entry_from_card(
+            entity,
+            card=card,
+            card_url=card_url,
+            source_agent_id=source_agent_id,
+            visibility=visibility,
+        )
+        if not matches_agent_filters(entry, filters):
+            return None, None
+        return entry, None
+
+    def _scope_entry(
+        self,
+        entity: DiscoveredEntity,
+        *,
+        source_agent_id: str,
+        visibility: str,
+    ) -> AgentDirectoryEntry:
+        """Build the visibility-only shell used before any restricted card fetch."""
+        metadata = entity.metadata
+        cluster_id = entity.cluster or self._cluster_id
+        environment_id = _string_metadata(metadata, "environmentId", "environment_id") or None
+        return AgentDirectoryEntry(
+            id="scope-only",
+            canonicalId="scope-only",
+            sourceAgentId=source_agent_id,
+            sourceInstanceId=self._instance_id,
+            clusterId=cluster_id,
+            environmentId=environment_id,
+            topologyNodeId=entity.id,
+            name=entity.name,
+            description="",
+            kind=self._agent_kind(entity),
+            cardUrl=entity.endpoints["a2aCard"],
+            cardVersion="",
+            cardHash="",
+            observedStatus=entity.status,
+            ownerId=_string_metadata(metadata, "ownerId", "owner_id") or None,
+            tenantId=_string_metadata(metadata, "tenantId", "tenant_id") or None,
+            visibility=visibility,
+            environmentMemberIds=_string_list_metadata(
+                metadata,
+                "environmentMemberIds",
+                "environment_member_ids",
+            ),
+        )
+
+    def _entry_from_card(
+        self,
+        entity: DiscoveredEntity,
+        *,
+        card: ResolvedAgentCard,
+        card_url: str,
+        source_agent_id: str,
+        visibility: str,
+    ) -> AgentDirectoryEntry:
+        metadata = entity.metadata
+        cluster_id = entity.cluster or self._cluster_id
+        environment_id = _string_metadata(metadata, "environmentId", "environment_id") or None
+        canonical_id = (
+            f"a2a-card:{card.card_hash}"
+            if card.signature_verified
+            else f"a2a-source:{self._instance_id}:{entity.id}"
+        )
+        provenance = AgentProvenance(
+            sourceAgentId=source_agent_id,
+            sourceInstanceId=self._instance_id,
+            clusterId=cluster_id,
+            environmentId=environment_id,
+            topologyNodeId=entity.id,
+        )
+        return AgentDirectoryEntry(
+            id=_stable_agent_id(canonical_id),
+            canonicalId=canonical_id,
+            sourceAgentId=source_agent_id,
+            sourceInstanceId=self._instance_id,
+            clusterId=cluster_id,
+            environmentId=environment_id,
+            topologyNodeId=entity.id,
+            name=card.name,
+            description=card.description,
+            kind=self._agent_kind(entity),
+            cardUrl=card_url,
+            cardVersion=card.version,
+            cardHash=card.card_hash,
+            signatureVerified=card.signature_verified,
+            signatureKeyIds=list(card.signature_key_ids),
+            skillIds=list(card.skills),
+            tags=list(card.tags),
+            defaultInputModes=list(card.default_input_modes),
+            defaultOutputModes=list(card.default_output_modes),
+            supportedInterfaces=list(card.supported_interfaces),
+            capabilities=card.capabilities,
+            observedStatus=entity.status,
+            activity=_string_metadata(metadata, "activity", "activityState", "activity_state"),
+            lastSeen=_string_metadata(metadata, "lastSeen", "lastActive", "last_active"),
+            ownerId=_string_metadata(metadata, "ownerId", "owner_id") or None,
+            tenantId=_string_metadata(metadata, "tenantId", "tenant_id") or None,
+            visibility=visibility,
+            environmentMemberIds=_string_list_metadata(
+                metadata,
+                "environmentMemberIds",
+                "environment_member_ids",
+            ),
+            provenance=[provenance],
+        )
+
+    @staticmethod
+    def _agent_kind(entity: DiscoveredEntity) -> str:
+        kind = _string_metadata(entity.metadata, "agentKind", "agent_kind")
+        if not kind and "volundr-session" in entity.source_kind:
+            kind = "workflow-session"
+        return kind if kind in _AGENT_KINDS else "workflow-session"

--- a/src/observatory/agent_directory.py
+++ b/src/observatory/agent_directory.py
@@ -14,7 +14,7 @@ from niuu.domain.agent_directory import (
     AgentDirectorySourceHealth,
     AgentDirectoryWarning,
     AgentProvenance,
-    is_agent_visible,
+    is_agent_scope_visible,
     matches_agent_filters,
 )
 from niuu.domain.models import Principal
@@ -148,17 +148,7 @@ class AgentDirectoryService:
         """Resolve a visible detail without disclosing inaccessible identifiers."""
         page = await self.list_agents(principal, headers=headers)
         return next(
-            (
-                entry
-                for entry in page.items
-                if agent_id
-                in {
-                    entry.id,
-                    entry.canonical_id,
-                    entry.source_agent_id,
-                    entry.topology_node_id,
-                }
-            ),
+            (entry for entry in page.items if entry.id == agent_id),
             None,
         )
 
@@ -204,12 +194,23 @@ class AgentDirectoryService:
         visibility = _string_metadata(metadata, "visibility", "a2aVisibility")
         if not visibility and "volundr-session" in entity.source_kind:
             visibility = "user"
-        entry_scope = self._scope_entry(
-            entity,
-            source_agent_id=source_agent_id,
-            visibility=visibility,
+        owner_id = _string_metadata(metadata, "ownerId", "owner_id") or None
+        tenant_id = _string_metadata(metadata, "tenantId", "tenant_id") or None
+        environment_id = _string_metadata(metadata, "environmentId", "environment_id") or None
+        environment_member_ids = _string_list_metadata(
+            metadata,
+            "environmentMemberIds",
+            "environment_member_ids",
         )
-        if not is_agent_visible(entry_scope, principal):
+        if environment_id and not environment_member_ids and principal.user_id != owner_id:
+            return None, None
+        if not is_agent_scope_visible(
+            owner_id=owner_id,
+            tenant_id=tenant_id,
+            visibility=visibility,
+            environment_member_ids=environment_member_ids,
+            principal=principal,
+        ):
             return None, None
 
         card_url = entity.endpoints["a2aCard"]
@@ -239,42 +240,6 @@ class AgentDirectoryService:
             return None, None
         return entry, None
 
-    def _scope_entry(
-        self,
-        entity: DiscoveredEntity,
-        *,
-        source_agent_id: str,
-        visibility: str,
-    ) -> AgentDirectoryEntry:
-        """Build the visibility-only shell used before any restricted card fetch."""
-        metadata = entity.metadata
-        cluster_id = entity.cluster or self._cluster_id
-        environment_id = _string_metadata(metadata, "environmentId", "environment_id") or None
-        return AgentDirectoryEntry(
-            id="scope-only",
-            canonicalId="scope-only",
-            sourceAgentId=source_agent_id,
-            sourceInstanceId=self._instance_id,
-            clusterId=cluster_id,
-            environmentId=environment_id,
-            topologyNodeId=entity.id,
-            name=entity.name,
-            description="",
-            kind=self._agent_kind(entity),
-            cardUrl=entity.endpoints["a2aCard"],
-            cardVersion="",
-            cardHash="",
-            observedStatus=entity.status,
-            ownerId=_string_metadata(metadata, "ownerId", "owner_id") or None,
-            tenantId=_string_metadata(metadata, "tenantId", "tenant_id") or None,
-            visibility=visibility,
-            environmentMemberIds=_string_list_metadata(
-                metadata,
-                "environmentMemberIds",
-                "environment_member_ids",
-            ),
-        )
-
     def _entry_from_card(
         self,
         entity: DiscoveredEntity,
@@ -287,9 +252,10 @@ class AgentDirectoryService:
         metadata = entity.metadata
         cluster_id = entity.cluster or self._cluster_id
         environment_id = _string_metadata(metadata, "environmentId", "environment_id") or None
+        fingerprint_identity = ",".join(card.signature_key_fingerprints)
         canonical_id = (
-            f"a2a-card:{card.card_hash}"
-            if card.signature_verified
+            f"a2a-card:{card.card_hash}:keys:{fingerprint_identity}"
+            if card.signature_verified and card.card_hash and fingerprint_identity
             else f"a2a-source:{self._instance_id}:{entity.id}"
         )
         provenance = AgentProvenance(
@@ -315,12 +281,15 @@ class AgentDirectoryService:
             cardHash=card.card_hash,
             signatureVerified=card.signature_verified,
             signatureKeyIds=list(card.signature_key_ids),
+            signatureKeyFingerprints=list(card.signature_key_fingerprints),
             skillIds=list(card.skills),
             tags=list(card.tags),
             defaultInputModes=list(card.default_input_modes),
             defaultOutputModes=list(card.default_output_modes),
             supportedInterfaces=list(card.supported_interfaces),
             capabilities=card.capabilities,
+            securitySchemes=card.security_schemes,
+            securityRequirements=list(card.security_requirements),
             observedStatus=entity.status,
             activity=_string_metadata(metadata, "activity", "activityState", "activity_state"),
             lastSeen=_string_metadata(metadata, "lastSeen", "lastActive", "last_active"),

--- a/src/observatory/app.py
+++ b/src/observatory/app.py
@@ -85,26 +85,6 @@ def _forward_headers(request: Request) -> dict[str, str]:
     return headers
 
 
-def _directory_filters(
-    skill: list[str] | None,
-    tag: list[str] | None,
-    kind: list[str] | None,
-    observed_status: list[str] | None,
-    environment_id: list[str] | None,
-    cluster: list[str] | None,
-    instance: list[str] | None,
-) -> AgentDirectoryFilters:
-    return AgentDirectoryFilters(
-        skills=tuple(skill or ()),
-        tags=tuple(tag or ()),
-        kinds=tuple(kind or ()),
-        statuses=tuple(observed_status or ()),
-        environment_ids=tuple(environment_id or ()),
-        cluster_ids=tuple(cluster or ()),
-        instance_ids=tuple(instance or ()),
-    )
-
-
 async def _topology_stream(
     discovery: ObservatoryDiscoveryService,
     headers: dict[str, str] | None = None,
@@ -172,14 +152,14 @@ def create_router() -> APIRouter:
         return await _agent_directory(request).list_agents(
             principal,
             headers=_forward_headers(request),
-            filters=_directory_filters(
-                skill,
-                tag,
-                kind,
-                observed_status,
-                environment_id,
-                cluster,
-                instance,
+            filters=AgentDirectoryFilters.from_values(
+                skills=skill,
+                tags=tag,
+                kinds=kind,
+                statuses=observed_status,
+                environment_ids=environment_id,
+                cluster_ids=cluster,
+                instance_ids=instance,
             ),
         )
 
@@ -377,6 +357,7 @@ def create_app(
                 timeout_seconds=directory_cfg.card_timeout_seconds,
                 default_cache_ttl_seconds=directory_cfg.card_cache_ttl_seconds,
                 signature_algorithms=directory_cfg.signature_algorithms,
+                authenticated_card_origins=directory_cfg.authenticated_card_origins,
             ),
             instance_id=directory_cfg.instance_id,
             cluster_id=directory_cfg.cluster_id,

--- a/src/observatory/app.py
+++ b/src/observatory/app.py
@@ -8,9 +8,16 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
-from fastapi import APIRouter, FastAPI, HTTPException, Request, status
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request, status
 from fastapi.responses import StreamingResponse
 
+from niuu.adapters.inbound.auth import extract_principal
+from niuu.domain.agent_directory import (
+    AgentDirectoryEntry,
+    AgentDirectoryFilters,
+    AgentDirectoryPage,
+)
+from niuu.domain.models import Principal
 from niuu.ports.http_auth import HttpAuthPort
 from niuu.service_databases import apply_service_database_settings, database_pool
 from niuu.settings_schema import (
@@ -19,6 +26,8 @@ from niuu.settings_schema import (
     SettingsSectionSchema,
 )
 from niuu.utils import import_class, resolve_secret_kwargs
+from observatory.a2a_cards import HttpAgentCardResolver
+from observatory.agent_directory import AgentDirectoryService
 from observatory.discovery import ObservatoryDiscoveryService
 from observatory.entity_discovery import build_discovery_adapter
 from observatory.registry import (
@@ -57,6 +66,10 @@ def _discovery(request: Request) -> ObservatoryDiscoveryService:
     return request.app.state.discovery_service
 
 
+def _agent_directory(request: Request) -> AgentDirectoryService:
+    return request.app.state.agent_directory_service
+
+
 def _create_http_auth_adapter(config) -> HttpAuthPort:
     cls = import_class(config.adapter)
     kwargs = resolve_secret_kwargs(config.kwargs, config.secret_kwargs_env)
@@ -70,6 +83,26 @@ def _forward_headers(request: Request) -> dict[str, str]:
         if value:
             headers[name] = value
     return headers
+
+
+def _directory_filters(
+    skill: list[str] | None,
+    tag: list[str] | None,
+    kind: list[str] | None,
+    observed_status: list[str] | None,
+    environment_id: list[str] | None,
+    cluster: list[str] | None,
+    instance: list[str] | None,
+) -> AgentDirectoryFilters:
+    return AgentDirectoryFilters(
+        skills=tuple(skill or ()),
+        tags=tuple(tag or ()),
+        kinds=tuple(kind or ()),
+        statuses=tuple(observed_status or ()),
+        environment_ids=tuple(environment_id or ()),
+        cluster_ids=tuple(cluster or ()),
+        instance_ids=tuple(instance or ()),
+    )
 
 
 async def _topology_stream(
@@ -119,6 +152,55 @@ def create_router() -> APIRouter:
             "status": "healthy",
             "guildUrl": request.app.state.guild_url,
         }
+
+    @router.get(
+        "/agents",
+        response_model=AgentDirectoryPage,
+        summary="List principal-visible addressable A2A agents",
+    )
+    async def list_agents(
+        request: Request,
+        skill: list[str] | None = Query(default=None),
+        tag: list[str] | None = Query(default=None),
+        kind: list[str] | None = Query(default=None),
+        observed_status: list[str] | None = Query(default=None, alias="status"),
+        environment_id: list[str] | None = Query(default=None, alias="environmentId"),
+        cluster: list[str] | None = Query(default=None),
+        instance: list[str] | None = Query(default=None),
+        principal: Principal = Depends(extract_principal),
+    ) -> AgentDirectoryPage:
+        return await _agent_directory(request).list_agents(
+            principal,
+            headers=_forward_headers(request),
+            filters=_directory_filters(
+                skill,
+                tag,
+                kind,
+                observed_status,
+                environment_id,
+                cluster,
+                instance,
+            ),
+        )
+
+    @router.get(
+        "/agents/{agent_id}",
+        response_model=AgentDirectoryEntry,
+        summary="Get one principal-visible addressable A2A agent",
+    )
+    async def get_agent(
+        request: Request,
+        agent_id: str,
+        principal: Principal = Depends(extract_principal),
+    ) -> AgentDirectoryEntry:
+        entry = await _agent_directory(request).get_agent(
+            agent_id,
+            principal,
+            headers=_forward_headers(request),
+        )
+        if entry is None:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+        return entry
 
     @router.get("/registry", summary="Get the observatory type registry")
     async def registry(request: Request) -> dict[str, object]:
@@ -273,6 +355,7 @@ def create_app(
     *,
     registry_repository: ObservatoryRegistryRepository | None = None,
     discovery_service: ObservatoryDiscoveryService | None = None,
+    agent_directory_service: AgentDirectoryService | None = None,
 ) -> FastAPI:
     """Create the Observatory ASGI app."""
     loaded_settings = apply_service_database_settings(settings or Settings(), "observatory")
@@ -285,6 +368,20 @@ def create_app(
             timeout_seconds=guild_cfg.timeout_seconds,
             discovery_adapter=build_discovery_adapter(loaded_settings.observatory.discovery),
         )
+    directory = agent_directory_service
+    if directory is None:
+        directory_cfg = loaded_settings.observatory.directory
+        directory = AgentDirectoryService(
+            discovery=discovery,
+            card_resolver=HttpAgentCardResolver(
+                timeout_seconds=directory_cfg.card_timeout_seconds,
+                default_cache_ttl_seconds=directory_cfg.card_cache_ttl_seconds,
+                signature_algorithms=directory_cfg.signature_algorithms,
+            ),
+            instance_id=directory_cfg.instance_id,
+            cluster_id=directory_cfg.cluster_id,
+            max_concurrency=directory_cfg.local_max_concurrency,
+        )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -292,6 +389,7 @@ def create_app(
             app.state.registry_repository = registry_repository
             await app.state.registry_repository.ensure_seeded()
             app.state.discovery_service = discovery
+            app.state.agent_directory_service = directory
             yield
             return
 
@@ -300,12 +398,14 @@ def create_app(
             await repo.ensure_seeded()
             app.state.registry_repository = repo
             app.state.discovery_service = discovery
+            app.state.agent_directory_service = directory
             yield
 
     app = FastAPI(title="Observatory API", lifespan=lifespan)
     app.state.settings = loaded_settings
     app.state.registry_repository = registry_repository or InMemoryObservatoryRegistryRepository()
     app.state.discovery_service = discovery
+    app.state.agent_directory_service = directory
     app.state.guild_url = getattr(discovery, "guild_url", getattr(discovery, "base_url", ""))
     app.state.guild_auth_adapter = loaded_settings.observatory.guild.auth.adapter
 

--- a/src/observatory/discovery.py
+++ b/src/observatory/discovery.py
@@ -28,6 +28,7 @@ class DiscoverySnapshot:
 
     topology: ObservatorySnapshot
     events: list[dict[str, str]]
+    result: DiscoveryResult
 
 
 def _utc_now() -> datetime:
@@ -80,9 +81,18 @@ class ObservatoryDiscoveryService:
     ) -> list[dict[str, str]]:
         return deepcopy((await self._get_snapshot(headers=headers)).events)
 
+    async def get_discovery_result(
+        self,
+        headers: Mapping[str, str] | None = None,
+    ) -> DiscoveryResult:
+        """Return the cached unfiltered source result for principal-aware projections."""
+        return deepcopy((await self._get_snapshot(headers=headers)).result)
+
     async def _get_snapshot(self, headers: Mapping[str, str] | None = None) -> DiscoverySnapshot:
         now = _utc_now()
-        cache_key = "request" if headers else "default"
+        # Discovery is source truth fetched with adapter-owned credentials. Principal-aware
+        # projections filter after this cache, so no restricted response is shared here.
+        cache_key = "source"
         cached = self._cached.get(cache_key)
         if cached is not None:
             cached_at, cached_snapshot = cached
@@ -120,7 +130,7 @@ class ObservatoryDiscoveryService:
             result = await self._discovery_adapter.discover()
         topology = topology_from_discovery(result)
         events = topology.pop("events", [])
-        return DiscoverySnapshot(topology=topology, events=events)
+        return DiscoverySnapshot(topology=topology, events=events, result=result)
 
     async def _safe_fetch(self, fetch: JsonFetcher, path: str) -> Any:
         try:

--- a/src/observatory/entity_discovery.py
+++ b/src/observatory/entity_discovery.py
@@ -569,6 +569,8 @@ class VolundrSessionsDiscoveryAdapter:
                 for key, value in {
                     "chat": session.get("chat_endpoint"),
                     "code": session.get("code_endpoint"),
+                    "a2a": session.get("a2aEndpointUrl") or session.get("a2a_endpoint_url"),
+                    "a2aCard": session.get("a2aCardUrl") or session.get("a2a_card_url"),
                 }.items()
                 if value
             }
@@ -594,6 +596,13 @@ class VolundrSessionsDiscoveryAdapter:
                         "createdAt": str(session.get("created_at") or ""),
                         "lastActive": str(session.get("last_active") or ""),
                         "workloadType": str(session.get("workload_type") or "session"),
+                        "agentKind": "workflow-session",
+                        "visibility": str(
+                            session.get("a2aVisibility") or session.get("a2a_visibility") or "user"
+                        ),
+                        "environmentId": str(
+                            session.get("environmentId") or session.get("environment_id") or ""
+                        ),
                     },
                 )
             )

--- a/src/observatory/plugin.py
+++ b/src/observatory/plugin.py
@@ -54,6 +54,11 @@ class ObservatoryPlugin(ServicePlugin):
     def api_route_domains(self) -> tuple[APIRouteDomain, ...]:
         return (
             APIRouteDomain(
+                name="observatory-agents-api",
+                prefixes=("/api/v1/observatory/agents",),
+                description="Principal-aware A2A Agent Directory routes.",
+            ),
+            APIRouteDomain(
                 name="observatory-registry-api",
                 prefixes=("/api/v1/observatory/registry",),
                 description="Observatory entity-type registry routes.",

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -104,6 +104,29 @@ def _public_session_endpoint(
     )
 
 
+def _public_workload_url(session: Session, *keys: str) -> str | None:
+    """Expose one explicitly configured HTTP(S) workload URL without leaking config."""
+    value = next(
+        (
+            str(session.workload_config.get(key) or "").strip()
+            for key in keys
+            if str(session.workload_config.get(key) or "").strip()
+        ),
+        "",
+    )
+    if not value:
+        return None
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    if parsed.username or parsed.password:
+        return None
+    return value
+
+
 def _server_side_ws_connect_overrides(
     ws_url: str,
     *,
@@ -724,6 +747,26 @@ class SessionResponse(BaseModel):
     code_endpoint: str | None = Field(
         description="Editor IDE URL (null when not running)",
     )
+    a2a_card_url: str | None = Field(
+        default=None,
+        serialization_alias="a2aCardUrl",
+        description="Standard Agent Card URL when this workflow session is A2A-addressable",
+    )
+    a2a_endpoint_url: str | None = Field(
+        default=None,
+        serialization_alias="a2aEndpointUrl",
+        description="Preferred A2A protocol endpoint when explicitly published by the workload",
+    )
+    environment_id: str | None = Field(
+        default=None,
+        serialization_alias="environmentId",
+        description="Environment containing the addressable workflow session",
+    )
+    a2a_visibility: str = Field(
+        default="user",
+        serialization_alias="a2aVisibility",
+        description="Explicit Agent Directory visibility scope",
+    )
     created_at: str = Field(description="ISO 8601 creation timestamp")
     updated_at: str = Field(description="ISO 8601 last update timestamp")
     last_active: str = Field(description="ISO 8601 last activity timestamp")
@@ -849,6 +892,32 @@ class SessionResponse(BaseModel):
                 public_host=public_host,
             ),
             code_endpoint=session.code_endpoint,
+            a2a_card_url=_public_workload_url(
+                session,
+                "a2aCardUrl",
+                "a2a_card_url",
+            ),
+            a2a_endpoint_url=_public_workload_url(
+                session,
+                "a2aEndpointUrl",
+                "a2a_endpoint_url",
+            ),
+            environment_id=(
+                str(
+                    session.workload_config.get("environmentId")
+                    or session.workload_config.get("environment_id")
+                    or ""
+                ).strip()
+                or None
+            ),
+            a2a_visibility=(
+                str(
+                    session.workload_config.get("a2aVisibility")
+                    or session.workload_config.get("a2a_visibility")
+                    or "user"
+                ).strip()
+                or "user"
+            ),
             created_at=session.created_at.isoformat(),
             updated_at=session.updated_at.isoformat(),
             last_active=(

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -120,9 +120,9 @@ def _public_workload_url(session: Session, *keys: str) -> str | None:
         parsed = urlsplit(value)
     except ValueError:
         return None
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
         return None
-    if parsed.username or parsed.password:
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
         return None
     return value
 

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -1494,11 +1494,56 @@ class ObservatoryGuildConfig(BaseModel):
     auth: HttpAuthAdapterConfig = Field(default_factory=HttpAuthAdapterConfig)
 
 
+class AgentDirectoryConfig(BaseModel):
+    """Local card resolution and Guild fan-out bounds for the Agent Directory."""
+
+    instance_id: str = Field(
+        default="local-observatory",
+        min_length=1,
+        description="Stable identity of this Observatory source.",
+    )
+    cluster_id: str = Field(
+        default="",
+        description="Cluster identity used when discovery records omit placement.",
+    )
+    card_timeout_seconds: float = Field(
+        default=4.0,
+        gt=0,
+        description="Timeout for Agent Card and signature-key retrieval.",
+    )
+    card_cache_ttl_seconds: float = Field(
+        default=300.0,
+        ge=0,
+        description="Fallback card cache TTL when the owning service omits Cache-Control.",
+    )
+    local_max_concurrency: int = Field(
+        default=8,
+        ge=1,
+        description="Maximum concurrent Agent Card resolutions per local directory request.",
+    )
+    guild_timeout_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        description="Timeout for each Guild-to-Observatory directory request.",
+    )
+    guild_max_concurrency: int = Field(
+        default=8,
+        ge=1,
+        description="Maximum concurrent Observatory fan-out requests from Guild.",
+    )
+    signature_algorithms: list[str] = Field(
+        default_factory=lambda: ["ES256", "ES384", "RS256", "RS384", "PS256", "EdDSA"],
+        min_length=1,
+        description="Accepted Agent Card JWS algorithms.",
+    )
+
+
 class ObservatoryConfig(BaseModel):
     """Observatory plugin configuration."""
 
     guild: ObservatoryGuildConfig = Field(default_factory=ObservatoryGuildConfig)
     discovery: list[DynamicAdapterConfig] = Field(default_factory=list)
+    directory: AgentDirectoryConfig = Field(default_factory=AgentDirectoryConfig)
 
 
 class Settings(BaseSettings):

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -1536,6 +1536,10 @@ class AgentDirectoryConfig(BaseModel):
         min_length=1,
         description="Accepted Agent Card JWS algorithms.",
     )
+    authenticated_card_origins: list[str] = Field(
+        default_factory=list,
+        description="HTTP(S) origins trusted to receive caller authentication for card retrieval.",
+    )
 
 
 class ObservatoryConfig(BaseModel):

--- a/tests/test_charts/test_service_chart_entrypoints.py
+++ b/tests/test_charts/test_service_chart_entrypoints.py
@@ -76,6 +76,7 @@ def test_agent_directory_chart_config_exposes_bounded_runtime_settings(chart: st
     assert ".Values.directory.cardTimeoutSeconds" in template
     assert ".Values.directory.guildMaxConcurrency" in template
     assert ".Values.directory.signatureAlgorithms" in template
+    assert ".Values.directory.authenticatedCardOrigins" in template
 
 
 @pytest.mark.parametrize("chart", CHARTS)

--- a/tests/test_charts/test_service_chart_entrypoints.py
+++ b/tests/test_charts/test_service_chart_entrypoints.py
@@ -64,6 +64,20 @@ def test_volundr_chart_uses_uvicorn_import_path() -> None:
     ]
 
 
+@pytest.mark.parametrize("chart", ["guild", "observatory"])
+def test_agent_directory_chart_config_exposes_bounded_runtime_settings(chart: str) -> None:
+    values = _load_values(chart)
+    template = (CHARTS_DIR / chart / "templates" / "configmap.yaml").read_text()
+
+    assert values["directory"]["cardTimeoutSeconds"] > 0
+    assert values["directory"]["localMaxConcurrency"] >= 1
+    assert values["directory"]["guildMaxConcurrency"] >= 1
+    assert "observatory:" in template
+    assert ".Values.directory.cardTimeoutSeconds" in template
+    assert ".Values.directory.guildMaxConcurrency" in template
+    assert ".Values.directory.signatureAlgorithms" in template
+
+
 @pytest.mark.parametrize("chart", CHARTS)
 def test_charts_default_niuu_deployment_cluster_value(chart: str) -> None:
     values = _load_values(chart)

--- a/tests/test_cli/test_plugins.py
+++ b/tests/test_cli/test_plugins.py
@@ -707,21 +707,23 @@ class TestObservatoryPlugin:
         route_domains = plugin.api_route_domains()
         assert route_domains
         assert [route_domain.name for route_domain in route_domains] == [
+            "observatory-agents-api",
             "observatory-registry-api",
             "observatory-topology-api",
             "observatory-events-api",
             "observatory-api",
         ]
-        assert route_domains[0].prefixes == ("/api/v1/observatory/registry",)
-        assert route_domains[1].prefixes == (
+        assert route_domains[0].prefixes == ("/api/v1/observatory/agents",)
+        assert route_domains[1].prefixes == ("/api/v1/observatory/registry",)
+        assert route_domains[2].prefixes == (
             "/api/v1/observatory/topology/stream",
             "/api/v1/observatory/topology",
         )
-        assert route_domains[2].prefixes == (
+        assert route_domains[3].prefixes == (
             "/api/v1/observatory/events/stream",
             "/api/v1/observatory/events",
         )
-        assert route_domains[3].prefixes == ("/api/v1/observatory",)
+        assert route_domains[4].prefixes == ("/api/v1/observatory",)
 
     def test_api_client_returns_instance(self) -> None:
         plugin = ObservatoryPlugin()

--- a/tests/test_cli/test_server.py
+++ b/tests/test_cli/test_server.py
@@ -380,6 +380,7 @@ class TestRouteDomainSelection:
             "niuu-repos-api",
             "niuu-shared-api",
             "observatory-api",
+            "observatory-agents-api",
             "observatory-events-api",
             "observatory-registry-api",
             "observatory-topology-api",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Tests for configuration module."""
 
 from volundr.config import (
+    AgentDirectoryConfig,
     DatabaseConfig,
     EventPipelineConfig,
     FeatureModuleConfig,
@@ -115,6 +116,26 @@ class TestSettings:
         assert any(
             "./start-dev" in pattern for pattern in settings.permission_auto_approval.allowlist
         )
+
+    def test_agent_directory_config_is_bounded_and_configurable(self):
+        settings = Settings(
+            observatory={
+                "directory": {
+                    "instance_id": "observatory-noatun",
+                    "cluster_id": "noatun",
+                    "local_max_concurrency": 3,
+                    "guild_max_concurrency": 4,
+                    "signature_algorithms": ["ES256"],
+                }
+            }
+        )
+
+        assert isinstance(settings.observatory.directory, AgentDirectoryConfig)
+        assert settings.observatory.directory.instance_id == "observatory-noatun"
+        assert settings.observatory.directory.cluster_id == "noatun"
+        assert settings.observatory.directory.local_max_concurrency == 3
+        assert settings.observatory.directory.guild_max_concurrency == 4
+        assert settings.observatory.directory.signature_algorithms == ["ES256"]
 
 
 class TestGitHubConfig:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -126,6 +126,7 @@ class TestSettings:
                     "local_max_concurrency": 3,
                     "guild_max_concurrency": 4,
                     "signature_algorithms": ["ES256"],
+                    "authenticated_card_origins": ["https://agents.example.test"],
                 }
             }
         )
@@ -136,6 +137,9 @@ class TestSettings:
         assert settings.observatory.directory.local_max_concurrency == 3
         assert settings.observatory.directory.guild_max_concurrency == 4
         assert settings.observatory.directory.signature_algorithms == ["ES256"]
+        assert settings.observatory.directory.authenticated_card_origins == [
+            "https://agents.example.test"
+        ]
 
 
 class TestGitHubConfig:

--- a/tests/test_niuu/test_agent_directory.py
+++ b/tests/test_niuu/test_agent_directory.py
@@ -55,6 +55,7 @@ def _entry(
     tenant_id: str = "tenant-a",
     card_hash: str = "card-hash",
     signature_verified: bool | None = None,
+    signature_key_fingerprints: tuple[str, ...] = ("signer-fingerprint",),
 ) -> AgentDirectoryEntry:
     topology_node_id = f"runtime:{source_instance_id}:skuld:{source_agent_id}"
     provenance = AgentProvenance(
@@ -78,6 +79,7 @@ def _entry(
         cardVersion="1.0.0",
         cardHash=card_hash,
         signatureVerified=signature_verified,
+        signatureKeyFingerprints=(list(signature_key_fingerprints) if signature_verified else []),
         skillIds=["code"],
         tags=["engineering"],
         defaultInputModes=["text/plain"],
@@ -204,10 +206,45 @@ async def test_aggregate_reconciles_only_verified_card_identity() -> None:
     page = await service.list_agents(instances, _principal(), headers={})
 
     assert len(page.items) == 1
-    assert page.items[0].canonical_id == "signed:verified-hash"
+    assert page.items[0].canonical_id == "signed:verified-hash:keys:signer-fingerprint"
     assert {
         (source.source_instance_id, source.source_agent_id) for source in page.items[0].provenance
     } == {("observatory-a", "agent-a"), ("observatory-b", "agent-b")}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_does_not_merge_same_card_signed_by_different_keys() -> None:
+    instances = [_instance("observatory-a", "cluster-a"), _instance("observatory-b", "cluster-b")]
+    client = _StubClient(
+        {
+            "observatory-a": _page(
+                "local-a",
+                _entry(
+                    "local-a",
+                    "agent-a",
+                    card_hash="copied-card",
+                    signature_verified=True,
+                    signature_key_fingerprints=("signer-a",),
+                ),
+            ),
+            "observatory-b": _page(
+                "local-b",
+                _entry(
+                    "local-b",
+                    "agent-b",
+                    card_hash="copied-card",
+                    signature_verified=True,
+                    signature_key_fingerprints=("signer-b",),
+                ),
+            ),
+        }
+    )
+    service = AgentDirectoryAggregationService(client=client, max_concurrency=2)  # type: ignore[arg-type]
+
+    page = await service.list_agents(instances, _principal(), headers={})
+
+    assert len(page.items) == 2
+    assert len({entry.canonical_id for entry in page.items}) == 2
 
 
 @pytest.mark.asyncio
@@ -227,6 +264,7 @@ async def test_aggregate_returns_healthy_results_with_failed_source_warning() ->
     assert page.partial is True
     assert page.warnings[0].source_instance_id == "observatory-b"
     assert page.warnings[0].code == "observatory-unavailable"
+    assert page.warnings[0].message == "Observatory Agent Directory request failed"
     assert any(source.status == "failed" for source in page.sources)
 
 

--- a/tests/test_niuu/test_agent_directory.py
+++ b/tests/test_niuu/test_agent_directory.py
@@ -1,0 +1,339 @@
+"""Tests for Guild's multi-instance Agent Directory aggregation."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+
+from niuu.adapters.outbound.http_agent_directory import HttpAgentDirectoryClient
+from niuu.domain.agent_directory import (
+    AgentDirectoryEntry,
+    AgentDirectoryFilters,
+    AgentDirectoryPage,
+    AgentDirectorySourceHealth,
+    AgentInterface,
+    AgentProvenance,
+)
+from niuu.domain.models import (
+    InstanceKind,
+    InstanceVisibility,
+    Principal,
+    RegisteredInstance,
+)
+from niuu.domain.services.agent_directory import AgentDirectoryAggregationService
+
+
+def _instance(instance_id: str, cluster: str) -> RegisteredInstance:
+    now = datetime.now(UTC)
+    return RegisteredInstance(
+        id=instance_id,
+        kind=InstanceKind.OBSERVATORY,
+        slug=instance_id,
+        name=instance_id,
+        base_url=f"https://{instance_id}.example.test/api/v1/observatory",
+        visibility=InstanceVisibility.TENANT,
+        owner_id=None,
+        tenant_id="tenant-a",
+        enabled=True,
+        is_default=False,
+        config={"cluster": cluster},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _entry(
+    source_instance_id: str,
+    source_agent_id: str,
+    *,
+    name: str = "Builder",
+    owner_id: str = "user-a",
+    tenant_id: str = "tenant-a",
+    card_hash: str = "card-hash",
+    signature_verified: bool | None = None,
+) -> AgentDirectoryEntry:
+    topology_node_id = f"runtime:{source_instance_id}:skuld:{source_agent_id}"
+    provenance = AgentProvenance(
+        sourceAgentId=source_agent_id,
+        sourceInstanceId=source_instance_id,
+        clusterId="local-cluster",
+        topologyNodeId=topology_node_id,
+    )
+    return AgentDirectoryEntry(
+        id=f"local-{source_agent_id}",
+        canonicalId=f"local:{source_instance_id}:{source_agent_id}",
+        sourceAgentId=source_agent_id,
+        sourceInstanceId=source_instance_id,
+        clusterId="local-cluster",
+        environmentId="environment-a",
+        topologyNodeId=topology_node_id,
+        name=name,
+        description="Builds software",
+        kind="workflow-session",
+        cardUrl=f"https://{source_instance_id}.example.test/cards/{source_agent_id}",
+        cardVersion="1.0.0",
+        cardHash=card_hash,
+        signatureVerified=signature_verified,
+        skillIds=["code"],
+        tags=["engineering"],
+        defaultInputModes=["text/plain"],
+        defaultOutputModes=["application/json"],
+        supportedInterfaces=[
+            AgentInterface(
+                url="https://agent.example.test/a2a",
+                protocolBinding="JSONRPC",
+                protocolVersion="1.0",
+            )
+        ],
+        observedStatus="healthy",
+        ownerId=owner_id,
+        tenantId=tenant_id,
+        visibility="user",
+        provenance=[provenance],
+    )
+
+
+class _StubClient:
+    def __init__(self, results: dict[str, AgentDirectoryPage | Exception]) -> None:
+        self.results = results
+        self.calls: list[tuple[str, dict[str, str], AgentDirectoryFilters]] = []
+        self.active = 0
+        self.max_active = 0
+
+    async def list_agents(
+        self,
+        instance: RegisteredInstance,
+        *,
+        headers: dict[str, str],
+        filters: AgentDirectoryFilters,
+    ) -> AgentDirectoryPage:
+        self.calls.append((instance.id, dict(headers), filters))
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        await asyncio.sleep(0)
+        self.active -= 1
+        result = self.results[instance.id]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _page(instance_id: str, *entries: AgentDirectoryEntry) -> AgentDirectoryPage:
+    return AgentDirectoryPage(
+        items=list(entries),
+        sources=[
+            AgentDirectorySourceHealth(
+                instanceId=instance_id,
+                clusterId="local-cluster",
+                status="healthy",
+                revision=f"revision-{instance_id}",
+            )
+        ],
+        revision=f"revision-{instance_id}",
+    )
+
+
+def _principal(user_id: str = "user-a", tenant_id: str = "tenant-a") -> Principal:
+    return Principal(user_id=user_id, email="", tenant_id=tenant_id, roles=["member"])
+
+
+@pytest.mark.asyncio
+async def test_aggregate_preserves_colliding_names_and_registry_provenance() -> None:
+    instances = [_instance("observatory-a", "cluster-a"), _instance("observatory-b", "cluster-b")]
+    client = _StubClient(
+        {
+            "observatory-a": _page(
+                "local-a",
+                _entry("local-a", "agent-a", name="Same Name", card_hash="same"),
+            ),
+            "observatory-b": _page(
+                "local-b",
+                _entry("local-b", "agent-b", name="Same Name", card_hash="same"),
+            ),
+        }
+    )
+    service = AgentDirectoryAggregationService(client=client, max_concurrency=1)  # type: ignore[arg-type]
+
+    page = await service.list_agents(
+        instances,
+        _principal(),
+        headers={"authorization": "Bearer caller"},
+    )
+
+    assert len(page.items) == 2
+    assert {entry.source_instance_id for entry in page.items} == {
+        "observatory-a",
+        "observatory-b",
+    }
+    assert len({entry.id for entry in page.items}) == 2
+    assert client.max_active == 1
+    assert all(call[1]["authorization"] == "Bearer caller" for call in client.calls)
+
+
+@pytest.mark.asyncio
+async def test_aggregate_reconciles_only_verified_card_identity() -> None:
+    instances = [_instance("observatory-a", "cluster-a"), _instance("observatory-b", "cluster-b")]
+    client = _StubClient(
+        {
+            "observatory-a": _page(
+                "local-a",
+                _entry(
+                    "local-a",
+                    "agent-a",
+                    card_hash="verified-hash",
+                    signature_verified=True,
+                ),
+            ),
+            "observatory-b": _page(
+                "local-b",
+                _entry(
+                    "local-b",
+                    "agent-b",
+                    card_hash="verified-hash",
+                    signature_verified=True,
+                ),
+            ),
+        }
+    )
+    service = AgentDirectoryAggregationService(client=client, max_concurrency=2)  # type: ignore[arg-type]
+
+    page = await service.list_agents(instances, _principal(), headers={})
+
+    assert len(page.items) == 1
+    assert page.items[0].canonical_id == "signed:verified-hash"
+    assert {
+        (source.source_instance_id, source.source_agent_id) for source in page.items[0].provenance
+    } == {("observatory-a", "agent-a"), ("observatory-b", "agent-b")}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_returns_healthy_results_with_failed_source_warning() -> None:
+    instances = [_instance("observatory-a", "cluster-a"), _instance("observatory-b", "cluster-b")]
+    client = _StubClient(
+        {
+            "observatory-a": _page("local-a", _entry("local-a", "agent-a")),
+            "observatory-b": httpx.ReadTimeout("slow source"),
+        }
+    )
+    service = AgentDirectoryAggregationService(client=client, max_concurrency=2)  # type: ignore[arg-type]
+
+    page = await service.list_agents(instances, _principal(), headers={})
+
+    assert [entry.source_agent_id for entry in page.items] == ["agent-a"]
+    assert page.partial is True
+    assert page.warnings[0].source_instance_id == "observatory-b"
+    assert page.warnings[0].code == "observatory-unavailable"
+    assert any(source.status == "failed" for source in page.sources)
+
+
+@pytest.mark.asyncio
+async def test_aggregate_preserves_source_partial_health_without_warning() -> None:
+    instance = _instance("observatory-a", "cluster-a")
+    source_page = _page("observatory-a", _entry("local-a", "agent-a"))
+    source_page.partial = True
+    client = _StubClient({"observatory-a": source_page})
+    service = AgentDirectoryAggregationService(client=client, max_concurrency=1)  # type: ignore[arg-type]
+
+    page = await service.list_agents([instance], _principal(), headers={})
+
+    assert page.partial is True
+    assert page.sources[0].status == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_rechecks_visibility_filters_and_detail() -> None:
+    instance = _instance("observatory-a", "cluster-a")
+    client = _StubClient(
+        {
+            "observatory-a": _page(
+                "local-a",
+                _entry("local-a", "visible"),
+                _entry("local-a", "hidden", owner_id="user-b"),
+                _entry("local-a", "cross-tenant", tenant_id="tenant-b"),
+            )
+        }
+    )
+    service = AgentDirectoryAggregationService(client=client, max_concurrency=2)  # type: ignore[arg-type]
+    filters = AgentDirectoryFilters(
+        skills=("code",),
+        tags=("engineering",),
+        kinds=("workflow-session",),
+        statuses=("healthy",),
+        environment_ids=("environment-a",),
+        cluster_ids=("local-cluster",),
+        instance_ids=("observatory-a",),
+    )
+
+    page = await service.list_agents(
+        [instance],
+        _principal(),
+        headers={},
+        filters=filters,
+    )
+    detail = await service.get_agent(page.items[0].id, [instance], _principal(), headers={})
+
+    assert [entry.source_agent_id for entry in page.items] == ["visible"]
+    assert detail is not None
+    assert detail.source_agent_id == "visible"
+    assert client.calls[0][2].instance_ids == ()
+
+
+@pytest.mark.asyncio
+async def test_http_client_forwards_filters_and_auth() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=_page("observatory-a").model_dump(by_alias=True))
+
+    client = HttpAgentDirectoryClient(
+        timeout_seconds=1.0,
+        transport=httpx.MockTransport(handler),
+    )
+    filters = AgentDirectoryFilters(
+        skills=("code",),
+        tags=("engineering",),
+        kinds=("workflow-session",),
+        statuses=("healthy",),
+        environment_ids=("environment-a",),
+        cluster_ids=("cluster-a",),
+        instance_ids=("observatory-a",),
+    )
+
+    await client.list_agents(
+        _instance("observatory-a", "cluster-a"),
+        headers={"authorization": "Bearer caller"},
+        filters=filters,
+    )
+
+    request = requests[0]
+    assert request.url.path == "/api/v1/observatory/agents"
+    assert request.headers["authorization"] == "Bearer caller"
+    assert request.url.params["skill"] == "code"
+    assert request.url.params["environmentId"] == "environment-a"
+
+
+@pytest.mark.asyncio
+async def test_http_client_accepts_full_endpoint_base_without_double_appending() -> None:
+    requests: list[httpx.Request] = []
+    client = HttpAgentDirectoryClient(
+        timeout_seconds=1.0,
+        transport=httpx.MockTransport(
+            lambda request: (
+                requests.append(request)
+                or httpx.Response(200, json=_page("observatory-a").model_dump(by_alias=True))
+            )
+        ),
+    )
+    instance = replace(
+        _instance("observatory-a", "cluster-a"),
+        base_url="https://observatory-a.example.test/api/v1/observatory/agents",
+    )
+
+    await client.list_agents(instance, headers={}, filters=AgentDirectoryFilters())
+
+    assert requests[0].url.path == "/api/v1/observatory/agents"

--- a/tests/test_niuu/test_rest_instances.py
+++ b/tests/test_niuu/test_rest_instances.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from httpx import Response
 
 from niuu.adapters.inbound.rest_instances import create_instances_router
+from niuu.domain.agent_directory import AgentDirectoryEntry, AgentDirectoryPage
 from niuu.domain.models import (
     InstanceKind,
     InstanceVisibility,
@@ -124,17 +125,76 @@ class StubInstanceService:
         return self.single_instance
 
 
+def _agent_entry() -> AgentDirectoryEntry:
+    return AgentDirectoryEntry(
+        id="agent-aggregate-1",
+        canonicalId="source:observatory-a:session-a",
+        sourceAgentId="session-a",
+        sourceInstanceId="observatory-a",
+        clusterId="noatun",
+        environmentId="environment-a",
+        topologyNodeId="runtime:noatun:skuld:skuld:session-a",
+        name="Builder",
+        description="Builds software",
+        kind="workflow-session",
+        cardUrl="https://agents.example.test/.well-known/agent-card.json",
+        cardVersion="1.0.0",
+        cardHash="card-hash",
+        skillIds=["code"],
+        tags=["engineering"],
+        observedStatus="healthy",
+        ownerId="user-a",
+        tenantId="tenant-a",
+        visibility="user",
+    )
+
+
+class StubAgentDirectoryAggregation:
+    def __init__(self) -> None:
+        self.entry = _agent_entry()
+        self.list_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+
+    async def list_agents(self, instances, principal, *, headers, filters):
+        self.list_calls.append(
+            {
+                "instances": instances,
+                "principal": principal,
+                "headers": headers,
+                "filters": filters,
+            }
+        )
+        return AgentDirectoryPage(items=[self.entry], revision="aggregate-revision")
+
+    async def get_agent(self, agent_id, instances, principal, *, headers):
+        self.get_calls.append(
+            {
+                "agent_id": agent_id,
+                "instances": instances,
+                "principal": principal,
+                "headers": headers,
+            }
+        )
+        return self.entry if agent_id == self.entry.id else None
+
+
 def _client(
     service: StubInstanceService,
     *,
     catalog: list[Any] | None = None,
+    agent_directory: StubAgentDirectoryAggregation | None = None,
 ) -> TestClient:
     app = FastAPI()
     if catalog is not None:
         app.state.settings = SimpleNamespace(
             niuu=SimpleNamespace(catalog=catalog),
         )
-    app.include_router(create_instances_router(service))  # type: ignore[arg-type]
+    app.include_router(
+        create_instances_router(  # type: ignore[arg-type]
+            service,
+            agent_directory=agent_directory,  # type: ignore[arg-type]
+        )
+    )
     return TestClient(app)
 
 
@@ -166,6 +226,58 @@ def test_list_instances_serializes_aliases_and_forwards_filters() -> None:
     assert response.json()[0]["isDefault"] is True
     assert service.list_calls[-1]["kind"] == InstanceKind.TING
     assert service.list_calls[-1]["enabled_only"] is True
+
+
+def test_aggregate_agent_directory_uses_visible_observatories_and_forwards_filters() -> None:
+    service = StubInstanceService()
+    service.visible_instances = [
+        _instance("observatory-a", kind=InstanceKind.OBSERVATORY),
+    ]
+    directory = StubAgentDirectoryAggregation()
+    client = _client(service, agent_directory=directory)
+
+    response = client.get(
+        "/api/v1/niuu/observatory/agents"
+        "?skill=code&tag=engineering&kind=workflow-session&status=healthy"
+        "&environmentId=environment-a&cluster=noatun&instance=observatory-a",
+        headers=_headers(),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["items"][0]["topologyNodeId"].endswith("session-a")
+    assert service.list_calls[-1]["kind"] == InstanceKind.OBSERVATORY
+    assert service.list_calls[-1]["enabled_only"] is True
+    call = directory.list_calls[-1]
+    assert call["principal"].user_id == "user-a"
+    assert call["headers"]["authorization"] == "Bearer test-token"
+    assert call["filters"].skills == ("code",)
+    assert call["filters"].tags == ("engineering",)
+    assert call["filters"].kinds == ("workflow-session",)
+    assert call["filters"].statuses == ("healthy",)
+    assert call["filters"].environment_ids == ("environment-a",)
+    assert call["filters"].cluster_ids == ("noatun",)
+    assert call["filters"].instance_ids == ("observatory-a",)
+
+
+def test_aggregate_agent_detail_returns_generic_404() -> None:
+    service = StubInstanceService()
+    service.visible_instances = [_instance("observatory-a", kind=InstanceKind.OBSERVATORY)]
+    directory = StubAgentDirectoryAggregation()
+    client = _client(service, agent_directory=directory)
+
+    found = client.get(
+        "/api/v1/niuu/observatory/agents/agent-aggregate-1",
+        headers=_headers(),
+    )
+    missing = client.get(
+        "/api/v1/niuu/observatory/agents/inaccessible",
+        headers=_headers(),
+    )
+
+    assert found.status_code == 200
+    assert found.json()["sourceInstanceId"] == "observatory-a"
+    assert missing.status_code == 404
+    assert missing.json() == {"detail": "Agent not found"}
 
 
 def test_get_instance_catalog_reads_catalog_from_settings() -> None:

--- a/tests/test_observatory/test_agent_directory.py
+++ b/tests/test_observatory/test_agent_directory.py
@@ -41,6 +41,15 @@ def _card_payload(
         ],
         "version": "1.2.3",
         "capabilities": {"streaming": True},
+        "securitySchemes": {
+            "bearer": {
+                "httpAuthSecurityScheme": {
+                    "scheme": "bearer",
+                    "bearerFormat": "JWT",
+                }
+            }
+        },
+        "securityRequirements": [{"schemes": {"bearer": {"list": []}}}],
         "defaultInputModes": ["text/plain"],
         "defaultOutputModes": ["application/json"],
         "skills": [
@@ -122,6 +131,7 @@ def _entity(
     *,
     tenant_id: str = "tenant-a",
     environment_members: list[str] | None = None,
+    visibility: str = "user",
 ) -> DiscoveredEntity:
     return DiscoveredEntity(
         id=f"runtime:noatun:skuld:skuld:{session_id}",
@@ -136,7 +146,7 @@ def _entity(
         metadata={
             "ownerId": owner_id,
             "tenantId": tenant_id,
-            "visibility": "user",
+            "visibility": visibility,
             "agentKind": "workflow-session",
             "environmentId": "environment-a",
             "environmentMemberIds": environment_members or [],
@@ -261,6 +271,30 @@ async def test_directory_hides_cross_tenant_owner_and_environment_non_member() -
 
 
 @pytest.mark.asyncio
+async def test_directory_fails_closed_without_authoritative_environment_membership() -> None:
+    card_url = "https://agent.example.test/.well-known/agent-card.json"
+    resolver = _StubCardResolver(
+        {
+            card_url: _resolved_card(
+                "Builder",
+                skill="code",
+                tag="engineering",
+                card_hash="hash",
+            )
+        }
+    )
+    service = _service(
+        [_entity("session-a", "user-b", card_url, visibility="tenant")],
+        resolver,
+    )
+
+    page = await service.list_agents(_principal(), headers={})
+
+    assert page.items == []
+    assert resolver.calls == []
+
+
+@pytest.mark.asyncio
 async def test_directory_returns_visible_card_warning_without_failing_page() -> None:
     card_url = "https://agent.example.test/.well-known/agent-card.json"
     resolver = _StubCardResolver({card_url: AgentCardResolutionError("card timed out")})
@@ -294,6 +328,7 @@ async def test_http_resolver_validates_and_conditionally_revalidates_agent_cards
         timeout_seconds=1.0,
         default_cache_ttl_seconds=5.0,
         signature_algorithms=["RS256"],
+        authenticated_card_origins=["https://agent.example.test"],
         transport=httpx.MockTransport(handler),
     )
     url = "https://agent.example.test/.well-known/agent-card.json"
@@ -312,7 +347,38 @@ async def test_http_resolver_validates_and_conditionally_revalidates_agent_cards
     assert first == second
     assert first.skills == ("code",)
     assert first.signature_verified is None
+    assert first.security_schemes["bearer"]["httpAuthSecurityScheme"]["scheme"] == "bearer"
+    assert first.security_requirements == ({"schemes": {"bearer": {}}},)
     assert calls[0].headers["authorization"] == "Bearer caller"
+
+
+@pytest.mark.asyncio
+async def test_http_resolver_only_forwards_auth_to_explicitly_trusted_origins() -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(200, json=_card_payload())
+
+    resolver = HttpAgentCardResolver(
+        timeout_seconds=1.0,
+        default_cache_ttl_seconds=5.0,
+        signature_algorithms=["RS256"],
+        authenticated_card_origins=["https://trusted.example.test"],
+        transport=httpx.MockTransport(handler),
+    )
+
+    await resolver.resolve(
+        "https://untrusted.example.test/.well-known/agent-card.json",
+        principal_key="tenant-a\0user-a",
+        headers={
+            "authorization": "Bearer caller",
+            "x-auth-user-id": "user-a",
+        },
+    )
+
+    assert "authorization" not in calls[0].headers
+    assert "x-auth-user-id" not in calls[0].headers
 
 
 @pytest.mark.asyncio
@@ -384,6 +450,7 @@ async def test_http_resolver_verifies_signed_agent_card() -> None:
 
     assert resolved.signature_verified is True
     assert resolved.signature_key_ids == ("agent-key",)
+    assert len(resolved.signature_key_fingerprints) == 1
 
     unsigned_resolver = HttpAgentCardResolver(
         timeout_seconds=1.0,
@@ -413,6 +480,12 @@ async def test_http_resolver_rejects_invalid_or_credential_bearing_cards() -> No
     with pytest.raises(AgentCardResolutionError, match="must not embed credentials"):
         await resolver.resolve(
             "https://user:secret@agent.example.test/card",
+            principal_key="principal",
+            headers={},
+        )
+    with pytest.raises(AgentCardResolutionError, match="cannot use query strings"):
+        await resolver.resolve(
+            "https://agent.example.test/card?token=secret",
             principal_key="principal",
             headers={},
         )

--- a/tests/test_observatory/test_agent_directory.py
+++ b/tests/test_observatory/test_agent_directory.py
@@ -1,0 +1,430 @@
+"""Tests for the principal-aware local Observatory Agent Directory."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from a2a.types import AgentCard
+from a2a.utils.signing import create_agent_card_signer
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from google.protobuf.json_format import MessageToDict
+from jwt.algorithms import RSAAlgorithm
+
+from niuu.domain.agent_directory import AgentDirectoryFilters
+from niuu.domain.models import Principal
+from niuu.ports.agent_cards import AgentCardResolutionError, ResolvedAgentCard
+from observatory.a2a_cards import HttpAgentCardResolver
+from observatory.agent_directory import AgentDirectoryService
+from observatory.discovery import ObservatoryDiscoveryService
+from observatory.entity_discovery import DiscoveredEntity, DiscoveryResult
+
+
+def _card_payload(
+    name: str = "Workflow Agent",
+    *,
+    skill: str = "code",
+    tag: str = "engineering",
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "description": "Completes an addressable workflow",
+        "supportedInterfaces": [
+            {
+                "url": "https://agents.example.test/a2a",
+                "protocolBinding": "JSONRPC",
+                "protocolVersion": "1.0",
+            }
+        ],
+        "version": "1.2.3",
+        "capabilities": {"streaming": True},
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["application/json"],
+        "skills": [
+            {
+                "id": skill,
+                "name": skill.title(),
+                "description": f"Performs {skill}",
+                "tags": [tag],
+            }
+        ],
+    }
+
+
+class _StaticDiscoveryAdapter:
+    def __init__(self, result: DiscoveryResult) -> None:
+        self._result = result
+
+    async def discover(self) -> DiscoveryResult:
+        return self._result
+
+
+class _StubAuth:
+    async def headers(self) -> dict[str, str]:
+        return {}
+
+
+class _StubCardResolver:
+    def __init__(self, cards: dict[str, ResolvedAgentCard | Exception]) -> None:
+        self.cards = cards
+        self.calls: list[tuple[str, str, dict[str, str]]] = []
+
+    async def resolve(
+        self,
+        card_url: str,
+        *,
+        principal_key: str,
+        headers: dict[str, str],
+    ) -> ResolvedAgentCard:
+        self.calls.append((card_url, principal_key, dict(headers)))
+        result = self.cards[card_url]
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+def _resolved_card(
+    name: str,
+    *,
+    skill: str,
+    tag: str,
+    card_hash: str,
+) -> ResolvedAgentCard:
+    from niuu.domain.agent_directory import AgentInterface
+
+    return ResolvedAgentCard(
+        name=name,
+        description=f"{name} description",
+        version="1.0.0",
+        skills=(skill,),
+        tags=(tag,),
+        default_input_modes=("text/plain",),
+        default_output_modes=("application/json",),
+        supported_interfaces=(
+            AgentInterface(
+                url="https://agents.example.test/a2a",
+                protocolBinding="JSONRPC",
+                protocolVersion="1.0",
+            ),
+        ),
+        capabilities={"streaming": True},
+        card_hash=card_hash,
+    )
+
+
+def _entity(
+    session_id: str,
+    owner_id: str,
+    card_url: str,
+    *,
+    tenant_id: str = "tenant-a",
+    environment_members: list[str] | None = None,
+) -> DiscoveredEntity:
+    return DiscoveredEntity(
+        id=f"runtime:noatun:skuld:skuld:{session_id}",
+        kind="skuld",
+        name=session_id,
+        cluster="noatun",
+        namespace="skuld",
+        status="healthy",
+        source_kind="volundr-session",
+        source_uid=session_id,
+        endpoints={"a2aCard": card_url},
+        metadata={
+            "ownerId": owner_id,
+            "tenantId": tenant_id,
+            "visibility": "user",
+            "agentKind": "workflow-session",
+            "environmentId": "environment-a",
+            "environmentMemberIds": environment_members or [],
+            "activity": "tooling",
+            "lastActive": "2026-07-14T12:00:00Z",
+        },
+    )
+
+
+def _service(
+    entities: list[DiscoveredEntity],
+    resolver: _StubCardResolver,
+) -> AgentDirectoryService:
+    discovery = ObservatoryDiscoveryService(
+        guild_url="http://guild.test",
+        auth=_StubAuth(),  # type: ignore[arg-type]
+        discovery_adapter=_StaticDiscoveryAdapter(DiscoveryResult(entities=entities)),
+    )
+    return AgentDirectoryService(
+        discovery=discovery,
+        card_resolver=resolver,  # type: ignore[arg-type]
+        instance_id="observatory-noatun",
+        cluster_id="noatun",
+        max_concurrency=2,
+    )
+
+
+def _principal(user_id: str = "user-a", tenant_id: str = "tenant-a") -> Principal:
+    return Principal(user_id=user_id, email="", tenant_id=tenant_id, roles=["member"])
+
+
+@pytest.mark.asyncio
+async def test_directory_filters_before_card_fetch_and_preserves_topology_identity() -> None:
+    visible_url = "https://visible.example.test/.well-known/agent-card.json"
+    hidden_url = "https://hidden.example.test/.well-known/agent-card.json"
+    resolver = _StubCardResolver(
+        {
+            visible_url: _resolved_card(
+                "Builder",
+                skill="code",
+                tag="engineering",
+                card_hash="visible-hash",
+            ),
+            hidden_url: _resolved_card(
+                "Hidden",
+                skill="finance",
+                tag="restricted",
+                card_hash="hidden-hash",
+            ),
+        }
+    )
+    service = _service(
+        [
+            _entity("session-a", "user-a", visible_url),
+            _entity("session-b", "user-b", hidden_url),
+        ],
+        resolver,
+    )
+
+    page = await service.list_agents(
+        _principal(),
+        headers={"authorization": "Bearer principal-a"},
+        filters=AgentDirectoryFilters(
+            skills=("code",),
+            tags=("engineering",),
+            kinds=("workflow-session",),
+            statuses=("healthy",),
+            environment_ids=("environment-a",),
+            cluster_ids=("noatun",),
+            instance_ids=("observatory-noatun",),
+        ),
+    )
+
+    assert len(page.items) == 1
+    assert page.items[0].source_agent_id == "session-a"
+    assert page.items[0].topology_node_id == "runtime:noatun:skuld:skuld:session-a"
+    assert page.items[0].supported_interfaces[0].protocol_version == "1.0"
+    assert resolver.calls == [
+        (
+            visible_url,
+            "tenant-a\0user-a",
+            {"authorization": "Bearer principal-a"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_directory_hides_cross_tenant_owner_and_environment_non_member() -> None:
+    card_url = "https://agent.example.test/.well-known/agent-card.json"
+    resolver = _StubCardResolver(
+        {
+            card_url: _resolved_card(
+                "Builder",
+                skill="code",
+                tag="engineering",
+                card_hash="hash",
+            )
+        }
+    )
+    service = _service(
+        [
+            _entity(
+                "session-a",
+                "user-a",
+                card_url,
+                environment_members=["user-b"],
+            )
+        ],
+        resolver,
+    )
+
+    page = await service.list_agents(_principal(), headers={})
+    cross_tenant = await service.list_agents(
+        _principal(tenant_id="tenant-b"),
+        headers={},
+    )
+
+    assert page.items == []
+    assert cross_tenant.items == []
+    assert resolver.calls == []
+    assert await service.get_agent("session-a", _principal(), headers={}) is None
+
+
+@pytest.mark.asyncio
+async def test_directory_returns_visible_card_warning_without_failing_page() -> None:
+    card_url = "https://agent.example.test/.well-known/agent-card.json"
+    resolver = _StubCardResolver({card_url: AgentCardResolutionError("card timed out")})
+    service = _service([_entity("session-a", "user-a", card_url)], resolver)
+
+    page = await service.list_agents(_principal(), headers={})
+
+    assert page.items == []
+    assert page.partial is True
+    assert page.sources[0].status == "degraded"
+    assert page.warnings[0].source_agent_id == "session-a"
+    assert page.warnings[0].code == "agent-card-unavailable"
+
+
+@pytest.mark.asyncio
+async def test_http_resolver_validates_and_conditionally_revalidates_agent_cards() -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        if len(calls) == 2:
+            assert request.headers["if-none-match"] == '"card-v1"'
+            return httpx.Response(304, headers={"Cache-Control": "max-age=60"})
+        return httpx.Response(
+            200,
+            json=_card_payload(),
+            headers={"ETag": '"card-v1"', "Cache-Control": "max-age=0"},
+        )
+
+    resolver = HttpAgentCardResolver(
+        timeout_seconds=1.0,
+        default_cache_ttl_seconds=5.0,
+        signature_algorithms=["RS256"],
+        transport=httpx.MockTransport(handler),
+    )
+    url = "https://agent.example.test/.well-known/agent-card.json"
+
+    first = await resolver.resolve(
+        url,
+        principal_key="tenant-a\0user-a",
+        headers={"authorization": "Bearer caller"},
+    )
+    second = await resolver.resolve(
+        url,
+        principal_key="tenant-a\0user-a",
+        headers={"authorization": "Bearer caller"},
+    )
+
+    assert first == second
+    assert first.skills == ("code",)
+    assert first.signature_verified is None
+    assert calls[0].headers["authorization"] == "Bearer caller"
+
+
+@pytest.mark.asyncio
+async def test_http_resolver_isolates_principals_and_honors_no_store() -> None:
+    calls: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request)
+        return httpx.Response(
+            200,
+            json=_card_payload(),
+            headers={"ETag": '"private-card"', "Cache-Control": "private, no-store"},
+        )
+
+    resolver = HttpAgentCardResolver(
+        timeout_seconds=1.0,
+        default_cache_ttl_seconds=60.0,
+        signature_algorithms=["RS256"],
+        transport=httpx.MockTransport(handler),
+    )
+    url = "https://agent.example.test/.well-known/agent-card.json"
+
+    await resolver.resolve(url, principal_key="tenant-a\0user-a", headers={})
+    await resolver.resolve(url, principal_key="tenant-a\0user-a", headers={})
+    await resolver.resolve(url, principal_key="tenant-a\0user-b", headers={})
+
+    assert len(calls) == 3
+    assert all("if-none-match" not in request.headers for request in calls)
+
+
+@pytest.mark.asyncio
+async def test_http_resolver_verifies_signed_agent_card() -> None:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    public_jwk = json.loads(RSAAlgorithm.to_jwk(private_key.public_key()))
+    public_jwk["kid"] = "agent-key"
+    card = HttpAgentCardResolver._parse_card(_card_payload())
+    signed: AgentCard = create_agent_card_signer(
+        private_pem,
+        {
+            "alg": "RS256",
+            "kid": "agent-key",
+            "jku": "https://agent.example.test/jwks.json",
+            "typ": "JOSE",
+        },
+    )(card)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/jwks.json":
+            return httpx.Response(200, json={"keys": [public_jwk]})
+        return httpx.Response(200, json=MessageToDict(signed))
+
+    resolver = HttpAgentCardResolver(
+        timeout_seconds=1.0,
+        default_cache_ttl_seconds=5.0,
+        signature_algorithms=["RS256"],
+        transport=httpx.MockTransport(handler),
+    )
+
+    resolved = await resolver.resolve(
+        "https://agent.example.test/.well-known/agent-card.json",
+        principal_key="tenant-a\0user-a",
+        headers={},
+    )
+
+    assert resolved.signature_verified is True
+    assert resolved.signature_key_ids == ("agent-key",)
+
+    unsigned_resolver = HttpAgentCardResolver(
+        timeout_seconds=1.0,
+        default_cache_ttl_seconds=5.0,
+        signature_algorithms=["RS256"],
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=_card_payload())),
+    )
+    unsigned = await unsigned_resolver.resolve(
+        "https://unsigned.example.test/.well-known/agent-card.json",
+        principal_key="tenant-a\0user-a",
+        headers={},
+    )
+    assert resolved.card_hash == unsigned.card_hash
+
+
+@pytest.mark.asyncio
+async def test_http_resolver_rejects_invalid_or_credential_bearing_cards() -> None:
+    resolver = HttpAgentCardResolver(
+        timeout_seconds=1.0,
+        default_cache_ttl_seconds=5.0,
+        signature_algorithms=["RS256"],
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, json={"name": "incomplete"})
+        ),
+    )
+
+    with pytest.raises(AgentCardResolutionError, match="must not embed credentials"):
+        await resolver.resolve(
+            "https://user:secret@agent.example.test/card",
+            principal_key="principal",
+            headers={},
+        )
+    with pytest.raises(AgentCardResolutionError, match="missing required fields"):
+        await resolver.resolve(
+            "https://agent.example.test/card",
+            principal_key="principal",
+            headers={},
+        )
+    with pytest.raises(ValueError, match="Unsupported Agent Card signature algorithm"):
+        HttpAgentCardResolver(
+            timeout_seconds=1.0,
+            default_cache_ttl_seconds=5.0,
+            signature_algorithms=["none"],
+        )

--- a/tests/test_observatory/test_app.py
+++ b/tests/test_observatory/test_app.py
@@ -8,6 +8,7 @@ from contextlib import asynccontextmanager
 
 from starlette.testclient import TestClient
 
+from niuu.domain.agent_directory import AgentDirectoryEntry, AgentDirectoryPage
 from observatory.app import _events_stream, _topology_stream, create_app
 from observatory.registry import (
     InMemoryObservatoryRegistryRepository,
@@ -109,6 +110,46 @@ class _RaisingRepository(InMemoryObservatoryRegistryRepository):
         raise RegistryNotFoundError(type_id)
 
 
+def _directory_entry() -> AgentDirectoryEntry:
+    return AgentDirectoryEntry(
+        id="agent-1",
+        canonicalId="source:observatory-a:session-a",
+        sourceAgentId="session-a",
+        sourceInstanceId="observatory-a",
+        clusterId="noatun",
+        environmentId="environment-a",
+        topologyNodeId="runtime:noatun:skuld:skuld:session-a",
+        name="Builder",
+        description="Builds software",
+        kind="workflow-session",
+        cardUrl="https://agents.example.test/.well-known/agent-card.json",
+        cardVersion="1.0.0",
+        cardHash="card-hash",
+        skillIds=["code"],
+        tags=["engineering"],
+        observedStatus="healthy",
+        activity="tooling",
+        ownerId="user-a",
+        tenantId="tenant-a",
+        visibility="user",
+    )
+
+
+class _StubAgentDirectory:
+    def __init__(self) -> None:
+        self.entry = _directory_entry()
+        self.list_calls: list[dict[str, object]] = []
+        self.get_calls: list[dict[str, object]] = []
+
+    async def list_agents(self, principal, *, headers, filters):
+        self.list_calls.append({"principal": principal, "headers": headers, "filters": filters})
+        return AgentDirectoryPage(items=[self.entry], revision="revision-a")
+
+    async def get_agent(self, agent_id, principal, *, headers):
+        self.get_calls.append({"agent_id": agent_id, "principal": principal, "headers": headers})
+        return self.entry if agent_id == self.entry.id else None
+
+
 def _extract_sse_payload(chunk: str) -> dict[str, object]:
     for line in chunk.splitlines():
         if line.startswith("data: "):
@@ -188,6 +229,61 @@ class TestObservatoryApp:
             assert payload["title"] == "Observatory"
             assert payload["sections"][0]["id"] == "streams"
             assert any(field["key"] == "guild_url" for field in payload["sections"][0]["fields"])
+
+    def test_agent_directory_forwards_principal_auth_and_all_filters(self) -> None:
+        directory = _StubAgentDirectory()
+        app = create_app(
+            registry_repository=InMemoryObservatoryRegistryRepository(),
+            discovery_service=_FakeDiscoveryService(),
+            agent_directory_service=directory,
+        )
+        headers = {
+            "authorization": "Bearer token",
+            "x-auth-user-id": "user-a",
+            "x-auth-tenant": "tenant-a",
+        }
+        with TestClient(app) as client:
+            response = client.get(
+                "/api/v1/observatory/agents"
+                "?skill=code&tag=engineering&kind=workflow-session&status=healthy"
+                "&environmentId=environment-a&cluster=noatun&instance=observatory-a",
+                headers=headers,
+            )
+
+        assert response.status_code == 200
+        assert response.json()["items"][0]["topologyNodeId"].endswith("session-a")
+        call = directory.list_calls[-1]
+        assert call["principal"].user_id == "user-a"
+        assert call["headers"]["authorization"] == "Bearer token"
+        assert call["filters"].skills == ("code",)
+        assert call["filters"].tags == ("engineering",)
+        assert call["filters"].kinds == ("workflow-session",)
+        assert call["filters"].statuses == ("healthy",)
+        assert call["filters"].environment_ids == ("environment-a",)
+        assert call["filters"].cluster_ids == ("noatun",)
+        assert call["filters"].instance_ids == ("observatory-a",)
+
+    def test_agent_directory_detail_does_not_disclose_missing_agent(self) -> None:
+        directory = _StubAgentDirectory()
+        app = create_app(
+            registry_repository=InMemoryObservatoryRegistryRepository(),
+            discovery_service=_FakeDiscoveryService(),
+            agent_directory_service=directory,
+        )
+        with TestClient(app) as client:
+            found = client.get(
+                "/api/v1/observatory/agents/agent-1",
+                headers={"x-auth-user-id": "user-a", "x-auth-tenant": "tenant-a"},
+            )
+            missing = client.get(
+                "/api/v1/observatory/agents/inaccessible",
+                headers={"x-auth-user-id": "user-a", "x-auth-tenant": "tenant-a"},
+            )
+
+        assert found.status_code == 200
+        assert found.json()["sourceAgentId"] == "session-a"
+        assert missing.status_code == 404
+        assert missing.json() == {"detail": "Agent not found"}
 
     def test_topology_stream_aliases_return_sse(self) -> None:
         first_chunk = asyncio.run(anext(_topology_stream(_FakeDiscoveryService())))

--- a/tests/test_observatory/test_entity_discovery.py
+++ b/tests/test_observatory/test_entity_discovery.py
@@ -584,6 +584,10 @@ async def test_volundr_sessions_adapter_projects_running_sessions() -> None:
                     "model": "codex",
                     "tokens_used": 2048,
                     "chat_endpoint": "wss://sessions.example/session",
+                    "a2aCardUrl": "https://sessions.example/.well-known/agent-card.json",
+                    "a2aEndpointUrl": "https://sessions.example/a2a",
+                    "environmentId": "environment-a",
+                    "a2aVisibility": "tenant",
                 }
             ],
         )
@@ -620,6 +624,14 @@ async def test_volundr_sessions_adapter_projects_running_sessions() -> None:
     assert session["parentId"] == "namespace-noatun-skuld"
     assert session["status"] == "healthy"
     assert session["tokens"] == 2048
+    assert session["endpoints"] == {
+        "chat": "wss://sessions.example/session",
+        "a2a": "https://sessions.example/a2a",
+        "a2aCard": "https://sessions.example/.well-known/agent-card.json",
+    }
+    assert session["environmentId"] == "environment-a"
+    assert session["visibility"] == "tenant"
+    assert session["agentKind"] == "workflow-session"
     assert snapshot["edges"] == [
         {
             "id": (

--- a/tests/test_observatory/test_plugin.py
+++ b/tests/test_observatory/test_plugin.py
@@ -52,11 +52,13 @@ def test_create_api_app_returns_fastapi(monkeypatch) -> None:
 def test_api_route_domains_include_registry_topology_and_events() -> None:
     plugin = ObservatoryPlugin()
     domains = plugin.api_route_domains()
-    assert len(domains) == 4
-    assert domains[0].name == "observatory-registry-api"
-    assert "/api/v1/observatory/topology/stream" in domains[1].prefixes
-    assert "/api/v1/observatory/events" in domains[2].prefixes
-    assert domains[3].prefixes == ("/api/v1/observatory",)
+    assert len(domains) == 5
+    assert domains[0].name == "observatory-agents-api"
+    assert domains[0].prefixes == ("/api/v1/observatory/agents",)
+    assert domains[1].name == "observatory-registry-api"
+    assert "/api/v1/observatory/topology/stream" in domains[2].prefixes
+    assert "/api/v1/observatory/events" in domains[3].prefixes
+    assert domains[4].prefixes == ("/api/v1/observatory",)
 
 
 def test_create_api_client_returns_cli_client() -> None:

--- a/tests/test_volundr/test_session_response_a2a.py
+++ b/tests/test_volundr/test_session_response_a2a.py
@@ -1,0 +1,42 @@
+"""Tests for the explicit Volundr workflow-session A2A publication path."""
+
+from volundr.adapters.inbound.rest import SessionResponse
+from volundr.domain.models import Session
+
+
+def test_session_response_exposes_only_explicit_safe_a2a_fields() -> None:
+    session = Session(
+        name="addressable-workflow",
+        workload_config={
+            "a2aCardUrl": "https://agent.example.test/.well-known/agent-card.json",
+            "a2aEndpointUrl": "https://agent.example.test/a2a",
+            "environmentId": "environment-a",
+            "a2aVisibility": "tenant",
+            "clientSecret": "must-not-leak",
+        },
+    )
+
+    payload = SessionResponse.from_session(session).model_dump(by_alias=True)
+
+    assert payload["a2aCardUrl"].endswith("agent-card.json")
+    assert payload["a2aEndpointUrl"] == "https://agent.example.test/a2a"
+    assert payload["environmentId"] == "environment-a"
+    assert payload["a2aVisibility"] == "tenant"
+    assert "clientSecret" not in payload
+    assert "workload_config" not in payload
+
+
+def test_session_response_rejects_credential_bearing_or_non_http_a2a_urls() -> None:
+    session = Session(
+        name="unsafe-workflow",
+        workload_config={
+            "a2a_card_url": "https://user:password@agent.example.test/card.json",
+            "a2a_endpoint_url": "file:///tmp/a2a.sock",
+        },
+    )
+
+    payload = SessionResponse.from_session(session).model_dump(by_alias=True)
+
+    assert payload["a2aCardUrl"] is None
+    assert payload["a2aEndpointUrl"] is None
+    assert payload["a2aVisibility"] == "user"

--- a/tests/test_volundr/test_session_response_a2a.py
+++ b/tests/test_volundr/test_session_response_a2a.py
@@ -30,7 +30,7 @@ def test_session_response_rejects_credential_bearing_or_non_http_a2a_urls() -> N
     session = Session(
         name="unsafe-workflow",
         workload_config={
-            "a2a_card_url": "https://user:password@agent.example.test/card.json",
+            "a2a_card_url": "https://agent.example.test/card.json?token=secret",
             "a2a_endpoint_url": "file:///tmp/a2a.sock",
         },
     )

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,26 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "a2a-sdk"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "culsans", marker = "python_full_version < '3.13'" },
+    { name = "google-api-core" },
+    { name = "googleapis-common-protos" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "json-rpc" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/7e/8ac10bbf8b15b16574355f39b17dbdf617a282c27b41c7ff2116e30336df/a2a_sdk-1.1.0.tar.gz", hash = "sha256:e8102dad1b36709dbdc3d19319e38e6dfa3b3a79c30416030eb2d482576be204", size = 375726, upload-time = "2026-05-29T09:34:43.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/ea/3a5b160cfd51c67759b08748051094d9365ceff18127633d0021950c9860/a2a_sdk-1.1.0-py3-none-any.whl", hash = "sha256:d7f5846caf18033d8bf3108b11ec827dd8dd32f867c98848ede0e39474be93be", size = 241886, upload-time = "2026-05-29T09:34:41.484Z" },
+]
+
+[[package]]
 name = "aio-pika"
 version = "9.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -128,6 +148,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
     { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
     { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
+]
+
+[[package]]
+name = "aiologic"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f1/7a/d51f2fde1e8ae8a83431f8e97b7a71e9358cdb1d4d2ce6be387fa44d68de/aiologic-0.17.1.tar.gz", hash = "sha256:2e1b93b9e88ced318c2a63ad7b382688f40cbfe40e3d42258d49dc9c5aea179d", size = 252354, upload-time = "2026-06-27T20:41:33.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/d3/2d310b1b839014034dba0cba685e492df8a5c7ad32c19cab7e979eed6554/aiologic-0.17.1-py3-none-any.whl", hash = "sha256:c66b319830fedb7ca3d2b2125fa6f5b653f89418c2a27ea76f259ec5f00943c0", size = 161331, upload-time = "2026-06-27T20:41:31.877Z" },
 ]
 
 [[package]]
@@ -581,34 +615,47 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
+]
+
+[[package]]
+name = "culsans"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiologic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811, upload-time = "2025-12-31T23:15:37.189Z" },
 ]
 
 [[package]]
@@ -770,6 +817,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/66/b4ba60005743e01933e22b4f62313e063f7460458b7d8a358427b4930013/google_auth-2.56.0.tar.gz", hash = "sha256:f90fa030b569a92654b9d690665a073841df33d57487be53db583a9a0867a553", size = 364629, upload-time = "2026-07-13T19:09:57.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/7d/cd3e187f14ce832e419e70709bfcc40cb0dc11517d5d03c9d3919bcc3101/google_auth-2.56.0-py3-none-any.whl", hash = "sha256:6e88c10217e07a92bfd01cac8ee99e32ccfb08414c3102e6c5b8d58f37a0d1e0", size = 257976, upload-time = "2026-07-13T19:09:42.685Z" },
 ]
 
 [[package]]
@@ -1101,6 +1177,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "json-rpc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854, upload-time = "2023-06-11T09:45:49.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450, upload-time = "2023-06-11T09:45:47.136Z" },
 ]
 
 [[package]]
@@ -1477,11 +1562,6 @@ name = "nuitka"
 version = "4.1.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3f/d8/bdb7febea4b4fe5d3d6fe2610f946771f03e792e05a5e8ec00b62c00b265/nuitka-4.1.3.tar.gz", hash = "sha256:838ff8899dc2f0b652d4fcf6c5d7466cb7ad5abcb005668ac622d1e40f4d8a8d", size = 4565475, upload-time = "2026-06-21T10:48:04.369Z" }
-
-[package.optional-dependencies]
-onefile = [
-    { name = "zstandard" },
-]
 
 [[package]]
 name = "numpy"
@@ -1957,6 +2037,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/44/767757fd2cdd4a60d7e4440d9f7b491d6131103d313638d2c03e06c268fb/proto_plus-1.28.1.tar.gz", hash = "sha256:832e68e7fe064cf90ab153b6e5eb935b27891bb89aaeb68b115e9b702f6cb168", size = 57166, upload-time = "2026-07-08T17:04:02.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/34/2f2b57dbfd145b995a29847a16b0903fce5ef6ad3c7aad740a609c5d3678/proto_plus-1.28.1-py3-none-any.whl", hash = "sha256:6660f5f1970874bdcfc3088b435188a36a37bd3596668f7d726417c4ae8cfbed", size = 50408, upload-time = "2026-07-08T17:03:34.532Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1969,6 +2061,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -3047,6 +3160,7 @@ name = "volundr"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "a2a-sdk" },
     { name = "asyncpg" },
     { name = "claude-agent-sdk" },
     { name = "cryptography" },
@@ -3079,7 +3193,7 @@ browser = [
     { name = "playwright" },
 ]
 cli = [
-    { name = "nuitka", extra = ["onefile"] },
+    { name = "nuitka" },
     { name = "ordered-set" },
     { name = "patchelf", marker = "sys_platform == 'linux'" },
     { name = "textual" },
@@ -3149,6 +3263,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", specifier = ">=1.1.0,<2" },
     { name = "aio-pika", marker = "extra == 'rabbitmq'", specifier = ">=9.6.2" },
     { name = "aiohttp", marker = "extra == 'dev'", specifier = ">=3.13.3" },
     { name = "aiohttp", marker = "extra == 'test'", specifier = ">=3.13.3" },
@@ -3263,6 +3378,70 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
     { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]
 
 [[package]]
@@ -3423,61 +3602,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/77/3c292c091b636c3a0af5c69e1d1ffe83261737d34075efc889fe25380b32/zeroconf-0.150.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c8ccc9e1772ce0030f77e6a49542e9b7ca4e8ae9ce1bef84a3a983be68ddf81c", size = 4225357, upload-time = "2026-06-22T18:25:30.468Z" },
     { url = "https://files.pythonhosted.org/packages/e5/5b/54758b003fe687757f9d8313a8ceaa7560e1c392ac109890782283ba1840/zeroconf-0.150.0-cp314-cp314t-win32.whl", hash = "sha256:576e72a9e9140d96ae110ceb0935f06fa41eeea8b2be53e442a6a00c84035194", size = 2599274, upload-time = "2026-06-22T18:25:32.463Z" },
     { url = "https://files.pythonhosted.org/packages/ff/be/9eb576ae5eeede25cd1e59f0be1ce6b2fcf7aa5a4ab4d6d05de2d30efc4a/zeroconf-0.150.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bdae152e80b848117691ab59aa8b16bf15323c0e9f3ddc38c6345af95a700a84", size = 3106484, upload-time = "2026-06-22T18:25:34.89Z" },
-]
-
-[[package]]
-name = "zstandard"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
-    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
-    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
-    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
-    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
-    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
-    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
-    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
-    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
-    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
-    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
-    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
-    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]

--- a/web-next/apps/niuu/src/services.test.ts
+++ b/web-next/apps/niuu/src/services.test.ts
@@ -62,6 +62,10 @@ const observatoryMocks = vi.hoisted(() => ({
   buildObservatoryRegistryHttpAdapter: vi.fn(() => ({})),
   buildObservatoryTopologySseStream: vi.fn(() => ({})),
   buildObservatoryEventsSseStream: vi.fn(() => ({})),
+  buildObservatoryAgentDirectoryHttpAdapter: vi.fn((client) => ({
+    kind: 'observatory-agents',
+    client,
+  })),
 }));
 
 const valkyrieMocks = vi.hoisted(() => ({
@@ -602,6 +606,12 @@ describe('buildServiceBackendStatus', () => {
       transport: 'http',
       target: 'http://localhost:8080/api/v1/observatory/topology',
       source: 'observatory',
+    });
+    expect(status['observatory.agents']).toEqual({
+      mode: 'live',
+      transport: 'http',
+      target: 'http://localhost:8080/api/v1/niuu/observatory',
+      source: 'niuu',
     });
     expect(status['ravn.personas']).toEqual({
       mode: 'live',
@@ -1744,6 +1754,34 @@ describe('buildServices', () => {
     expect(observatoryMocks.buildObservatoryEventsSseStream).toHaveBeenCalledWith(
       'http://localhost:8080/api/v1/observatory/events',
     );
+    expect(observatoryMocks.buildObservatoryAgentDirectoryHttpAdapter).toHaveBeenCalledWith({
+      basePath: 'http://localhost:8080/api/v1/observatory',
+    });
+  });
+
+  it('normalizes an explicit aggregate agent directory endpoint to its service root', () => {
+    const services = buildServices({
+      demoMode: false,
+      theme: 'ice',
+      plugins: {},
+      services: {
+        'observatory.agents': {
+          mode: 'http',
+          baseUrl: 'https://guild.example.test/api/v1/niuu/observatory/agents',
+        },
+      },
+    } as any);
+
+    expect(queryMocks.createApiClient).toHaveBeenCalledWith(
+      'https://guild.example.test/api/v1/niuu/observatory',
+    );
+    expect(observatoryMocks.buildObservatoryAgentDirectoryHttpAdapter).toHaveBeenCalledWith({
+      basePath: 'https://guild.example.test/api/v1/niuu/observatory',
+    });
+    expect(services['observatory.agents']).toEqual({
+      kind: 'observatory-agents',
+      client: { basePath: 'https://guild.example.test/api/v1/niuu/observatory' },
+    });
   });
 
   it('prefers explicit observatory surface overrides over the grouped observatory base', () => {

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -46,6 +46,8 @@ import {
   buildObservatoryRegistryHttpAdapter,
   buildObservatoryTopologySseStream,
   buildObservatoryEventsSseStream,
+  buildObservatoryAgentDirectoryHttpAdapter,
+  type IAgentDirectory,
 } from '@niuulabs/plugin-observatory';
 import {
   createMockVolundrService,
@@ -438,20 +440,31 @@ function resolveTingServiceBase(
 
 function resolveObservatoryServiceBase(
   config: Pick<NiuuConfig, 'services'>,
-  serviceKey: 'observatory.registry' | 'observatory.topology' | 'observatory.events',
+  serviceKey:
+    'observatory.registry' | 'observatory.topology' | 'observatory.events' | 'observatory.agents',
 ): string | null {
   const explicitBase = resolveDirectServiceBase(config, serviceKey);
   if (explicitBase) {
     if (serviceKey === 'observatory.registry') {
       return explicitBase.replace(/\/registry\/?$/, '');
     }
+    if (serviceKey === 'observatory.agents') {
+      return explicitBase.replace(/\/agents\/?$/, '');
+    }
     return explicitBase;
+  }
+
+  if (serviceKey === 'observatory.agents') {
+    const aggregateBase = resolveNiuuRegistryBase(config);
+    if (aggregateBase) return `${aggregateBase}/observatory`;
   }
 
   const groupedBase = resolveDirectServiceBase(config, 'observatory');
   if (!groupedBase) return null;
 
-  if (serviceKey === 'observatory.registry') return groupedBase;
+  if (serviceKey === 'observatory.registry' || serviceKey === 'observatory.agents') {
+    return groupedBase;
+  }
   if (serviceKey === 'observatory.topology') return `${groupedBase}/topology`;
   return `${groupedBase}/events`;
 }
@@ -661,20 +674,36 @@ function resolveCanonicalServiceStatus(
 
 function resolveObservatoryServiceStatus(
   config: Pick<NiuuConfig, 'services'>,
-  serviceKey: 'observatory.registry' | 'observatory.topology' | 'observatory.events',
+  serviceKey:
+    'observatory.registry' | 'observatory.topology' | 'observatory.events' | 'observatory.agents',
 ): ServiceBackendStatus {
   const explicit = resolveDirectServiceStatus(config, 'http', serviceKey);
   if (explicit.mode === 'live') {
     if (serviceKey === 'observatory.registry' && explicit.target) {
       return { ...explicit, target: explicit.target.replace(/\/registry\/?$/, '') };
     }
+    if (serviceKey === 'observatory.agents' && explicit.target) {
+      return { ...explicit, target: explicit.target.replace(/\/agents\/?$/, '') };
+    }
     return explicit;
+  }
+
+  if (serviceKey === 'observatory.agents') {
+    const aggregateBase = resolveNiuuRegistryBase(config);
+    if (aggregateBase) {
+      return {
+        mode: 'live',
+        transport: 'http',
+        target: `${aggregateBase}/observatory`,
+        source: 'niuu',
+      };
+    }
   }
 
   const grouped = resolveDirectServiceStatus(config, 'http', 'observatory');
   if (grouped.mode !== 'live' || !grouped.target) return grouped;
 
-  if (serviceKey === 'observatory.registry') {
+  if (serviceKey === 'observatory.registry' || serviceKey === 'observatory.agents') {
     return { ...grouped, source: 'observatory' };
   }
   if (serviceKey === 'observatory.topology') {
@@ -698,6 +727,7 @@ export function buildServiceBackendStatus(
     'observatory.registry': resolveObservatoryServiceStatus(config, 'observatory.registry'),
     'observatory.topology': resolveObservatoryServiceStatus(config, 'observatory.topology'),
     'observatory.events': resolveObservatoryServiceStatus(config, 'observatory.events'),
+    'observatory.agents': resolveObservatoryServiceStatus(config, 'observatory.agents'),
     'ravn.personas': resolveRavnServiceStatus(config, 'ravn.personas'),
     'ravn.ravens': resolveRavnServiceStatus(config, 'ravn.ravens'),
     'ravn.residents': resolveRavnServiceStatus(config, 'ravn.ravens'),
@@ -1397,6 +1427,7 @@ export function buildServices(config: NiuuConfig): ServicesMap {
   const observatoryRegistryBase = resolveObservatoryServiceBase(config, 'observatory.registry');
   const observatoryTopologyBase = resolveObservatoryServiceBase(config, 'observatory.topology');
   const observatoryEventsBase = resolveObservatoryServiceBase(config, 'observatory.events');
+  const observatoryAgentsBase = resolveObservatoryServiceBase(config, 'observatory.agents');
   const observatoryRegistry = observatoryRegistryBase
     ? buildObservatoryRegistryHttpAdapter(createApiClient(observatoryRegistryBase))
     : demoService(config, 'observatory.registry', createMockRegistryRepository);
@@ -1406,6 +1437,9 @@ export function buildServices(config: NiuuConfig): ServicesMap {
   const observatoryEvents = observatoryEventsBase
     ? buildObservatoryEventsSseStream(observatoryEventsBase)
     : demoService(config, 'observatory.events', createMockEventStream);
+  const observatoryAgents = observatoryAgentsBase
+    ? buildObservatoryAgentDirectoryHttpAdapter(createApiClient(observatoryAgentsBase))
+    : unavailableService<IAgentDirectory>('observatory.agents');
   // ── Valkyrie ──
   const valkyrieBase = resolveValkyrieServiceBase(config, 'valkyrie');
   const valkyrieReviewsBase = resolveValkyrieServiceBase(config, 'valkyrie.reviews');
@@ -1517,6 +1551,7 @@ export function buildServices(config: NiuuConfig): ServicesMap {
     'observatory.registry': observatoryRegistry,
     'observatory.topology': observatoryTopology,
     'observatory.events': observatoryEvents,
+    'observatory.agents': observatoryAgents,
     valkyrie,
     'valkyrie.reviews': valkyrieReviews,
     'valkyrie.skills': valkyrieSkills,

--- a/web-next/packages/plugin-observatory/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/http.test.ts
@@ -4,8 +4,15 @@ import {
   buildObservatoryRegistryHttpAdapter,
   buildObservatoryTopologySseStream,
   buildObservatoryEventsSseStream,
+  buildObservatoryAgentDirectoryHttpAdapter,
 } from './http';
-import type { Registry, Topology, ObservatoryEvent } from '../domain';
+import type {
+  AgentDirectoryEntry,
+  AgentDirectoryPage,
+  Registry,
+  Topology,
+  ObservatoryEvent,
+} from '../domain';
 
 const emptyRegistry: Registry = {
   version: 1,
@@ -110,6 +117,56 @@ describe('buildObservatoryRegistryHttpAdapter', () => {
     const result = await adapter.saveRegistry(emptyRegistry);
     expect(result).toEqual(emptyRegistry);
     expect(saved).toEqual([emptyRegistry]);
+  });
+});
+
+describe('buildObservatoryAgentDirectoryHttpAdapter', () => {
+  it('encodes every repeatable directory filter and loads detail safely', async () => {
+    const calls: string[] = [];
+    const page = {
+      items: [],
+      warnings: [],
+      sources: [],
+      partial: false,
+      revision: 'revision-a',
+    } satisfies AgentDirectoryPage;
+    const detail = { id: 'agent/one' } as AgentDirectoryEntry;
+    const client = {
+      ...fakeClient(emptyRegistry),
+      async get<T>(endpoint: string): Promise<T> {
+        calls.push(endpoint);
+        return (endpoint.startsWith('/agents?') ? page : detail) as T;
+      },
+    };
+    const adapter = buildObservatoryAgentDirectoryHttpAdapter(client);
+
+    await expect(
+      adapter.listAgents({
+        skills: ['code', 'review'],
+        tags: ['engineering'],
+        kinds: ['workflow-session'],
+        statuses: ['healthy'],
+        environmentIds: ['environment-a'],
+        clusterIds: ['noatun'],
+        instanceIds: ['observatory-a'],
+      }),
+    ).resolves.toEqual(page);
+    await expect(adapter.getAgent('agent/one')).resolves.toEqual(detail);
+
+    expect(calls[0]).toBe(
+      '/agents?skill=code&skill=review&tag=engineering&kind=workflow-session&status=healthy&environmentId=environment-a&cluster=noatun&instance=observatory-a',
+    );
+    expect(calls[1]).toBe('/agents/agent%2Fone');
+  });
+
+  it('propagates transport failures', async () => {
+    const client = {
+      ...fakeClient(emptyRegistry),
+      get: vi.fn().mockRejectedValue(new Error('directory failed')),
+    };
+    const adapter = buildObservatoryAgentDirectoryHttpAdapter(client);
+
+    await expect(adapter.listAgents()).rejects.toThrow('directory failed');
   });
 });
 

--- a/web-next/packages/plugin-observatory/src/adapters/http.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/http.ts
@@ -20,8 +20,43 @@ import type {
   IEventStream,
   TopologyListener,
   ObservatoryEventListener,
+  IAgentDirectory,
 } from '../ports';
-import type { Registry, Topology, ObservatoryEvent } from '../domain';
+import type {
+  AgentDirectoryEntry,
+  AgentDirectoryFilters,
+  AgentDirectoryPage,
+  Registry,
+  Topology,
+  ObservatoryEvent,
+} from '../domain';
+
+function agentDirectoryQuery(filters: AgentDirectoryFilters = {}): string {
+  const query = new URLSearchParams();
+  const append = (name: string, values: readonly string[] | undefined) => {
+    for (const value of values ?? []) query.append(name, value);
+  };
+  append('skill', filters.skills);
+  append('tag', filters.tags);
+  append('kind', filters.kinds);
+  append('status', filters.statuses);
+  append('environmentId', filters.environmentIds);
+  append('cluster', filters.clusterIds);
+  append('instance', filters.instanceIds);
+  const encoded = query.toString();
+  return encoded ? `?${encoded}` : '';
+}
+
+export function buildObservatoryAgentDirectoryHttpAdapter(client: ApiClient): IAgentDirectory {
+  return {
+    listAgents(filters): Promise<AgentDirectoryPage> {
+      return client.get<AgentDirectoryPage>(`/agents${agentDirectoryQuery(filters)}`);
+    },
+    getAgent(agentId): Promise<AgentDirectoryEntry> {
+      return client.get<AgentDirectoryEntry>(`/agents/${encodeURIComponent(agentId)}`);
+    },
+  };
+}
 
 function toObservatoryEventType(raw: Record<string, unknown>): ObservatoryEvent['type'] {
   const explicitType = typeof raw.type === 'string' ? raw.type.toUpperCase() : '';

--- a/web-next/packages/plugin-observatory/src/application/useAgents.test.tsx
+++ b/web-next/packages/plugin-observatory/src/application/useAgents.test.tsx
@@ -1,0 +1,57 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentDirectoryPage } from '../domain';
+import type { IAgentDirectory } from '../ports';
+import { useAgents } from './useAgents';
+
+const emptyPage: AgentDirectoryPage = {
+  items: [],
+  warnings: [],
+  sources: [],
+  partial: false,
+  revision: 'revision-a',
+};
+
+function wrap(directory: IAgentDirectory) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={{ 'observatory.agents': directory }}>
+          {children}
+        </ServicesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useAgents', () => {
+  it('reports loading before returning a principal-scoped page', async () => {
+    let resolve!: (page: AgentDirectoryPage) => void;
+    const listAgents = vi.fn(() => new Promise<AgentDirectoryPage>((next) => (resolve = next)));
+    const directory = { listAgents, getAgent: vi.fn() } as IAgentDirectory;
+    const { result } = renderHook(() => useAgents({ skills: ['code'] }), {
+      wrapper: wrap(directory),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    resolve(emptyPage);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(emptyPage);
+    expect(listAgents).toHaveBeenCalledWith({ skills: ['code'] });
+  });
+
+  it('surfaces directory failures', async () => {
+    const directory = {
+      listAgents: vi.fn().mockRejectedValue(new Error('observatory unavailable')),
+      getAgent: vi.fn(),
+    } as IAgentDirectory;
+    const { result } = renderHook(() => useAgents(), { wrapper: wrap(directory) });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error('observatory unavailable'));
+  });
+});

--- a/web-next/packages/plugin-observatory/src/application/useAgents.test.tsx
+++ b/web-next/packages/plugin-observatory/src/application/useAgents.test.tsx
@@ -3,9 +3,9 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { ServicesProvider } from '@niuulabs/plugin-sdk';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import type { AgentDirectoryPage } from '../domain';
+import type { AgentDirectoryEntry, AgentDirectoryPage } from '../domain';
 import type { IAgentDirectory } from '../ports';
-import { useAgents } from './useAgents';
+import { useAgent, useAgents } from './useAgents';
 
 const emptyPage: AgentDirectoryPage = {
   items: [],
@@ -53,5 +53,20 @@ describe('useAgents', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error).toEqual(new Error('observatory unavailable'));
+  });
+});
+
+describe('useAgent', () => {
+  it('loads one directory entry by its stable ID', async () => {
+    const entry = { id: 'agent-one' } as AgentDirectoryEntry;
+    const getAgent = vi.fn().mockResolvedValue(entry);
+    const directory = { listAgents: vi.fn(), getAgent } as IAgentDirectory;
+    const { result } = renderHook(() => useAgent('agent-one'), {
+      wrapper: wrap(directory),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(entry);
+    expect(getAgent).toHaveBeenCalledWith('agent-one');
   });
 });

--- a/web-next/packages/plugin-observatory/src/application/useAgents.ts
+++ b/web-next/packages/plugin-observatory/src/application/useAgents.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { useService } from '@niuulabs/plugin-sdk';
+import type { AgentDirectoryFilters } from '../domain';
+import type { IAgentDirectory } from '../ports';
+
+export function useAgents(filters: AgentDirectoryFilters = {}) {
+  const directory = useService<IAgentDirectory>('observatory.agents');
+  return useQuery({
+    queryKey: ['observatory', 'agents', filters],
+    queryFn: () => directory.listAgents(filters),
+  });
+}
+
+export function useAgent(agentId: string) {
+  const directory = useService<IAgentDirectory>('observatory.agents');
+  return useQuery({
+    queryKey: ['observatory', 'agents', agentId],
+    queryFn: () => directory.getAgent(agentId),
+    enabled: Boolean(agentId),
+  });
+}

--- a/web-next/packages/plugin-observatory/src/domain/agentDirectory.test.ts
+++ b/web-next/packages/plugin-observatory/src/domain/agentDirectory.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentDirectoryEntry, Topology } from './index';
+import { findAgentTopologyNode } from './agentDirectory';
+
+describe('findAgentTopologyNode', () => {
+  it('associates an aggregate directory record with its existing topology node', () => {
+    const topology: Topology = {
+      nodes: [
+        {
+          id: 'runtime:noatun:skuld:skuld:session-a',
+          typeId: 'skuld',
+          label: 'session-a',
+          parentId: null,
+          status: 'healthy',
+        },
+      ],
+      edges: [],
+      timestamp: '2026-07-14T12:00:00Z',
+    };
+    const entry = {
+      topologyNodeId: 'runtime:noatun:skuld:skuld:session-a',
+    } as Pick<AgentDirectoryEntry, 'topologyNodeId'>;
+
+    expect(findAgentTopologyNode(entry, topology)).toBe(topology.nodes[0]);
+  });
+
+  it('returns undefined when the source topology is not loaded', () => {
+    const topology: Topology = { nodes: [], edges: [], timestamp: '' };
+    expect(findAgentTopologyNode({ topologyNodeId: 'missing' }, topology)).toBeUndefined();
+  });
+});

--- a/web-next/packages/plugin-observatory/src/domain/agentDirectory.ts
+++ b/web-next/packages/plugin-observatory/src/domain/agentDirectory.ts
@@ -1,0 +1,91 @@
+import type { Topology, TopologyNode } from './index';
+
+export type AgentKind = 'steward' | 'resident' | 'workflow-session';
+export type AgentDirectorySourceStatus = 'healthy' | 'degraded' | 'failed';
+
+export interface AgentInterface {
+  url: string;
+  protocolBinding: string;
+  protocolVersion: string;
+  tenant: string;
+}
+
+export interface AgentProvenance {
+  sourceAgentId: string;
+  sourceInstanceId: string;
+  clusterId: string;
+  environmentId: string | null;
+  topologyNodeId: string;
+}
+
+export interface AgentDirectoryEntry {
+  id: string;
+  canonicalId: string;
+  sourceAgentId: string;
+  sourceInstanceId: string;
+  clusterId: string;
+  environmentId: string | null;
+  topologyNodeId: string;
+  name: string;
+  description: string;
+  kind: AgentKind;
+  cardUrl: string;
+  cardVersion: string;
+  cardHash: string;
+  signatureVerified: boolean | null;
+  signatureKeyIds: string[];
+  skillIds: string[];
+  tags: string[];
+  defaultInputModes: string[];
+  defaultOutputModes: string[];
+  supportedInterfaces: AgentInterface[];
+  capabilities: Record<string, unknown>;
+  observedStatus: string;
+  activity: string;
+  lastSeen: string;
+  ownerId: string | null;
+  tenantId: string | null;
+  visibility: string;
+  provenance: AgentProvenance[];
+}
+
+export interface AgentDirectoryWarning {
+  sourceInstanceId: string;
+  sourceAgentId: string | null;
+  code: string;
+  message: string;
+}
+
+export interface AgentDirectorySourceHealth {
+  instanceId: string;
+  clusterId: string;
+  status: AgentDirectorySourceStatus;
+  revision: string;
+  message: string;
+}
+
+export interface AgentDirectoryPage {
+  items: AgentDirectoryEntry[];
+  warnings: AgentDirectoryWarning[];
+  sources: AgentDirectorySourceHealth[];
+  partial: boolean;
+  revision: string;
+}
+
+export interface AgentDirectoryFilters {
+  skills?: string[];
+  tags?: string[];
+  kinds?: AgentKind[];
+  statuses?: string[];
+  environmentIds?: string[];
+  clusterIds?: string[];
+  instanceIds?: string[];
+}
+
+/** Resolve an aggregate directory entry back to the topology node it projects. */
+export function findAgentTopologyNode(
+  entry: Pick<AgentDirectoryEntry, 'topologyNodeId'>,
+  topology: Topology,
+): TopologyNode | undefined {
+  return topology.nodes.find((node) => node.id === entry.topologyNodeId);
+}

--- a/web-next/packages/plugin-observatory/src/domain/agentDirectory.ts
+++ b/web-next/packages/plugin-observatory/src/domain/agentDirectory.ts
@@ -34,12 +34,15 @@ export interface AgentDirectoryEntry {
   cardHash: string;
   signatureVerified: boolean | null;
   signatureKeyIds: string[];
+  signatureKeyFingerprints: string[];
   skillIds: string[];
   tags: string[];
   defaultInputModes: string[];
   defaultOutputModes: string[];
   supportedInterfaces: AgentInterface[];
   capabilities: Record<string, unknown>;
+  securitySchemes: Record<string, unknown>;
+  securityRequirements: Array<Record<string, unknown>>;
   observedStatus: string;
   activity: string;
   lastSeen: string;

--- a/web-next/packages/plugin-observatory/src/domain/index.ts
+++ b/web-next/packages/plugin-observatory/src/domain/index.ts
@@ -12,6 +12,19 @@
 // Import the domain bases we extend locally.
 import type { EntityType as BaseEntityType, TypeRegistry } from '@niuulabs/domain';
 
+export type {
+  AgentKind,
+  AgentInterface,
+  AgentProvenance,
+  AgentDirectoryEntry,
+  AgentDirectoryWarning,
+  AgentDirectorySourceHealth,
+  AgentDirectorySourceStatus,
+  AgentDirectoryPage,
+  AgentDirectoryFilters,
+} from './agentDirectory';
+export { findAgentTopologyNode } from './agentDirectory';
+
 // Re-export shared primitives so consumers can import from a single package.
 export type { EntityShape, EntityCategory, TypeRegistry } from '@niuulabs/domain';
 

--- a/web-next/packages/plugin-observatory/src/index.tsx
+++ b/web-next/packages/plugin-observatory/src/index.tsx
@@ -39,8 +39,15 @@ export {
   buildObservatoryRegistryHttpAdapter,
   buildObservatoryTopologySseStream,
   buildObservatoryEventsSseStream,
+  buildObservatoryAgentDirectoryHttpAdapter,
 } from './adapters/http';
-export type { IRegistryRepository, ILiveTopologyStream, IEventStream } from './ports';
+export type {
+  IRegistryRepository,
+  ILiveTopologyStream,
+  IEventStream,
+  IAgentDirectory,
+} from './ports';
+export { useAgent, useAgents } from './application/useAgents';
 export type {
   EntityType,
   EntityTypeField,
@@ -63,7 +70,17 @@ export type {
   Run,
   ObservatoryEventType,
   ObservatoryEvent,
+  AgentKind,
+  AgentInterface,
+  AgentProvenance,
+  AgentDirectoryEntry,
+  AgentDirectoryWarning,
+  AgentDirectorySourceHealth,
+  AgentDirectorySourceStatus,
+  AgentDirectoryPage,
+  AgentDirectoryFilters,
 } from './domain';
+export { findAgentTopologyNode } from './domain';
 
 // Overlay components — re-exported for consumers who want to embed them
 export { EntityDrawer } from './ui/overlays/EntityDrawer';

--- a/web-next/packages/plugin-observatory/src/ports/index.ts
+++ b/web-next/packages/plugin-observatory/src/ports/index.ts
@@ -1,4 +1,17 @@
-import type { Registry, Topology, ObservatoryEvent } from '../domain';
+import type {
+  AgentDirectoryEntry,
+  AgentDirectoryFilters,
+  AgentDirectoryPage,
+  Registry,
+  Topology,
+  ObservatoryEvent,
+} from '../domain';
+
+/** Principal-scoped searchable view of A2A-addressable topology entities. */
+export interface IAgentDirectory {
+  listAgents(filters?: AgentDirectoryFilters): Promise<AgentDirectoryPage>;
+  getAgent(agentId: string): Promise<AgentDirectoryEntry>;
+}
 
 /**
  * Provides read access to the versioned entity-type registry.


### PR DESCRIPTION
## Summary

- add principal-aware local A2A Agent Directory list/detail APIs to Observatory
- aggregate visible registered Observatory directories through Guild with bounded fan-out, source health, collision-safe identities, and verified-card merging
- project explicitly configured Volundr workflow-session Agent Cards onto existing Observatory topology entities
- add the Observatory web data layer, service resolution, operator configuration, Helm wiring, and protocol/security documentation

## Compatibility and security

The implementation uses the official `a2a-sdk` and targets A2A protocol 1.0 semantics. Cards are validated before indexing, including their standard interfaces, capabilities, security schemes/requirements, skills, and modes. Signed-card reconciliation requires successful verification, an identical canonical signature-free card hash, and the same verified public-key fingerprints.

Visibility is enforced before restricted cards are fetched. Environment-scoped entries without authoritative membership metadata fail closed for non-owners. Card caches are partitioned by principal and URL. Caller authentication is sent to Agent Card endpoints only when the operator explicitly trusts the exact origin; public/untrusted card origins receive no caller credentials. Credential-bearing card/key URLs and redirects are rejected, and JWK sets require HTTPS. Guild independently rechecks owner, tenant, and visibility while Environment membership remains enforced by each principal-aware Observatory source.

## Review pass

A post-implementation review simplified the shared Pydantic aliasing and REST filter construction and removed the visibility-only placeholder entry. It also fixed credential forwarding to arbitrary workload-configured card origins, strengthened signed-card identity against copied cards signed by different keys, removed raw aggregate error disclosure, rejected credential-bearing publication URLs, preserved A2A security declarations, and added fail-closed behavior when Environment membership is unavailable.

## Validation

- `ruff check` and `ruff format` passed for the changed backend files
- 347 focused backend tests passed
- 84 focused frontend tests passed
- plugin-observatory and Niuu TypeScript checks passed
- targeted ESLint and Prettier checks passed
- Observatory and Guild Helm lint/template passed
- `git diff --check`

Earlier branch validation also passed the full web suite (5,508 tests with coverage gates), frontend package/application builds, and a repository-wide backend run with 16,924 passing tests. The remaining repository-wide backend failures were pre-existing/injected-environment failures involving runtime authentication/configuration and unavailable tooling, not this change.
