### PR TITLE
fix: address release CodeQL findings

### DIFF
--- a/src/volundr/adapters/inbound/rest_openshell_credentials.py
+++ b/src/volundr/adapters/inbound/rest_openshell_credentials.py
@@ -36,8 +36,8 @@ def create_openshell_credentials_router(
                 audience=value("audience"),
                 scope=value("scope"),
             )
-        except (UnicodeDecodeError, ValueError) as exc:
-            return _oauth_error("invalid_grant", str(exc), 401)
+        except (UnicodeDecodeError, ValueError):
+            return _oauth_error("invalid_grant", "credential grant rejected", 401)
 
         return JSONResponse(
             {

--- a/tests/test_adapters/test_rest_openshell_credentials.py
+++ b/tests/test_adapters/test_rest_openshell_credentials.py
@@ -59,5 +59,8 @@ def test_token_endpoint_returns_oauth_error_without_secret_details() -> None:
     )
 
     assert response.status_code == 401
-    assert response.json()["error"] == "invalid_grant"
+    assert response.json() == {
+        "error": "invalid_grant",
+        "error_description": "credential grant rejected",
+    }
     assert response.headers["cache-control"] == "no-store"

--- a/web-next/packages/plugin-valkyrie/src/domain.ts
+++ b/web-next/packages/plugin-valkyrie/src/domain.ts
@@ -227,7 +227,7 @@ export function decisionNeedsApproval(
   return decisionHasRealAction(decision);
 }
 
-const REDUNDANT_PREFIX = /^valkyrie[\s:]+\S+\s+in\s+\S+\s+/i;
+const REDUNDANT_PREFIX = /^valkyrie(?:\s+|:\s*)\S+\s+in\s+\S+\s+/i;
 
 /**
  * The row headline: the record's own `summary` sentence, stripped of any


### PR DESCRIPTION
## What changed

- make Valkyrie prefix matching linear by removing overlapping regex repetitions
- return a stable OAuth error description instead of broker exception details
- strengthen the credential endpoint regression assertion

## Root cause

The release comparison exposed an overlapping quantified regex and a trust-boundary response that serialized `ValueError` messages directly.

## Verification

- `pnpm exec vitest run packages/plugin-valkyrie/src/domain.test.ts` — 88 passed
- `pnpm --filter @niuulabs/plugin-valkyrie typecheck`
- `uv run pytest tests/test_adapters/test_rest_openshell_credentials.py -q` — 2 passed
- Ruff lint and format checks
- `git diff --check`