### PR TITLE
fix(observatory): honor explicit image tag

### DIFF
--- a/charts/observatory/templates/_helpers.tpl
+++ b/charts/observatory/templates/_helpers.tpl
@@ -77,7 +77,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Return the proper image name (global overrides local)
+Return the proper image name (local tag overrides global default)
 */}}
 {{- define "observatory.image" -}}
 {{- $registryName := .Values.image.registry -}}
@@ -87,7 +87,7 @@ Return the proper image name (global overrides local)
   {{- if .Values.global.image.registry -}}
     {{- $registryName = .Values.global.image.registry -}}
   {{- end -}}
-  {{- if .Values.global.image.tag -}}
+  {{- if and (not .Values.image.tag) .Values.global.image.tag -}}
     {{- $tag = .Values.global.image.tag -}}
   {{- end -}}
 {{- end -}}

--- a/tests/test_charts/test_niuu_chart.py
+++ b/tests/test_charts/test_niuu_chart.py
@@ -87,6 +87,19 @@ class TestIngressTemplate:
         assert _service_for_path(rendered, "/s") == "niuu-test-volundr"
 
 
+def test_observatory_image_tag_overrides_global_default() -> None:
+    rendered = _render_niuu_chart(
+        "--set",
+        "global.image.tag=global-tag",
+        "--set",
+        "observatory.image.tag=observatory-tag",
+    )
+
+    assert _deployment_image(rendered, "niuu-test-observatory") == (
+        "ghcr.io/niuulabs/niuu:observatory-tag"
+    )
+
+
 def test_guild_envoy_accepts_websocket_upgrades() -> None:
     envoy_template = (GUILD_CHART_DIR / "templates" / "envoy-configmap.yaml").read_text()
 
@@ -142,3 +155,14 @@ def _service_for_path(rendered_yaml: str, path: str) -> str:
                 if route["path"] == path:
                     return route["backend"]["service"]["name"]
     raise AssertionError(f"route path not found: {path}")
+
+
+def _deployment_image(rendered_yaml: str, name: str) -> str:
+    for document in yaml.safe_load_all(rendered_yaml):
+        if (
+            isinstance(document, dict)
+            and document.get("kind") == "Deployment"
+            and document.get("metadata", {}).get("name") == name
+        ):
+            return document["spec"]["template"]["spec"]["containers"][0]["image"]
+    raise AssertionError(f"deployment not found: {name}")


### PR DESCRIPTION
## Summary
- let an explicit Observatory image tag override the umbrella global default, matching Ting/Ravn behavior
- add an umbrella render test proving the selected deployment image

## Verification
- `tests/test_charts/test_niuu_chart.py`: 10 passed
- `helm lint charts/observatory`
- Ruff check and formatting pass