### PR TITLE
fix(security): confine warden paths and sanitize logs

### DIFF
--- a/src/mimir/adapters/markdown.py
+++ b/src/mimir/adapters/markdown.py
@@ -76,6 +76,11 @@ from niuu.ports.search import SearchPort
 
 logger = logging.getLogger(__name__)
 
+
+def _sanitize_log(value: object) -> str:
+    return str(value).replace("\n", "\\n").replace("\r", "\\r")
+
+
 # Maximum characters per search chunk (~500 tokens).
 _CHUNK_MAX_CHARS = 2000
 _SEARCH_RESULT_LIMIT = 20
@@ -678,7 +683,7 @@ class MarkdownMimirAdapter(MimirPort):
         else:
             self._update_index_entry(path, content)
 
-        logger.info("mimir: upserted page %s (new=%s)", path, is_new)
+        logger.info("mimir: upserted page %s (new=%s)", _sanitize_log(path), is_new)
 
         # NIU-582: emit mimir.page.written to Sleipnir catalog (best-effort)
         if self._sleipnir_publisher is not None and _catalog_page_written is not None:

--- a/src/ravn/adapters/mimir/composite.py
+++ b/src/ravn/adapters/mimir/composite.py
@@ -56,6 +56,10 @@ from ravn.domain.mimir import MimirMount, WriteRouting
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_log(value: object) -> str:
+    return str(value).replace("\n", "\\n").replace("\r", "\\r")
+
+
 class CompositeMimirAdapter(MimirPort):
     """Fan-out across multiple MimirPort instances with configurable routing.
 
@@ -322,9 +326,9 @@ class CompositeMimirAdapter(MimirPort):
             mount = self._mount_map.get(name)
             if mount is None:
                 logger.warning(
-                    "composite mimir: write routing named unknown mount %r for path %r",
-                    name,
-                    path,
+                    "composite mimir: write routing named unknown mount %s for path %s",
+                    _sanitize_log(name),
+                    _sanitize_log(path),
                 )
                 continue
             try:
@@ -406,6 +410,14 @@ class CompositeMimirAdapter(MimirPort):
                 continue
             try:
                 await mount.port.upsert_page(path, content, meta=meta)
-                logger.debug("composite mimir: wrote %r to mount %r", path, name)
+                logger.debug(
+                    "composite mimir: wrote %s to mount %s",
+                    _sanitize_log(path),
+                    _sanitize_log(name),
+                )
             except Exception as exc:
-                logger.warning("composite mimir: upsert_page failed on %r: %s", name, exc)
+                logger.warning(
+                    "composite mimir: upsert_page failed on %s: %s",
+                    _sanitize_log(name),
+                    _sanitize_log(exc),
+                )

--- a/src/ravn/api/__init__.py
+++ b/src/ravn/api/__init__.py
@@ -215,6 +215,23 @@ def create_app(
             for offset, line in enumerate(lines[start:])
         ]
 
+    def read_confined_log_entries(
+        warden_dir: Path,
+        configured_path: str,
+        *,
+        default_name: str,
+        source: str,
+        limit: int,
+    ) -> list[WardenLogEntry]:
+        root = warden_dir.expanduser().resolve()
+        candidate = Path(configured_path).expanduser() if configured_path else root / default_name
+        if not candidate.is_absolute():
+            candidate = root / candidate
+        candidate = candidate.resolve()
+        if not candidate.is_relative_to(root):
+            return []
+        return read_log_entries(candidate, source=source, limit=limit)
+
     def merge_log_entries(*groups: list[WardenLogEntry], limit: int) -> list[WardenLogEntry]:
         merged = [entry for group in groups for entry in group]
         merged.sort(key=lambda entry: (_entry_sort_timestamp(entry.timestamp), entry.id))
@@ -603,15 +620,18 @@ def create_app(
 
         normalized_stream = stream.strip().lower()
         limit = max(1, min(limit, 1000))
-        default_stdout = store.warden_dir(warden_id) / "warden.log"
-        default_stderr = store.warden_dir(warden_id) / "warden.error.log"
-        stdout_entries = read_log_entries(
-            Path(warden.supervisor.stdout_log or default_stdout),
+        warden_dir = store.warden_dir(warden_id)
+        stdout_entries = read_confined_log_entries(
+            warden_dir,
+            warden.supervisor.stdout_log,
+            default_name="warden.log",
             source="stdout",
             limit=limit,
         )
-        stderr_entries = read_log_entries(
-            Path(warden.supervisor.stderr_log or default_stderr),
+        stderr_entries = read_confined_log_entries(
+            warden_dir,
+            warden.supervisor.stderr_log,
+            default_name="warden.error.log",
             source="stderr",
             limit=limit,
         )
@@ -642,15 +662,18 @@ def create_app(
                 detail="Warden not found",
             )
         limit = max(1, min(limit, 1000))
-        default_stdout = store.warden_dir(warden_id) / "warden.log"
-        stdout_entries = read_log_entries(
-            Path(warden.supervisor.stdout_log or default_stdout),
+        warden_dir = store.warden_dir(warden_id)
+        stdout_entries = read_confined_log_entries(
+            warden_dir,
+            warden.supervisor.stdout_log,
+            default_name="warden.log",
             source="stdout",
             limit=limit,
         )
-        default_stderr = store.warden_dir(warden_id) / "warden.error.log"
-        stderr_entries = read_log_entries(
-            Path(warden.supervisor.stderr_log or default_stderr),
+        stderr_entries = read_confined_log_entries(
+            warden_dir,
+            warden.supervisor.stderr_log,
+            default_name="warden.error.log",
             source="stderr",
             limit=limit,
         )

--- a/src/ravn/warden/artifacts.py
+++ b/src/ravn/warden/artifacts.py
@@ -17,6 +17,15 @@ from niuu.domain.model_runtime import (
 from ravn.warden.models import WardenSpec
 
 
+def confined_path(root: Path, *parts: str) -> Path:
+    """Return a resolved child path that cannot escape *root*."""
+    resolved_root = root.expanduser().resolve()
+    candidate = resolved_root.joinpath(*parts).resolve()
+    if candidate == resolved_root or not candidate.is_relative_to(resolved_root):
+        raise ValueError("warden path must remain within its configured root")
+    return candidate
+
+
 def service_label(warden_id: str) -> str:
     """Return the canonical supervisor label for one warden."""
     return f"dev.niuu.ravn.warden.{warden_id}"
@@ -24,17 +33,17 @@ def service_label(warden_id: str) -> str:
 
 def runtime_config_path(warden_dir: Path) -> Path:
     """Return the generated runtime config path for one warden."""
-    return warden_dir / "config.yaml"
+    return confined_path(warden_dir, "config.yaml")
 
 
 def log_path(warden_dir: Path) -> Path:
     """Return the stdout log path for one warden."""
-    return warden_dir / "warden.log"
+    return confined_path(warden_dir, "warden.log")
 
 
 def error_log_path(warden_dir: Path) -> Path:
     """Return the stderr log path for one warden."""
-    return warden_dir / "warden.error.log"
+    return confined_path(warden_dir, "warden.error.log")
 
 
 def local_python_executable() -> str:
@@ -139,7 +148,11 @@ def runtime_config_payload(
     if not write_mounts and read_mounts:
         write_mounts = [read_mounts[0]]
     all_mounts = list(dict.fromkeys([*read_mounts, *write_mounts]))
-    state_root = (warden_dir or (Path.home() / ".ravn" / "wardens" / spec.id)).expanduser()
+    state_root = (
+        warden_dir.expanduser().resolve()
+        if warden_dir is not None
+        else confined_path(Path.home() / ".ravn" / "wardens", spec.id)
+    )
     queue_journal_path = state_root / "queue.json"
     daemon_state_dir = state_root / "state"
 

--- a/src/ravn/warden/store.py
+++ b/src/ravn/warden/store.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import yaml
 
 from ravn.ports.warden_deployer import WardenDeploymentPort
-from ravn.warden.artifacts import runtime_config_path, service_label
+from ravn.warden.artifacts import confined_path, runtime_config_path, service_label
 from ravn.warden.models import WardenSpec
 from ravn.warden.observability import latest_warden_dream
 
@@ -215,7 +215,7 @@ class WardenStore:
         return candidate
 
     def warden_dir(self, warden_id: str) -> Path:
-        return self._root / warden_id
+        return confined_path(self._root, warden_id)
 
     def spec_path(self, warden_id: str) -> Path:
         return self.warden_dir(warden_id) / "warden.yaml"

--- a/tests/test_ravn/test_ravn_api.py
+++ b/tests/test_ravn/test_ravn_api.py
@@ -2737,6 +2737,26 @@ def test_get_warden_logs_supports_all_streams_and_parsed_lines(tmp_path):
     assert {entry["source"] for entry in merged} == {"stdout", "stderr"}
 
 
+def test_get_warden_logs_cannot_read_outside_warden_directory(tmp_path):
+    outside_log = tmp_path / "outside.log"
+    outside_log.write_text("secret\n", encoding="utf-8")
+    store = _store(tmp_path / "wardens")
+    created = store.create(WardenSpec(id="", name="Research Warden"))
+    store.save(
+        created.model_copy(
+            update={
+                "supervisor": created.supervisor.model_copy(update={"stdout_log": str(outside_log)})
+            }
+        )
+    )
+    client = TestClient(create_app(warden_store=store))
+
+    resp = client.get(f"/api/v1/ravn/wardens/{created.id}/logs?stream=stdout")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
 def test_get_warden_logs_rejects_invalid_stream(tmp_path):
     store = _store(tmp_path)
     created = store.create(WardenSpec(id="", name="Research Warden"))

--- a/tests/test_ravn/test_warden_helpers.py
+++ b/tests/test_ravn/test_warden_helpers.py
@@ -63,6 +63,20 @@ def test_local_python_executable_falls_back_when_sys_executable_is_empty() -> No
         assert local_python_executable() == "/usr/bin/python3"
 
 
+def test_runtime_config_payload_rejects_warden_id_path_traversal() -> None:
+    spec = WardenSpec(id="../outside", name="Outside")
+
+    with pytest.raises(ValueError, match="configured root"):
+        runtime_config_payload(spec)
+
+
+def test_warden_store_rejects_id_path_traversal(tmp_path: Path) -> None:
+    store = WardenStore(root=tmp_path / "wardens")
+
+    with pytest.raises(ValueError, match="configured root"):
+        store.warden_dir("../outside")
+
+
 def test_runtime_config_payload_defaults_write_mount_and_enables_secondary_roles(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- confine warden IDs and generated artifacts beneath their configured roots
- restrict supervisor log reads to each warden directory
- escape CR/LF in user-controlled Mímir log fields

## Validation
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- 232 affected Ravn/Mímir tests passed

Closes the newly exposed CodeQL path-injection and log-injection findings blocking release PR #855.