### PR TITLE
Expose live resident context in the HUD

### DIFF
--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -989,6 +989,14 @@ class HttpChannelConfig(BaseModel):
         ge=1,
         description="Maximum recent in-flight activity events returned per resident task.",
     )
+    resident_hud_task_context_max_chars: int = Field(
+        default=4000,
+        ge=200,
+        description=(
+            "Maximum characters of bounded active-task observations and objectives "
+            "returned to the resident HUD."
+        ),
+    )
     resident_hud_trace_url_template: str = Field(
         default="",
         description=(

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -90,6 +90,60 @@ _MIMIR_PAGE_WRITTEN_OUTCOME = "mimir.page.written"
 _DREAM_CYCLE_TRIGGER = "dream_cycle:cron"
 _DREAM_COUNT_FIELDS = ("pages_updated", "entities_created", "lint_fixes")
 _RAVN_TASK_STARTED = "ravn.task.started"
+_TRACEPARENT_PATTERN = re.compile(
+    r"^[\da-fA-F]{2}-([\da-fA-F]{32})-[\da-fA-F]{16}-[\da-fA-F]{2}$"
+)
+
+
+def _bounded_hud_text(value: str, limit: int) -> str:
+    text = value.strip()
+    if len(text) <= limit:
+        return text
+    return f"{text[: max(0, limit - 1)].rstrip()}…"
+
+
+def _markdown_section(value: str, heading_prefix: str) -> str:
+    """Return one Markdown section without coupling the HUD to task semantics."""
+    collecting = False
+    collected: list[str] = []
+    wanted = heading_prefix.casefold()
+    for line in value.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            heading = stripped.lstrip("#").strip().casefold()
+            if collecting:
+                break
+            collecting = heading.startswith(wanted)
+            continue
+        if collecting:
+            collected.append(line)
+    return "\n".join(collected).strip()
+
+
+def _resident_hud_task_input(task: AgentTask, limit: int) -> dict[str, str]:
+    context = task.initiative_context.strip()
+    first_line = next((line.strip() for line in context.splitlines() if line.strip()), task.title)
+    summary = first_line.lstrip("#").strip() or task.title
+    observations = _markdown_section(context, "observed signals")
+    if not observations:
+        observations = _markdown_section(context, "signal")
+    if not observations:
+        observations = context
+    objective = _markdown_section(context, "your task")
+    return {
+        "summary": _bounded_hud_text(summary, limit),
+        "observations": _bounded_hud_text(observations, limit),
+        "objective": _bounded_hud_text(objective, limit),
+    }
+
+
+def _trace_id_from_carrier(carrier: Mapping[str, str]) -> str:
+    direct = str(carrier.get("trace_id") or "").strip()
+    if re.fullmatch(r"[\da-fA-F]{32}", direct):
+        return direct.lower()
+    traceparent = str(carrier.get("traceparent") or "").strip()
+    match = _TRACEPARENT_PATTERN.fullmatch(traceparent)
+    return match.group(1).lower() if match else ""
 _RAVN_TASK_DROPPED = "ravn.task.dropped"
 _RESIDENT_VALKYRIE_SCHEMA_REPAIR_TRIGGER = "schema_repair:resident_valkyrie"
 
@@ -1167,20 +1221,32 @@ class DriveLoop:
 
     def resident_hud_status(self) -> dict[str, object]:
         """Return factual, bounded-by-store runtime state for the resident HUD."""
+        context_limit = self._settings.gateway.channels.http.resident_hud_task_context_max_chars
         active: list[dict[str, object]] = []
         for task_id in self.active_task_ids():
             task = self._inflight_tasks.get(task_id) or self._active_task_contexts.get(task_id)
             result = self._result_store.get(task_id)
+            events = list(result.events if result is not None else [])
+            agent = self._active_agents.get(task_id)
+            iteration_budget = getattr(agent, "iteration_budget", None)
             active.append(
                 {
                     "task_id": task_id,
                     "title": task.title if task is not None else "",
                     "triggered_by": task.triggered_by if task is not None else "",
+                    "persona": (
+                        task.persona
+                        if task is not None and task.persona
+                        else getattr(self._persona_config, "name", "")
+                    ),
                     "root_correlation_id": (
                         task.root_correlation_id or task.task_id if task is not None else task_id
                     ),
                     "case_id": task.resident_case_id if task is not None else "",
                     "turn_index": task.resident_turn_index if task is not None else 0,
+                    "trace_id": (
+                        _trace_id_from_carrier(task.trace_context) if task is not None else ""
+                    ),
                     "started_at": (
                         result.started_at.isoformat()
                         if result is not None
@@ -1188,20 +1254,48 @@ class DriveLoop:
                         if task is not None
                         else ""
                     ),
+                    "input": (
+                        _resident_hud_task_input(task, context_limit) if task is not None else {}
+                    ),
+                    "progress": {
+                        "iteration": int(getattr(iteration_budget, "consumed", 0) or 0),
+                        "iteration_budget": int(getattr(iteration_budget, "total", 0) or 0),
+                        "tool_calls": sum(event.type == "tool_start" for event in events),
+                        "warnings": sum(
+                            event.type == "error" or "[warning]" in event.summary.casefold()
+                            for event in events
+                        ),
+                    },
                     "events": [
                         {
                             "type": event.type,
                             "summary": event.summary,
                             "timestamp": event.timestamp.isoformat(),
                         }
-                        for event in (result.events if result is not None else [])
+                        for event in events
                     ],
                 }
             )
+        queued = [
+            {
+                "task_id": task.task_id,
+                "title": task.title,
+                "triggered_by": task.triggered_by,
+                "root_correlation_id": task.root_correlation_id or task.task_id,
+                "created_at": task.created_at.isoformat(),
+                "input_summary": _resident_hud_task_input(task, context_limit)["summary"],
+            }
+            for _priority, _counter, task in sorted(
+                list(self._queue._queue)  # type: ignore[attr-defined]
+            )
+        ]
         return {
             "active_tasks": active,
             "active_count": len(active),
             "queued_count": self._queue.qsize(),
+            "queue_capacity": self._config.task_queue_max,
+            "queued_tasks": queued,
+            "model": self._settings.effective_model(),
         }
 
     def queued_task_ids(self) -> list[str]:

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -90,9 +90,7 @@ _MIMIR_PAGE_WRITTEN_OUTCOME = "mimir.page.written"
 _DREAM_CYCLE_TRIGGER = "dream_cycle:cron"
 _DREAM_COUNT_FIELDS = ("pages_updated", "entities_created", "lint_fixes")
 _RAVN_TASK_STARTED = "ravn.task.started"
-_TRACEPARENT_PATTERN = re.compile(
-    r"^[\da-fA-F]{2}-([\da-fA-F]{32})-[\da-fA-F]{16}-[\da-fA-F]{2}$"
-)
+_TRACEPARENT_PATTERN = re.compile(r"^[\da-fA-F]{2}-([\da-fA-F]{32})-[\da-fA-F]{16}-[\da-fA-F]{2}$")
 
 
 def _bounded_hud_text(value: str, limit: int) -> str:
@@ -144,6 +142,8 @@ def _trace_id_from_carrier(carrier: Mapping[str, str]) -> str:
     traceparent = str(carrier.get("traceparent") or "").strip()
     match = _TRACEPARENT_PATTERN.fullmatch(traceparent)
     return match.group(1).lower() if match else ""
+
+
 _RAVN_TASK_DROPPED = "ravn.task.dropped"
 _RESIDENT_VALKYRIE_SCHEMA_REPAIR_TRIGGER = "schema_repair:resident_valkyrie"
 

--- a/src/ravn/static/resident-hud.html
+++ b/src/ravn/static/resident-hud.html
@@ -16,7 +16,7 @@
   html,body{height:100%}
   body{
     background:var(--bg); color:var(--tx); font-family:var(--mono);
-    font-size:13px; line-height:1.45; overflow:hidden;
+    font-size:13px; line-height:1.45; overflow:auto;
     -webkit-font-smoothing:antialiased;
   }
   body::before{
@@ -28,7 +28,7 @@
     content:""; position:fixed; inset:0; pointer-events:none; z-index:99;
     background:radial-gradient(ellipse at 50% 42%,transparent 52%,rgba(0,0,0,.72) 100%);
   }
-  .app{height:100vh; display:flex; flex-direction:column; padding:14px 18px 12px; gap:10px}
+  .app{min-height:100vh; display:flex; flex-direction:column; padding:14px 18px 12px; gap:10px}
 
   /* ── header ─────────────────────────────────────────── */
   .top{display:flex; align-items:flex-start; gap:22px; border-bottom:1px solid var(--line); padding-bottom:10px}
@@ -66,16 +66,55 @@
   .current span{color:var(--dim);font-size:10px;letter-spacing:.08em}
   .runtime-meta{display:flex;gap:14px;color:var(--dim);font-size:10px;white-space:nowrap}
   .runtime-meta b{color:var(--tx);font-weight:500}
-  .activity{display:none;grid-template-columns:auto 1fr;gap:12px;background:var(--panel);
-    border:1px solid var(--line);padding:8px 12px;min-height:38px}
-  .activity.on{display:grid}
-  .activity h2{font-size:9px;letter-spacing:.24em;text-transform:uppercase;color:var(--obs);
-    font-weight:500;padding-top:2px}
-  .activity-list{display:flex;gap:8px;overflow-x:auto}
-  .activity-event{border-left:2px solid var(--line2);padding:2px 8px;color:var(--dim);
-    font-size:10px;min-width:160px;max-width:300px}
-  .activity-event.tool_start{border-color:var(--obs);color:var(--tx)}
-  .activity-event.error{border-color:var(--gap);color:var(--gap)}
+  .live-layout{display:none;grid-template-columns:minmax(300px,1.05fr) minmax(380px,1.4fr)
+    minmax(250px,.8fr);gap:9px;min-height:250px;max-height:390px}
+  .live-layout.on{display:grid}
+  .live-card{background:var(--panel);border:1px solid var(--line);min-height:0;
+    display:flex;flex-direction:column}
+  .live-card>header{display:flex;align-items:center;justify-content:space-between;gap:12px;
+    padding:8px 11px;border-bottom:1px solid var(--line);min-height:34px}
+  .live-card h2{font-size:9.5px;letter-spacing:.24em;text-transform:uppercase;color:var(--obs);
+    font-weight:500}
+  .live-meta{display:flex;gap:12px;color:var(--dim2);font-size:9px;letter-spacing:.08em;
+    white-space:nowrap}
+  .live-meta b{color:var(--tx);font-weight:500}
+  .live-body{padding:10px;overflow-y:auto;min-height:0}
+  .live-body::-webkit-scrollbar{width:4px}
+  .live-body::-webkit-scrollbar-thumb{background:var(--line2)}
+  .context-summary{display:block;color:var(--tx);font-size:14px;line-height:1.45;
+    margin-bottom:10px}
+  .context-block{margin-top:9px;padding-top:9px;border-top:1px solid var(--line)}
+  .context-block .lb{display:block;color:var(--dim2);font-size:8.5px;letter-spacing:.22em;
+    text-transform:uppercase;margin-bottom:5px}
+  .context-block pre,.context-block .text{white-space:pre-wrap;overflow-wrap:anywhere;color:var(--dim);
+    font:10.5px/1.55 var(--mono)}
+  .judgment-state{display:flex;justify-content:space-between;gap:12px;color:var(--dim);
+    font-size:10px}
+  .judgment-state b{color:var(--hyp);font-weight:500}
+  .identity-line{color:var(--dim2);font-size:8.5px;overflow-wrap:anywhere}
+  .activity-list{display:flex;flex-direction:column;gap:7px}
+  .activity-event{display:grid;grid-template-columns:62px 72px minmax(0,1fr);gap:8px;
+    border-left:2px solid var(--line2);padding:7px 9px;background:var(--panel2);
+    color:var(--dim);font-size:10px}
+  .activity-event .at{color:var(--dim2)}
+  .activity-event .kind{color:var(--dim);letter-spacing:.08em;text-transform:uppercase}
+  .activity-event .event-main{min-width:0;white-space:pre-wrap;overflow-wrap:anywhere;color:var(--tx)}
+  .activity-event .event-result{margin-top:5px;padding-top:5px;border-top:1px solid var(--line);
+    color:var(--dim);white-space:pre-wrap}
+  .activity-event .duration{color:var(--dim2);margin-left:7px}
+  .activity-event.tool_start{border-color:var(--obs)}
+  .activity-event.error,.activity-event.warning{border-color:var(--gap)}
+  .activity-event.error .event-main,.activity-event.warning .event-result{color:var(--gap)}
+  .queue-card h2{color:var(--hyp)}
+  .queue-list{display:flex;flex-direction:column;gap:6px}
+  .queue-item{padding:7px 8px;border:1px solid var(--line);background:var(--panel2)}
+  .queue-item b{display:block;color:var(--tx);font-size:10px;font-weight:500;
+    white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .queue-item span{display:block;color:var(--dim2);font-size:8.5px;margin-top:3px}
+  .queue-pressure{color:var(--hyp)}
+  .active-trace{font-size:8.5px;color:var(--obs);text-decoration:none;border:1px solid var(--obs);
+    padding:3px 7px;letter-spacing:.1em;text-transform:uppercase;white-space:nowrap}
+  .active-trace[hidden]{display:none}
 
   /* ── wake bar ───────────────────────────────────────── */
   .wake{display:flex; align-items:center; gap:16px; background:var(--panel);
@@ -98,7 +137,7 @@
 
   /* ── columns ────────────────────────────────────────── */
   .cols{flex:1 1 auto; display:grid; grid-template-columns:1.45fr 1fr 1fr .95fr 1.05fr;
-    gap:9px; min-height:0}
+    gap:9px; min-height:320px}
   .col{background:var(--panel); border:1px solid var(--line); display:flex; flex-direction:column; min-height:0}
   .col>h2{font-size:9.5px; letter-spacing:.26em; text-transform:uppercase; padding:8px 11px;
     border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; font-weight:500}
@@ -162,7 +201,12 @@
   .trace{font-size:9px;color:var(--obs);letter-spacing:.12em;text-transform:uppercase;
     text-decoration:none;border:1px solid var(--obs);padding:4px 9px}
   .trace[hidden]{display:none}
-  @media (max-width:1100px){ .cols{grid-template-columns:1fr 1fr}  .charter{display:none} }
+  @media (max-width:1100px){
+    .live-layout{grid-template-columns:1fr;max-height:none}
+    .live-card{max-height:360px}
+    .cols{grid-template-columns:1fr 1fr}
+    .charter{display:none}
+  }
 </style>
 </head>
 <body>
@@ -199,9 +243,54 @@
     </div>
   </div>
 
-  <div class="activity" id="activity">
-    <h2>Current activity</h2>
-    <div class="activity-list" id="activity-list"></div>
+  <div class="live-layout" id="live-layout">
+    <section class="live-card">
+      <header>
+        <h2>What happened</h2>
+        <a class="active-trace" id="active-trace" target="_blank" rel="noreferrer" hidden>Open trace</a>
+      </header>
+      <div class="live-body">
+        <strong class="context-summary" id="input-summary">—</strong>
+        <div class="context-block">
+          <span class="lb">Observed input</span>
+          <pre id="input-observations">—</pre>
+        </div>
+        <div class="context-block">
+          <span class="lb">Current objective</span>
+          <div class="text" id="input-objective">—</div>
+        </div>
+        <div class="context-block judgment-state">
+          <span>Current judgment</span>
+          <b id="current-judgment">Not emitted yet</b>
+        </div>
+        <div class="context-block identity-line" id="task-identity">—</div>
+      </div>
+    </section>
+
+    <section class="live-card">
+      <header>
+        <h2>Current progress</h2>
+        <div class="live-meta">
+          <span>ELAPSED <b id="live-elapsed">—</b></span>
+          <span>ITERATION <b id="live-iteration">—</b></span>
+          <span>TOOLS <b id="live-tools">0</b></span>
+          <span>WARNINGS <b id="live-warnings">0</b></span>
+        </div>
+      </header>
+      <div class="live-body">
+        <div class="activity-list" id="activity-list"></div>
+      </div>
+    </section>
+
+    <section class="live-card queue-card">
+      <header>
+        <h2>Waiting work</h2>
+        <span class="queue-pressure" id="queue-pressure">0 queued</span>
+      </header>
+      <div class="live-body">
+        <div class="queue-list" id="queue-list"></div>
+      </div>
+    </section>
   </div>
 
   <div class="wake">
@@ -355,6 +444,109 @@ function judgmentFacts(t){
   return facts;
 }
 
+function clockTime(value){
+  const d=value?new Date(value):null;
+  return d&&!isNaN(d)?d.toISOString().slice(11,19):"—";
+}
+
+function elapsedSince(value){
+  const started=value?new Date(value):null;
+  if(!started||isNaN(started)) return "—";
+  const seconds=Math.max(0,Math.floor((Date.now()-started.getTime())/1000));
+  if(seconds<60) return seconds+"s";
+  const minutes=Math.floor(seconds/60), rest=seconds%60;
+  if(minutes<60) return minutes+"m "+rest+"s";
+  return Math.floor(minutes/60)+"h "+(minutes%60)+"m";
+}
+
+function activityRows(events){
+  const useful=(events||[]).filter(event=>
+    !(event.type==="thought"&&/^thinking:\s*$/i.test(event.summary||""))
+  );
+  const rows=[];
+  for(let x=0;x<useful.length;x++){
+    const event=useful[x], next=useful[x+1];
+    if(event.type==="tool_start"&&next?.type==="tool_result"){
+      rows.push({...event,result:next.summary||"",resultTimestamp:next.timestamp});
+      x++;
+      continue;
+    }
+    rows.push(event);
+  }
+  return rows;
+}
+
+function renderActivity(events){
+  const list=document.getElementById("activity-list");
+  list.replaceChildren();
+  const rows=activityRows(events);
+  if(!rows.length){
+    const empty=document.createElement("div");
+    empty.className="empty";
+    empty.textContent="Waiting for the first observable action";
+    list.appendChild(empty);
+    return;
+  }
+  rows.forEach(event=>{
+    const row=document.createElement("div");
+    const type=String(event.type||"event").replace(/[^a-z0-9_-]/gi,"-");
+    const warning=/\[warning\]/i.test(event.result||event.summary||"");
+    row.className=`activity-event ${type}${warning?" warning":""}`;
+
+    const at=document.createElement("span");
+    at.className="at";
+    at.textContent=clockTime(event.timestamp);
+    const kind=document.createElement("span");
+    kind.className="kind";
+    kind.textContent=type.replace(/_/g," ");
+    const main=document.createElement("div");
+    main.className="event-main";
+    main.textContent=event.summary||type;
+    if(event.result){
+      const result=document.createElement("div");
+      result.className="event-result";
+      result.textContent=event.result.replace(/^→\s*/,"");
+      if(event.resultTimestamp&&event.timestamp){
+        const duration=document.createElement("span");
+        duration.className="duration";
+        const ms=Math.max(0,new Date(event.resultTimestamp)-new Date(event.timestamp));
+        duration.textContent=`${ms<1000?ms+"ms":(ms/1000).toFixed(1)+"s"}`;
+        result.appendChild(duration);
+      }
+      main.appendChild(result);
+    }
+    row.append(at,kind,main);
+    list.appendChild(row);
+  });
+  const viewport=list.parentElement;
+  if(viewport) viewport.scrollTop=viewport.scrollHeight;
+}
+
+function renderQueue(runtime){
+  const queued=runtime.queued_tasks||[], count=runtime.queued_count||0,
+        capacity=runtime.queue_capacity||0, list=document.getElementById("queue-list");
+  document.getElementById("queue-pressure").textContent=capacity
+    ? `${count} / ${capacity} queued`:`${count} queued`;
+  list.replaceChildren();
+  if(!queued.length){
+    const empty=document.createElement("div");
+    empty.className="empty";
+    empty.textContent="No work waiting";
+    list.appendChild(empty);
+    return;
+  }
+  queued.forEach(task=>{
+    const item=document.createElement("div");
+    item.className="queue-item";
+    const title=document.createElement("b");
+    title.textContent=task.input_summary||task.title||task.task_id||"Queued task";
+    const meta=document.createElement("span");
+    meta.textContent=`${elapsedSince(task.created_at)} waiting · ${task.triggered_by||"unknown trigger"}`;
+    item.append(title,meta);
+    list.appendChild(item);
+  });
+}
+
 function renderRuntime(d){
   const runtime=d.runtime||{}, active=runtime.active_tasks||[], task=active[0]||null;
   const state=runtime.state||"idle", stateEl=document.getElementById("rstate");
@@ -365,7 +557,9 @@ function renderRuntime(d){
   document.getElementById("rtitle").textContent=task?.title||(
     state==="waiting_operator"?"Waiting for an operator answer":"No task is executing"
   );
-  document.getElementById("rtrigger").textContent=task?.triggered_by||(
+  document.getElementById("rtrigger").textContent=task
+    ? `${task.triggered_by||"unknown trigger"}${runtime.model?" · "+runtime.model:""}`
+    : (
     runtime.pending_questions?.[0]?.question||
     "The resident is waiting for a signal, schedule, or operator answer."
   );
@@ -373,18 +567,35 @@ function renderRuntime(d){
   document.getElementById("rupdated").textContent=generated&&!isNaN(generated)
     ? generated.toISOString().slice(11,19)+"Z":"—";
 
-  const activity=document.getElementById("activity"), events=task?.events||[];
-  activity.classList.toggle("on",events.length>0);
-  const activityList=document.getElementById("activity-list");
-  activityList.replaceChildren();
-  events.forEach(event=>{
-    const row=document.createElement("div");
-    row.className="activity-event";
-    const eventType=String(event.type||"").replace(/[^a-z0-9_-]/gi,"-");
-    if(eventType) row.classList.add(eventType);
-    row.textContent=event.summary||event.type||"";
-    activityList.appendChild(row);
-  });
+  const live=document.getElementById("live-layout"), input=task?.input||{},
+        progress=task?.progress||{}, events=task?.events||[];
+  live.classList.toggle("on",Boolean(task)||(runtime.queued_count||0)>0);
+  document.getElementById("input-summary").textContent=input.summary||task?.title||"Waiting to start";
+  document.getElementById("input-observations").textContent=input.observations||(
+    task?"No bounded input excerpt was captured.":"The next queued task has not started."
+  );
+  document.getElementById("input-objective").textContent=input.objective||(
+    task?"No objective excerpt was captured.":"—"
+  );
+  document.getElementById("current-judgment").textContent=task
+    ?"Not emitted yet":"Waiting to start";
+  document.getElementById("task-identity").textContent=task
+    ? `TASK ${task.task_id||"—"} · ROOT ${task.root_correlation_id||"—"}`
+    :"—";
+  document.getElementById("live-elapsed").textContent=task?elapsedSince(task.started_at):"—";
+  document.getElementById("live-iteration").textContent=progress.iteration_budget
+    ? `${progress.iteration||0} / ${progress.iteration_budget}`:`${progress.iteration||0}`;
+  document.getElementById("live-tools").textContent=progress.tool_calls||0;
+  document.getElementById("live-warnings").textContent=progress.warnings||0;
+  renderActivity(events);
+  renderQueue(runtime);
+
+  const activeTrace=document.getElementById("active-trace"),
+        activeTraceUrl=task?.trace_id
+          ? safeHttpUrl(d.hud?.trace_url_template||"",task.trace_id):"";
+  activeTrace.hidden=!activeTraceUrl;
+  if(activeTraceUrl) activeTrace.href=activeTraceUrl;
+  else activeTrace.removeAttribute("href");
 }
 
 function renderEmpty(){

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -66,6 +66,8 @@ def _make_drive_loop_with_mesh(
     settings.budget.warn_at_percent = 80
     settings.budget.input_token_cost_per_million = 3.0
     settings.budget.output_token_cost_per_million = 15.0
+    settings.gateway.channels.http.resident_hud_task_context_max_chars = 4000
+    settings.effective_model.return_value = "test-model"
 
     dl = DriveLoop(agent_factory=_agent_factory, config=cfg, settings=settings)
     return dl, captured
@@ -139,6 +141,20 @@ class TestDriveLoopChannelConstruction:
     def test_resident_hud_status_reports_factual_active_task_and_bounded_activity(self):
         dl, _ = _make_drive_loop_with_mesh(cascade_enabled=True)
         task = _make_task("active-task")
+        task.initiative_context = """\
+# Signals since your last look — 4 observation(s)
+
+## Observed signals (bounded payload excerpts)
+
+- `status` (warning, workshop): payload=Muninn paused with ErrorCode 3
+
+## Your task
+
+Determine whether the observations require action.
+"""
+        task.trace_context = {
+            "traceparent": "00-56ca7fcf3496a1e9fe7136f55a110c2a-0123456789abcdef-01"
+        }
         dl._active_tasks[task.task_id] = MagicMock()
         dl._inflight_tasks[task.task_id] = task
         dl._result_store.start(task.task_id, task.triggered_by)
@@ -160,10 +176,26 @@ class TestDriveLoopChannelConstruction:
                 "task_id": "active-task",
                 "title": "test",
                 "triggered_by": "test",
+                "persona": "",
                 "root_correlation_id": "active-task",
                 "case_id": "",
                 "turn_index": 0,
+                "trace_id": "56ca7fcf3496a1e9fe7136f55a110c2a",
                 "started_at": dl._result_store.get("active-task").started_at.isoformat(),
+                "input": {
+                    "summary": "Signals since your last look — 4 observation(s)",
+                    "observations": (
+                        "- `status` (warning, workshop): "
+                        "payload=Muninn paused with ErrorCode 3"
+                    ),
+                    "objective": "Determine whether the observations require action.",
+                },
+                "progress": {
+                    "iteration": 0,
+                    "iteration_budget": 0,
+                    "tool_calls": 1,
+                    "warnings": 0,
+                },
                 "events": [
                     {
                         "type": "tool_start",
@@ -171,6 +203,32 @@ class TestDriveLoopChannelConstruction:
                         "timestamp": "2026-07-25T00:00:00+00:00",
                     }
                 ],
+            }
+        ]
+        assert status["queue_capacity"] == 10
+        assert status["queued_tasks"] == []
+        assert status["model"] == "test-model"
+
+    def test_resident_hud_status_describes_waiting_tasks(self):
+        dl, _ = _make_drive_loop_with_mesh(cascade_enabled=True)
+        task = _make_task("queued-task")
+        task.title = "Resident signal window: 3 observation(s)"
+        task.triggered_by = "signal:durable_window"
+        task.root_correlation_id = "signal-window:workshop:abc"
+        task.initiative_context = "# Signals since your last look — 3 observation(s)"
+        dl._queue.put_nowait((task.priority, 1, task))
+
+        status = dl.resident_hud_status()
+
+        assert status["queued_count"] == 1
+        assert status["queued_tasks"] == [
+            {
+                "task_id": "queued-task",
+                "title": "Resident signal window: 3 observation(s)",
+                "triggered_by": "signal:durable_window",
+                "root_correlation_id": "signal-window:workshop:abc",
+                "created_at": task.created_at.isoformat(),
+                "input_summary": "Signals since your last look — 3 observation(s)",
             }
         ]
 

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -185,8 +185,7 @@ Determine whether the observations require action.
                 "input": {
                     "summary": "Signals since your last look — 4 observation(s)",
                     "observations": (
-                        "- `status` (warning, workshop): "
-                        "payload=Muninn paused with ErrorCode 3"
+                        "- `status` (warning, workshop): payload=Muninn paused with ErrorCode 3"
                     ),
                     "objective": "Determine whether the observations require action.",
                 },

--- a/tests/test_ravn/test_gateway_http.py
+++ b/tests/test_ravn/test_gateway_http.py
@@ -560,6 +560,9 @@ def test_resident_hud_serves_live_durable_and_inflight_state_without_operator_to
     page = client.get("/resident/hud")
     assert page.status_code == 200
     assert "RESIDENT · HUD" in page.text
+    assert "What happened" in page.text
+    assert "Current progress" in page.text
+    assert "Waiting work" in page.text
     assert "octoprint_job_stats" not in page.text
 
     payload = client.get("/resident/hud-data").json()


### PR DESCRIPTION
## What changed

- exposes the active task's bounded observed input and objective in the resident HUD
- links the active W3C trace directly into Tempo
- shows live iteration budget, tool-call count, warnings, elapsed time, and paired tool results
- exposes the real bounded waiting queue and queue capacity
- keeps live work visually separate from persisted completed judgments

## Why

The previous HUD showed a horizontal stream of low-level capture summaries but did not answer what happened, what the resident is trying to determine, how far it has progressed, or what is waiting behind it. The underlying runtime already had most of that information; this change surfaces it without introducing another state or telemetry layer and without fabricating partial model judgments.

## Validation

- `node --check` on the embedded HUD JavaScript
- `uv run ruff check src/ravn/config.py src/ravn/drive_loop.py tests/test_ravn/test_drive_loop_channel_construction.py tests/test_ravn/test_gateway_http.py`
- `uv run pytest -q tests/test_ravn/test_drive_loop_channel_construction.py tests/test_ravn/test_gateway_http.py tests/test_ravn/test_config.py` (146 passed)
- browser visual pass against a live Ivaldi HUD payload
