### PR TITLE
fix(ravn): match Kubernetes tool capability aliases

### DIFF
--- a/src/ravn/valkyrie_evolution/resident_learning.py
+++ b/src/ravn/valkyrie_evolution/resident_learning.py
@@ -1686,17 +1686,20 @@ class ResidentLearningRuntime:
 
     async def _find_installed_skill_by_capability(self, capability: str) -> Any | None:
         rows = await self._skills.list_skills()
-        marker = f"capability: {capability}"
+        capabilities = [capability]
+        if capability.startswith("inspect.kubernetes."):
+            capabilities.append(capability.replace("inspect.kubernetes.", "inspect.", 1))
+        markers = [f"capability: {candidate}" for candidate in capabilities]
         for row in rows:
             skill = row["skill"]
-            if marker in str(skill.get("content", "")):
+            if any(marker in str(skill.get("content", "")) for marker in markers):
                 return type("RunnableSkill", (), skill)()
 
         # Agent-tool artifacts installed before they were represented in the
         # managed skill registry still need to be discoverable and metered.
         # Register the durable envelope lazily, then use it for this signal.
         for record in self._iter_learned_tool_inventory():
-            if marker not in record["skill_content"]:
+            if not any(marker in record["skill_content"] for marker in markers):
                 continue
             try:
                 skill = await self._skills.create(

--- a/tests/test_ravn/test_valkyrie_tool_runtime.py
+++ b/tests/test_ravn/test_valkyrie_tool_runtime.py
@@ -440,7 +440,7 @@ async def test_peer_adoption_reviews_canaries_and_installs_agent_tool(tmp_path) 
 
 async def test_existing_agent_tool_is_registered_and_used_on_matching_signal(tmp_path) -> None:
     peer = _runtime(tmp_path, "k8s-existing-agent-tool")
-    capability = "inspect.kubernetes.pod.oomkilled"
+    capability = "inspect.pod.oomkilled"
     learned = LearnedToolArtifact(
         artifact_id=f"learned-tool:{capability}:v1",
         manifest=LearnedToolManifest(


### PR DESCRIPTION
A generated Kubernetes tool may omit the provider segment in its manifest name (`inspect.configmap.backoff`) while normalized resident signals include it (`inspect.kubernetes.configmap.backoff`). Match the provider-qualified form to that constrained alias so the adopted artifact can be reused without renaming it.

Proof:
- 89 focused resident/tool/signal runtime tests pass
- Ruff passes
- diff check passes