### PR TITLE
fix(build): include OTEL runtime dependencies

### DIFF
--- a/containers/niuu/Dockerfile
+++ b/containers/niuu/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /app
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 COPY pyproject.toml uv.lock README.md /app/
 COPY src/ /app/src/
-RUN uv sync --frozen --no-dev --no-editable --extra k8s --extra nats --extra openshell \
+RUN uv sync --frozen --no-dev --no-editable --extra k8s --extra nats --extra openshell --extra otel \
     && mkdir -p /dist-root/data/mimir
 
 FROM python:3.14-slim-trixie@sha256:b877e50bd90de10af8d82c57a022fc2e0dc731c5320d762a27986facfc3355c1


### PR DESCRIPTION
## What changed

- includes the existing `otel` dependency extra in the production Niuu image

## Why

Ravn already has complete configuration and runtime wiring for OTLP traces and metrics, but the production image omitted the exporters and SDK. Enabling observability in a deployed resident would otherwise fail at startup.

## Impact

Production Niuu images can enable the existing OpenTelemetry path through configuration. No runtime behavior changes while observability remains disabled.

## Validation

- `git diff --check`
- verified the selected production extras resolve all seven OpenTelemetry packages
- no application code changed