### PR TITLE
Track Valkyrie skill learning provenance

### DIFF
--- a/src/ravn/api/valkyrie_metrics.py
+++ b/src/ravn/api/valkyrie_metrics.py
@@ -47,6 +47,10 @@ def render_valkyrie_skill_metrics(
             valkyrie_id=skill.get("valkyrieId", ""),
             skill_name=skill.get("skillName", ""),
             has_code=str(bool(skill.get("hasCode"))).lower(),
+            learning_origin=skill.get("learningOrigin", "unknown"),
+            learning_scope=skill.get("learningScope", ""),
+            source_environment_id=skill.get("sourceEnvironmentId", ""),
+            source_valkyrie_id=skill.get("sourceValkyrieId", ""),
         )
         lines.append(f"ravn_valkyrie_skill_installed{labels} 1")
 

--- a/src/ravn/api/valkyrie_skills.py
+++ b/src/ravn/api/valkyrie_skills.py
@@ -77,10 +77,25 @@ def skill_record_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
     adopted_at = str(payload.get("adopted_at") or "")
     if not adopted_at and event_type == EVOLUTION_ACTIVATED_EVENT:
         adopted_at = observed_at
+    valkyrie_id = str(payload.get("valkyrie_id") or "")
+    source_valkyrie_id = str(payload.get("source_valkyrie_id") or "")
+    learning_scope = str(payload.get("learning_scope") or payload.get("scope") or "")
+    learning_source = str(payload.get("learning_source") or "")
+    learning_origin = str(payload.get("learning_origin") or "")
+    if not learning_origin:
+        if source_valkyrie_id:
+            learning_origin = "local" if source_valkyrie_id == valkyrie_id else "peer"
+        elif learning_source.startswith("flock-learning:") or learning_scope in {
+            "flock",
+            "shared",
+        }:
+            learning_origin = "unknown"
+        else:
+            learning_origin = "local"
     return {
         "skillName": skill_name,
         "environmentId": canonical_environment_id(payload.get("environment_id")),
-        "valkyrieId": str(payload.get("valkyrie_id") or ""),
+        "valkyrieId": valkyrie_id,
         "description": str(payload.get("summary_text") or ""),
         "content": str(payload.get("skill_content") or ""),
         "toolCode": str(payload.get("tool_code") or ""),
@@ -88,6 +103,11 @@ def skill_record_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
         "requirements": [str(entry) for entry in list(payload.get("requirements") or [])],
         "manifest": dict(manifest) if isinstance(manifest, dict) else {},
         "learningId": str(payload.get("learning_id") or ""),
+        "learningOrigin": learning_origin,
+        "learningScope": learning_scope,
+        "learningSource": learning_source,
+        "sourceEnvironmentId": str(payload.get("source_environment_id") or ""),
+        "sourceValkyrieId": source_valkyrie_id,
         "adoptedAt": adopted_at,
         "observedAt": observed_at,
     }

--- a/src/ravn/skills/management.py
+++ b/src/ravn/skills/management.py
@@ -31,6 +31,8 @@ class SkillLifecycle:
     pinned: bool = False
     version: int = 1
     source: str = "manual"
+    source_environment_id: str = ""
+    source_valkyrie_id: str = ""
     action_safety_class: str = "read_only"
     created_at: str = ""
     updated_at: str = ""
@@ -66,6 +68,8 @@ class SkillManagementRegistry:
         environment_id: str = "",
         domain: str = "",
         source: str = "manual",
+        source_environment_id: str = "",
+        source_valkyrie_id: str = "",
         action_safety_class: str = "read_only",
     ) -> Skill:
         self._validate_name_content(name, content)
@@ -93,6 +97,8 @@ class SkillManagementRegistry:
             environment_id=environment_id,
             domain=domain,
             source=source,
+            source_environment_id=source_environment_id,
+            source_valkyrie_id=source_valkyrie_id,
             action_safety_class=action_safety_class,
             created_at=skill.created_at.isoformat(),
             updated_at=skill.created_at.isoformat(),
@@ -106,6 +112,9 @@ class SkillManagementRegistry:
         name: str,
         content: str | None = None,
         description: str | None = None,
+        source: str | None = None,
+        source_environment_id: str | None = None,
+        source_valkyrie_id: str | None = None,
     ) -> Skill:
         skill = await self._require_skill(name, include_archived=True)
         updated = Skill(
@@ -128,6 +137,12 @@ class SkillManagementRegistry:
         meta.version += 1
         meta.status = "active"
         meta.archived_at = ""
+        if source is not None:
+            meta.source = source
+        if source_environment_id is not None:
+            meta.source_environment_id = source_environment_id
+        if source_valkyrie_id is not None:
+            meta.source_valkyrie_id = source_valkyrie_id
         meta.updated_at = datetime.now(UTC).isoformat()
         self._save()
         return updated

--- a/src/ravn/valkyrie_evolution/resident_learning.py
+++ b/src/ravn/valkyrie_evolution/resident_learning.py
@@ -418,6 +418,12 @@ class ResidentLearningRuntime:
                     "summary_text": manifest.description,
                     "learning_id": artifact.artifact_id,
                     "adopted_at": artifact.created_at,
+                    "learning_scope": str(artifact.provenance.get("scope") or "environment"),
+                    "learning_source": f"flock-learning:{artifact.artifact_id}",
+                    "source_environment_id": str(
+                        artifact.provenance.get("source_environment_id") or ""
+                    ),
+                    "source_valkyrie_id": str(artifact.provenance.get("source_valkyrie_id") or ""),
                 }
             )
         return records
@@ -452,6 +458,10 @@ class ResidentLearningRuntime:
                     "summary_text": str(skill.get("description") or ""),
                     "learning_id": str(metadata.get("skill_id") or ""),
                     "adopted_at": str(metadata.get("created_at") or skill.get("created_at") or ""),
+                    "learning_scope": str(metadata.get("scope") or "private"),
+                    "learning_source": str(metadata.get("source") or "manual"),
+                    "source_environment_id": str(metadata.get("source_environment_id") or ""),
+                    "source_valkyrie_id": str(metadata.get("source_valkyrie_id") or ""),
                 }
             )
         return records
@@ -474,6 +484,9 @@ class ResidentLearningRuntime:
 
     async def _publish_skill_inventory_record(self, record: dict[str, Any]) -> bool:
         """Publish one inventory event; log and swallow a per-skill failure."""
+        source_valkyrie_id = str(record.get("source_valkyrie_id") or "")
+        learning_source = str(record.get("learning_source") or "")
+        learning_scope = str(record.get("learning_scope") or "")
         try:
             await self._publisher.publish(
                 SleipnirEvent(
@@ -492,6 +505,16 @@ class ResidentLearningRuntime:
                         "test_code": record.get("test_code") or "",
                         "requirements": list(record.get("requirements") or []),
                         "summary_text": record.get("summary_text") or "",
+                        "learning_scope": learning_scope,
+                        "learning_source": learning_source,
+                        "learning_origin": _learning_origin(
+                            source_valkyrie_id=source_valkyrie_id,
+                            resident_valkyrie_id=self.identity.valkyrie_id,
+                            learning_source=learning_source,
+                            learning_scope=learning_scope,
+                        ),
+                        "source_environment_id": record.get("source_environment_id") or "",
+                        "source_valkyrie_id": source_valkyrie_id,
                     },
                     summary=(
                         f"{self.identity.valkyrie_id} has installed skill {record['skill_name']}"
@@ -1585,6 +1608,8 @@ class ResidentLearningRuntime:
                 environment_id=self.identity.environment_id,
                 domain=self.identity.domain or artifact.domain,
                 source=f"flock-learning:{artifact.learning_id}",
+                source_environment_id=artifact.source_environment_id,
+                source_valkyrie_id=artifact.source_valkyrie_id,
                 action_safety_class=_safety_class_from_content(build.skill_content),
             )
         except ValueError:
@@ -1592,6 +1617,9 @@ class ResidentLearningRuntime:
                 name=build.skill_name,
                 content=build.skill_content,
                 description=build.description,
+                source=f"flock-learning:{artifact.learning_id}",
+                source_environment_id=artifact.source_environment_id,
+                source_valkyrie_id=artifact.source_valkyrie_id,
             )
             await self._skills.promote(
                 build.skill_name,
@@ -2063,6 +2091,7 @@ def review_inputs(
             "promotion_id": artifact.promotion_id,
             "source_environment_id": artifact.source_environment_id,
             "source_valkyrie_id": artifact.source_valkyrie_id,
+            "scope": _normalise_scope(artifact.scope),
             "learned_tool_manifest": dict(artifact.learned_tool_manifest),
         },
     )
@@ -2073,6 +2102,21 @@ def _build_artifact_type(artifact: ResidentLearningArtifact) -> str:
     if artifact.artifact_type == "tool_skill":
         return "ravn_skill_tool"
     return artifact.artifact_type
+
+
+def _learning_origin(
+    *,
+    source_valkyrie_id: str,
+    resident_valkyrie_id: str,
+    learning_source: str = "",
+    learning_scope: str = "",
+) -> str:
+    """Classify installed learning without inventing missing historic provenance."""
+    if source_valkyrie_id:
+        return "local" if source_valkyrie_id == resident_valkyrie_id else "peer"
+    if learning_source.startswith("flock-learning:") or learning_scope in {"flock", "shared"}:
+        return "unknown"
+    return "local"
 
 
 def _agent_tool_content(

--- a/tests/test_ravn/test_resident_learning_runtime.py
+++ b/tests/test_ravn/test_resident_learning_runtime.py
@@ -648,6 +648,9 @@ async def test_start_publishes_inventory_snapshot_and_stop_cancels_heartbeat(tmp
         description="Already here.",
         scope="environment",
         environment_id="cluster-b",
+        source="flock-learning:peer-learning-1",
+        source_environment_id="cluster-a",
+        source_valkyrie_id="valkyrie:k8s-a",
     )
     runtime = ResidentLearningRuntime(
         identity=ResidentLearningIdentity(
@@ -668,7 +671,13 @@ async def test_start_publishes_inventory_snapshot_and_stop_cancels_heartbeat(tmp
     await bus.flush()
 
     inventory = [e for e in events if e.event_type == EVOLUTION_SKILL_INVENTORY_EVENT]
-    assert any(e.payload["skill_name"] == "valkyrie-preexisting-skill" for e in inventory)
+    skill_event = next(
+        e for e in inventory if e.payload["skill_name"] == "valkyrie-preexisting-skill"
+    )
+    assert skill_event.payload["learning_origin"] == "peer"
+    assert skill_event.payload["learning_scope"] == "environment"
+    assert skill_event.payload["source_environment_id"] == "cluster-a"
+    assert skill_event.payload["source_valkyrie_id"] == "valkyrie:k8s-a"
     assert runtime._inventory_task is not None
 
     await runtime.stop()

--- a/tests/test_ravn/test_skill_management.py
+++ b/tests/test_ravn/test_skill_management.py
@@ -52,6 +52,9 @@ async def test_create_environment_skill_is_immediately_discoverable(tmp_path: Pa
         environment_id="cluster-a",
         domain="k8s",
         action_safety_class="read_only",
+        source="flock-learning:learning-1",
+        source_environment_id="cluster-source",
+        source_valkyrie_id="valkyrie:k8s-source",
     )
 
     listed = await manager.list_skills()
@@ -61,6 +64,19 @@ async def test_create_environment_skill_is_immediately_discoverable(tmp_path: Pa
     assert runnable.name == "k8s restart probe"
     assert listed[0]["metadata"]["scope"] == "environment"
     assert listed[0]["metadata"]["environment_id"] == "cluster-a"
+    assert listed[0]["metadata"]["source_environment_id"] == "cluster-source"
+    assert listed[0]["metadata"]["source_valkyrie_id"] == "valkyrie:k8s-source"
+
+    await manager.update(
+        name="k8s restart probe",
+        source="flock-learning:learning-2",
+        source_environment_id="cluster-new-source",
+        source_valkyrie_id="valkyrie:k8s-new-source",
+    )
+    shown = await manager.show("k8s restart probe")
+    assert shown["metadata"]["source"] == "flock-learning:learning-2"
+    assert shown["metadata"]["source_environment_id"] == "cluster-new-source"
+    assert shown["metadata"]["source_valkyrie_id"] == "valkyrie:k8s-new-source"
 
 
 async def test_duplicate_active_skill_is_rejected(tmp_path: Path) -> None:

--- a/tests/test_ravn/test_valkyrie_metrics.py
+++ b/tests/test_ravn/test_valkyrie_metrics.py
@@ -18,6 +18,10 @@ def _skills() -> list[dict[str, Any]]:
             "valkyrieId": "valkyrie-ymir-k8s",
             "skillName": 'Detect "OIDC"',
             "hasCode": False,
+            "learningOrigin": "peer",
+            "learningScope": "environment",
+            "sourceEnvironmentId": "env-k8s-valhalla",
+            "sourceValkyrieId": "valkyrie-valhalla-k8s",
         }
     ]
 
@@ -40,7 +44,9 @@ def test_render_metrics_exposes_inventory_and_judgment_backed_usage() -> None:
     body = render_valkyrie_skill_metrics(_skills(), _stats())
 
     assert 'skill_name="Detect \\"OIDC\\""' in body
-    assert 'has_code="false"} 1' in body
+    assert 'has_code="false"' in body
+    assert 'learning_origin="peer"' in body
+    assert 'source_valkyrie_id="valkyrie-valhalla-k8s"' in body
     assert "ravn_valkyrie_skill_uses{" in body
     assert "} 3" in body
     assert "ravn_valkyrie_skill_successes{" in body

--- a/tests/test_ravn/test_valkyrie_skills.py
+++ b/tests/test_ravn/test_valkyrie_skills.py
@@ -31,6 +31,8 @@ def _activation_event(**payload_overrides: Any) -> dict[str, Any]:
         "skill_name": _SKILL_NAME,
         "artifact_type": "tool_skill",
         "scope": "flock",
+        "source_environment_id": "cluster-source",
+        "source_valkyrie_id": "valkyrie:source",
         "review_outcome": "approve",
         "autonomy_mode": "guarded",
         "skill_content": f"# skill: {_SKILL_NAME}\n\nInspect pod events first.\n",
@@ -68,6 +70,11 @@ def test_skill_record_canonicalizes_environment_and_carries_artifact() -> None:
         "requirements": ["kubernetes==29.0.0"],
         "manifest": {"capability": "inspect.kubernetes.pod.oomkilled"},
         "learningId": "learn-k8s-oom",
+        "learningOrigin": "peer",
+        "learningScope": "flock",
+        "learningSource": "",
+        "sourceEnvironmentId": "cluster-source",
+        "sourceValkyrieId": "valkyrie:source",
         "adoptedAt": "2026-07-03T08:00:00+00:00",
         "observedAt": "2026-07-03T08:00:00+00:00",
     }
@@ -106,6 +113,16 @@ def test_skill_record_handles_inventory_event_and_canonicalizes_env() -> None:
     assert record["manifest"] == {"capability": "inspect.kubernetes.pod.oomkilled"}
     assert record["adoptedAt"] == ""
     assert record["observedAt"] == "2026-07-03T08:00:00+00:00"
+    assert record["learningOrigin"] == "peer"
+
+
+def test_skill_record_marks_old_shared_learning_provenance_unknown() -> None:
+    record = skill_record_from_event(
+        _inventory_event(source_environment_id="", source_valkyrie_id="")
+    )
+
+    assert record is not None
+    assert record["learningOrigin"] == "unknown"
 
 
 def test_inventory_uses_durable_adoption_timestamp() -> None:


### PR DESCRIPTION
## What changed

- persist source environment and source Valkyrie IDs with managed learned skills
- retain the same provenance in learned-tool artifacts and periodic resident inventory events
- classify installed skills as `local`, `peer`, or `unknown` without guessing historic ownership
- expose origin, scope, and source IDs on the Ravn skill mirror and Prometheus inventory metric

## Why

The dashboard could distinguish tool-bearing skills from guidance, but the periodic inventory discarded adoption provenance. Operators therefore could not tell whether a resident learned a skill locally or adopted it through shared learning.

Existing flock-learned skills that predate source persistence are reported as `unknown`; future adoptions are attributed to their actual source Valkyrie.

## Validation

- `uv run ruff check` on changed source and tests
- `uv run pytest -q tests/test_ravn/test_skill_management.py tests/test_ravn/test_resident_learning_runtime.py tests/test_ravn/test_valkyrie_skills.py tests/test_ravn/test_valkyrie_metrics.py` (42 passed)
