### PR TITLE
Mark legacy skill provenance unknown

### DIFF
--- a/src/ravn/api/valkyrie_skills.py
+++ b/src/ravn/api/valkyrie_skills.py
@@ -90,6 +90,10 @@ def skill_record_from_event(event: dict[str, Any]) -> dict[str, Any] | None:
             "shared",
         }:
             learning_origin = "unknown"
+        elif event_type == EVOLUTION_SKILL_INVENTORY_EVENT:
+            # Legacy inventory snapshots omitted both learning source and
+            # origin, so calling them local would invent provenance.
+            learning_origin = "unknown"
         else:
             learning_origin = "local"
     return {

--- a/tests/test_ravn/test_valkyrie_skills.py
+++ b/tests/test_ravn/test_valkyrie_skills.py
@@ -125,6 +125,15 @@ def test_skill_record_marks_old_shared_learning_provenance_unknown() -> None:
     assert record["learningOrigin"] == "unknown"
 
 
+def test_skill_record_does_not_invent_origin_for_legacy_inventory() -> None:
+    record = skill_record_from_event(
+        _inventory_event(scope="", source_environment_id="", source_valkyrie_id="")
+    )
+
+    assert record is not None
+    assert record["learningOrigin"] == "unknown"
+
+
 def test_inventory_uses_durable_adoption_timestamp() -> None:
     record = skill_record_from_event(_inventory_event(adopted_at="2026-06-13T09:15:00+00:00"))
 


### PR DESCRIPTION
## What changed

- classify legacy resident inventory events with no origin or source fields as `unknown`
- add a regression test for a pre-provenance inventory payload with no scope

## Why

Live verification showed that old inventory events from residents not yet upgraded were being called `local`. Those events cannot prove local or peer origin, so `unknown` is the only truthful value until the resident republishes the new inventory contract.

## Validation

- `uv run ruff check src/ravn/api/valkyrie_skills.py tests/test_ravn/test_valkyrie_skills.py`
- `uv run pytest -q tests/test_ravn/test_valkyrie_skills.py tests/test_ravn/test_valkyrie_metrics.py` (20 passed)
