### PR TITLE
fix(ravn): configure default A2A task metadata

### DIFF
--- a/src/ravn/adapters/channels/capture.py
+++ b/src/ravn/adapters/channels/capture.py
@@ -26,6 +26,7 @@ Sleipnir streaming extension path (NIU-545, future work):
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -48,6 +49,7 @@ class CapturedEvent:
     type: str
     summary: str  # human-readable one-liner
     timestamp: datetime
+    details: dict[str, object] | None = None
 
 
 @dataclass
@@ -135,6 +137,14 @@ class TaskResultStore:
         """Return task IDs currently marked as running."""
         return [tid for tid, r in self._store.items() if r.status == "running"]
 
+    def results(self) -> tuple[TaskResult, ...]:
+        """Return the bounded results in insertion order for factual projections."""
+        return tuple(
+            result
+            for task_id in self._insertion_order
+            if (result := self._store.get(task_id)) is not None
+        )
+
 
 def _summarise_event(event: RavnEvent) -> str:
     """Produce a human-readable one-liner for each event type."""
@@ -163,6 +173,47 @@ def _summarise_event(event: RavnEvent) -> str:
     raise AssertionError("Unreachable _summarise_event fallthrough")
 
 
+def _capture_details(event: RavnEvent) -> dict[str, object] | None:
+    """Retain bounded structured tool facts for live runtime projections."""
+    if event.type == RavnEventType.TOOL_START:
+        tool_input = event.payload.get("input")
+        return {
+            "tool_name": str(event.payload.get("tool_name") or ""),
+            "input": _bounded_mapping(tool_input) if isinstance(tool_input, dict) else {},
+        }
+    if event.type == RavnEventType.TOOL_RESULT:
+        result = str(event.payload.get("result") or "")
+        try:
+            parsed: object = json.loads(result)
+        except (TypeError, ValueError):
+            parsed = result[:8_000]
+        if isinstance(parsed, dict):
+            parsed = _bounded_mapping(parsed)
+        elif not isinstance(parsed, str):
+            parsed = str(parsed)[:8_000]
+        return {
+            "tool_name": str(event.payload.get("tool_name") or ""),
+            "result": parsed,
+            "is_error": bool(event.payload.get("is_error")),
+        }
+    return None
+
+
+def _bounded_mapping(value: dict[object, object]) -> dict[str, object]:
+    """Keep identifying tool inputs without retaining unbounded prompts."""
+    bounded: dict[str, object] = {}
+    for key, item in list(value.items())[:16]:
+        name = str(key)[:128]
+        if isinstance(item, str):
+            bounded[name] = item[:2_000]
+        elif item is None or isinstance(item, bool | int | float):
+            bounded[name] = item
+        else:
+            rendered = json.dumps(item, default=str, sort_keys=True)
+            bounded[name] = rendered[:2_000]
+    return bounded
+
+
 class CaptureChannel(ChannelPort):
     """Accumulates all events for a task into a retrievable result.
 
@@ -187,6 +238,7 @@ class CaptureChannel(ChannelPort):
             type=str(event.type),
             summary=summary,
             timestamp=event.timestamp,
+            details=_capture_details(event),
         )
         self._store.append_event(self._task_id, captured)
 

--- a/src/ravn/adapters/tools/a2a_task.py
+++ b/src/ravn/adapters/tools/a2a_task.py
@@ -31,6 +31,7 @@ class A2ATaskTool(ToolPort):
         trusted_origins: list[str] | None = None,
         result_max_chars: int = _DEFAULT_RESULT_MAX_CHARS,
         message_max_chars: int = _DEFAULT_MESSAGE_MAX_CHARS,
+        default_start_metadata: dict[str, Any] | None = None,
     ) -> None:
         self._directory = agent_directory
         self._client = client
@@ -39,6 +40,7 @@ class A2ATaskTool(ToolPort):
         )
         self._result_max_chars = max(1_000, result_max_chars)
         self._message_max_chars = max(1_000, message_max_chars)
+        self._default_start_metadata = dict(default_start_metadata or {})
 
     @property
     def name(self) -> str:
@@ -225,12 +227,14 @@ class A2ATaskTool(ToolPort):
             if skill_id not in agent.skill_ids:
                 raise _A2ATaskError(f"Agent {agent.id!r} does not publish skill {skill_id!r}")
             supplied_metadata = input.get("metadata")
-            metadata = dict(supplied_metadata) if isinstance(supplied_metadata, dict) else {}
-            self._validate_metadata(metadata)
+            metadata = dict(self._default_start_metadata)
+            if isinstance(supplied_metadata, dict):
+                metadata.update(supplied_metadata)
             metadata["skillId"] = skill_id
             trace_context = get_observability().inject()
             if trace_context:
                 metadata["traceContext"] = trace_context
+            self._validate_metadata(metadata)
             return await self._rpc(
                 endpoint,
                 "SendMessage",

--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -391,6 +391,7 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
             "trusted_origins": ctx["a2a_trusted_origins"],
             "message_max_chars": s.gateway.platform.a2a_message_max_chars,
             "result_max_chars": s.gateway.platform.a2a_result_max_chars,
+            "default_start_metadata": s.gateway.platform.a2a_default_metadata,
         },
     ),
     "ting_plan": BuiltinToolDef(

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1127,6 +1127,13 @@ class PlatformToolsConfig(BaseModel):
         ge=1_000,
         description="Maximum model-facing A2A task snapshot size.",
     )
+    a2a_default_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Default metadata for new A2A tasks. Explicit tool input overrides these "
+            "values; Ravn always sets skillId and traceContext itself."
+        ),
+    )
     workflow_aliases: dict[str, PlatformWorkflowAliasConfig] = Field(
         default_factory=dict,
         description=(

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -91,6 +91,15 @@ _DREAM_CYCLE_TRIGGER = "dream_cycle:cron"
 _DREAM_COUNT_FIELDS = ("pages_updated", "entities_created", "lint_fixes")
 _RAVN_TASK_STARTED = "ravn.task.started"
 _TRACEPARENT_PATTERN = re.compile(r"^[\da-fA-F]{2}-([\da-fA-F]{32})-[\da-fA-F]{16}-[\da-fA-F]{2}$")
+_A2A_TERMINAL_STATES = frozenset(
+    {
+        "TASK_STATE_CANCELED",
+        "TASK_STATE_CANCELLED",
+        "TASK_STATE_COMPLETED",
+        "TASK_STATE_FAILED",
+        "TASK_STATE_REJECTED",
+    }
+)
 
 
 def _bounded_hud_text(value: str, limit: int) -> str:
@@ -133,6 +142,120 @@ def _resident_hud_task_input(task: AgentTask, limit: int) -> dict[str, str]:
         "observations": _bounded_hud_text(observations, limit),
         "objective": _bounded_hud_text(objective, limit),
     }
+
+
+def _resident_hud_a2a_tasks(
+    results: tuple[TaskResult, ...],
+    *,
+    active_parent_ids: set[str],
+) -> list[dict[str, object]]:
+    """Project the latest observed state of non-terminal A2A tasks."""
+    sessions: dict[str, dict[str, object]] = {}
+    for result in results:
+        pending_input: dict[str, object] | None = None
+        pending_started_at: datetime | None = None
+        for event in result.events:
+            details = event.details if isinstance(event.details, dict) else {}
+            if details.get("tool_name") != "a2a_task":
+                continue
+            if event.type == "tool_start":
+                supplied = details.get("input")
+                pending_input = dict(supplied) if isinstance(supplied, dict) else {}
+                pending_started_at = event.timestamp
+                continue
+            if event.type != "tool_result":
+                continue
+            payload = details.get("result")
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except ValueError:
+                    payload = {}
+            if not isinstance(payload, dict):
+                pending_input = None
+                pending_started_at = None
+                continue
+
+            agent_id = str(payload.get("agent_id") or (pending_input or {}).get("agent_id") or "")
+            task_id = str(payload.get("task_id") or (pending_input or {}).get("task_id") or "")
+            if not agent_id or not task_id:
+                pending_input = None
+                pending_started_at = None
+                continue
+            state = str(payload.get("state") or "TASK_STATE_UNSPECIFIED")
+            key = f"{agent_id}:{task_id}"
+            if state in _A2A_TERMINAL_STATES:
+                sessions.pop(key, None)
+            else:
+                prior = sessions.get(key, {})
+                questions = payload.get("pending_questions")
+                if isinstance(questions, str):
+                    try:
+                        questions = json.loads(questions)
+                    except ValueError:
+                        questions = []
+                question = ""
+                if isinstance(questions, list) and questions and isinstance(questions[0], dict):
+                    question = str(questions[0].get("question") or "")
+                task_input = pending_input or {}
+                sessions[key] = {
+                    "agent_id": agent_id,
+                    "skill_id": str(task_input.get("skill_id") or prior.get("skill_id") or ""),
+                    "task_id": task_id,
+                    "state": state,
+                    "operation": str(payload.get("operation") or task_input.get("operation") or ""),
+                    "input_required": bool(payload.get("input_required")),
+                    "question": _bounded_hud_text(question, 500),
+                    "prompt": _bounded_hud_text(
+                        str(task_input.get("prompt") or prior.get("prompt") or ""),
+                        500,
+                    ),
+                    "status_message": _bounded_hud_text(
+                        str(payload.get("status_message") or ""),
+                        500,
+                    ),
+                    "parent_task_id": result.task_id,
+                    "parent_active": result.task_id in active_parent_ids,
+                    "started_at": prior.get("started_at")
+                    or (pending_started_at or event.timestamp).isoformat(),
+                    "observed_at": event.timestamp.isoformat(),
+                }
+            pending_input = None
+            pending_started_at = None
+
+        if pending_input is not None and pending_started_at is not None:
+            agent_id = str(pending_input.get("agent_id") or "")
+            if agent_id:
+                supplied_task_id = str(pending_input.get("task_id") or "")
+                key = (
+                    supplied_task_id
+                    and f"{agent_id}:{supplied_task_id}"
+                    or (f"call:{result.task_id}:{pending_started_at.isoformat()}")
+                )
+                prior = sessions.get(key, {})
+                sessions[key] = {
+                    "agent_id": agent_id,
+                    "skill_id": str(pending_input.get("skill_id") or prior.get("skill_id") or ""),
+                    "task_id": supplied_task_id,
+                    "state": "CALL_IN_PROGRESS",
+                    "operation": str(pending_input.get("operation") or ""),
+                    "input_required": False,
+                    "question": "",
+                    "prompt": _bounded_hud_text(
+                        str(pending_input.get("prompt") or prior.get("prompt") or ""),
+                        500,
+                    ),
+                    "status_message": "",
+                    "parent_task_id": result.task_id,
+                    "parent_active": result.task_id in active_parent_ids,
+                    "started_at": prior.get("started_at") or pending_started_at.isoformat(),
+                    "observed_at": pending_started_at.isoformat(),
+                }
+    return sorted(
+        sessions.values(),
+        key=lambda item: str(item.get("observed_at") or ""),
+        reverse=True,
+    )
 
 
 def _trace_id_from_carrier(carrier: Mapping[str, str]) -> str:
@@ -1222,8 +1345,10 @@ class DriveLoop:
     def resident_hud_status(self) -> dict[str, object]:
         """Return factual, bounded-by-store runtime state for the resident HUD."""
         context_limit = self._settings.gateway.channels.http.resident_hud_task_context_max_chars
+        active_task_ids = self.active_task_ids()
+        active_parent_ids = set(active_task_ids)
         active: list[dict[str, object]] = []
-        for task_id in self.active_task_ids():
+        for task_id in active_task_ids:
             task = self._inflight_tasks.get(task_id) or self._active_task_contexts.get(task_id)
             result = self._result_store.get(task_id)
             events = list(result.events if result is not None else [])
@@ -1289,12 +1414,18 @@ class DriveLoop:
                 list(self._queue._queue)  # type: ignore[attr-defined]
             )
         ]
+        a2a_tasks = _resident_hud_a2a_tasks(
+            self._result_store.results(),
+            active_parent_ids=active_parent_ids,
+        )
         return {
             "active_tasks": active,
             "active_count": len(active),
             "queued_count": self._queue.qsize(),
             "queue_capacity": self._config.task_queue_max,
             "queued_tasks": queued,
+            "a2a_tasks": a2a_tasks,
+            "a2a_count": len(a2a_tasks),
             "model": self._settings.effective_model(),
         }
 

--- a/src/ravn/static/resident-hud.html
+++ b/src/ravn/static/resident-hud.html
@@ -112,6 +112,24 @@
   .activity-event.tool_start{border-color:var(--obs)}
   .activity-event.error,.activity-event.warning{border-color:var(--gap)}
   .activity-event.error .event-main,.activity-event.warning .event-result{color:var(--gap)}
+  .a2a-panel{border:1px solid var(--line2);background:rgba(168,112,245,.05);
+    margin-bottom:10px}
+  .a2a-panel[hidden]{display:none}
+  .a2a-panel>header{display:flex;align-items:center;justify-content:space-between;
+    padding:6px 8px;border-bottom:1px solid var(--line);color:var(--unk);
+    font-size:9px;letter-spacing:.16em;text-transform:uppercase}
+  .a2a-list{display:flex;flex-direction:column;gap:1px}
+  .a2a-task{padding:8px;border-left:2px solid var(--unk);background:var(--panel2)}
+  .a2a-task.input-required{border-left-color:var(--hyp)}
+  .a2a-task .a2a-title{display:flex;align-items:center;justify-content:space-between;
+    gap:8px;color:var(--tx);font-size:10px}
+  .a2a-task .a2a-state{color:var(--unk);font-size:8.5px;letter-spacing:.08em;
+    text-transform:uppercase;white-space:nowrap}
+  .a2a-task.input-required .a2a-state{color:var(--hyp)}
+  .a2a-task .a2a-detail{color:var(--dim);font-size:9px;margin-top:4px;
+    white-space:pre-wrap;overflow-wrap:anywhere}
+  .a2a-task .a2a-meta{color:var(--dim2);font-size:8px;margin-top:4px;
+    overflow-wrap:anywhere}
   .queue-card h2{color:var(--hyp)}
   .queue-list{display:flex;flex-direction:column;gap:6px}
   .queue-item{padding:7px 8px;border:1px solid var(--line);background:var(--panel2)}
@@ -247,6 +265,7 @@
     </div>
     <div class="runtime-meta">
       <span>ACTIVE <b id="ractive">0</b></span>
+      <span>A2A <b id="ra2a">0</b></span>
       <span>QUEUED <b id="rqueued">0</b></span>
       <span>UPDATED <b id="rupdated">—</b></span>
     </div>
@@ -287,6 +306,13 @@
         </div>
       </header>
       <div class="live-body">
+        <section class="a2a-panel" id="a2a-panel" hidden>
+          <header>
+            <span>Open A2A tasks</span>
+            <b id="a2a-count">0</b>
+          </header>
+          <div class="a2a-list" id="a2a-list"></div>
+        </section>
         <div class="activity-list" id="activity-list"></div>
       </div>
     </section>
@@ -634,6 +660,41 @@ function renderActivity(events){
   }
 }
 
+function a2aState(value){
+  return String(value||"unknown").replace(/^TASK_STATE_/,"").replace(/_/g," ");
+}
+
+function renderA2A(runtime){
+  const tasks=runtime.a2a_tasks||[], panel=document.getElementById("a2a-panel"),
+        list=document.getElementById("a2a-list");
+  document.getElementById("ra2a").textContent=runtime.a2a_count||tasks.length;
+  document.getElementById("a2a-count").textContent=tasks.length;
+  panel.hidden=!tasks.length;
+  list.replaceChildren();
+  tasks.forEach(task=>{
+    const item=document.createElement("article");
+    item.className=`a2a-task${task.input_required?" input-required":""}`;
+    const title=document.createElement("div");
+    title.className="a2a-title";
+    const identity=document.createElement("b");
+    identity.textContent=task.skill_id||task.agent_id||"Peer task";
+    const state=document.createElement("span");
+    state.className="a2a-state";
+    state.textContent=a2aState(task.state);
+    title.append(identity,state);
+    const detail=document.createElement("div");
+    detail.className="a2a-detail";
+    detail.textContent=task.question||task.status_message||task.prompt||"No status detail returned.";
+    const meta=document.createElement("div");
+    meta.className="a2a-meta";
+    const taskId=task.task_id||"awaiting task id";
+    const parent=task.parent_active?"parent running":"parent turn complete";
+    meta.textContent=`${task.agent_id||"unknown peer"} · ${taskId} · ${parent} · observed ${elapsedSince(task.observed_at)} ago`;
+    item.append(title,detail,meta);
+    list.appendChild(item);
+  });
+}
+
 function renderQueue(runtime){
   const queued=runtime.queued_tasks||[], count=runtime.queued_count||0,
         capacity=runtime.queue_capacity||0, list=document.getElementById("queue-list");
@@ -703,7 +764,10 @@ function renderRuntime(d){
 
   const live=document.getElementById("live-layout"), input=task?.input||{},
         progress=task?.progress||{}, events=task?.events||[];
-  live.classList.toggle("on",Boolean(task)||(runtime.queued_count||0)>0);
+  live.classList.toggle(
+    "on",
+    Boolean(task)||(runtime.queued_count||0)>0||(runtime.a2a_count||0)>0
+  );
   document.getElementById("input-summary").textContent=input.summary||task?.title||"Waiting to start";
   renderObservations(input.observations||(
     task?"":"The next queued task has not started."
@@ -721,6 +785,7 @@ function renderRuntime(d){
     ? `${progress.iteration||0} / ${progress.iteration_budget}`:`${progress.iteration||0}`;
   document.getElementById("live-tools").textContent=progress.tool_calls||0;
   document.getElementById("live-warnings").textContent=progress.warnings||0;
+  renderA2A(runtime);
   renderActivity(events);
   renderQueue(runtime);
 

--- a/tests/test_ravn/test_a2a_task_tool.py
+++ b/tests/test_ravn/test_a2a_task_tool.py
@@ -209,6 +209,38 @@ async def test_a2a_task_propagates_active_trace_in_message_metadata(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_a2a_task_merges_configured_start_metadata_with_explicit_input() -> None:
+    client = _Client([{"task": {"id": "task-1", "status": {"state": "TASK_STATE_SUBMITTED"}}}])
+    tool = A2ATaskTool(
+        agent_directory=_Directory(_agent()),
+        client=client,
+        default_start_metadata={
+            "connectionId": "configured-target",
+            "model": "configured-model",
+            "skillId": "must-not-win",
+        },
+    )
+
+    result = await tool.execute(
+        {
+            "operation": "start",
+            "agent_id": _agent().id,
+            "skill_id": "review",
+            "prompt": "Review the change.",
+            "metadata": {"model": "requested-model"},
+        }
+    )
+
+    assert not result.is_error
+    metadata = client.posts[0][1]["params"]["message"]["metadata"]
+    assert metadata == {
+        "connectionId": "configured-target",
+        "model": "requested-model",
+        "skillId": "review",
+    }
+
+
+@pytest.mark.asyncio
 async def test_a2a_task_rejects_unknown_agent_and_unpublished_skill() -> None:
     unknown = A2ATaskTool(agent_directory=_Directory(), client=_Client([]))
     missing_agent = await unknown.execute(

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -206,6 +206,8 @@ Determine whether the observations require action.
         ]
         assert status["queue_capacity"] == 10
         assert status["queued_tasks"] == []
+        assert status["a2a_count"] == 0
+        assert status["a2a_tasks"] == []
         assert status["model"] == "test-model"
 
     def test_resident_hud_status_describes_waiting_tasks(self):
@@ -230,6 +232,110 @@ Determine whether the observations require action.
                 "input_summary": "Signals since your last look — 3 observation(s)",
             }
         ]
+
+    def test_resident_hud_status_projects_latest_non_terminal_a2a_task(self):
+        dl, _ = _make_drive_loop_with_mesh(cascade_enabled=True)
+        parent = _make_task("parent-task")
+        dl._active_tasks[parent.task_id] = MagicMock()
+        dl._inflight_tasks[parent.task_id] = parent
+        dl._result_store.start(parent.task_id, parent.triggered_by)
+        started_at = datetime(2026, 7, 25, 10, 0, tzinfo=UTC)
+        observed_at = datetime(2026, 7, 25, 10, 1, tzinfo=UTC)
+        dl._result_store.append_event(
+            parent.task_id,
+            CapturedEvent(
+                type="tool_start",
+                summary="tool: a2a_task(...)",
+                timestamp=started_at,
+                details={
+                    "tool_name": "a2a_task",
+                    "input": {
+                        "operation": "start",
+                        "agent_id": "agent-1",
+                        "skill_id": "research",
+                        "prompt": "Investigate the observed fault.",
+                    },
+                },
+            ),
+        )
+        dl._result_store.append_event(
+            parent.task_id,
+            CapturedEvent(
+                type="tool_result",
+                summary="→ working",
+                timestamp=observed_at,
+                details={
+                    "tool_name": "a2a_task",
+                    "result": {
+                        "operation": "start",
+                        "agent_id": "agent-1",
+                        "task_id": "task-1",
+                        "state": "TASK_STATE_INPUT_REQUIRED",
+                        "input_required": True,
+                        "pending_questions": [{"question": "Which firmware version?"}],
+                    },
+                    "is_error": False,
+                },
+            ),
+        )
+
+        status = dl.resident_hud_status()
+
+        assert status["a2a_count"] == 1
+        assert status["a2a_tasks"] == [
+            {
+                "agent_id": "agent-1",
+                "skill_id": "research",
+                "task_id": "task-1",
+                "state": "TASK_STATE_INPUT_REQUIRED",
+                "operation": "start",
+                "input_required": True,
+                "question": "Which firmware version?",
+                "prompt": "Investigate the observed fault.",
+                "status_message": "",
+                "parent_task_id": "parent-task",
+                "parent_active": True,
+                "started_at": started_at.isoformat(),
+                "observed_at": observed_at.isoformat(),
+            }
+        ]
+
+        dl._result_store.append_event(
+            parent.task_id,
+            CapturedEvent(
+                type="tool_start",
+                summary="tool: a2a_task(...)",
+                timestamp=observed_at,
+                details={
+                    "tool_name": "a2a_task",
+                    "input": {
+                        "operation": "get",
+                        "agent_id": "agent-1",
+                        "task_id": "task-1",
+                    },
+                },
+            ),
+        )
+        dl._result_store.append_event(
+            parent.task_id,
+            CapturedEvent(
+                type="tool_result",
+                summary="→ complete",
+                timestamp=datetime(2026, 7, 25, 10, 2, tzinfo=UTC),
+                details={
+                    "tool_name": "a2a_task",
+                    "result": {
+                        "operation": "get",
+                        "agent_id": "agent-1",
+                        "task_id": "task-1",
+                        "state": "TASK_STATE_COMPLETED",
+                    },
+                    "is_error": False,
+                },
+            ),
+        )
+
+        assert dl.resident_hud_status()["a2a_tasks"] == []
 
     @pytest.mark.asyncio
     async def test_no_cascade_skuld_and_mesh_uses_composite(self):


### PR DESCRIPTION
Allows deployment configuration to supply default metadata for newly started A2A tasks. Explicit model-supplied metadata still wins, while Ravn retains ownership of skillId and trace context.

Live A2A discovery and JSON-RPC dispatch worked, but a Research Campaign without an execution target fell through to Ting’s default executor and failed because that executor had no Codex auth document. The model should choose the peer, skill, and task; it should not have to guess an opaque deployment-specific connection UUID.

Validation:
- 179 focused Ravn configuration and A2A tests passed
- Ruff check and formatting passed
- live standard A2A task launch with the configured target remained active instead of failing at startup