### PR TITLE
fix(ravn): authorize Ting downstream Forge spawn

### DIFF
--- a/src/ravn/adapters/tool_build/ting_workflow.py
+++ b/src/ravn/adapters/tool_build/ting_workflow.py
@@ -38,10 +38,9 @@ logger = logging.getLogger(__name__)
 _DONE_STATUSES = frozenset({"completed", "complete", "failed", "error", "cancelled"})
 _FAILED_STATUSES = frozenset({"failed", "error", "cancelled"})
 
-#: The one scope this backend's launch endpoint enforces
-#: (ting POST /api/v1/ting/workflows/{id}/launch). Requested at the workload
-#: exchange so the build token is least-privilege.
-TING_BUILD_SCOPE = "ting:workflow:launch"
+#: Scopes required by the Ting launch and its downstream Forge session spawn.
+#: Ting forwards the caller's token to Forge, so both are required end to end.
+TING_BUILD_SCOPES = ("ting:workflow:launch", "forge:session:create")
 
 
 class TingWorkflowToolBuildBackend(ToolBuildBackend):
@@ -73,7 +72,7 @@ class TingWorkflowToolBuildBackend(ToolBuildBackend):
                 workload_token_file=workload_token_file,
                 workload_exchange_url=workload_exchange_url,
                 workload_audiences=workload_audiences,
-                workload_scopes=[TING_BUILD_SCOPE],
+                workload_scopes=list(TING_BUILD_SCOPES),
             )
         )
         self._base_url = base_url.rstrip("/")

--- a/tests/test_ravn/test_tool_build_backends.py
+++ b/tests/test_ravn/test_tool_build_backends.py
@@ -544,6 +544,28 @@ def test_client_from_workload_identity_exchanges_projected_token(tmp_path: Path)
     assert client._headers()["Authorization"] == "Bearer workload-jwt"
 
 
+def test_ting_backend_requests_end_to_end_build_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_client_from_workload_identity(**kwargs: object) -> _FakeHttpClient:
+        captured.update(kwargs)
+        return _FakeHttpClient({})
+
+    monkeypatch.setattr(
+        "ravn.adapters.tool_build.ting_workflow.client_from_workload_identity",
+        fake_client_from_workload_identity,
+    )
+
+    TingWorkflowToolBuildBackend(base_url="https://ting.example", workflow_id="wf-1")
+
+    assert captured["workload_scopes"] == [
+        "ting:workflow:launch",
+        "forge:session:create",
+    ]
+
+
 def test_client_external_token_env_is_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("EXTERNAL_TOOL_BUILD_TOKEN", "external-123")
 


### PR DESCRIPTION
## Summary
- request `ting:workflow:launch` for the workflow launch
- request `forge:session:create` for the Forge session Ting opens with the same build token
- keep the token bounded to the two known end-to-end build scopes

## Live failure
A Valkyrie `build_tool` call reached Ting, but launch failed because Forge returned 403: `Build token is missing the required scope: forge:session:create`.

## Verification
- `uv run --frozen pytest tests/test_ravn/test_tool_build_backends.py -q` (36 passed)
- `uv run --frozen ruff check ...`
- `git diff --check`