### PR TITLE
feat(valkyrie): expose learned skill usage telemetry

### DIFF
--- a/charts/ravn/templates/servicemonitor.yaml
+++ b/charts/ravn/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ravn.fullname" . }}
+  labels:
+    {{- include "ravn.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ravn.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | quote }}
+      interval: {{ .Values.serviceMonitor.interval | quote }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | quote }}
+{{- end }}

--- a/charts/ravn/values.yaml
+++ b/charts/ravn/values.yaml
@@ -45,6 +45,12 @@ service:
   targetPort: 8084
   annotations: {}
 
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  path: /api/v1/ravn/metrics
+
 config:
   host: "0.0.0.0"
   port: 8084

--- a/src/ravn/api/__init__.py
+++ b/src/ravn/api/__init__.py
@@ -946,6 +946,7 @@ def create_app(
         create_odin_review_router,
     )
     from ravn.api.valkyrie_history_service import ValkyrieHistoryService  # noqa: PLC0415
+    from ravn.api.valkyrie_metrics import create_valkyrie_metrics_router  # noqa: PLC0415
     from ravn.api.valkyrie_skills import (  # noqa: PLC0415
         ValkyrieSkillMirror,
         create_valkyrie_skills_router,
@@ -1053,6 +1054,7 @@ def create_app(
         )
     )
     app.include_router(create_valkyrie_skills_router(valkyrie_skills))
+    app.include_router(create_valkyrie_metrics_router(valkyrie_skills, valkyrie_history))
     app.include_router(
         create_odin_review_router(
             odin_review_service,

--- a/src/ravn/api/valkyrie_metrics.py
+++ b/src/ravn/api/valkyrie_metrics.py
@@ -1,0 +1,100 @@
+"""Prometheus projection of installed and exercised Valkyrie skills."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Protocol
+
+from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
+
+from ravn.api.valkyrie_skills import ValkyrieSkillMirror
+
+
+class SkillStatsReader(Protocol):
+    async def skill_stats(self, *, environment_id: str = "") -> list[dict[str, Any]]: ...
+
+
+def _escape(value: Any) -> str:
+    return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _labels(**values: Any) -> str:
+    return "{" + ",".join(f'{key}="{_escape(value)}"' for key, value in values.items()) + "}"
+
+
+def _timestamp(value: Any) -> float:
+    if not value:
+        return 0.0
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return 0.0
+
+
+def render_valkyrie_skill_metrics(
+    skills: list[dict[str, Any]],
+    stats: list[dict[str, Any]],
+) -> str:
+    """Render durable skill inventory and judgment-backed use totals."""
+    lines = [
+        "# HELP ravn_valkyrie_skill_installed Installed skill inventory (1 = present).",
+        "# TYPE ravn_valkyrie_skill_installed gauge",
+    ]
+    for skill in skills:
+        labels = _labels(
+            environment_id=skill.get("environmentId", ""),
+            valkyrie_id=skill.get("valkyrieId", ""),
+            skill_name=skill.get("skillName", ""),
+            has_code=str(bool(skill.get("hasCode"))).lower(),
+        )
+        lines.append(f"ravn_valkyrie_skill_installed{labels} 1")
+
+    metric_fields = (
+        ("uses", "uses", "Judgment-backed uses of an installed skill."),
+        ("successes", "successes", "Successful judgment-backed skill uses."),
+        ("failures", "failures", "Failed or regressed judgment-backed skill uses."),
+    )
+    for suffix, field, help_text in metric_fields:
+        name = f"ravn_valkyrie_skill_{suffix}"
+        lines.extend((f"# HELP {name} {help_text}", f"# TYPE {name} gauge"))
+        for stat in stats:
+            labels = _labels(
+                environment_id=stat.get("environmentId", ""),
+                skill_name=stat.get("skillName", ""),
+                capability=stat.get("capability", ""),
+            )
+            lines.append(f"{name}{labels} {int(stat.get(field) or 0)}")
+
+    lines.extend(
+        (
+            "# HELP ravn_valkyrie_skill_last_used_timestamp_seconds "
+            "Unix timestamp of the latest judgment-backed skill use.",
+            "# TYPE ravn_valkyrie_skill_last_used_timestamp_seconds gauge",
+        )
+    )
+    for stat in stats:
+        labels = _labels(
+            environment_id=stat.get("environmentId", ""),
+            skill_name=stat.get("skillName", ""),
+            capability=stat.get("capability", ""),
+        )
+        lines.append(
+            "ravn_valkyrie_skill_last_used_timestamp_seconds"
+            f"{labels} {_timestamp(stat.get('lastUsedAt')):g}"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def create_valkyrie_metrics_router(
+    mirror: ValkyrieSkillMirror,
+    history: SkillStatsReader,
+) -> APIRouter:
+    router = APIRouter(tags=["Ravn Valkyries"])
+
+    @router.get("/api/v1/ravn/metrics", response_class=PlainTextResponse)
+    async def metrics() -> PlainTextResponse:
+        body = render_valkyrie_skill_metrics(mirror.list_all(), await history.skill_stats())
+        return PlainTextResponse(body, media_type="text/plain; version=0.0.4")
+
+    return router

--- a/src/ravn/api/valkyrie_skills.py
+++ b/src/ravn/api/valkyrie_skills.py
@@ -68,10 +68,15 @@ def skill_record_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
     if str(event.get("event_type") or "") not in _SKILL_RECORD_EVENT_TYPES:
         return None
     payload = _payload(event)
+    event_type = str(event.get("event_type") or "")
     skill_name = str(payload.get("skill_name") or "").strip()
     if not skill_name:
         return None
     manifest = payload.get("learned_tool_manifest")
+    observed_at = _timestamp(event)
+    adopted_at = str(payload.get("adopted_at") or "")
+    if not adopted_at and event_type == EVOLUTION_ACTIVATED_EVENT:
+        adopted_at = observed_at
     return {
         "skillName": skill_name,
         "environmentId": canonical_environment_id(payload.get("environment_id")),
@@ -83,7 +88,8 @@ def skill_record_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
         "requirements": [str(entry) for entry in list(payload.get("requirements") or [])],
         "manifest": dict(manifest) if isinstance(manifest, dict) else {},
         "learningId": str(payload.get("learning_id") or ""),
-        "adoptedAt": _timestamp(event),
+        "adoptedAt": adopted_at,
+        "observedAt": observed_at,
     }
 
 
@@ -104,7 +110,11 @@ class ValkyrieSkillMirror:
         record = skill_record_from_event(_event_dict(event))
         if record is None:
             return
-        self._records[(record["environmentId"], record["skillName"])] = record
+        key = (record["environmentId"], record["skillName"])
+        previous = self._records.get(key)
+        if previous is not None and not record["adoptedAt"]:
+            record["adoptedAt"] = previous["adoptedAt"]
+        self._records[key] = record
 
     def list(self, environment_id: str) -> list[dict[str, Any]]:
         """Code-free summaries of the environment's learned skills."""
@@ -121,6 +131,13 @@ class ValkyrieSkillMirror:
     def get(self, environment_id: str, name: str) -> dict[str, Any] | None:
         """Full record — description, markdown, tool code, tests — or None."""
         return self._records.get((canonical_environment_id(environment_id), name))
+
+    def list_all(self) -> list[dict[str, Any]]:
+        """Code-free summaries for metrics across every configured environment."""
+        return sorted(
+            (_summary(record) for record in self._records.values()),
+            key=lambda summary: (summary["environmentId"], summary["skillName"]),
+        )
 
 
 def create_valkyrie_skills_router(mirror: ValkyrieSkillMirror) -> APIRouter:

--- a/src/ravn/valkyrie_evolution/resident_learning.py
+++ b/src/ravn/valkyrie_evolution/resident_learning.py
@@ -417,6 +417,7 @@ class ResidentLearningRuntime:
                     "requirements": list(artifact.requirements),
                     "summary_text": manifest.description,
                     "learning_id": artifact.artifact_id,
+                    "adopted_at": artifact.created_at,
                 }
             )
         return records
@@ -450,6 +451,7 @@ class ResidentLearningRuntime:
                     "requirements": [],
                     "summary_text": str(skill.get("description") or ""),
                     "learning_id": str(metadata.get("skill_id") or ""),
+                    "adopted_at": str(metadata.get("created_at") or skill.get("created_at") or ""),
                 }
             )
         return records
@@ -483,6 +485,7 @@ class ResidentLearningRuntime:
                         "skill_name": record["skill_name"],
                         "status": SKILL_INVENTORY_STATUS_PRESENT,
                         "learning_id": record.get("learning_id") or "",
+                        "adopted_at": record.get("adopted_at") or "",
                         "skill_content": record.get("skill_content") or "",
                         "learned_tool_manifest": dict(record.get("learned_tool_manifest") or {}),
                         "tool_code": record.get("tool_code") or "",

--- a/tests/test_ravn/test_learning_ledger.py
+++ b/tests/test_ravn/test_learning_ledger.py
@@ -536,6 +536,7 @@ async def test_publish_skill_inventory_emits_one_event_per_learned_tool(tmp_path
     assert "def run(input)" in payload["tool_code"]
     assert payload["learned_tool_manifest"]["name"] == SKILL
     assert payload["skill_content"]  # non-empty synthesized skill body
+    assert payload["adopted_at"]
 
 
 async def test_publish_skill_inventory_includes_managed_skills(tmp_path) -> None:
@@ -559,6 +560,7 @@ async def test_publish_skill_inventory_includes_managed_skills(tmp_path) -> None
     drain = next(e for e in events if e.payload["skill_name"] == "valkyrie-drain-node")
     assert drain.payload["skill_content"].startswith("# skill: valkyrie-drain-node")
     assert drain.payload["summary_text"] == "Drain a node safely."
+    assert drain.payload["adopted_at"]
 
 
 async def test_publish_skill_inventory_skips_a_bad_artifact(tmp_path) -> None:

--- a/tests/test_ravn/test_valkyrie_metrics.py
+++ b/tests/test_ravn/test_valkyrie_metrics.py
@@ -1,0 +1,85 @@
+"""Prometheus metrics for installed and exercised Valkyrie skills."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ravn.api.valkyrie_metrics import create_valkyrie_metrics_router, render_valkyrie_skill_metrics
+from ravn.api.valkyrie_skills import ValkyrieSkillMirror
+
+
+def _skills() -> list[dict[str, Any]]:
+    return [
+        {
+            "environmentId": "env-k8s-ymir",
+            "valkyrieId": "valkyrie-ymir-k8s",
+            "skillName": 'Detect "OIDC"',
+            "hasCode": False,
+        }
+    ]
+
+
+def _stats() -> list[dict[str, Any]]:
+    return [
+        {
+            "environmentId": "env-k8s-ymir",
+            "skillName": 'Detect "OIDC"',
+            "capability": "inspect.kubernetes.job",
+            "uses": 3,
+            "successes": 2,
+            "failures": 1,
+            "lastUsedAt": "2026-07-15T10:00:00+00:00",
+        }
+    ]
+
+
+def test_render_metrics_exposes_inventory_and_judgment_backed_usage() -> None:
+    body = render_valkyrie_skill_metrics(_skills(), _stats())
+
+    assert 'skill_name="Detect \\"OIDC\\""' in body
+    assert 'has_code="false"} 1' in body
+    assert "ravn_valkyrie_skill_uses{" in body
+    assert "} 3" in body
+    assert "ravn_valkyrie_skill_successes{" in body
+    assert "ravn_valkyrie_skill_failures{" in body
+    assert "ravn_valkyrie_skill_last_used_timestamp_seconds{" in body
+
+
+def test_render_metrics_handles_absent_usage_without_inventing_it() -> None:
+    body = render_valkyrie_skill_metrics(_skills(), [])
+
+    assert "ravn_valkyrie_skill_installed{" in body
+    assert "ravn_valkyrie_skill_uses{" not in body
+
+
+def test_metrics_endpoint_reads_current_mirror_and_history() -> None:
+    class History:
+        async def skill_stats(self, *, environment_id: str = "") -> list[dict[str, Any]]:
+            assert environment_id == ""
+            return _stats()
+
+    mirror = ValkyrieSkillMirror()
+    mirror._records[("env-k8s-ymir", 'Detect "OIDC"')] = {  # noqa: SLF001
+        **_skills()[0],
+        "description": "OIDC failure pattern",
+        "content": "# Skill",
+        "toolCode": "",
+        "testCode": "",
+        "requirements": [],
+        "manifest": {},
+        "learningId": "learning-1",
+        "adoptedAt": "2026-06-13T00:00:00+00:00",
+        "observedAt": "2026-07-15T10:00:00+00:00",
+    }
+    app = FastAPI()
+    app.include_router(create_valkyrie_metrics_router(mirror, History()))
+
+    response = TestClient(app).get("/api/v1/ravn/metrics")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/plain")
+    assert 'environment_id="env-k8s-ymir"' in response.text
+    assert "ravn_valkyrie_skill_uses{" in response.text

--- a/tests/test_ravn/test_valkyrie_skills.py
+++ b/tests/test_ravn/test_valkyrie_skills.py
@@ -69,6 +69,7 @@ def test_skill_record_canonicalizes_environment_and_carries_artifact() -> None:
         "manifest": {"capability": "inspect.kubernetes.pod.oomkilled"},
         "learningId": "learn-k8s-oom",
         "adoptedAt": "2026-07-03T08:00:00+00:00",
+        "observedAt": "2026-07-03T08:00:00+00:00",
     }
 
 
@@ -103,6 +104,16 @@ def test_skill_record_handles_inventory_event_and_canonicalizes_env() -> None:
     assert record["testCode"] == _TEST_CODE
     assert record["requirements"] == ["kubernetes==29.0.0"]
     assert record["manifest"] == {"capability": "inspect.kubernetes.pod.oomkilled"}
+    assert record["adoptedAt"] == ""
+    assert record["observedAt"] == "2026-07-03T08:00:00+00:00"
+
+
+def test_inventory_uses_durable_adoption_timestamp() -> None:
+    record = skill_record_from_event(_inventory_event(adopted_at="2026-06-13T09:15:00+00:00"))
+
+    assert record is not None
+    assert record["adoptedAt"] == "2026-06-13T09:15:00+00:00"
+    assert record["observedAt"] == "2026-07-03T08:00:00+00:00"
 
 
 def test_skill_record_defaults_for_pre_enrichment_events() -> None:
@@ -128,6 +139,7 @@ def test_skill_record_defaults_for_pre_enrichment_events() -> None:
     assert record["requirements"] == []
     assert record["manifest"] == {}
     assert record["adoptedAt"]
+    assert record["observedAt"]
 
 
 def test_skill_record_formats_datetime_timestamps() -> None:
@@ -187,6 +199,7 @@ async def test_mirror_latest_wins_across_activation_and_inventory() -> None:
     record = mirror.get("env-k8s-valhalla", _SKILL_NAME)
     assert record is not None
     assert record["description"] == "from-inventory"
+    assert record["adoptedAt"] == "2026-07-03T08:00:00+00:00"
 
 
 @pytest.mark.asyncio

--- a/web-next/packages/plugin-valkyrie/src/adapters/mock.ts
+++ b/web-next/packages/plugin-valkyrie/src/adapters/mock.ts
@@ -1746,6 +1746,7 @@ export function createSeedLearnedSkills(): LearnedSkillRecord[] {
         'Read-only probe that inspects OOMKilled pods and correlates them with memory limits.',
       learningId: 'learning-oom-probe',
       adoptedAt: '2026-06-01T09:00:00Z',
+      observedAt: '2026-07-15T10:00:00Z',
       hasCode: true,
       content: SEED_SKILL_CONTENT,
       toolCode: SEED_TOOL_CODE,
@@ -1760,6 +1761,7 @@ export function createSeedLearnedSkills(): LearnedSkillRecord[] {
       description: 'Checks image pull-secret freshness after a registry token rollover.',
       learningId: 'learning-registry-check',
       adoptedAt: '2026-05-28T16:30:00Z',
+      observedAt: '2026-07-15T10:00:00Z',
       hasCode: false,
       content:
         '# skill: registry-token-refresh-check\n\n## Overview\nVerify image pull secrets ' +
@@ -1780,6 +1782,7 @@ function toLearnedSkillSummary(record: LearnedSkillRecord): LearnedSkillSummary 
     description: record.description,
     learningId: record.learningId,
     adoptedAt: record.adoptedAt,
+    observedAt: record.observedAt,
     hasCode: record.hasCode,
   };
 }

--- a/web-next/packages/plugin-valkyrie/src/domain.ts
+++ b/web-next/packages/plugin-valkyrie/src/domain.ts
@@ -144,6 +144,7 @@ export interface LearnedSkillSummary {
   description: string;
   learningId: string;
   adoptedAt: string;
+  observedAt?: string;
   hasCode: boolean;
 }
 

--- a/web-next/packages/plugin-valkyrie/src/ui/SkillViewer.test.tsx
+++ b/web-next/packages/plugin-valkyrie/src/ui/SkillViewer.test.tsx
@@ -12,7 +12,7 @@ describe('SkillViewer', () => {
     expect(screen.queryByRole('dialog')).toBeNull();
   });
 
-  it('shows description, adoption info, requirements, markdown, and both code blocks', async () => {
+  it('shows description, installation info, requirements, markdown, and both code blocks', async () => {
     render(
       <SkillViewer
         environmentId="env-k8s-valhalla"
@@ -25,7 +25,7 @@ describe('SkillViewer', () => {
     const dialog = await screen.findByRole('dialog');
     expect(dialog).toHaveTextContent('k8s_memory_pressure_probe');
     await waitFor(() => expect(dialog).toHaveTextContent('Read-only probe that inspects'));
-    expect(dialog).toHaveTextContent('Adopted');
+    expect(dialog).toHaveTextContent('Installed');
     expect(dialog).toHaveTextContent('valkyrie-valhalla-runa');
     expect(dialog).toHaveTextContent('kubernetes>=29.0.0');
     // skill markdown

--- a/web-next/packages/plugin-valkyrie/src/ui/SkillViewer.tsx
+++ b/web-next/packages/plugin-valkyrie/src/ui/SkillViewer.tsx
@@ -80,8 +80,8 @@ export function SkillViewer({
             <>
               <p className="niuu:leading-6 niuu:text-text-primary">{skill.description}</p>
               <p className="niuu:text-xs niuu:text-text-muted">
-                Adopted {timeAgo(skill.adoptedAt)} ago by {skill.valkyrieId} · learning{' '}
-                {skill.learningId}
+                {skill.adoptedAt ? `Installed ${timeAgo(skill.adoptedAt)} ago` : 'Installed'} by{' '}
+                {skill.valkyrieId} · learning {skill.learningId}
               </p>
               {skill.requirements.length > 0 ? (
                 <div>

--- a/web-next/packages/plugin-valkyrie/src/ui/ValkyrieConsolePage.test.tsx
+++ b/web-next/packages/plugin-valkyrie/src/ui/ValkyrieConsolePage.test.tsx
@@ -570,7 +570,9 @@ describe('ValkyrieConsolePage', () => {
       ).toBeInTheDocument(),
     );
     expect(panel).toHaveTextContent('Read-only probe that inspects');
-    expect(panel).toHaveTextContent('adopted');
+    expect(panel).toHaveTextContent('installed');
+    expect(panel).toHaveTextContent('recorded use');
+    expect(panel).toHaveTextContent('no recorded use');
     expect(within(panel).getByTestId('learned-skill-registry_token_refresh_check')).toBeVisible();
   });
 
@@ -654,7 +656,7 @@ describe('ValkyrieConsolePage', () => {
 
     const panel = screen.getByTestId('valkyrie-learned-skills');
     await waitFor(() =>
-      expect(panel).toHaveTextContent('No learned skills adopted on this environment yet'),
+      expect(panel).toHaveTextContent('No learned skills installed on this environment yet'),
     );
   });
 

--- a/web-next/packages/plugin-valkyrie/src/ui/ValkyrieConsolePage.tsx
+++ b/web-next/packages/plugin-valkyrie/src/ui/ValkyrieConsolePage.tsx
@@ -40,6 +40,7 @@ import {
   type LearningRecord,
   type LearningScope,
   type RealmTrustGrant,
+  type SkillUsageStat,
   type ValkyrieDashboard,
   type ValkyrieEventTelemetry,
   type ValkyrieResident,
@@ -1408,11 +1409,13 @@ function LearnedSkillStrip({
 
 function LearnedSkillsPanel({
   skills,
+  skillStats,
   isLoading,
   error,
   onViewSkill,
 }: {
   skills: LearnedSkillSummary[];
+  skillStats: SkillUsageStat[];
   isLoading: boolean;
   error: unknown;
   onViewSkill: (name: string) => void;
@@ -1441,28 +1444,42 @@ function LearnedSkillsPanel({
             yet. Redeploy the platform API with the current build to enable it.
           </p>
         ) : null}
-        {skills.map((skill) => (
-          <button
-            key={skill.skillName}
-            type="button"
-            data-testid={`learned-skill-${skill.skillName}`}
-            onClick={() => onViewSkill(skill.skillName)}
-            className="niuu:rounded-md niuu:border niuu:border-solid niuu:border-transparent niuu:bg-bg-primary niuu:p-3 niuu:text-left niuu:hover:border-brand/70"
-          >
-            <div className="niuu:flex niuu:items-center niuu:justify-between niuu:gap-3">
-              <span className="niuu:truncate niuu:font-mono niuu:text-sm niuu:text-brand">
-                {skill.skillName}
-              </span>
-              <span className="niuu:shrink-0 niuu:text-[10px] niuu:text-text-muted">
-                adopted {timeAgo(skill.adoptedAt)} ago
-              </span>
-            </div>
-            <p className="niuu:mt-1 niuu:text-xs niuu:text-text-muted">{skill.description}</p>
-          </button>
-        ))}
+        {skills.map((skill) => {
+          const usage = skillStats.find(
+            (row) => row.environmentId === skill.environmentId && row.skillName === skill.skillName,
+          );
+          const inventoryAge = skill.observedAt ? ` · seen ${timeAgo(skill.observedAt)} ago` : '';
+          return (
+            <button
+              key={skill.skillName}
+              type="button"
+              data-testid={`learned-skill-${skill.skillName}`}
+              onClick={() => onViewSkill(skill.skillName)}
+              className="niuu:rounded-md niuu:border niuu:border-solid niuu:border-transparent niuu:bg-bg-primary niuu:p-3 niuu:text-left niuu:hover:border-brand/70"
+            >
+              <div className="niuu:flex niuu:items-center niuu:justify-between niuu:gap-3">
+                <span className="niuu:truncate niuu:font-mono niuu:text-sm niuu:text-brand">
+                  {skill.skillName}
+                </span>
+                <span className="niuu:shrink-0 niuu:text-[10px] niuu:text-text-muted">
+                  {skill.adoptedAt
+                    ? `installed ${timeAgo(skill.adoptedAt)} ago`
+                    : `installed${inventoryAge}`}
+                </span>
+              </div>
+              <p className="niuu:mt-1 niuu:text-xs niuu:text-text-muted">{skill.description}</p>
+              <p className="niuu:mt-2 niuu:text-[10px] niuu:text-text-muted">
+                {skill.hasCode ? 'executable tool' : 'guidance'} ·{' '}
+                {usage
+                  ? `${usage.uses} recorded use${usage.uses === 1 ? '' : 's'} · ${usage.successes} succeeded · ${usage.failures} failed`
+                  : 'no recorded use'}
+              </p>
+            </button>
+          );
+        })}
         {!isLoading && !error && skills.length === 0 ? (
           <p className={`niuu:text-sm ${MUTED}`}>
-            No learned skills adopted on this environment yet.
+            No learned skills installed on this environment yet.
           </p>
         ) : null}
       </div>
@@ -1495,6 +1512,7 @@ function Console({ dashboard }: { dashboard: ValkyrieDashboard }) {
     Boolean(selected),
   );
   const skillsQuery = useValkyrieSkills(selected?.environmentId ?? '', Boolean(selected));
+  const skillStatsQuery = useSkillStats(selected?.environmentId ?? '');
   // A realm's slug IS the environment's raw id; its build grant governs
   // what this resident may build, ahead of the configured autonomy mode.
   const realmSlug = realmSlugForEnvironment(selected?.environmentId ?? '');
@@ -1636,6 +1654,7 @@ function Console({ dashboard }: { dashboard: ValkyrieDashboard }) {
               />
               <LearnedSkillsPanel
                 skills={skills}
+                skillStats={skillStatsQuery.data ?? []}
                 isLoading={skillsQuery.isLoading}
                 error={skillsQuery.error}
                 onViewSkill={setViewedSkillName}


### PR DESCRIPTION
## Summary
- preserve the real installation timestamp across inventory heartbeats and expose inventory observation time separately
- label resident skills as executable tools or guidance and show judgment-backed use/success/failure evidence in the Valkyrie UI
- export Prometheus metrics for installed skills, recorded uses, outcomes, and last-use time
- add an optional Ravn ServiceMonitor using the Envoy-facing service port

## Why
The UI currently labels inventory heartbeat time as adoption time, making old resident knowledge look newly learned. The exact Sigrun OpenBao/OIDC item is installed guidance, but has zero recorded uses. This change makes those states explicit and gives Grafana a truthful metric contract.

## Validation
- 4,284 Ravn tests passed
- 5,512 web tests passed with 92.98% statements / 85.16% branches
- web typecheck passed
- Ruff passed
- Helm lint and ServiceMonitor rendering passed