### PR TITLE
fix(valkyrie): tolerate incomplete feedback payloads

### DIFF
--- a/web-next/packages/plugin-valkyrie/src/domain.test.ts
+++ b/web-next/packages/plugin-valkyrie/src/domain.test.ts
@@ -850,4 +850,8 @@ describe('learning feedback verdicts', () => {
     expect(learningFeedbackVerdictLabel('useful')).toBe('Useful');
     expect(learningFeedbackVerdictLabel('vetoed_by_odin')).toBe('vetoed by odin');
   });
+
+  it('treats an incomplete feedback payload as awaiting', () => {
+    expect(learningFeedbackVerdictLabel(undefined)).toBe('Awaiting');
+  });
 });

--- a/web-next/packages/plugin-valkyrie/src/domain.ts
+++ b/web-next/packages/plugin-valkyrie/src/domain.ts
@@ -657,7 +657,8 @@ export const LEARNING_FEEDBACK_VERDICTS: ReadonlyArray<{
 ];
 
 /** Human label for a feedback verdict ("wrong_tier" → "Wrong tier"). */
-export function learningFeedbackVerdictLabel(verdict: string): string {
+export function learningFeedbackVerdictLabel(verdict?: string): string {
+  if (!verdict) return 'Awaiting';
   const known = LEARNING_FEEDBACK_VERDICTS.find((entry) => entry.verdict === verdict);
   if (known) return known.label;
   return verdict.replace(/_/g, ' ');


### PR DESCRIPTION
## What changed

- Treat a missing learning-feedback verdict as `Awaiting` in the shared formatter.
- Add a regression test for the incomplete live payload shape.

## Why

Live telemetry can briefly expose a truthy feedback object without a `verdict`. The Valkyrie learning card passed that missing value into `.replace()`, crashing the route. The shared guard keeps both cards and the learning drawer renderable while telemetry converges.

## Validation

- `pnpm test` — 5,504 tests passed; coverage gates passed
- `pnpm -F @niuulabs/plugin-valkyrie typecheck`
- `pnpm -F @niuulabs/plugin-valkyrie build`
- Prettier check for the changed files
- Live learned-skill click verified against Yggdrasil
