### PR TITLE
fix(observatory): project A2A metadata from HelmReleases

### DIFF
--- a/src/observatory/agent_directory.py
+++ b/src/observatory/agent_directory.py
@@ -190,7 +190,7 @@ class AgentDirectoryService:
         filters: AgentDirectoryFilters,
     ) -> tuple[AgentDirectoryEntry | None, AgentDirectoryWarning | None]:
         metadata = entity.metadata
-        source_agent_id = entity.source_uid or entity.id
+        source_agent_id = _string_metadata(metadata, "sessionId") or entity.source_uid or entity.id
         visibility = _string_metadata(metadata, "visibility", "a2aVisibility")
         if not visibility and "volundr-session" in entity.source_kind:
             visibility = "user"

--- a/src/observatory/entity_discovery.py
+++ b/src/observatory/entity_discovery.py
@@ -709,6 +709,14 @@ class FluxHelmReleaseSessionDiscoveryAdapter:
                 f"runtime:{_slug(self._cluster or 'local')}:"
                 f"{_slug(self._namespace)}:skuld:{_slug(session_id)}"
             )
+            endpoints = {
+                key: str(value)
+                for key, value in {
+                    "a2a": session_values.get("a2aEndpointUrl"),
+                    "a2aCard": session_values.get("a2aCardUrl"),
+                }.items()
+                if value
+            }
             entities.append(
                 DiscoveredEntity(
                     id=entity_id,
@@ -720,10 +728,15 @@ class FluxHelmReleaseSessionDiscoveryAdapter:
                     source_adapter=self.__class__.__name__,
                     source_kind="flux-helmrelease",
                     source_uid=str(metadata.get("uid") or ""),
+                    endpoints=endpoints,
                     metadata={
                         "sessionId": session_id,
                         "model": str(session_values.get("model") or ""),
                         "imageTag": str(image_values.get("tag") or ""),
+                        "ownerId": str(session_values.get("ownerId") or ""),
+                        "tenantId": str(session_values.get("tenantId") or ""),
+                        "visibility": str(session_values.get("a2aVisibility") or "user"),
+                        "environmentId": str(session_values.get("environmentId") or ""),
                         "resources": [
                             {
                                 "kind": "helmrelease",

--- a/src/volundr/adapters/outbound/contributors/core.py
+++ b/src/volundr/adapters/outbound/contributors/core.py
@@ -43,6 +43,26 @@ class CoreSessionContributor(SessionContributor):
             },
         }
 
+        workload = context.workload_config
+        card_url = str(workload.get("a2aCardUrl") or workload.get("a2a_card_url") or "").strip()
+        if card_url:
+            values["session"].update(
+                {
+                    "a2aCardUrl": card_url,
+                    "a2aEndpointUrl": str(
+                        workload.get("a2aEndpointUrl") or workload.get("a2a_endpoint_url") or ""
+                    ).strip(),
+                    "environmentId": str(
+                        workload.get("environmentId") or workload.get("environment_id") or ""
+                    ).strip(),
+                    "a2aVisibility": str(
+                        workload.get("a2aVisibility") or workload.get("a2a_visibility") or "user"
+                    ).strip(),
+                    "ownerId": session.owner_id or "",
+                    "tenantId": session.tenant_id or "",
+                }
+            )
+
         if self._ingress_enabled:
             values["ingress"] = {
                 "host": f"{session.name}.{self._base_domain}",

--- a/tests/test_adapters/test_contributors/test_core.py
+++ b/tests/test_adapters/test_contributors/test_core.py
@@ -37,6 +37,34 @@ class TestCoreSessionContributor:
         result = await c.contribute(session, ctx)
         assert "localServices" not in result.values
 
+    async def test_projects_safe_a2a_directory_metadata(self, session):
+        session.owner_id = "owner-1"
+        session.tenant_id = "tenant-1"
+        result = await CoreSessionContributor(base_domain="example.com").contribute(
+            session,
+            SessionContext(
+                workload_config={
+                    "a2a_card_url": "https://agent.example/card.json",
+                    "a2a_endpoint_url": "https://agent.example/a2a",
+                    "environment_id": "production",
+                    "a2a_visibility": "tenant",
+                    "secret": "must-not-leak",
+                }
+            ),
+        )
+
+        assert result.values["session"] == {
+            "id": str(session.id),
+            "name": "test-session",
+            "model": "claude-sonnet-4-20250514",
+            "a2aCardUrl": "https://agent.example/card.json",
+            "a2aEndpointUrl": "https://agent.example/a2a",
+            "environmentId": "production",
+            "a2aVisibility": "tenant",
+            "ownerId": "owner-1",
+            "tenantId": "tenant-1",
+        }
+
     async def test_pod_spec_is_none(self, session):
         c = CoreSessionContributor(base_domain="example.com")
         result = await c.contribute(session, SessionContext())

--- a/tests/test_observatory/test_entity_discovery.py
+++ b/tests/test_observatory/test_entity_discovery.py
@@ -675,6 +675,12 @@ async def test_flux_helmrelease_session_adapter_projects_ready_dev_sessions(
                         "id": session_id,
                         "name": f"session-{session_id[:4]}",
                         "model": "gpt-5.5",
+                        "a2aCardUrl": "https://agent.example/card.json",
+                        "a2aEndpointUrl": "https://agent.example/a2a",
+                        "environmentId": "production",
+                        "a2aVisibility": "tenant",
+                        "ownerId": "owner-1",
+                        "tenantId": "tenant-1",
                     },
                 }
             },
@@ -734,6 +740,15 @@ async def test_flux_helmrelease_session_adapter_projects_ready_dev_sessions(
     assert [node["label"] for node in session_nodes] == ["session-0025"]
     assert session_nodes[0]["parentId"] == "namespace-noatun-skuld"
     assert session_nodes[0]["model"] == "gpt-5.5"
+    entity = next(item for item in result.entities if item.kind == "skuld")
+    assert entity.endpoints == {
+        "a2a": "https://agent.example/a2a",
+        "a2aCard": "https://agent.example/card.json",
+    }
+    assert entity.metadata["environmentId"] == "production"
+    assert entity.metadata["visibility"] == "tenant"
+    assert entity.metadata["ownerId"] == "owner-1"
+    assert entity.metadata["tenantId"] == "tenant-1"
     assert len(snapshot["edges"]) == 1
     assert snapshot["edges"][0]["relationType"] == "manages"
 

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.helpers.test.ts
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.helpers.test.ts
@@ -14,6 +14,7 @@ import {
   buildPresetRuntimePayload,
   buildResourceConfig,
   buildSessionSource,
+  buildWorkloadConfig,
   buildYamlRuntimeFields,
   definitionToTaskType,
   deriveCliTool,
@@ -52,6 +53,7 @@ function makeForm(overrides: Partial<WizardForm> = {}): WizardForm {
     mountPath: '~/code/niuu',
     sessionName: '',
     personaName: '',
+    workloadConfig: {},
     systemPrompt: '',
     initialPrompt: '',
     trackerQuery: '',
@@ -392,6 +394,22 @@ describe('LaunchWizard helpers', () => {
     expect(hasPresetBackedRuntime(makeForm({ envVars: [{ key: 'A', value: '1' }] }))).toBe(true);
     expect(hasPresetBackedRuntime(makeForm({ setupScripts: ['echo hi'] }))).toBe(true);
     expect(hasPresetBackedRuntime(makeForm({ personaName: 'reviewer' }))).toBe(true);
+    expect(
+      hasPresetBackedRuntime(makeForm({ workloadConfig: { a2aCardUrl: 'https://agent.test' } })),
+    ).toBe(true);
+    expect(
+      buildWorkloadConfig(
+        makeForm({ workloadConfig: { persona: 'old', a2aCardUrl: 'https://agent.test' } }),
+      ),
+    ).toEqual({ a2aCardUrl: 'https://agent.test' });
+    expect(
+      buildWorkloadConfig(
+        makeForm({
+          personaName: 'reviewer',
+          workloadConfig: { persona: 'old', a2aCardUrl: 'https://agent.test' },
+        }),
+      ),
+    ).toEqual({ persona: 'reviewer', a2aCardUrl: 'https://agent.test' });
   });
 
   it('builds preset payload variants for git, local mount, and blank flows', () => {

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizard.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizard.test.tsx
@@ -377,6 +377,9 @@ integration_ids:
   - github-primary
 setup_scripts:
   - pnpm lint
+workload_config:
+  a2aCardUrl: https://anybrowse.dev/.well-known/agent-card.json
+  a2aVisibility: public
 source:
   type: local_mount
   local_path: ~/code/niuu/custom
@@ -409,6 +412,46 @@ source:
     expect(screen.getByText('LOG_LEVEL=debug')).toBeInTheDocument();
     expect(screen.getByText('pnpm lint')).toBeInTheDocument();
     expect(screen.getByText(/Keep answers short\./)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('wizard-back'));
+    await screen.findByTestId('step-runtime-content');
+    fireEvent.click(screen.getByText('show advanced'));
+    fireEvent.click(screen.getByText('edit as yaml'));
+    expect(
+      (screen.getByPlaceholderText('Launch spec YAML') as HTMLTextAreaElement).value,
+    ).toContain('a2aCardUrl: https://anybrowse.dev/.well-known/agent-card.json');
+  });
+
+  it('launches with arbitrary workload config entered as yaml', async () => {
+    const service = createMockVolundrService();
+    const startSession = vi.spyOn(service, 'startSession');
+    wrap(true, vi.fn(), service);
+
+    await advanceToRuntime();
+    fireEvent.click(screen.getByText('show advanced'));
+    fireEvent.click(screen.getByText('edit as yaml'));
+
+    const yamlEditor = screen.getByPlaceholderText('Launch spec YAML') as HTMLTextAreaElement;
+    fireEvent.change(yamlEditor, {
+      target: {
+        value: `${yamlEditor.value}\nworkload_config:\n  a2aCardUrl: https://anybrowse.dev/.well-known/agent-card.json\n  a2aVisibility: public\n`,
+      },
+    });
+    fireEvent.click(screen.getByText('form view'));
+    fireEvent.click(screen.getByTestId('wizard-next'));
+    await screen.findByTestId('step-confirm-content');
+    fireEvent.click(screen.getByTestId('wizard-next'));
+
+    await waitFor(() =>
+      expect(startSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workloadConfig: {
+            a2aCardUrl: 'https://anybrowse.dev/.well-known/agent-card.json',
+            a2aVisibility: 'public',
+          },
+        }),
+      ),
+    );
   });
 
   it('applies a saved preset and can clear back to custom runtime settings', async () => {

--- a/web-next/packages/plugin-volundr/src/ui/LaunchWizardAdvancedRuntime.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/LaunchWizardAdvancedRuntime.tsx
@@ -78,6 +78,7 @@ export function AdvancedRuntimeSection({
       if (parsed.integrationIds) patch.selectedIntegrations = parsed.integrationIds;
       if (parsed.setupScripts) patch.setupScripts = parsed.setupScripts;
       if (parsed.workloadConfig) {
+        patch.workloadConfig = parsed.workloadConfig;
         patch.personaName =
           typeof parsed.workloadConfig.persona === 'string' ? parsed.workloadConfig.persona : '';
       }

--- a/web-next/packages/plugin-volundr/src/ui/launchWizardModel.ts
+++ b/web-next/packages/plugin-volundr/src/ui/launchWizardModel.ts
@@ -9,6 +9,7 @@ import type {
   VolundrLaunchSpec,
   VolundrTarget,
   VolundrWorkspace,
+  WorkloadConfig,
 } from '../models/volundr.model';
 
 export type WizardStep = 'source' | 'runtime' | 'confirm' | 'booting';
@@ -30,6 +31,7 @@ export interface WizardForm {
   mountPath: string;
   sessionName: string;
   personaName: string;
+  workloadConfig: WorkloadConfig;
   systemPrompt: string;
   initialPrompt: string;
   trackerQuery: string;
@@ -511,6 +513,11 @@ export function normalizeEnvVars(
   );
 }
 
+export function buildWorkloadConfig(form: WizardForm): WorkloadConfig {
+  const { persona: _persona, ...workloadConfig } = form.workloadConfig ?? {};
+  return form.personaName ? { ...workloadConfig, persona: form.personaName } : workloadConfig;
+}
+
 export function buildPresetRuntimePayload(
   form: WizardForm,
   presetName?: string,
@@ -550,7 +557,7 @@ export function buildPresetRuntimePayload(
     repos: [],
     setupScripts: form.setupScripts.filter((script) => script.trim()),
     workspaceLayout: {},
-    workloadConfig: form.personaName ? { persona: form.personaName } : {},
+    workloadConfig: buildWorkloadConfig(form),
   };
 }
 
@@ -619,14 +626,14 @@ export function buildYamlRuntimeFields(form: WizardForm) {
             },
     integrationIds: form.selectedIntegrations,
     setupScripts: form.setupScripts.filter((script) => script.trim()),
-    workloadConfig: form.personaName ? { persona: form.personaName } : {},
+    workloadConfig: buildWorkloadConfig(form),
   };
 }
 
 export function hasPresetBackedRuntime(form: WizardForm): boolean {
   return (
     form.mcpServers.length > 0 ||
-    Boolean(form.personaName) ||
+    Object.keys(buildWorkloadConfig(form)).length > 0 ||
     form.envVars.some((entry) => entry.key.trim()) ||
     form.setupScripts.some((script) => script.trim())
   );

--- a/web-next/packages/plugin-volundr/src/ui/useLaunchWizard.ts
+++ b/web-next/packages/plugin-volundr/src/ui/useLaunchWizard.ts
@@ -24,6 +24,7 @@ import {
   buildPresetRuntimePayload,
   buildResourceConfig,
   buildSessionSource,
+  buildWorkloadConfig,
   deriveSessionName,
   definitionToTaskType,
   filterModelsForDefinition,
@@ -85,6 +86,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
     mountPath: '~/code/niuu',
     sessionName: '',
     personaName: '',
+    workloadConfig: {},
     systemPrompt: '',
     initialPrompt: '',
     trackerQuery: '',
@@ -302,6 +304,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
         systemPrompt: preset.systemPrompt ?? '',
         personaName:
           typeof preset.workloadConfig.persona === 'string' ? preset.workloadConfig.persona : '',
+        workloadConfig: { ...preset.workloadConfig },
         selectedCredentials: [...preset.envSecretRefs],
         selectedIntegrations: [...preset.integrationIds],
         mcpServers: [...preset.mcpServers],
@@ -484,7 +487,7 @@ export function useLaunchWizard({ open, initialLaunchSpecRef }: LaunchWizardProp
         resourceConfig: buildResourceConfig(form),
         systemPrompt: form.systemPrompt.trim() || undefined,
         initialPrompt: form.initialPrompt.trim() || undefined,
-        workloadConfig: {},
+        workloadConfig: buildWorkloadConfig(form),
       });
 
       setCreatedSessionId(session.id);


### PR DESCRIPTION
## What changed

- publish the allowlisted Agent Directory fields into each session HelmRelease
- project those fields from Flux-discovered sessions into Observatory
- use the Volundr session ID as the directory source identity

## Why

Kubernetes sites reconcile session truth from Flux HelmReleases. The Agent Directory feature only projected A2A metadata from the Volundr HTTP discovery adapter, so a session with a valid `a2aCardUrl` remained invisible on Flux-discovered sites.

Only the safe card URL, endpoint, environment, visibility, owner, and tenant fields are copied; raw workload configuration is not exposed.

## Validation

- `ruff check` on the changed files
- `pytest -q tests/test_adapters/test_contributors tests/test_observatory` (281 passed)
- live official-SDK resolution of a public Anybrowse Agent Card, including ETag-backed cache population and in-memory reuse
- live rejection of an invalid PaKi card signature
