### PR TITLE
fix(ravn): keep A2A execution routing in Ting

### DIFF
--- a/src/ravn/adapters/tools/a2a_task.py
+++ b/src/ravn/adapters/tools/a2a_task.py
@@ -31,7 +31,6 @@ class A2ATaskTool(ToolPort):
         trusted_origins: list[str] | None = None,
         result_max_chars: int = _DEFAULT_RESULT_MAX_CHARS,
         message_max_chars: int = _DEFAULT_MESSAGE_MAX_CHARS,
-        default_start_metadata: dict[str, Any] | None = None,
     ) -> None:
         self._directory = agent_directory
         self._client = client
@@ -40,7 +39,6 @@ class A2ATaskTool(ToolPort):
         )
         self._result_max_chars = max(1_000, result_max_chars)
         self._message_max_chars = max(1_000, message_max_chars)
-        self._default_start_metadata = dict(default_start_metadata or {})
 
     @property
     def name(self) -> str:
@@ -227,14 +225,12 @@ class A2ATaskTool(ToolPort):
             if skill_id not in agent.skill_ids:
                 raise _A2ATaskError(f"Agent {agent.id!r} does not publish skill {skill_id!r}")
             supplied_metadata = input.get("metadata")
-            metadata = dict(self._default_start_metadata)
-            if isinstance(supplied_metadata, dict):
-                metadata.update(supplied_metadata)
+            metadata = dict(supplied_metadata) if isinstance(supplied_metadata, dict) else {}
+            self._validate_metadata(metadata)
             metadata["skillId"] = skill_id
             trace_context = get_observability().inject()
             if trace_context:
                 metadata["traceContext"] = trace_context
-            self._validate_metadata(metadata)
             return await self._rpc(
                 endpoint,
                 "SendMessage",

--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -391,7 +391,6 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
             "trusted_origins": ctx["a2a_trusted_origins"],
             "message_max_chars": s.gateway.platform.a2a_message_max_chars,
             "result_max_chars": s.gateway.platform.a2a_result_max_chars,
-            "default_start_metadata": s.gateway.platform.a2a_default_metadata,
         },
     ),
     "ting_plan": BuiltinToolDef(

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1127,13 +1127,6 @@ class PlatformToolsConfig(BaseModel):
         ge=1_000,
         description="Maximum model-facing A2A task snapshot size.",
     )
-    a2a_default_metadata: dict[str, Any] = Field(
-        default_factory=dict,
-        description=(
-            "Default metadata for new A2A tasks. Explicit tool input overrides these "
-            "values; Ravn always sets skillId and traceContext itself."
-        ),
-    )
     workflow_aliases: dict[str, PlatformWorkflowAliasConfig] = Field(
         default_factory=dict,
         description=(

--- a/tests/test_ravn/test_a2a_task_tool.py
+++ b/tests/test_ravn/test_a2a_task_tool.py
@@ -209,38 +209,6 @@ async def test_a2a_task_propagates_active_trace_in_message_metadata(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_a2a_task_merges_configured_start_metadata_with_explicit_input() -> None:
-    client = _Client([{"task": {"id": "task-1", "status": {"state": "TASK_STATE_SUBMITTED"}}}])
-    tool = A2ATaskTool(
-        agent_directory=_Directory(_agent()),
-        client=client,
-        default_start_metadata={
-            "connectionId": "configured-target",
-            "model": "configured-model",
-            "skillId": "must-not-win",
-        },
-    )
-
-    result = await tool.execute(
-        {
-            "operation": "start",
-            "agent_id": _agent().id,
-            "skill_id": "review",
-            "prompt": "Review the change.",
-            "metadata": {"model": "requested-model"},
-        }
-    )
-
-    assert not result.is_error
-    metadata = client.posts[0][1]["params"]["message"]["metadata"]
-    assert metadata == {
-        "connectionId": "configured-target",
-        "model": "requested-model",
-        "skillId": "review",
-    }
-
-
-@pytest.mark.asyncio
 async def test_a2a_task_rejects_unknown_agent_and_unpublished_skill() -> None:
     unknown = A2ATaskTool(agent_directory=_Directory(), client=_Client([]))
     missing_agent = await unknown.execute(


### PR DESCRIPTION
## Summary
- remove the caller-side `a2a_default_metadata` configuration surface
- stop Ravn from injecting receiver deployment routing into A2A messages
- retain the independent resident HUD A2A task projection

Ting already selects Guild's `is_default` Volundr target; deployment configuration will mark the working Valhalla target as default.

## Verification
- `uv run --extra dev pytest -q tests/test_ravn` (4550 passed, 7 skipped)
- focused A2A/HUD tests (18 passed)
- Ruff lint and format checks