### PR TITLE
chore: sync main into dev before release

### DIFF
--- a/containers/skuld/npm-tools/package-lock.json
+++ b/containers/skuld/npm-tools/package-lock.json
@@ -6,15 +6,15 @@
     "": {
       "name": "skuld-cli-tools",
       "dependencies": {
-        "@anthropic-ai/claude-code": "2.1.131",
+        "@anthropic-ai/claude-code": "2.1.163",
         "@openai/codex": "0.139.0",
         "opencode-ai": "1.14.29"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.131.tgz",
-      "integrity": "sha512-FYzfx3D4zRLo0CnldnCBiR1jPzIEDOQFBx7nZ1DhpJPEE0oKQkcKZ8LqgbhcQyX93djDThfqcBcoT3UJ0RuWIg==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.163.tgz",
+      "integrity": "sha512-aK+hmLIaxp6v2M/fifhrCdYJ+kuQuGOl4Iok+AwRijeZl/HMn55rkwF6lEIq1Ny0xNCp2UKiZcmCegyoMumoWg==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN README.md",
       "bin": {
@@ -24,20 +24,20 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-code-darwin-arm64": "2.1.131",
-        "@anthropic-ai/claude-code-darwin-x64": "2.1.131",
-        "@anthropic-ai/claude-code-linux-arm64": "2.1.131",
-        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.131",
-        "@anthropic-ai/claude-code-linux-x64": "2.1.131",
-        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.131",
-        "@anthropic-ai/claude-code-win32-arm64": "2.1.131",
-        "@anthropic-ai/claude-code-win32-x64": "2.1.131"
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.163",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.163",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.163",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.163",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.163",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.163",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.163",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.163"
       }
     },
     "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.131.tgz",
-      "integrity": "sha512-CAxN9D+xp4AOpDTC3GldPo3C6hrvEXkGjmDGotVHAnP3dEgLKznJL/9fp5tbiMD12J1cVet8mVYmxsZ5IK+ZWQ==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.163.tgz",
+      "integrity": "sha512-SZPoYNIjj8Osgde5m2UtJcUlKPqnqajc1uwzBk87qU+cqpMKg2KNBMN5rGUoHCX81fNs6jdWJuKuJgCB6Eqazw==",
       "cpu": [
         "arm64"
       ],
@@ -48,9 +48,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-darwin-x64": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.131.tgz",
-      "integrity": "sha512-TdlkDKIzXrn00Ic63XvHxScQZvjgDfaOxLrFkO4YvEYCJdsVLT4XcUZngPZRRZfgFNruKTDD17G8fW9rkqLPag==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.163.tgz",
+      "integrity": "sha512-MTy4TO8LUqnRxGXoIE3Jk5bYgiRqvJlXSIZxAO2m69Is9HK+mLevzU9Rr1ZKy+49ExJCNp8392G6+LEUP5+hdQ==",
       "cpu": [
         "x64"
       ],
@@ -61,11 +61,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.131.tgz",
-      "integrity": "sha512-9ZLYrd2gQZsW9/6QVm6QD2SE/9/hGMW9rQXTsmIJgwhjGjctU5/GkW40QYsGMg1ANM9x+SDmHW5MRJpRi1ibVg==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.163.tgz",
+      "integrity": "sha512-DLKiXFVTIuUfTnmeGoOEvOTwv5z0xi0yY1wSigubX3Q0jP12RgL3IBYOAtb4ytM3voAi4n/NhixvTwOWly2EEw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -74,11 +77,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.131.tgz",
-      "integrity": "sha512-oip6BkHHH7pDB/qPA38z4bXS8FgFgmfZnwRTGABWsVGGNglNY0APnxzBXJh/OtDgDrmnLMxpXXii2qbl5Nefmg==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.163.tgz",
+      "integrity": "sha512-Quu85w7PxNYxxikc0tMQvT5EQH4debsci8EuTx97AYiuptmHmKgi5EkwQxwNo8YXS5IttwUU9QLc41FA6JEa8A==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -87,11 +93,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.131.tgz",
-      "integrity": "sha512-RN1Ho8c37kFymtvmjsT2Vot4MAmoWMAP9pDhBWYbDB2NRJFVvd02tV4UHK86l49U9F/Qo60vSSOnfniYugxMAA==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.163.tgz",
+      "integrity": "sha512-K0CAuLxVqLhenPzi56Ysx157GHDXvcSyegyEFlr3jKdmjIClBynQZlRdZdePeQWBdmz5KrnzJ/lT5zzSH5GKUQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -100,11 +109,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.131.tgz",
-      "integrity": "sha512-GqAeOrQmbKh+gJ+y5ypWf0HLbM9eqkQB1qfHYktEb8bIqKbFm55Icj9PDJzaTXt27N9GN5jfryxWKAqcFekuKQ==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.163.tgz",
+      "integrity": "sha512-DAEhRqBlUkURnOiVGQWIu3Mje466l9dOSQn8TVZx3HdZwUtb0JiRul4rIGWuV10APnVpKteUHdw3WvBASkKluQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -113,9 +125,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-arm64": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.131.tgz",
-      "integrity": "sha512-86DM5Rm+wjdLpSn1qSXOoWBHSDJoGSyuPtAtKSjaecc553ddDjetuUpqHgTivihIsoLFthi8SYoKFUO/tjONpQ==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.163.tgz",
+      "integrity": "sha512-wqFdygVVhpl3SZ9OlWx41+sU9G45FeSxHqXS9vKoHGk+h7n8SdNLipiXcqslhTBIilcKslQpq9WxlU8o8gyjeQ==",
       "cpu": [
         "arm64"
       ],
@@ -126,9 +138,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-code-win32-x64": {
-      "version": "2.1.131",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.131.tgz",
-      "integrity": "sha512-78qRdNl2EiDKR2j5lNtXXePyvilxl838yHJq7rz3hOzpkJJ3VflPy7DUlRyI3g0/KpfAVRmE5zRTmp1Sl/bKMA==",
+      "version": "2.1.163",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.163.tgz",
+      "integrity": "sha512-uTd+gFmqTQ9lVsA9dsVBYKeIKj6lB5zVNWWKUqV9RdDavDFXTgbbPw7LffEfQcbkiAU4UK+CQFuRRqXjJqsCDQ==",
       "cpu": [
         "x64"
       ],

--- a/containers/skuld/npm-tools/package.json
+++ b/containers/skuld/npm-tools/package.json
@@ -2,7 +2,7 @@
   "name": "skuld-cli-tools",
   "private": true,
   "dependencies": {
-    "@anthropic-ai/claude-code": "2.1.131",
+    "@anthropic-ai/claude-code": "2.1.163",
     "@openai/codex": "0.139.0",
     "opencode-ai": "1.14.29"
   }


### PR DESCRIPTION
## Summary

- merge the two main-only dependency commits back into `dev`
- preserve Anthropic CLI `2.1.163` from `main`
- preserve Codex CLI `0.144.1` from `dev`
- make the subsequent `dev` → `main` release PR conflict-free

## Verification

- `npm install --package-lock-only --ignore-scripts`
- `npm ci --ignore-scripts`
- JSON parse validation for `package.json` and `package-lock.json`
- npm audit: 0 vulnerabilities