### PR TITLE
Fix A2A workflow selection contract

### DIFF
--- a/src/ravn/adapters/tool_build/a2a.py
+++ b/src/ravn/adapters/tool_build/a2a.py
@@ -735,7 +735,7 @@ class A2AToolBuildBackend(ToolBuildBackend):
     ) -> dict[str, Any]:
         operation_id = request.operation_id or str(uuid4())
         metadata: dict[str, Any] = {
-            "workflowId": workflow_id,
+            "skillId": workflow_id,
             "sessionName": f"tool-build-{request.name}",
         }
         if self._repo:

--- a/src/ravn/adapters/tools/a2a_task.py
+++ b/src/ravn/adapters/tools/a2a_task.py
@@ -227,7 +227,7 @@ class A2ATaskTool(ToolPort):
             supplied_metadata = input.get("metadata")
             metadata = dict(supplied_metadata) if isinstance(supplied_metadata, dict) else {}
             self._validate_metadata(metadata)
-            metadata.update({"skillId": skill_id, "workflowId": skill_id})
+            metadata["skillId"] = skill_id
             trace_context = get_observability().inject()
             if trace_context:
                 metadata["traceContext"] = trace_context

--- a/src/ting/api/a2a.py
+++ b/src/ting/api/a2a.py
@@ -115,7 +115,7 @@ def campaign_to_task(campaign: WorkflowCampaign) -> Task:
     task.metadata.update(
         {
             "sessionId": campaign.session_id,
-            "workflowId": str(campaign.workflow_id),
+            "skillId": str(campaign.workflow_id),
             "workflowName": campaign.workflow_name,
             "campaignName": campaign.name,
             **({"repo": str(campaign.metadata["repo"])} if campaign.metadata.get("repo") else {}),
@@ -179,10 +179,10 @@ class WorkflowTaskHandler(RequestHandler):
 
         existing = await self._campaign_for_message(message.message_id)
         if existing is not None:
-            requested_workflow_id = str(metadata.get("workflowId") or "")
-            if requested_workflow_id != str(existing.workflow_id):
+            requested_skill_id = str(metadata.get("skillId") or "")
+            if requested_skill_id != str(existing.workflow_id):
                 raise InvalidParamsError(
-                    f"messageId {message.message_id!r} already belongs to another workflow"
+                    f"messageId {message.message_id!r} already belongs to another skill"
                 )
             get_observability().event(
                 "ting.a2a.workflow.launch.reused",
@@ -744,16 +744,16 @@ class WorkflowTaskHandler(RequestHandler):
         )
 
     async def _resolve_workflow(self, metadata: dict[str, Any]):
-        raw_id = str(metadata.get("workflowId") or "").strip()
+        raw_id = str(metadata.get("skillId") or "").strip()
         if not raw_id:
-            raise InvalidParamsError("message metadata must include workflowId")
+            raise InvalidParamsError("message metadata must include skillId")
         try:
             workflow_id = UUID(raw_id)
         except ValueError as exc:
-            raise InvalidParamsError(f"workflowId is not a valid UUID: {raw_id}") from exc
+            raise InvalidParamsError(f"skillId is not a valid UUID: {raw_id}") from exc
         workflow = await self._workflow_repo.get_workflow(workflow_id)
         if workflow is None or not _can_view_workflow(workflow, self._principal):
-            raise InvalidParamsError(f"unknown workflow: {raw_id}")
+            raise InvalidParamsError(f"unknown skill: {raw_id}")
         return workflow
 
     async def _owned_campaign(self, task_id: str) -> WorkflowCampaign:

--- a/src/ting/config.py
+++ b/src/ting/config.py
@@ -1069,7 +1069,7 @@ class A2AConfig(BaseModel):
     agent_description: str = Field(
         default=(
             "Launchable Niuu platform workflows. Each skill is a Ting workflow; "
-            "send a message with metadata.workflowId to start a run. Reply to a "
+            "send a message with metadata.skillId to start a run. Reply to a "
             "task in INPUT_REQUIRED with metadata.gateDecision "
             '("approve" or "request_changes") to resolve its workflow gate.'
         ),

--- a/tests/test_ravn/test_a2a_task_tool.py
+++ b/tests/test_ravn/test_a2a_task_tool.py
@@ -173,7 +173,7 @@ async def test_a2a_task_preserves_task_state_questions_artifacts_and_provenance(
         "CancelTask",
     ]
     start_message = client.posts[0][1]["params"]["message"]
-    assert start_message["metadata"] == {"skillId": "review", "workflowId": "review"}
+    assert start_message["metadata"] == {"skillId": "review"}
     reply_message = client.posts[2][1]["params"]["message"]
     assert reply_message["taskId"] == "task-1"
     assert reply_message["metadata"] == {"requestId": "question-1"}

--- a/tests/test_ravn/test_tool_build_backends.py
+++ b/tests/test_ravn/test_tool_build_backends.py
@@ -884,7 +884,7 @@ async def test_a2a_backend_builds_from_inline_canonical_artifact() -> None:
     send_body = client.post_bodies[0]
     assert send_body["method"] == "SendMessage"
     message = send_body["params"]["message"]
-    assert message["metadata"]["workflowId"] == "wf-1"
+    assert message["metadata"]["skillId"] == "wf-1"
     assert message["metadata"]["sessionName"] == "tool-build-mimir_metric_window"
     assert message["parts"][0]["text"]
     assert client.post_bodies[1]["method"] == "GetTask"
@@ -1058,7 +1058,7 @@ async def test_a2a_backend_selects_skill_by_tag() -> None:
     result = await backend.build(_request())
 
     assert result.provenance["workflow_id"] == "wf-9"
-    assert client.post_bodies[0]["params"]["message"]["metadata"]["workflowId"] == "wf-9"
+    assert client.post_bodies[0]["params"]["message"]["metadata"]["skillId"] == "wf-9"
 
 
 async def test_a2a_backend_fetches_url_part_artifact() -> None:

--- a/tests/test_ting/test_a2a_tasks.py
+++ b/tests/test_ting/test_a2a_tasks.py
@@ -364,13 +364,13 @@ def _rpc(
     )
 
 
-def _send_params(workflow_id: str, *, prompt: str = "Build the widget tool") -> dict[str, Any]:
+def _send_params(skill_id: str, *, prompt: str = "Build the widget tool") -> dict[str, Any]:
     return {
         "message": {
             "messageId": "msg-1",
             "role": "ROLE_USER",
             "parts": [{"text": prompt}],
-            "metadata": {"workflowId": workflow_id, "model": "gpt-5.5"},
+            "metadata": {"skillId": skill_id, "model": "gpt-5.5"},
         }
     }
 
@@ -393,7 +393,7 @@ class TestSendMessage:
         assert response.status_code == 200
         result = response.json()["result"]["task"]
         assert result["status"]["state"] == "TASK_STATE_SUBMITTED"
-        assert result["metadata"]["workflowId"] == str(workflow.id)
+        assert result["metadata"]["skillId"] == str(workflow.id)
         assert result["metadata"]["sessionId"] == "session-123"
 
         assert len(port.spawned) == 1
@@ -427,26 +427,27 @@ class TestSendMessage:
         assert retried["contextId"] == "resident-operation-1"
         assert len(port.spawned) == 1
 
-    def test_missing_workflow_id_is_invalid_params(self) -> None:
+    def test_workflow_id_does_not_select_an_a2a_skill(self) -> None:
         client, _, _ = _make_client()
         params = _send_params(str(uuid4()))
-        del params["message"]["metadata"]["workflowId"]
+        skill_id = params["message"]["metadata"].pop("skillId")
+        params["message"]["metadata"]["workflowId"] = skill_id
 
         response = _rpc(client, "SendMessage", params)
 
         assert response.status_code == 200
         error = response.json()["error"]
         assert error["code"] == -32602
-        assert "workflowId" in error["message"]
+        assert "skillId" in error["message"]
 
-    def test_unknown_workflow_is_invalid_params(self) -> None:
+    def test_unknown_skill_is_invalid_params(self) -> None:
         client, _, _ = _make_client()
 
         response = _rpc(client, "SendMessage", _send_params(str(uuid4())))
 
         error = response.json()["error"]
         assert error["code"] == -32602
-        assert "unknown workflow" in error["message"]
+        assert "unknown skill" in error["message"]
 
     def test_empty_prompt_is_invalid_params(self) -> None:
         workflow = _make_workflow()


### PR DESCRIPTION
## What changed

- send one explicit `skillId` selector for A2A task starts
- resolve the advertised A2A skill to the Ting workflow internally
- remove the duplicate `workflowId` selector from A2A requests and task responses
- reject the obsolete `workflowId`-only request instead of preserving a fallback
- align the dedicated A2A tool-build backend with the same contract

## Why

Ravn was emitting both `skillId` and Ting’s internal `workflowId` for the same selection. That leaked Ting’s implementation detail into the generic A2A client and created two competing selectors. The Agent Card already advertises each Ting workflow as an A2A skill, so that advertised skill is now the single traceable selector on the A2A surface.

## Impact

Ravn and Ting must be deployed together. Ting’s non-A2A REST APIs continue to use `workflowId` and are unchanged.

## Validation

- Ruff format and lint pass
- 128 focused Ravn, Ting, Agent Card, capability catalog, tool-build, and Volundr A2A tests pass
- regression coverage proves `workflowId` alone is rejected on the A2A endpoint