### PR TITLE
fix(ravn): preserve HUD task progress

### DIFF
--- a/src/ravn/adapters/channels/capture.py
+++ b/src/ravn/adapters/channels/capture.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Literal
 
@@ -63,6 +63,7 @@ class TaskResult:
     triggered_by: str
     started_at: datetime
     completed_at: datetime | None
+    metadata: dict[str, object] = field(default_factory=dict)
 
 
 class TaskResultStore:
@@ -79,7 +80,13 @@ class TaskResultStore:
         self._store: dict[str, TaskResult] = {}
         self._insertion_order: list[str] = []
 
-    def start(self, task_id: str, triggered_by: str) -> None:
+    def start(
+        self,
+        task_id: str,
+        triggered_by: str,
+        *,
+        metadata: dict[str, object] | None = None,
+    ) -> None:
         """Register a new running task.  Evicts oldest if at capacity."""
         result = TaskResult(
             task_id=task_id,
@@ -89,6 +96,7 @@ class TaskResultStore:
             triggered_by=triggered_by,
             started_at=datetime.now(UTC),
             completed_at=None,
+            metadata=dict(metadata or {}),
         )
         if task_id in self._store:
             self._store[task_id] = result

--- a/src/ravn/adapters/channels/gateway_http.py
+++ b/src/ravn/adapters/channels/gateway_http.py
@@ -278,8 +278,11 @@ class HttpGateway:
         active_tasks = runtime.get("active_tasks")
         if not isinstance(active_tasks, list):
             active_tasks = []
+        recent_tasks = runtime.get("recent_tasks")
+        if not isinstance(recent_tasks, list):
+            recent_tasks = []
         event_limit = self._config.resident_hud_activity_max_events
-        for task in active_tasks:
+        for task in [*active_tasks, *recent_tasks]:
             if isinstance(task, dict) and isinstance(task.get("events"), list):
                 task["events"] = task["events"][-event_limit:]
 
@@ -295,6 +298,7 @@ class HttpGateway:
             **runtime,
             "state": state,
             "active_tasks": active_tasks,
+            "recent_tasks": recent_tasks,
             "active_count": active_count,
             "queued_count": queued_count,
             "pending_questions": pending,
@@ -302,6 +306,7 @@ class HttpGateway:
         payload["hud"] = {
             "poll_interval_seconds": self._config.resident_hud_poll_interval_seconds,
             "stale_after_seconds": self._config.resident_hud_stale_after_seconds,
+            "recent_task_limit": self._config.resident_hud_recent_tasks,
             "trace_url_template": self._config.resident_hud_trace_url_template,
         }
         return payload

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -989,6 +989,11 @@ class HttpChannelConfig(BaseModel):
         ge=1,
         description="Maximum recent in-flight activity events returned per resident task.",
     )
+    resident_hud_recent_tasks: int = Field(
+        default=5,
+        ge=1,
+        description="Maximum completed tasks retained in the resident HUD progress history.",
+    )
     resident_hud_task_context_max_chars: int = Field(
         default=4000,
         ge=200,

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -37,7 +37,7 @@ from ravn.adapters.channels.silent import SilentChannel
 from ravn.adapters.channels.skuld_channel import SkuldChannel
 from ravn.adapters.channels.task_context import TaskContextChannel
 from ravn.adapters.events.noop_publisher import NoOpEventPublisher
-from ravn.config import BudgetConfig, InitiativeConfig, Settings
+from ravn.config import BudgetConfig, HttpChannelConfig, InitiativeConfig, Settings
 from ravn.domain.budget import DailyBudgetTracker, compute_cost
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.domain.exceptions import LLMError
@@ -100,6 +100,7 @@ _A2A_TERMINAL_STATES = frozenset(
         "TASK_STATE_REJECTED",
     }
 )
+_HTTP_DEFAULTS = HttpChannelConfig()
 
 
 def _bounded_hud_text(value: str, limit: int) -> str:
@@ -107,6 +108,11 @@ def _bounded_hud_text(value: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return f"{text[: max(0, limit - 1)].rstrip()}…"
+
+
+def _integer_setting(value: object, default: int) -> int:
+    """Use validated integer settings while tolerating loose test doubles."""
+    return value if isinstance(value, int) else default
 
 
 def _markdown_section(value: str, heading_prefix: str) -> str:
@@ -141,6 +147,70 @@ def _resident_hud_task_input(task: AgentTask, limit: int) -> dict[str, str]:
         "summary": _bounded_hud_text(summary, limit),
         "observations": _bounded_hud_text(observations, limit),
         "objective": _bounded_hud_text(objective, limit),
+    }
+
+
+def _resident_hud_task_metadata(
+    task: AgentTask,
+    *,
+    context_limit: int,
+    persona: str,
+) -> dict[str, object]:
+    """Capture stable task facts needed after the live task object is released."""
+    return {
+        "resident_hud": True,
+        "title": task.title,
+        "persona": task.persona or persona,
+        "root_correlation_id": task.root_correlation_id or task.task_id,
+        "case_id": task.resident_case_id,
+        "turn_index": task.resident_turn_index,
+        "trace_id": _trace_id_from_carrier(task.trace_context),
+        "input": _resident_hud_task_input(task, context_limit),
+    }
+
+
+def _resident_hud_result(
+    result: TaskResult,
+    *,
+    iteration: int | None = None,
+    iteration_budget: int | None = None,
+) -> dict[str, object]:
+    """Project one captured task into the stable HUD task shape."""
+    metadata = result.metadata
+    return {
+        "task_id": result.task_id,
+        "title": str(metadata.get("title") or ""),
+        "triggered_by": result.triggered_by,
+        "persona": str(metadata.get("persona") or ""),
+        "root_correlation_id": str(metadata.get("root_correlation_id") or result.task_id),
+        "case_id": str(metadata.get("case_id") or ""),
+        "turn_index": int(metadata.get("turn_index") or 0),
+        "trace_id": str(metadata.get("trace_id") or ""),
+        "status": result.status,
+        "started_at": result.started_at.isoformat(),
+        "completed_at": result.completed_at.isoformat() if result.completed_at else "",
+        "input": metadata.get("input") if isinstance(metadata.get("input"), dict) else {},
+        "progress": {
+            "iteration": int(metadata.get("iteration") or 0) if iteration is None else iteration,
+            "iteration_budget": (
+                int(metadata.get("iteration_budget") or 0)
+                if iteration_budget is None
+                else iteration_budget
+            ),
+            "tool_calls": sum(event.type == "tool_start" for event in result.events),
+            "warnings": sum(
+                event.type == "error" or "[warning]" in event.summary.casefold()
+                for event in result.events
+            ),
+        },
+        "events": [
+            {
+                "type": event.type,
+                "summary": event.summary,
+                "timestamp": event.timestamp.isoformat(),
+            }
+            for event in result.events
+        ],
     }
 
 
@@ -1344,16 +1414,36 @@ class DriveLoop:
 
     def resident_hud_status(self) -> dict[str, object]:
         """Return factual, bounded-by-store runtime state for the resident HUD."""
-        context_limit = self._settings.gateway.channels.http.resident_hud_task_context_max_chars
+        http_config = self._settings.gateway.channels.http
+        context_limit = _integer_setting(
+            http_config.resident_hud_task_context_max_chars,
+            _HTTP_DEFAULTS.resident_hud_task_context_max_chars,
+        )
         active_task_ids = self.active_task_ids()
         active_parent_ids = set(active_task_ids)
         active: list[dict[str, object]] = []
         for task_id in active_task_ids:
             task = self._inflight_tasks.get(task_id) or self._active_task_contexts.get(task_id)
             result = self._result_store.get(task_id)
-            events = list(result.events if result is not None else [])
             agent = self._active_agents.get(task_id)
             iteration_budget = getattr(agent, "iteration_budget", None)
+            if result is not None:
+                if task is not None and result.metadata.get("resident_hud") is not True:
+                    result.metadata.update(
+                        _resident_hud_task_metadata(
+                            task,
+                            context_limit=context_limit,
+                            persona=getattr(self._persona_config, "name", ""),
+                        )
+                    )
+                active.append(
+                    _resident_hud_result(
+                        result,
+                        iteration=int(getattr(iteration_budget, "consumed", 0) or 0),
+                        iteration_budget=int(getattr(iteration_budget, "total", 0) or 0),
+                    )
+                )
+                continue
             active.append(
                 {
                     "task_id": task_id,
@@ -1372,35 +1462,32 @@ class DriveLoop:
                     "trace_id": (
                         _trace_id_from_carrier(task.trace_context) if task is not None else ""
                     ),
-                    "started_at": (
-                        result.started_at.isoformat()
-                        if result is not None
-                        else task.created_at.isoformat()
-                        if task is not None
-                        else ""
-                    ),
+                    "status": "running",
+                    "started_at": task.created_at.isoformat() if task is not None else "",
+                    "completed_at": "",
                     "input": (
                         _resident_hud_task_input(task, context_limit) if task is not None else {}
                     ),
                     "progress": {
                         "iteration": int(getattr(iteration_budget, "consumed", 0) or 0),
                         "iteration_budget": int(getattr(iteration_budget, "total", 0) or 0),
-                        "tool_calls": sum(event.type == "tool_start" for event in events),
-                        "warnings": sum(
-                            event.type == "error" or "[warning]" in event.summary.casefold()
-                            for event in events
-                        ),
+                        "tool_calls": 0,
+                        "warnings": 0,
                     },
-                    "events": [
-                        {
-                            "type": event.type,
-                            "summary": event.summary,
-                            "timestamp": event.timestamp.isoformat(),
-                        }
-                        for event in events
-                    ],
+                    "events": [],
                 }
             )
+        recent_task_limit = _integer_setting(
+            http_config.resident_hud_recent_tasks,
+            _HTTP_DEFAULTS.resident_hud_recent_tasks,
+        )
+        recent = [
+            _resident_hud_result(result)
+            for result in reversed(self._result_store.results())
+            if result.status != "running"
+            and result.task_id not in active_parent_ids
+            and result.metadata.get("resident_hud") is True
+        ][:recent_task_limit]
         queued = [
             {
                 "task_id": task.task_id,
@@ -1421,6 +1508,7 @@ class DriveLoop:
         return {
             "active_tasks": active,
             "active_count": len(active),
+            "recent_tasks": recent,
             "queued_count": self._queue.qsize(),
             "queue_capacity": self._config.task_queue_max,
             "queued_tasks": queued,
@@ -2326,7 +2414,23 @@ class DriveLoop:
             peer_id = self._settings.mesh.own_peer_id if self._settings.mesh.enabled else ""
             logger.info("drive_loop: task %s setting up channels", task.task_id)
             if self._settings.cascade.enabled:
-                self._result_store.start(task.task_id, task.triggered_by)
+                http_config = self._settings.gateway.channels.http
+                metadata = None
+                if http_config.resident_hud_enabled is True:
+                    context_limit = _integer_setting(
+                        http_config.resident_hud_task_context_max_chars,
+                        _HTTP_DEFAULTS.resident_hud_task_context_max_chars,
+                    )
+                    metadata = _resident_hud_task_metadata(
+                        task,
+                        context_limit=context_limit,
+                        persona=getattr(self._persona_config, "name", ""),
+                    )
+                self._result_store.start(
+                    task.task_id,
+                    task.triggered_by,
+                    metadata=metadata,
+                )
                 capture_channel = CaptureChannel(task.task_id, self._result_store)
                 extra: list[ChannelPort] = []
                 if self._skuld_channel is not None:
@@ -2679,6 +2783,13 @@ class DriveLoop:
                 await self._finalise_thread(thread_path, success)
             return outcome
         finally:
+            result = self._result_store.get(task.task_id)
+            if result is not None:
+                iteration_budget = getattr(agent, "iteration_budget", None)
+                result.metadata["iteration"] = int(getattr(iteration_budget, "consumed", 0) or 0)
+                result.metadata["iteration_budget"] = int(
+                    getattr(iteration_budget, "total", 0) or 0
+                )
             if not success and self._resident_runtime is not None:
                 release = getattr(self._resident_runtime, "release_failed_task", None)
                 if release is not None:

--- a/src/ravn/static/resident-hud.html
+++ b/src/ravn/static/resident-hud.html
@@ -112,6 +112,25 @@
   .activity-event.tool_start{border-color:var(--obs)}
   .activity-event.error,.activity-event.warning{border-color:var(--gap)}
   .activity-event.error .event-main,.activity-event.warning .event-result{color:var(--gap)}
+  .progress-heading{display:flex;align-items:center;gap:8px}
+  .progress-status{border:1px solid var(--line2);padding:2px 5px;color:var(--dim);
+    font-size:8px;letter-spacing:.12em;text-transform:uppercase}
+  .progress-status.running{color:var(--obs);border-color:var(--obs)}
+  .progress-status.complete{color:var(--att);border-color:var(--att)}
+  .progress-status.failed,.progress-status.cancelled{color:var(--gap);border-color:var(--gap)}
+  .task-history{display:flex;gap:5px;overflow-x:auto;padding-bottom:8px;margin-bottom:9px;
+    border-bottom:1px solid var(--line)}
+  .task-history[hidden]{display:none}
+  .task-choice{flex:0 0 160px;min-width:0;text-align:left;font:9px/1.35 var(--mono);
+    color:var(--dim);background:var(--panel2);border:1px solid var(--line);
+    padding:6px 7px;cursor:pointer}
+  .task-choice b{display:block;color:var(--tx);font-weight:500;white-space:nowrap;
+    overflow:hidden;text-overflow:ellipsis}
+  .task-choice span{display:block;margin-top:2px;color:var(--dim2);text-transform:uppercase;
+    letter-spacing:.08em}
+  .task-choice.on{border-color:var(--obs);background:rgba(47,214,195,.05)}
+  .task-choice.running span{color:var(--obs)}
+  .task-choice.failed span,.task-choice.cancelled span{color:var(--gap)}
   .a2a-panel{border:1px solid var(--line2);background:rgba(168,112,245,.05);
     margin-bottom:10px}
   .a2a-panel[hidden]{display:none}
@@ -307,7 +326,10 @@
 
     <section class="live-card">
       <header>
-        <h2>Current progress</h2>
+        <div class="progress-heading">
+          <h2>Current progress</h2>
+          <span class="progress-status" id="progress-status">waiting</span>
+        </div>
         <div class="live-meta">
           <span>ELAPSED <b id="live-elapsed">—</b></span>
           <span>ITERATION <b id="live-iteration">—</b></span>
@@ -316,6 +338,7 @@
         </div>
       </header>
       <div class="live-body">
+        <div class="task-history" id="task-history" hidden></div>
         <section class="a2a-panel" id="a2a-panel" hidden>
           <header>
             <span>Open A2A tasks</span>
@@ -390,6 +413,7 @@ let D=RESIDENTS[0], FIELDS=[], HUE={}, FIELD_BODY={}, FIELD_COUNT={}, i=0, timer
 const cols=document.getElementById("cols"), track=document.getElementById("track"),
       evo=document.getElementById("evo");
 let lastSuccess=0, staleTimer=null;
+let selectedTaskId="", lastActiveTaskId="";
 
 function esc(s){return String(s).replace(/[&<>"']/g,c=>(
   {"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]
@@ -512,6 +536,18 @@ function elapsedSince(value){
   return Math.floor(minutes/60)+"h "+(minutes%60)+"m";
 }
 
+function taskDuration(task){
+  if(!task?.started_at) return "—";
+  if(!task.completed_at) return elapsedSince(task.started_at);
+  const started=new Date(task.started_at), completed=new Date(task.completed_at);
+  if(isNaN(started)||isNaN(completed)) return "—";
+  const seconds=Math.max(0,Math.floor((completed-started)/1000));
+  if(seconds<60) return seconds+"s";
+  const minutes=Math.floor(seconds/60), rest=seconds%60;
+  if(minutes<60) return minutes+"m "+rest+"s";
+  return Math.floor(minutes/60)+"h "+(minutes%60)+"m";
+}
+
 function observationEntries(value){
   const entries=[];
   let current=[];
@@ -626,7 +662,7 @@ function activityRows(events){
   return rows;
 }
 
-function renderActivity(events){
+function renderActivity(events, emptyMessage="Waiting for the first observable action"){
   const list=document.getElementById("activity-list");
   const viewport=list.parentElement, previousScroll=viewport?.scrollTop||0;
   const stickToBottom=!viewport||
@@ -636,7 +672,7 @@ function renderActivity(events){
   if(!rows.length){
     const empty=document.createElement("div");
     empty.className="empty";
-    empty.textContent="Waiting for the first observable action";
+    empty.textContent=emptyMessage;
     list.appendChild(empty);
     return;
   }
@@ -760,18 +796,101 @@ function renderQueue(runtime){
   }
 }
 
+function renderTaskHistory(tasks, selected, d){
+  const history=document.getElementById("task-history");
+  history.replaceChildren();
+  history.hidden=!tasks.length;
+  tasks.forEach(task=>{
+    const button=document.createElement("button");
+    const status=String(task.status||"unknown").toLowerCase();
+    button.type="button";
+    button.className=`task-choice ${status}${task.task_id===selected?" on":""}`;
+    button.title=task.task_id||"";
+    const title=document.createElement("b");
+    title.textContent=task.title||task.task_id||"Resident task";
+    const meta=document.createElement("span");
+    meta.textContent=`${status} · ${status==="running"?taskDuration(task):clockTime(task.completed_at)}`;
+    button.append(title,meta);
+    button.onclick=()=>{
+      selectedTaskId=task.task_id||"";
+      renderRuntime(d);
+    };
+    history.appendChild(button);
+  });
+}
+
+function durableTasks(d){
+  const limit=d.hud?.recent_task_limit||5;
+  return [...(d.turns||[])].reverse()
+    .filter(turn=>turn.task_id)
+    .slice(0,limit)
+    .map(turn=>{
+      const judgment=turn.judgment||turn;
+      return {
+        task_id:turn.task_id,
+        title:turn.triggered_by
+          ?label(turn.triggered_by.replaceAll(":","_"))
+          :`Resident turn ${turn.turn_index??"—"}`,
+        triggered_by:turn.triggered_by||"",
+        persona:turn.persona||"",
+        root_correlation_id:turn.root_correlation_id||turn.task_id,
+        case_id:turn.case_id||"",
+        turn_index:turn.turn_index||0,
+        trace_id:judgment.correlation_ids?.trace||"",
+        status:"complete",
+        started_at:"",
+        completed_at:turn.updated_at||"",
+        input:{
+          summary:turn.triggered_by
+            ? label(turn.triggered_by.replace(/:/g,"_"))
+            :"Completed resident judgment",
+          observations:"",
+          objective:turn.selected_next_action||"",
+        },
+        progress:{
+          iteration:0,
+          iteration_budget:0,
+          tool_calls:(turn.tools_used||[]).length,
+          warnings:0,
+        },
+        events:[],
+        durable:true,
+      };
+    });
+}
+
 function renderRuntime(d){
-  const runtime=d.runtime||{}, active=runtime.active_tasks||[], task=active[0]||null;
+  const runtime=d.runtime||{},
+        active=(runtime.active_tasks||[]).map(task=>({
+          ...task,status:task.status||"running"
+        })),
+        recent=runtime.recent_tasks||[], history=[],
+        historyLimit=d.hud?.recent_task_limit||5;
+  [...recent,...durableTasks(d)].forEach(item=>{
+    if(history.length>=historyLimit) return;
+    if(active.some(current=>current.task_id===item.task_id)) return;
+    if(!history.some(current=>current.task_id===item.task_id)) history.push(item);
+  });
+  const tasks=[...active,...history];
+  const activeTask=active[0]||null, activeTaskId=activeTask?.task_id||"";
+  if(activeTaskId&&(!selectedTaskId||selectedTaskId===lastActiveTaskId)){
+    selectedTaskId=activeTaskId;
+  }
+  if(!tasks.some(task=>task.task_id===selectedTaskId)){
+    selectedTaskId=activeTaskId||tasks[0]?.task_id||"";
+  }
+  lastActiveTaskId=activeTaskId;
+  const task=tasks.find(item=>item.task_id===selectedTaskId)||null;
   const state=runtime.state||"idle", stateEl=document.getElementById("rstate");
   stateEl.className="state "+state;
   stateEl.textContent=state.replace(/_/g," ").toUpperCase();
   document.getElementById("ractive").textContent=runtime.active_count||0;
   document.getElementById("rqueued").textContent=runtime.queued_count||0;
-  document.getElementById("rtitle").textContent=task?.title||(
+  document.getElementById("rtitle").textContent=activeTask?.title||(
     state==="waiting_operator"?"Waiting for an operator answer":"No task is executing"
   );
-  document.getElementById("rtrigger").textContent=task
-    ? `${task.triggered_by||"unknown trigger"}${runtime.model?" · "+runtime.model:""}`
+  document.getElementById("rtrigger").textContent=activeTask
+    ? `${activeTask.triggered_by||"unknown trigger"}${runtime.model?" · "+runtime.model:""}`
     : (
     runtime.pending_questions?.[0]?.question||
     "The resident is waiting for a signal, schedule, or operator answer."
@@ -786,6 +905,7 @@ function renderRuntime(d){
     "on",
     Boolean(task)||(runtime.queued_count||0)>0||(runtime.a2a_count||0)>0
   );
+  renderTaskHistory(tasks,selectedTaskId,d);
   document.getElementById("input-summary").textContent=input.summary||task?.title||"Waiting to start";
   renderObservations(input.observations||(
     task?"":"The next queued task has not started."
@@ -793,18 +913,34 @@ function renderRuntime(d){
   document.getElementById("input-objective").textContent=input.objective||(
     task?"No objective excerpt was captured.":"—"
   );
-  document.getElementById("current-judgment").textContent=task
-    ?"Not emitted yet":"Waiting to start";
+  const matchingTurn=(d.turns||[]).find(turn=>turn.task_id===task?.task_id),
+        judgment=matchingTurn?.judgment||matchingTurn||{},
+        status=String(task?.status||"waiting").toLowerCase(),
+        statusEl=document.getElementById("progress-status");
+  statusEl.className=`progress-status ${status}`;
+  statusEl.textContent=status;
+  document.getElementById("current-judgment").textContent=!task
+    ?"Waiting to start"
+    :status==="running"
+      ?"Not emitted yet"
+      :(judgment.decision||judgment.verdict||status).toString().replace(/_/g," ");
   document.getElementById("task-identity").textContent=task
     ? `TASK ${task.task_id||"—"} · ROOT ${task.root_correlation_id||"—"}`
     :"—";
-  document.getElementById("live-elapsed").textContent=task?elapsedSince(task.started_at):"—";
+  document.getElementById("live-elapsed").textContent=task?taskDuration(task):"—";
   document.getElementById("live-iteration").textContent=progress.iteration_budget
     ? `${progress.iteration||0} / ${progress.iteration_budget}`:`${progress.iteration||0}`;
   document.getElementById("live-tools").textContent=progress.tool_calls||0;
   document.getElementById("live-warnings").textContent=progress.warnings||0;
   renderA2A(runtime);
-  renderActivity(events);
+  renderActivity(
+    events,
+    task?.durable
+      ?task.trace_id
+        ?"This task was restored from its durable turn record. Detailed activity remains available through the trace."
+        :"This task was restored from its durable turn record; detailed live activity was not retained."
+      :"Waiting for the first observable action"
+  );
   renderQueue(runtime);
 
   const activeTrace=document.getElementById("active-trace"),

--- a/tests/test_ravn/test_capture.py
+++ b/tests/test_ravn/test_capture.py
@@ -168,13 +168,14 @@ class TestTaskResultStore:
 
     def test_restarting_same_task_id_overwrites(self):
         store = TaskResultStore()
-        store.start("t1", "first")
+        store.start("t1", "first", metadata={"title": "first task"})
         store.set_output("t1", "first output")
-        store.start("t1", "second")
+        store.start("t1", "second", metadata={"title": "second task"})
         result = store.get("t1")
         assert result.output == ""
         assert result.status == "running"
         assert result.triggered_by == "second"
+        assert result.metadata == {"title": "second task"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -62,6 +62,9 @@ def _make_drive_loop_with_mesh(
     settings.cascade.enabled = cascade_enabled
     settings.mesh.enabled = mesh_enabled
     settings.mesh.own_peer_id = peer_id
+    settings.gateway.channels.http.resident_hud_enabled = True
+    settings.gateway.channels.http.resident_hud_task_context_max_chars = 4000
+    settings.gateway.channels.http.resident_hud_recent_tasks = 5
     settings.budget.daily_cap_usd = 100.0
     settings.budget.warn_at_percent = 80
     settings.budget.input_token_cost_per_million = 3.0
@@ -181,7 +184,9 @@ Determine whether the observations require action.
                 "case_id": "",
                 "turn_index": 0,
                 "trace_id": "56ca7fcf3496a1e9fe7136f55a110c2a",
+                "status": "running",
                 "started_at": dl._result_store.get("active-task").started_at.isoformat(),
+                "completed_at": "",
                 "input": {
                     "summary": "Signals since your last look — 4 observation(s)",
                     "observations": (
@@ -204,10 +209,70 @@ Determine whether the observations require action.
                 ],
             }
         ]
+        assert status["recent_tasks"] == []
         assert status["queue_capacity"] == 10
         assert status["queued_tasks"] == []
         assert status["a2a_count"] == 0
         assert status["a2a_tasks"] == []
+
+    def test_resident_hud_status_retains_recent_completed_task(self):
+        from datetime import UTC, datetime
+
+        from ravn.adapters.channels.capture import CapturedEvent
+
+        dl, _ = _make_drive_loop_with_mesh(cascade_enabled=True)
+        dl._result_store.start(
+            "completed-task",
+            "resident:scheduled_wake",
+            metadata={
+                "resident_hud": True,
+                "title": "Review the workshop",
+                "persona": "Ivaldi",
+                "root_correlation_id": "root-completed",
+                "case_id": "case-completed",
+                "turn_index": 3,
+                "trace_id": "trace-completed",
+                "input": {
+                    "summary": "Review the workshop",
+                    "observations": "Printer is idle",
+                    "objective": "Decide whether to act",
+                },
+                "iteration": 2,
+                "iteration_budget": 8,
+            },
+        )
+        dl._result_store.append_event(
+            "completed-task",
+            CapturedEvent(
+                type="tool_start",
+                summary="tool: research()",
+                timestamp=datetime(2026, 7, 26, tzinfo=UTC),
+            ),
+        )
+        dl._result_store.set_output("completed-task", "No action required")
+
+        status = dl.resident_hud_status()
+
+        assert status["active_tasks"] == []
+        assert len(status["recent_tasks"]) == 1
+        recent = status["recent_tasks"][0]
+        assert recent["task_id"] == "completed-task"
+        assert recent["title"] == "Review the workshop"
+        assert recent["status"] == "complete"
+        assert recent["completed_at"]
+        assert recent["progress"] == {
+            "iteration": 2,
+            "iteration_budget": 8,
+            "tool_calls": 1,
+            "warnings": 0,
+        }
+        assert recent["events"] == [
+            {
+                "type": "tool_start",
+                "summary": "tool: research()",
+                "timestamp": "2026-07-26T00:00:00+00:00",
+            }
+        ]
         assert status["model"] == "test-model"
 
     def test_resident_hud_status_describes_waiting_tasks(self):

--- a/tests/test_ravn/test_gateway_http.py
+++ b/tests/test_ravn/test_gateway_http.py
@@ -553,6 +553,17 @@ def test_resident_hud_serves_live_durable_and_inflight_state_without_operator_to
                     ],
                 }
             ],
+            "recent_tasks": [
+                {
+                    "task_id": "task-completed",
+                    "title": "Completed inspection",
+                    "status": "complete",
+                    "events": [
+                        {"type": "thought", "summary": "Considering evidence"},
+                        {"type": "response", "summary": "No action required"},
+                    ],
+                }
+            ],
         }
     )
     client = TestClient(gateway.app)
@@ -562,6 +573,9 @@ def test_resident_hud_serves_live_durable_and_inflight_state_without_operator_to
     assert "RESIDENT · HUD" in page.text
     assert "What happened" in page.text
     assert "Current progress" in page.text
+    assert 'id="progress-status"' in page.text
+    assert 'id="task-history"' in page.text
+    assert "function durableTasks(d)" in page.text
     assert "Waiting work" in page.text
     assert 'class="track-scroll"' in page.text
     assert "function newestFirst(turns)" in page.text
@@ -575,6 +589,10 @@ def test_resident_hud_serves_live_durable_and_inflight_state_without_operator_to
     assert payload["runtime"]["active_tasks"][0]["events"] == [
         {"type": "tool_start", "summary": "Calling research"}
     ]
+    assert payload["runtime"]["recent_tasks"][0]["events"] == [
+        {"type": "response", "summary": "No action required"}
+    ]
+    assert payload["hud"]["recent_task_limit"] == 5
     turn = payload["turns"][0]
     assert turn["judgment"]["decision"] == "investigate"
     assert turn["judgment"]["correlation_ids"]["trace"] == "trace-123"


### PR DESCRIPTION
## What changed

- retain a bounded history of completed resident tasks in the existing task result store
- keep the operator-selected task stable across HUD polling and show task status, duration, activity, and judgment
- reconstruct completed task cards from durable resident turn records after process restart without fabricating lost live events

## Why

The Current progress panel represented only the active task tail. It therefore appeared to reset whenever a task completed, a newer task started, or the pod restarted.

## Validation

- 69 focused Ravn HUD/channel tests passed
- Ruff lint and format checks passed
- browser interaction verified active/history selection remains stable across polls