### PR TITLE
fix(observatory): accept forwarded workload identity

### DIFF
--- a/charts/observatory/templates/envoy-configmap.yaml
+++ b/charts/observatory/templates/envoy-configmap.yaml
@@ -88,6 +88,41 @@ data:
                                 - header_name: {{ .headerName | quote }}
                                   claim_name: {{ .claimName | quote }}
                                 {{- end }}
+                            {{- if .Values.envoy.jwt.workload.enabled }}
+                            workload:
+                              issuer: {{ .Values.envoy.jwt.workload.issuer | quote }}
+                              {{- if .Values.envoy.jwt.workload.audiences }}
+                              audiences:
+                                {{- range .Values.envoy.jwt.workload.audiences }}
+                                - {{ . | quote }}
+                                {{- end }}
+                              {{- end }}
+                              from_headers:
+                                - name: Authorization
+                                  value_prefix: "Bearer "
+                              remote_jwks:
+                                http_uri:
+                                  uri: {{ .Values.envoy.jwt.workload.jwksUri | quote }}
+                                  cluster: workload_jwks
+                                  timeout: {{ .Values.envoy.jwt.workload.jwksTimeout | default "5s" }}
+                                cache_duration:
+                                  seconds: {{ .Values.envoy.jwt.workload.jwksCacheDurationSeconds | default 300 }}
+                              forward: true
+                              payload_in_metadata: jwt_payload
+                              claim_to_headers:
+                                - header_name: {{ .Values.envoy.headerNames.userId }}
+                                  claim_name: sub
+                                - header_name: {{ .Values.envoy.headerNames.email }}
+                                  claim_name: email
+                                - header_name: {{ .Values.envoy.headerNames.tenant }}
+                                  claim_name: {{ .Values.envoy.jwt.workload.tenantClaim | default "tenant_id" }}
+                                - header_name: {{ .Values.envoy.headerNames.roles }}
+                                  claim_name: {{ .Values.envoy.jwt.workload.rolesClaim | default "resource_access.volundr-api.roles" }}
+                                {{- range .Values.envoy.jwt.workload.extraClaimHeaders }}
+                                - header_name: {{ .headerName | quote }}
+                                  claim_name: {{ .claimName | quote }}
+                                {{- end }}
+                            {{- end }}
                           rules:
                             - match:
                                 prefix: "/"
@@ -101,7 +136,14 @@ data:
                             - match:
                                 prefix: "/"
                               requires:
+                                {{- if .Values.envoy.jwt.workload.enabled }}
+                                requires_any:
+                                  requirements:
+                                    - provider_name: keycloak
+                                    - provider_name: workload
+                                {{- else }}
                                 provider_name: keycloak
+                                {{- end }}
                       {{- end }}
                       {{- with .Values.envoy.extraHttpFilters }}
                       {{- toYaml . | nindent 22 }}
@@ -145,6 +187,28 @@ data:
               "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
               sni: {{ .Values.envoy.jwt.keycloakHost | quote }}
           {{- end }}
+        {{- if .Values.envoy.jwt.workload.enabled }}
+        - name: workload_jwks
+          connect_timeout: {{ .Values.envoy.connectTimeout }}
+          type: STRICT_DNS
+          lb_policy: ROUND_ROBIN
+          load_assignment:
+            cluster_name: workload_jwks
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: {{ .Values.envoy.jwt.workload.jwksHost | quote }}
+                          port_value: {{ .Values.envoy.jwt.workload.jwksPort | default 443 }}
+          {{- if .Values.envoy.jwt.workload.jwksTls }}
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: {{ .Values.envoy.jwt.workload.jwksHost | quote }}
+          {{- end }}
+        {{- end }}
         {{- end }}
         {{- with .Values.envoy.extraClusters }}
         {{- toYaml . | nindent 8 }}

--- a/charts/observatory/values.yaml
+++ b/charts/observatory/values.yaml
@@ -141,6 +141,21 @@ envoy:
     extraClaimHeaders: []
     bypassPrefixes:
       - /health
+    # Additional verifier for short-lived Niuu workload tokens forwarded by
+    # Guild's Agent Directory aggregation.
+    workload:
+      enabled: false
+      issuer: ""
+      audiences: []
+      jwksUri: ""
+      jwksHost: ""
+      jwksPort: 443
+      jwksTls: true
+      jwksTimeout: "5s"
+      jwksCacheDurationSeconds: 300
+      tenantClaim: "tenant_id"
+      rolesClaim: "resource_access.volundr-api.roles"
+      extraClaimHeaders: []
   extraHttpFilters: []
   extraClusters: []
 

--- a/tests/test_workload_identity.py
+++ b/tests/test_workload_identity.py
@@ -596,6 +596,50 @@ def test_ravn_accepts_external_workload_jwks_provider() -> None:
     assert 'address: "yggdrasil.niuu.world"' in result.stdout
 
 
+def test_observatory_accepts_forwarded_workload_identity() -> None:
+    chart_dir = Path(__file__).parent.parent / "charts" / "observatory"
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(chart_dir),
+            "--set",
+            "envoy.enabled=true",
+            "--set",
+            "envoy.jwt.enabled=true",
+            "--set",
+            "envoy.jwt.issuer=https://keycloak.example/realms/volundr",
+            "--set",
+            "envoy.jwt.jwksUri=https://keycloak.example/certs",
+            "--set",
+            "envoy.jwt.keycloakHost=keycloak.example",
+            "--set",
+            "envoy.jwt.workload.enabled=true",
+            "--set",
+            f"envoy.jwt.workload.issuer={EXCHANGE_ISSUER}",
+            "--set",
+            "envoy.jwt.workload.audiences[0]=volundr-api",
+            "--set",
+            f"envoy.jwt.workload.jwksUri={EXCHANGE_ISSUER}/jwks",
+            "--set",
+            "envoy.jwt.workload.jwksHost=yggdrasil.niuu.world",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"helm template failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+
+    assert "workload:" in result.stdout
+    assert "requires_any:" in result.stdout
+    assert "- provider_name: keycloak" in result.stdout
+    assert "- provider_name: workload" in result.stdout
+    assert "cluster: workload_jwks" in result.stdout
+    assert 'address: "yggdrasil.niuu.world"' in result.stdout
+
+
 def _render_chart(chart: str) -> str:
     chart_dir = Path(__file__).parent.parent / "charts" / chart
     result = subprocess.run(


### PR DESCRIPTION
## What changed

- add an optional workload JWT provider to the Observatory Envoy chart
- allow either Keycloak user JWTs or forwarded Niuu workload JWTs
- map workload claims into the existing trusted identity headers
- add Helm rendering coverage for the workload identity path

## Why

Guild forwards its exchanged workload token while aggregating Observatory Agent Directories. Observatory Envoy previously accepted only Keycloak tokens, so every downstream directory request was rejected and Guild returned zero peers.

## Validation

- published chart `0.0.0-observatory-workload-identity.927`
- deployed through infrastructure GitOps commit `b20c4d5b`
- verified Guild returns 2 real agents from 7 healthy sources, with 1 unrelated Valaskjalf warning
- verified downstream Observatory endpoints return HTTP 200 with the full resident workload audience set