### PR TITLE
Add readable Valkyrie skill names

### DIFF
--- a/src/ravn/api/valkyrie_metrics.py
+++ b/src/ravn/api/valkyrie_metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any, Protocol
 
@@ -9,6 +10,24 @@ from fastapi import APIRouter
 from fastapi.responses import PlainTextResponse
 
 from ravn.api.valkyrie_skills import ValkyrieSkillMirror
+
+_DISPLAY_WORDS = {
+    "backofflimitexceeded": "Backoff Limit Exceeded",
+    "clustersecretstore": "ClusterSecretStore",
+    "cnpg": "CNPG",
+    "cronjob": "CronJob",
+    "daemonset": "DaemonSet",
+    "deadlineexceeded": "Deadline Exceeded",
+    "failedattachvolume": "Failed Attach Volume",
+    "failedmount": "Failed Mount",
+    "k8s": "K8s",
+    "oidc": "OIDC",
+    "openbao": "OpenBao",
+    "outofcpu": "OutOfCPU",
+    "pvc": "PVC",
+    "replicaset": "ReplicaSet",
+    "statefulset": "StatefulSet",
+}
 
 
 class SkillStatsReader(Protocol):
@@ -21,6 +40,22 @@ def _escape(value: Any) -> str:
 
 def _labels(**values: Any) -> str:
     return "{" + ",".join(f'{key}="{_escape(value)}"' for key, value in values.items()) + "}"
+
+
+def _display_name(value: Any) -> str:
+    name = str(value).strip()
+    if not name or " " in name:
+        return name
+    name = re.sub(
+        r"^(?:valkyrie[-_.])?inspect[-_.](?:kubernetes|k8s)[-_.]",
+        "",
+        name,
+        flags=re.IGNORECASE,
+    )
+    name = re.sub(r"^valkyrie[-_.]", "", name, flags=re.IGNORECASE)
+    return " ".join(
+        _DISPLAY_WORDS.get(word.lower(), word.capitalize()) for word in re.split(r"[-_.]+", name)
+    )
 
 
 def _timestamp(value: Any) -> float:
@@ -46,6 +81,7 @@ def render_valkyrie_skill_metrics(
             environment_id=skill.get("environmentId", ""),
             valkyrie_id=skill.get("valkyrieId", ""),
             skill_name=skill.get("skillName", ""),
+            skill_display_name=_display_name(skill.get("skillName", "")),
             has_code=str(bool(skill.get("hasCode"))).lower(),
             learning_origin=skill.get("learningOrigin", "unknown"),
             learning_scope=skill.get("learningScope", ""),
@@ -66,6 +102,7 @@ def render_valkyrie_skill_metrics(
             labels = _labels(
                 environment_id=stat.get("environmentId", ""),
                 skill_name=stat.get("skillName", ""),
+                skill_display_name=_display_name(stat.get("skillName", "")),
                 capability=stat.get("capability", ""),
             )
             lines.append(f"{name}{labels} {int(stat.get(field) or 0)}")
@@ -81,6 +118,7 @@ def render_valkyrie_skill_metrics(
         labels = _labels(
             environment_id=stat.get("environmentId", ""),
             skill_name=stat.get("skillName", ""),
+            skill_display_name=_display_name(stat.get("skillName", "")),
             capability=stat.get("capability", ""),
         )
         lines.append(

--- a/tests/test_ravn/test_valkyrie_metrics.py
+++ b/tests/test_ravn/test_valkyrie_metrics.py
@@ -61,6 +61,18 @@ def test_render_metrics_handles_absent_usage_without_inventing_it() -> None:
     assert "ravn_valkyrie_skill_uses{" not in body
 
 
+def test_render_metrics_exposes_readable_names_without_changing_identity() -> None:
+    skill = {
+        **_skills()[0],
+        "skillName": "valkyrie-inspect-kubernetes-pod-failedmount",
+    }
+
+    body = render_valkyrie_skill_metrics([skill], [])
+
+    assert 'skill_name="valkyrie-inspect-kubernetes-pod-failedmount"' in body
+    assert 'skill_display_name="Pod Failed Mount"' in body
+
+
 def test_metrics_endpoint_reads_current_mirror_and_history() -> None:
     class History:
         async def skill_stats(self, *, environment_id: str = "") -> list[dict[str, Any]]:


### PR DESCRIPTION
## What changed

- add a deterministic `skill_display_name` label to installed and usage metrics
- remove redundant `valkyrie-inspect-kubernetes` prefixes from display names
- format slug separators and common platform acronyms without changing canonical `skill_name`

## Why

The Grafana dashboard needs operator-friendly names, but renaming canonical skills would break durable telemetry joins. A separate presentation label keeps identity stable and makes tables and charts readable.

## Validation

- `uv run ruff check src/ravn/api/valkyrie_metrics.py tests/test_ravn/test_valkyrie_metrics.py`
- `uv run pytest -q tests/test_ravn/test_valkyrie_metrics.py` (4 passed)
