### PR TITLE
feat(ravn): expose latest skill outcome

### DIFF
--- a/src/ravn/api/valkyrie_metrics.py
+++ b/src/ravn/api/valkyrie_metrics.py
@@ -29,6 +29,12 @@ _DISPLAY_WORDS = {
     "statefulset": "StatefulSet",
 }
 
+_OUTCOME_DISPLAY = {
+    "using_adopted_learning": "Successful use",
+    "adopted_learning_failed": "Failed",
+    "adopted_learning_regressed": "Regressed",
+}
+
 
 class SkillStatsReader(Protocol):
     async def skill_stats(self, *, environment_id: str = "") -> list[dict[str, Any]]: ...
@@ -65,6 +71,11 @@ def _timestamp(value: Any) -> float:
         return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
     except ValueError:
         return 0.0
+
+
+def _outcome_display(value: Any) -> str:
+    outcome = str(value).strip()
+    return _OUTCOME_DISPLAY.get(outcome, _display_name(outcome))
 
 
 def render_valkyrie_skill_metrics(
@@ -115,11 +126,14 @@ def render_valkyrie_skill_metrics(
         )
     )
     for stat in stats:
+        last_outcome = stat.get("lastOutcome", "")
         labels = _labels(
             environment_id=stat.get("environmentId", ""),
             skill_name=stat.get("skillName", ""),
             skill_display_name=_display_name(stat.get("skillName", "")),
             capability=stat.get("capability", ""),
+            last_outcome=last_outcome,
+            last_outcome_display=_outcome_display(last_outcome),
         )
         lines.append(
             "ravn_valkyrie_skill_last_used_timestamp_seconds"

--- a/tests/test_ravn/test_valkyrie_metrics.py
+++ b/tests/test_ravn/test_valkyrie_metrics.py
@@ -36,6 +36,7 @@ def _stats() -> list[dict[str, Any]]:
             "successes": 2,
             "failures": 1,
             "lastUsedAt": "2026-07-15T10:00:00+00:00",
+            "lastOutcome": "adopted_learning_regressed",
         }
     ]
 
@@ -52,6 +53,8 @@ def test_render_metrics_exposes_inventory_and_judgment_backed_usage() -> None:
     assert "ravn_valkyrie_skill_successes{" in body
     assert "ravn_valkyrie_skill_failures{" in body
     assert "ravn_valkyrie_skill_last_used_timestamp_seconds{" in body
+    assert 'last_outcome="adopted_learning_regressed"' in body
+    assert 'last_outcome_display="Regressed"' in body
 
 
 def test_render_metrics_handles_absent_usage_without_inventing_it() -> None:


### PR DESCRIPTION
## What changed
- expose the canonical latest learned-skill outcome on the existing last-used metric
- add a readable outcome label for Grafana tables

## Why
The inventory tables need a truthful latest outcome column. Lifetime success/failure counters cannot identify the most recent result.

## Validation
- `uv run pytest -q tests/test_ravn/test_valkyrie_metrics.py`
- `uv run ruff check src/ravn/api/valkyrie_metrics.py tests/test_ravn/test_valkyrie_metrics.py`