### PR TITLE
fix(ravn): align Mimir source provenance

### DIFF
--- a/src/mimir/router.py
+++ b/src/mimir/router.py
@@ -50,6 +50,7 @@ from niuu.domain.mimir import (
     MimirPageMeta,
     MimirSource,
     compute_content_hash,
+    compute_source_id,
 )
 from niuu.ports.mimir import MimirPort
 from ravn.adapters.tools._url_security import check_ssrf
@@ -1838,7 +1839,7 @@ class MimirRouter:
         ) -> IngestResponse:
             port, _ = self._resolve_port(request.mount)
             content_hash = compute_content_hash(request.content)
-            source_id = "src_" + content_hash[:16]
+            source_id = compute_source_id(request.content)
             source = MimirSource(
                 source_id=source_id,
                 title=request.title,

--- a/src/niuu/domain/mimir.py
+++ b/src/niuu/domain/mimir.py
@@ -58,6 +58,11 @@ def compute_content_hash(content: str) -> str:
     return hashlib.sha256(content.encode()).hexdigest()
 
 
+def compute_source_id(content: str) -> str:
+    """Return the canonical identifier for an immutable raw source."""
+    return "src_" + compute_content_hash(content)[:16]
+
+
 # ---------------------------------------------------------------------------
 # Slug utility
 # ---------------------------------------------------------------------------

--- a/src/ravn/adapters/mimir/http.py
+++ b/src/ravn/adapters/mimir/http.py
@@ -150,6 +150,12 @@ class HttpMimirAdapter(MimirPort):
         response = await self._request("POST", "/mimir/ingest", json=payload)
         response.raise_for_status()
         data = response.json()
+        returned_source_id = str(data.get("source_id") or "")
+        if returned_source_id != source.source_id:
+            raise RuntimeError(
+                "Mímir source ID contract mismatch: "
+                f"expected {source.source_id}, received {returned_source_id or '<missing>'}"
+            )
         return data.get("pages_updated", [])
 
     async def query(self, question: str) -> MimirQueryResult:

--- a/src/ravn/adapters/tools/mimir_tools.py
+++ b/src/ravn/adapters/tools/mimir_tools.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from mimir.compiled_truth import parse_page as parse_compiled_truth_page
-from niuu.domain.mimir import MimirSource, compute_content_hash
+from niuu.domain.mimir import MimirSource, compute_content_hash, compute_source_id
 from ravn.adapters.tools.entity_extractor import EntityExtractor
 from ravn.adapters.tools.file_security import PathSecurityError, resolve_safe
 from ravn.domain.models import ToolResult
@@ -32,10 +32,6 @@ logger = logging.getLogger(__name__)
 _PERMISSION = "mimir:write"
 _PERMISSION_READ = "mimir:read"
 _MIMIR_SOURCE_INGESTED_EVENT = "mimir.source.ingested"
-
-
-def _source_id_from_content(title: str, content: str) -> str:
-    return "src_" + compute_content_hash(f"{title}:{content}")[:16]
 
 
 def _is_provenance_optional_research_path(path: str) -> bool:
@@ -196,7 +192,7 @@ class MimirIngestTool(ToolPort):
             return ToolResult(tool_call_id="", content="title is required", is_error=True)
 
         source = MimirSource(
-            source_id=_source_id_from_content(title, content),
+            source_id=compute_source_id(content),
             title=title,
             content=content,
             source_type=source_type,

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -2618,6 +2618,11 @@ class DriveLoop:
                     )
                 )
 
+            if success:
+                success = await self._emit_mesh_outcome_event(task, response_text, success=True)
+                if not success:
+                    self._result_store.set_status(task.task_id, "failed")
+
             outcome = "success" if success else "error"
             telemetry.event(
                 "ravn.task.lifecycle",
@@ -2637,9 +2642,6 @@ class DriveLoop:
             await self._emit_sleipnir_task_completed(task, outcome, response_text=response_text)
             if success:
                 await self._emit_sleipnir_mimir_dream_completed(task, response_text=response_text)
-
-            # Publish outcome event to mesh for other agents to consume
-            await self._emit_mesh_outcome_event(task, response_text, success)
 
             await self._event_publisher.publish(
                 RavnEvent(
@@ -3151,7 +3153,7 @@ class DriveLoop:
 
     async def _emit_mesh_outcome_event(
         self, task: AgentTask, response_text: str, success: bool
-    ) -> None:
+    ) -> bool:
         """Publish persona outcomes for both routing and outward visibility.
 
         Canonical outcome events always keep the persona's declared
@@ -3164,21 +3166,21 @@ class DriveLoop:
         react without replacing the canonical outward event.
         """
         if self._persona_config is None:
-            return
+            return success
         if not success:
             logger.info(
                 "drive_loop: skipping mesh outcome publish for failed task_id=%s persona=%s",
                 task.task_id,
                 self._persona_config.name,
             )
-            return
+            return False
 
         # Parse outcome block from response
         parsed = _parse_outcome_for_persona(response_text, self._persona_config)
         outcome_fields = dict(parsed.fields) if parsed is not None else {}
         canonical_event_type = self._persona_config.produces.event_type
         if not canonical_event_type:
-            return
+            return True
         tool_fields = task.tool_outcomes.get(canonical_event_type) or {}
         for key, value in tool_fields.items():
             outcome_fields.setdefault(key, value)
@@ -3306,7 +3308,7 @@ class DriveLoop:
                     errors=validation_errors,
                     canonical_event_type=canonical_event_type,
                 )
-                return
+                return False
             valid = True
 
         outcome_errors: list[str] = []
@@ -3363,7 +3365,7 @@ class DriveLoop:
                     task.workflow_node_id or "-",
                     sorted(allowed_topics),
                 )
-                return
+                return False
 
         canonical_payload = dict(base_payload)
         canonical_payload["event_type"] = canonical_event_type
@@ -3416,7 +3418,7 @@ class DriveLoop:
             )
 
         if outcome_errors:
-            return
+            return False
 
         if self._mesh is None:
             mesh_available = False
@@ -3456,10 +3458,10 @@ class DriveLoop:
             await self._publish_help_needed(task, help_event)
 
         if not mesh_available:
-            return
+            return True
 
         if not alias_event_type or alias_event_type == canonical_event_type:
-            return
+            return True
 
         alias_payload = dict(base_payload)
         alias_payload["event_type"] = alias_event_type
@@ -3500,6 +3502,7 @@ class DriveLoop:
                     "Failed to emit routing outcome alias to skuld; continuing.",
                     exc_info=True,
                 )
+        return True
 
     async def _emit_sleipnir_valkyrie_outcome(
         self,

--- a/tests/ravn/integration/test_http_mimir_integration.py
+++ b/tests/ravn/integration/test_http_mimir_integration.py
@@ -15,6 +15,7 @@ network required.  Covers:
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
@@ -23,6 +24,7 @@ from fastapi import FastAPI
 
 from mimir.adapters.markdown import MarkdownMimirAdapter
 from mimir.router import MimirRouter
+from niuu.domain.mimir import MimirSource, compute_content_hash, compute_source_id
 from ravn.adapters.mimir.composite import CompositeMimirAdapter
 from ravn.adapters.mimir.http import HttpMimirAdapter
 from ravn.domain.mimir import MimirMount, WriteRouting
@@ -54,6 +56,29 @@ def _http_adapter_over_asgi(app: FastAPI) -> HttpMimirAdapter:
 # ---------------------------------------------------------------------------
 # Integration: round-trip via HttpMimirAdapter + ASGI Mimir service
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_round_trip_ingest_preserves_canonical_source_id(tmp_path: Path) -> None:
+    app = _make_mimir_app(tmp_path / "hosted")
+    adapter = _http_adapter_over_asgi(app)
+    content = "Canonical provenance survives the HTTP boundary."
+    source_id = compute_source_id(content)
+    source = MimirSource(
+        source_id=source_id,
+        title="Provenance",
+        content=content,
+        source_type="research",
+        ingested_at=datetime.now(UTC),
+        content_hash=compute_content_hash(content),
+    )
+
+    await adapter.ingest(source)
+
+    stored = await adapter.read_source(source_id)
+    assert stored is not None
+    assert stored.source_id == source_id
+    assert stored.content == content
 
 
 @pytest.mark.asyncio

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -1314,6 +1314,24 @@ async def test_run_task_swallows_emit_session_ended_errors(tmp_path: Path) -> No
     assert task.task_id not in loop._active_agents
 
 
+@pytest.mark.asyncio
+async def test_run_task_fails_when_workflow_outcome_is_rejected(tmp_path: Path) -> None:
+    loop, factory = _make_drive_loop(tmp_path)
+    loop._settings.cascade.enabled = True
+    mock_agent = AsyncMock()
+    mock_agent.run_turn = AsyncMock(return_value=None)
+    mock_agent.emit_session_ended = AsyncMock()
+    factory.return_value = mock_agent
+    loop._emit_mesh_outcome_event = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    task = _make_task()
+    result = await loop._run_task_observed(task)
+
+    assert result == "error"
+    mock_agent.emit_session_ended.assert_awaited_once_with("error")
+    assert loop._result_store.get(task.task_id).status == "failed"
+
+
 # ---------------------------------------------------------------------------
 # DriveLoop — integration: cron trigger fires run_turn
 # ---------------------------------------------------------------------------

--- a/tests/ravn/unit/test_http_mimir.py
+++ b/tests/ravn/unit/test_http_mimir.py
@@ -78,6 +78,17 @@ async def test_ingest_returns_page_paths(adapter: HttpMimirAdapter) -> None:
     assert result == ["technical/test.md"]
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_ingest_rejects_source_id_contract_mismatch(adapter: HttpMimirAdapter) -> None:
+    respx.post("http://mimir.test/mimir/ingest").mock(
+        return_value=Response(200, json={"source_id": "src_different", "pages_updated": []})
+    )
+
+    with pytest.raises(RuntimeError, match="source ID contract mismatch"):
+        await adapter.ingest(_source())
+
+
 # ---------------------------------------------------------------------------
 # HttpMimirAdapter.search
 # ---------------------------------------------------------------------------

--- a/tests/ravn/unit/test_mimir.py
+++ b/tests/ravn/unit/test_mimir.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from niuu.domain.mimir import compute_source_id
 from ravn.adapters.mimir.markdown import (
     MarkdownMimirAdapter,
     _extract_summary,
@@ -548,7 +549,7 @@ async def test_mimir_ingest_tool_success(tmp_path: Path) -> None:
     )
     assert not result.is_error
     assert "Ingested source" in result.content
-    assert "source_id: src_" in result.content
+    assert f"source_id: {compute_source_id('Some content.')}" in result.content
     assert "source_type: document" in result.content
 
 

--- a/tests/test_mimir/unit/test_router.py
+++ b/tests/test_mimir/unit/test_router.py
@@ -17,6 +17,7 @@ from fastapi.testclient import TestClient
 from mimir.adapters.markdown import MarkdownMimirAdapter
 from mimir.registry import MimirRegistryStore
 from mimir.router import MimirRouter
+from niuu.domain.mimir import compute_source_id
 from ravn.adapters.mimir.composite import CompositeMimirAdapter
 from ravn.domain.mimir import MimirMount, WriteRouting
 
@@ -629,8 +630,7 @@ def test_ingest_source(client: TestClient) -> None:
     resp = client.post("/mimir/ingest", json=payload)
     assert resp.status_code == 200
     data = resp.json()
-    assert "source_id" in data
-    assert data["source_id"].startswith("src_")
+    assert data["source_id"] == compute_source_id(payload["content"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_drive_loop_outcome_contract.py
+++ b/tests/test_ravn/test_drive_loop_outcome_contract.py
@@ -1114,8 +1114,9 @@ brief_path: research/campaigns/example/brief.md
 ---end---
 """
 
-        await dl._emit_mesh_outcome_event(task, response_text, success=True)
+        accepted = await dl._emit_mesh_outcome_event(task, response_text, success=True)
 
+        assert accepted is False
         mesh.publish.assert_not_awaited()
         canonical = skuld_channel.emit.await_args.args[0]
         assert canonical.payload["event_type"] == "research.frame.completed"


### PR DESCRIPTION
## Summary
- use one canonical content-derived Mimir source ID on both sides of the existing HTTP boundary
- reject server/client source-ID disagreement immediately
- propagate rejected workflow outcomes into the existing task/session failure lifecycle instead of leaving A2A campaigns WORKING

## Validation
- ruff check and format pass
- focused Mimir and workflow tests pass
- full make verify running