### PR TITLE
test: address release review feedback

### DIFF
--- a/tests/test_adapters/test_device_tokens.py
+++ b/tests/test_adapters/test_device_tokens.py
@@ -69,12 +69,14 @@ async def test_list_for_owner_returns_devices(repository, mock_pool, device_row)
 
 async def test_delete_returns_true_when_removed(repository, mock_pool):
     mock_pool.execute.return_value = "DELETE 1"
-    assert await repository.delete("user-1", "tok") is True
+    deleted = await repository.delete("user-1", "tok")
+    assert deleted is True
 
 
 async def test_delete_returns_false_when_absent(repository, mock_pool):
     mock_pool.execute.return_value = "DELETE 0"
-    assert await repository.delete("user-1", "tok") is False
+    deleted = await repository.delete("user-1", "tok")
+    assert deleted is False
 
 
 async def test_row_to_device_naive_datetime(repository, device_row):

--- a/tests/test_adapters/test_flux.py
+++ b/tests/test_adapters/test_flux.py
@@ -1090,7 +1090,8 @@ class TestFluxResidentRuntimeController:
             await pod_manager.suspend(runtime)
             await pod_manager.resume(runtime)
             await pod_manager.restart(runtime, _resident_profile())
-            assert await pod_manager.delete(runtime)
+            deleted = await pod_manager.delete(runtime)
+            assert deleted
 
         release_name = f"resident-{runtime.id}"
         assert patch_release.await_args_list[0].args == (

--- a/tests/test_adapters/test_local_resident_runtime.py
+++ b/tests/test_adapters/test_local_resident_runtime.py
@@ -202,7 +202,8 @@ async def test_local_resident_lifecycle_uses_existing_runtime_contract(
     assert target is not None
     assert target.connect_port == 49152
 
-    assert await controller.delete(runtime) is True
+    deleted = await controller.delete(runtime)
+    assert deleted is True
     assert str(runtime.id) not in registry.ports
     assert not (tmp_path / str(runtime.id)).exists()
     await controller.close()
@@ -400,7 +401,8 @@ async def test_local_lifecycle_handles_nonrunning_and_missing_containers(
     assert suspended.observed_state is ResidentObservedState.SUSPENDED
 
     container.remove(force=True)
-    assert await controller.delete(runtime) is False
+    deleted = await controller.delete(runtime)
+    assert deleted is False
     with pytest.raises(RuntimeError, match="does not exist"):
         await controller.restart(runtime, profile)
 

--- a/tests/test_adapters/test_openshell_gateway.py
+++ b/tests/test_adapters/test_openshell_gateway.py
@@ -943,7 +943,8 @@ async def test_hermes_rollback_and_delete_cleanup_machine_credential(
     client.deleted.clear()
     client.created = {"providers": ()}
     store.values[HERMES_CREDENTIAL_NAME] = {"api_key": "delete-me"}
-    assert await manager.delete(runtime)
+    deleted = await manager.delete(runtime)
+    assert deleted
     assert store.deletes == [
         credential_key,
         credential_key,
@@ -1325,7 +1326,8 @@ async def test_resident_delete_removes_service_sandbox_and_provider_grants(
     monkeypatch.setattr(adapter.asyncio, "sleep", AsyncMock())
     manager = adapter.OpenShellGatewayPodManager(client=client)
 
-    assert await manager.delete(runtime)
+    deleted = await manager.delete(runtime)
+    assert deleted
     assert client.deleted_services == [
         {"sandbox_name": f"resident-{runtime.id.hex[:19]}", "service": "skuld"}
     ]

--- a/tests/test_adapters/test_postgres_resident_runtimes.py
+++ b/tests/test_adapters/test_postgres_resident_runtimes.py
@@ -128,8 +128,10 @@ async def test_missing_get_and_delete_result() -> None:
     runtime_id = uuid4()
 
     assert await repository.get(runtime_id) is None
-    assert await repository.delete(runtime_id)
-    assert not await repository.delete(runtime_id)
+    deleted = await repository.delete(runtime_id)
+    deleted_again = await repository.delete(runtime_id)
+    assert deleted
+    assert not deleted_again
 
 
 async def test_reconciliation_list_excludes_deleted_intent() -> None:

--- a/tests/test_domain/test_resident_runtime.py
+++ b/tests/test_domain/test_resident_runtime.py
@@ -639,7 +639,8 @@ async def test_lifecycle_observation_and_delete_use_one_record(runtime_service) 
     assert resumed.desired_state is ResidentDesiredState.RUNNING
     assert observed.observed_state is ResidentObservedState.ACTIVE
     assert observed.backend_ref["kind"] == "Sandbox"
-    assert await service.delete(principal, runtime.id)
+    deleted = await service.delete(principal, runtime.id)
+    assert deleted
     assert runtime.id not in repository.items
 
 

--- a/web-next/packages/plugin-ting/src/ui/researchCampaignModel.test.ts
+++ b/web-next/packages/plugin-ting/src/ui/researchCampaignModel.test.ts
@@ -107,7 +107,8 @@ describe('research campaign model', () => {
   it('handles drawer state without a browser global', () => {
     vi.stubGlobal('window', undefined);
     expect(readDrawerState()).toEqual({ open: false, tab: 'files' });
-    expect(writeDrawerState({ open: true, tab: 'files', file: 'brief.md' })).toBeUndefined();
+    writeDrawerState({ open: true, tab: 'files', file: 'brief.md' });
+    expect(readDrawerState()).toEqual({ open: false, tab: 'files' });
   });
 
   it('formats clocks, elapsed time, and word counts defensively', () => {


### PR DESCRIPTION
## What changed

- execute async delete calls before asserting their results
- verify the returnless Ting drawer writer through observable drawer state

## Why

This addresses every unresolved code-quality thread on release PR #855. Calls inside Python `assert` statements can disappear under optimized execution, and a `void` TypeScript function should be tested through its behavior rather than its return value.

## Verification

- affected Python test files: 174 passed
- Ting research campaign model: 12 passed
- Ruff lint and format checks
- `@niuulabs/plugin-ting` typecheck
- `git diff --check`