### PR TITLE
fix(sleipnir): guard optional nats client

### DIFF
--- a/src/sleipnir/adapters/nats_transport.py
+++ b/src/sleipnir/adapters/nats_transport.py
@@ -88,7 +88,7 @@ try:
     _NATS_AVAILABLE = True
 except ImportError:  # pragma: no cover
     DEFAULT_BUFFER_SIZE = 0
-    NatsClient = None  # type: ignore[assignment,misc]
+    NatsClient = object  # type: ignore[assignment,misc]
     TcpTransport = object  # type: ignore[assignment,misc]
     _NATS_AVAILABLE = False
 
@@ -190,6 +190,7 @@ class _HttpConnectNatsClient(NatsClient):
     """nats-py client that preserves the CONNECT transport before it is connected."""
 
     def __init__(self, proxy_url: str) -> None:
+        _require_nats()
         super().__init__()
         self._proxy_url = proxy_url
 
@@ -214,6 +215,7 @@ async def _connect_nats(
     proxy_url: str,
     options: dict[str, Any],
 ) -> Any:
+    _require_nats()
     resolved_proxy = _sandbox_proxy_url(proxy_url)
     if not resolved_proxy:
         return await nats.connect(

--- a/tests/test_domain/test_resident_runtime.py
+++ b/tests/test_domain/test_resident_runtime.py
@@ -678,7 +678,9 @@ async def test_delete_removes_resident_trace_spans_after_backend_cleanup() -> No
     principal = _principal()
     runtime = await service.create_record(principal, name="Muninn", profile_id="ravn-openshell")
 
-    assert await service.delete(principal, runtime.id)
+    deleted = await service.delete(principal, runtime.id)
+
+    assert deleted
 
     assert controller.actions == ["delete"]
     spans.delete_by_session.assert_awaited_once_with(runtime.id)

--- a/tests/test_sleipnir/test_nats_transport_optional.py
+++ b/tests/test_sleipnir/test_nats_transport_optional.py
@@ -1,0 +1,31 @@
+"""Regression coverage for installations without the optional NATS client."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_nats_transport_module_imports_without_nats() -> None:
+    script = """
+import sys
+
+class BlockNats:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "nats" or fullname.startswith("nats."):
+            raise ImportError("blocked optional dependency")
+        return None
+
+sys.meta_path.insert(0, BlockNats())
+from sleipnir.adapters.nats_transport import _HttpConnectNatsClient, nats_available
+
+assert not nats_available()
+try:
+    _HttpConnectNatsClient("http://127.0.0.1:3128")
+except ImportError:
+    pass
+else:
+    raise AssertionError("client construction must require nats-py")
+"""
+
+    subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
## Summary
- keep the NATS transport module importable when the optional `nats-py` dependency is absent
- fail client construction and connection through the existing dependency guard
- remove the remaining side-effecting async assertion from the release diff

## Validation
- 143 relevant Sleipnir/resident-runtime tests passed
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`

Addresses the three remaining unresolved code-quality threads on release PR #855.