### PR TITLE
fix(ting): stop workflow canvas hijacking scroll

### DIFF
--- a/web-next/packages/plugin-ting/src/ui/WorkflowBuilder/GraphView.test.tsx
+++ b/web-next/packages/plugin-ting/src/ui/WorkflowBuilder/GraphView.test.tsx
@@ -401,8 +401,11 @@ describe('GraphView', () => {
       value: () => ({ left: 0, top: 0, width: 800, height: 600 }),
     });
 
-    fireEvent.wheel(svg, { deltaY: -100 });
     const graphLayer = svg.querySelector('g');
+    fireEvent.wheel(svg, { deltaY: -100 });
+    expect(graphLayer).toHaveAttribute('transform', 'translate(0,0) scale(1)');
+
+    fireEvent.wheel(svg, { deltaY: -100, ctrlKey: true });
     expect(graphLayer).toHaveAttribute('transform', 'translate(0,0) scale(1.1)');
 
     fireEvent.mouseDown(svg, { clientX: 10, clientY: 20 });

--- a/web-next/packages/plugin-ting/src/ui/WorkflowBuilder/GraphView.tsx
+++ b/web-next/packages/plugin-ting/src/ui/WorkflowBuilder/GraphView.tsx
@@ -1116,6 +1116,7 @@ export function GraphView({
     const el = svgRef.current;
     if (!el) return;
     function handleWheel(e: WheelEvent) {
+      if (!e.metaKey && !e.ctrlKey) return;
       e.preventDefault();
       setTransform((prev) => {
         const delta = e.deltaY < 0 ? 1.1 : 0.9;


### PR DESCRIPTION
## Summary
- allow ordinary wheel/trackpad scrolling over the Ting workflow canvas
- require Ctrl or Command for canvas zoom, matching the visible help text
- cover both ordinary scrolling and modifier-assisted zoom

## Verification
- `pnpm test` (5,515 tests; 93% statements / 85.21% branches)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`