### PR TITLE
fix(a2a): restore peer capability discovery

### DIFF
--- a/src/observatory/entity_discovery.py
+++ b/src/observatory/entity_discovery.py
@@ -1079,6 +1079,21 @@ class KubernetesDiscoveryAdapter:
         entity_id = (
             f"runtime:{_slug(cluster)}:{_slug(namespace)}:{_slug(type_id)}:{_slug(logical_name)}"
         )
+        entity_metadata: dict[str, Any] = {
+            "component": component or "",
+            "app": app_name or "",
+            "resources": [
+                {
+                    "kind": resource_kind,
+                    "name": name,
+                    "uid": str(metadata.get("uid") or ""),
+                    "generation": metadata.get("generation"),
+                }
+            ],
+        }
+        visibility = annotations.get("observatory.niuu.world/a2a-visibility")
+        if visibility:
+            entity_metadata["visibility"] = visibility
         return DiscoveredEntity(
             id=entity_id,
             kind=type_id if type_id in _KNOWN_TYPE_IDS else "service",
@@ -1091,19 +1106,8 @@ class KubernetesDiscoveryAdapter:
             source_adapter=self.__class__.__name__,
             source_kind="kubernetes",
             source_uid=str(metadata.get("uid") or ""),
-            endpoints=_endpoints_for_k8s(resource_kind, item, labels),
-            metadata={
-                "component": component or "",
-                "app": app_name or "",
-                "resources": [
-                    {
-                        "kind": resource_kind,
-                        "name": name,
-                        "uid": str(metadata.get("uid") or ""),
-                        "generation": metadata.get("generation"),
-                    }
-                ],
-            },
+            endpoints=_endpoints_for_k8s(resource_kind, item, labels, annotations),
+            metadata=entity_metadata,
         )
 
 
@@ -1535,6 +1539,7 @@ def _endpoints_for_k8s(
     resource_kind: str,
     item: dict[str, Any],
     labels: dict[str, str],
+    annotations: dict[str, str],
 ) -> dict[str, str]:
     metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
     spec = item.get("spec") if isinstance(item.get("spec"), dict) else {}
@@ -1544,6 +1549,9 @@ def _endpoints_for_k8s(
     public = labels.get("niuu.world/public-url")
     if public:
         endpoints["public"] = public
+    a2a_card = annotations.get("observatory.niuu.world/a2a-card-url")
+    if a2a_card:
+        endpoints["a2aCard"] = a2a_card
     if resource_kind == "service" and namespace and name:
         endpoints["internal"] = f"http://{name}.{namespace}.svc.cluster.local"
     if resource_kind == "ingress":

--- a/src/ravn/adapters/tools/capability_catalog.py
+++ b/src/ravn/adapters/tools/capability_catalog.py
@@ -58,9 +58,7 @@ class CapabilityListTool(ToolPort):
             "resident learned tools, resident skills, configured remote workflows, "
             "and peer Agent Card skills. Use this before building new tools so existing "
             "capabilities are not duplicated. Entries tagged 'learned' are not native "
-            "tools — execute them by name with learned_tool_run. A filtered miss includes "
-            "a compact catalog_preview; use it to choose a broader query or kind before "
-            "concluding that no relevant capability exists."
+            "tools — execute them by name with learned_tool_run."
         )
 
     @property
@@ -72,10 +70,6 @@ class CapabilityListTool(ToolPort):
                     "type": "string",
                     "enum": [kind.value for kind in CapabilityKind],
                     "description": "Optional capability kind filter.",
-                },
-                "query": {
-                    "type": "string",
-                    "description": "Optional case-insensitive text filter.",
                 },
                 "tags": {
                     "type": "array",
@@ -112,7 +106,6 @@ class CapabilityListTool(ToolPort):
             capabilities,
             kind=kind,
             tags=_string_list(input.get("tags")),
-            query=str(input.get("query") or ""),
             require_all_tags=bool(input.get("require_all_tags") or False),
         )
         limit = _int_in_range(input.get("limit"), default=100, minimum=1, maximum=500)

--- a/src/ravn/domain/capability_catalog.py
+++ b/src/ravn/domain/capability_catalog.py
@@ -266,12 +266,10 @@ def filter_capabilities(
     *,
     kind: CapabilityKind | None = None,
     tags: list[str] | None = None,
-    query: str = "",
     require_all_tags: bool = False,
 ) -> list[Capability]:
     """Filter portable capability entries without changing routing behavior."""
     wanted_tags = {_norm(item) for item in tags or [] if _norm(item)}
-    normalized_query = _norm(query)
     filtered: list[Capability] = []
     for capability in capabilities:
         if kind is not None and capability.kind is not kind:
@@ -281,18 +279,6 @@ def filter_capabilities(
             if require_all_tags and not wanted_tags.issubset(capability_tags):
                 continue
             if not require_all_tags and not (wanted_tags & capability_tags):
-                continue
-        if normalized_query:
-            haystack = " ".join(
-                [
-                    capability.capability_id,
-                    capability.kind.value,
-                    capability.name,
-                    capability.description,
-                    " ".join(capability.tags),
-                ]
-            ).casefold()
-            if normalized_query not in haystack:
                 continue
         filtered.append(capability)
     return filtered

--- a/src/ting/api/a2a_card.py
+++ b/src/ting/api/a2a_card.py
@@ -85,7 +85,7 @@ def _workflow_skill(workflow: WorkflowDefinition) -> AgentSkill:
         id=str(workflow.id),
         name=workflow.name,
         description=workflow.description,
-        tags=tags,
+        tags=tags or ["workflow"],
     )
 
 

--- a/tests/ravn/unit/test_composition_root.py
+++ b/tests/ravn/unit/test_composition_root.py
@@ -415,9 +415,7 @@ class TestBuildTools:
         by_name = {tool.name: tool for tool in tools}
         assert "persisted_metric_window" not in by_name
 
-        listed = await by_name["capability_list"].execute(
-            {"kind": "tool", "query": "persisted_metric_window"}
-        )
+        listed = await by_name["capability_list"].execute({"kind": "tool", "tags": ["learned"]})
         assert not listed.is_error
         payload = json.loads(listed.content)
         assert payload["count"] == 1

--- a/tests/test_observatory/test_entity_discovery.py
+++ b/tests/test_observatory/test_entity_discovery.py
@@ -142,6 +142,59 @@ async def test_kubernetes_discovery_projects_valkyrie_type(tmp_path, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_kubernetes_discovery_projects_a2a_agent_annotations(tmp_path, monkeypatch) -> None:
+    service_account = tmp_path / "sa"
+    service_account.mkdir()
+    (service_account / "token").write_text("token", encoding="utf-8")
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "kubernetes.test")
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "metadata": {
+                            "name": "niuu-ting",
+                            "namespace": "volundr",
+                            "uid": "uid-ting",
+                            "labels": {
+                                "niuu.world/cluster": "ymir",
+                                "app.kubernetes.io/name": "ting",
+                                "app.kubernetes.io/component": "saga-coordinator",
+                            },
+                            "annotations": {
+                                "observatory.niuu.world/a2a-card-url": (
+                                    "https://yggdrasil.example/.well-known/agent-card.json"
+                                ),
+                                "observatory.niuu.world/a2a-visibility": "system",
+                            },
+                        },
+                        "status": {
+                            "phase": "Running",
+                        },
+                    }
+                ]
+            },
+        )
+
+    adapter = KubernetesDiscoveryAdapter(
+        cluster="ymir",
+        include_kinds=["pods"],
+        service_account_root=str(service_account),
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = await adapter.discover()
+
+    assert len(result.entities) == 1
+    assert result.entities[0].endpoints == {
+        "a2aCard": "https://yggdrasil.example/.well-known/agent-card.json"
+    }
+    assert result.entities[0].metadata["visibility"] == "system"
+
+
+@pytest.mark.asyncio
 async def test_kubernetes_discovery_collapses_resources_to_logical_entities(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/test_ravn/test_capability_catalog.py
+++ b/tests/test_ravn/test_capability_catalog.py
@@ -101,7 +101,7 @@ def test_workflow_capability_is_a_catalog_entry_not_a_signal_route() -> None:
     assert capability.to_codex_action()["kind"] == "workflow"
 
 
-def test_filter_capabilities_by_kind_tag_and_query() -> None:
+def test_filter_capabilities_by_kind_and_tag() -> None:
     capabilities = [
         capability_from_tool(
             name="mimir_search",
@@ -121,6 +121,5 @@ def test_filter_capabilities_by_kind_tag_and_query() -> None:
             capabilities,
             kind=CapabilityKind.WORKFLOW,
             tags=["tool-builder"],
-            query="builder",
         )
     ] == ["Tool Builder"]

--- a/tests/test_ravn/test_capability_list_tool.py
+++ b/tests/test_ravn/test_capability_list_tool.py
@@ -154,33 +154,25 @@ async def test_capability_list_filters_catalog_without_routing() -> None:
 
 
 @pytest.mark.asyncio
-async def test_capability_list_distinguishes_no_match_from_empty_catalog() -> None:
+async def test_capability_list_returns_complete_catalog_without_text_filtering() -> None:
     tool = CapabilityListTool(
         tools_provider=lambda: [FakeTool()],
         agent_directory=FakeAgentDirectory(),
     )
 
-    result = await tool.execute({"query": "unknown machine protocol"})
+    assert "query" not in tool.input_schema["properties"]
+
+    result = await tool.execute({})
 
     payload = json.loads(result.content)
-    assert payload["capabilities"] == []
-    assert payload["total"] == 0
+    assert [item["name"] for item in payload["capabilities"]] == [
+        "mimir_search",
+        "Research environment",
+    ]
+    assert payload["total"] == 2
     assert payload["catalog_total"] == 2
     assert payload["catalog_counts"] == {"tool": 1, "agent_skill": 1}
-    assert payload["catalog_preview"] == [
-        {
-            "id": "tool:mimir_search",
-            "kind": "tool",
-            "name": "mimir_search",
-            "source": "ravn",
-        },
-        {
-            "id": "agent:agent-1:research",
-            "kind": "agent_skill",
-            "name": "Research environment",
-            "source": "agent-card",
-        },
-    ]
+    assert payload["catalog_preview"] == []
 
 
 @pytest.mark.asyncio
@@ -190,7 +182,7 @@ async def test_capability_list_projects_agent_card_skills_with_invocation_metada
         agent_directory=FakeAgentDirectory(),
     )
 
-    result = await tool.execute({"kind": "agent_skill", "query": "research"})
+    result = await tool.execute({"kind": "agent_skill"})
 
     assert not result.is_error
     payload = json.loads(result.content)

--- a/tests/test_ting/test_a2a_card.py
+++ b/tests/test_ting/test_a2a_card.py
@@ -125,6 +125,17 @@ class TestAgentCard:
         card = parse_agent_card(response.json())
         assert list(card.skills) == []
 
+    def test_workflow_without_declared_tags_gets_protocol_tag(self) -> None:
+        workflow = _workflow()
+        workflow.graph["tags"] = []
+        client = _client(InMemoryWorkflowRepository([workflow]))
+
+        response = client.get(CARD_PATH)
+
+        assert response.status_code == 200
+        card = parse_agent_card(response.json())
+        assert list(card.skills[0].tags) == ["workflow"]
+
     def test_new_workflow_appears_without_restart(self) -> None:
         repo = InMemoryWorkflowRepository([_workflow()])
         client = _client(repo)


### PR DESCRIPTION
## Summary
- remove misleading free-text filtering from the model-facing capability catalog
- publish Ting Agent Cards through existing Observatory Kubernetes discovery annotations
- ensure every Ting workflow skill satisfies the A2A required non-empty tags contract

## Verification
- full suite: 17,376 passed, 1 stale expectation failed; updated that expectation to use kind/tag selection
- affected composition and A2A suites: 52 passed
- Ruff check and formatting pass