### PR TITLE
fix(ravn): bound resident context growth

### DIFF
--- a/docs/operator/valkyrie-self-improvement.md
+++ b/docs/operator/valkyrie-self-improvement.md
@@ -190,11 +190,24 @@ resident_evolution:
 
 Related bounds (all NIU-1118):
 
+- `context_management.context_window_tokens` (0 = unknown) — the model's real
+  context window. Ravn subtracts the configured maximum output tokens before
+  deriving the safe prompt ceiling; it never infers this value from a model
+  name.
 - `context_management.max_prompt_tokens` (0 = off) — hard per-call budget for
-  the estimated prompt (system + tool schemas + history). When a turn still
+  the conservative estimated prompt (system + tool schemas + complete nested
+  tool/history payloads). The lower of this value and
+  `context_window_tokens - llm.max_tokens` wins. When a turn still
   exceeds it after context compression, the call fails loudly with a
   per-section breakdown instead of overflowing the model window. Every turn
-  also logs a `prompt_composition:` line with per-section token estimates.
+  also records a `ravn.prompt.budget` trace event and exposes the current
+  estimate, ceiling, output reservation, and compaction state in the resident
+  HUD.
+- `context_management.token_estimate_safety_factor` (default 1.5) — conservative
+  multiplier for providers that do not expose an exact preflight token count.
+- `resident_state.directed_message_context_max_chars` (default 4000) — bounds
+  prior room output carried into a human-directed task; the current human
+  message is not truncated.
 - `tools.max_result_chars` (default 100000, 0 = off) — caps one tool result's
   contribution to history. Compression protects the most recent messages, so
   a single giant result (observed: a 229MB mimir result) would otherwise make

--- a/scripts/setups/configs/ivaldi-local-workshop.yaml
+++ b/scripts/setups/configs/ivaldi-local-workshop.yaml
@@ -64,7 +64,7 @@ environment:
         nkeys_seed_file: ~/.ravn/ivaldi-local/laevateinn-consumer.nk
 
 llm:
-  model: nvidia/nemotron-3-super
+  model: Qwen/Qwen3.6-35B-A3B-FP8
   max_tokens: 6144
   timeout: 180
   provider:
@@ -74,6 +74,7 @@ llm:
       api_key: ""
 
 context_management:
+  context_window_tokens: 131072
   max_prompt_tokens: 100000
 
 memory:

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import itertools
-import json
 import logging
 import re
 import time
@@ -135,6 +134,8 @@ class RavnAgent:
         stop_on_outcome: bool = False,
         # NIU-1118: hard per-call prompt budget; 0 disables
         max_prompt_tokens: int = 0,
+        context_window_tokens: int = 0,
+        token_estimate_safety_factor: float = 1.0,
         # NIU-1118: cap one tool result's contribution to history; 0 disables
         max_tool_result_chars: int = 0,
     ) -> None:
@@ -190,8 +191,20 @@ class RavnAgent:
         self._mimir = mimir
         # NIU-594: persona config for outcome block parsing
         self._persona_config = persona_config
-        # NIU-1118: hard per-call prompt budget; 0 disables
-        self._max_prompt_tokens = max_prompt_tokens
+        self._context_window_tokens = max(0, context_window_tokens)
+        self._token_estimate_safety_factor = max(1.0, token_estimate_safety_factor)
+        if self._context_window_tokens and self._max_tokens >= self._context_window_tokens:
+            raise ValueError("max_tokens must be smaller than context_window_tokens")
+        prompt_ceilings = [
+            value
+            for value in (
+                max(0, max_prompt_tokens),
+                max(0, self._context_window_tokens - self._max_tokens),
+            )
+            if value > 0
+        ]
+        self._max_prompt_tokens = min(prompt_ceilings) if prompt_ceilings else 0
+        self._last_prompt_budget_status: dict[str, int | float | bool] = {}
         # NIU-1118: cap one tool result's contribution to history; 0 disables
         self._max_tool_result_chars = max_tool_result_chars
 
@@ -224,6 +237,11 @@ class RavnAgent:
     def last_compression_result(self) -> CompressionResult | None:
         """Compression result from the most recent turn, or None."""
         return self._last_compression_result
+
+    @property
+    def prompt_budget_status(self) -> dict[str, int | float | bool]:
+        """Latest preflight prompt-budget facts for telemetry and the resident HUD."""
+        return dict(self._last_prompt_budget_status)
 
     @property
     def task_id(self) -> str:
@@ -462,6 +480,12 @@ class RavnAgent:
             prompt_sections = self._prompt_section_estimates(effective_system, messages_for_llm)
             if iteration == 0:
                 self._log_prompt_composition(prompt_sections)
+            self._record_prompt_budget(
+                prompt_sections,
+                compressed=bool(
+                    self._last_compression_result and self._last_compression_result.was_compressed
+                ),
+            )
             self._enforce_prompt_budget(prompt_sections)
 
             thinking_param = self._resolve_thinking(
@@ -683,20 +707,24 @@ class RavnAgent:
         audit NIU-1118 asks for — the data that shows WHERE an oversized
         drive-loop prompt comes from.
         """
-        sections: dict[str, int] = {}
+        rough_sections: dict[str, int] = {}
         tool_defs = self._tool_defs()
-        sections["tool_schemas"] = TokenEstimator.rough(
-            json.dumps(tool_defs, default=str, sort_keys=True)
-        )
+        rough_sections["tool_schemas"] = TokenEstimator.rough_structured(tool_defs)
         if self._prompt_builder is not None:
             for name, text in self._prompt_builder.section_texts().items():
-                sections[f"system:{name}"] = TokenEstimator.rough(text)
+                rough_sections[f"system:{name}"] = TokenEstimator.rough(text)
         elif isinstance(effective_system, str):
-            sections["system"] = TokenEstimator.rough(effective_system)
+            rough_sections["system"] = TokenEstimator.rough(effective_system)
         else:
-            sections["system"] = TokenEstimator.rough_blocks(effective_system)
-        sections["history"] = TokenEstimator.rough_messages(messages)
-        return sections
+            rough_sections["system"] = TokenEstimator.rough_blocks(effective_system)
+        rough_sections["history"] = TokenEstimator.rough_messages(messages)
+        return {
+            name: TokenEstimator.conservative(
+                tokens,
+                self._token_estimate_safety_factor,
+            )
+            for name, tokens in rough_sections.items()
+        }
 
     def _log_prompt_composition(self, sections: dict[str, int]) -> None:
         total = sum(sections.values())
@@ -707,6 +735,43 @@ class RavnAgent:
             breakdown,
             len(self._tools),
             len(self._session.messages),
+        )
+
+    def _record_prompt_budget(
+        self,
+        sections: dict[str, int],
+        *,
+        compressed: bool,
+    ) -> None:
+        estimated = sum(sections.values())
+        status: dict[str, int | float | bool] = {
+            "estimated_prompt_tokens": estimated,
+            "prompt_budget_tokens": self._max_prompt_tokens,
+            "output_reserve_tokens": self._max_tokens,
+            "context_window_tokens": self._context_window_tokens,
+            "token_estimate_safety_factor": self._token_estimate_safety_factor,
+            "compressed": compressed,
+        }
+        self._last_prompt_budget_status = status
+        attributes = {
+            "ravn.prompt.estimated_tokens": estimated,
+            "ravn.prompt.budget_tokens": self._max_prompt_tokens,
+            "ravn.prompt.output_reserve_tokens": self._max_tokens,
+            "ravn.prompt.context_window_tokens": self._context_window_tokens,
+            "ravn.prompt.estimate_safety_factor": self._token_estimate_safety_factor,
+            "ravn.prompt.compressed": compressed,
+        }
+        telemetry = get_observability()
+        telemetry.set_attributes(attributes)
+        telemetry.event("ravn.prompt.budget", attributes=attributes, content=sections)
+        telemetry.gauge(
+            "ravn.prompt.estimated_tokens",
+            estimated,
+            attributes={
+                "gen_ai.request.model": self._model,
+                "gen_ai.agent.name": self._persona or "ravn",
+            },
+            description="Conservative preflight estimate of prompt tokens.",
         )
 
     def _enforce_prompt_budget(self, sections: dict[str, int]) -> None:
@@ -796,9 +861,12 @@ class RavnAgent:
             if isinstance(effective_system, list)
             else TokenEstimator.rough(effective_system)
         )
+        tool_tokens = TokenEstimator.rough_structured(self._tool_defs())
         messages, result = await self._compressor.maybe_compress(
             self._session.messages,
             system_tokens=system_tokens,
+            tool_tokens=tool_tokens,
+            prompt_budget_tokens=self._max_prompt_tokens,
             todos=self._session.todos or None,
             memory_summary=memory_summary or None,
         )

--- a/src/ravn/budget.py
+++ b/src/ravn/budget.py
@@ -10,7 +10,10 @@ so the agent can decide whether to compress context.
 
 from __future__ import annotations
 
+import json
+import math
 from dataclasses import dataclass, field
+from typing import Any
 
 from ravn.domain.models import Message, TokenUsage
 
@@ -60,6 +63,23 @@ class TokenEstimator:
         return total // _CHARS_PER_TOKEN
 
     @staticmethod
+    def rough_structured(value: Any) -> int:
+        """Estimate a complete structured payload, including nested values."""
+        rendered = json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+        return len(rendered) // _CHARS_PER_TOKEN
+
+    @staticmethod
+    def conservative(tokens: int, safety_factor: float) -> int:
+        """Apply a configured safety factor to a rough token estimate."""
+        return math.ceil(max(0, tokens) * max(1.0, safety_factor))
+
+    @staticmethod
     def from_usage(usage: TokenUsage) -> int:
         """Return the accurate total from an API usage record."""
         return usage.total_tokens
@@ -69,13 +89,15 @@ class TokenEstimator:
         content = msg.content
         if isinstance(content, str):
             return len(content)
-        total = 0
-        for block in content:
-            if isinstance(block, dict):
-                for v in block.values():
-                    if isinstance(v, str):
-                        total += len(v)
-        return total
+        return len(
+            json.dumps(
+                content,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            )
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -442,6 +442,8 @@ def _build_agent(
         persona_config=persona_config,
         stop_on_outcome=persona_config.stop_on_outcome if persona_config else False,
         max_prompt_tokens=settings.context_management.max_prompt_tokens,
+        context_window_tokens=settings.context_management.context_window_tokens,
+        token_estimate_safety_factor=settings.context_management.token_estimate_safety_factor,
         max_tool_result_chars=settings.tools.max_result_chars,
     )
 
@@ -1239,6 +1241,8 @@ async def _run_gateway(
             output_token_cost_per_million=settings.memory.output_token_cost_per_million,
             extended_thinking=extended_thinking,
             max_prompt_tokens=settings.context_management.max_prompt_tokens,
+            context_window_tokens=settings.context_management.context_window_tokens,
+            token_estimate_safety_factor=(settings.context_management.token_estimate_safety_factor),
             max_tool_result_chars=settings.tools.max_result_chars,
         )
 

--- a/src/ravn/cli/daemon_runtime.py
+++ b/src/ravn/cli/daemon_runtime.py
@@ -244,6 +244,8 @@ async def _run_daemon(
             stop_on_outcome=resolved_persona.stop_on_outcome if resolved_persona else False,
             # NIU-1118: hard per-call prompt budget (0 disables)
             max_prompt_tokens=settings.context_management.max_prompt_tokens,
+            context_window_tokens=settings.context_management.context_window_tokens,
+            token_estimate_safety_factor=(settings.context_management.token_estimate_safety_factor),
             # NIU-1118: bound one tool result's contribution to history
             max_tool_result_chars=settings.tools.max_result_chars,
             session_join_manager=(

--- a/src/ravn/cli/resident_runtime_wiring.py
+++ b/src/ravn/cli/resident_runtime_wiring.py
@@ -208,6 +208,7 @@ def _build_resident_runtime(
         tool_result_max_chars=cfg.continuation_tool_result_max_chars,
         scheduled_wake_default_seconds=cfg.scheduled_wake_default_seconds,
         stewardship_interval_seconds=cfg.stewardship_interval_seconds,
+        directed_messages_enabled=settings.resident_inbox.directed_messages_enabled,
     )
 
 

--- a/src/ravn/cli/tool_builders.py
+++ b/src/ravn/cli/tool_builders.py
@@ -477,6 +477,9 @@ def _build_compressor(settings: Settings, llm: Any) -> Any:
         protect_first=cm.protect_first_messages,
         protect_last=cm.effective_protect_last(),
         compression_threshold=cm.compression_threshold,
+        context_window=cm.context_window_tokens,
+        output_reserve=settings.effective_max_tokens(),
+        token_estimate_safety_factor=cm.token_estimate_safety_factor,
     )
 
 

--- a/src/ravn/compression.py
+++ b/src/ravn/compression.py
@@ -1,7 +1,7 @@
 """Context compression for long Ravn sessions.
 
-When a session's estimated token count exceeds a threshold (default 80% of the
-model's context window — leaving <20% remaining), the ContextCompressor performs
+When a session's conservative estimated token count exceeds a threshold
+(default 80% of the configured safe prompt budget), the ContextCompressor performs
 *intelligent compaction*: rather than summarising the full conversation, it
 produces a structured state document that preserves decision-relevant information
 while discarding redundant content.
@@ -46,7 +46,7 @@ Protected regions
 
 Trigger
 -------
-- Automatic: when remaining context budget < 20% of max_tokens
+- Automatic: when estimated prompt use exceeds 80% of the safe prompt budget
   (``compression_threshold`` defaults to 0.8).
 - Manual: callers may call ``maybe_compress`` at any time.
 
@@ -111,15 +111,6 @@ _FALLBACK_DOCUMENT = (
     "- None"
 )
 
-# Default context window sizes for well-known models.
-_MODEL_CONTEXT_WINDOWS: dict[str, int] = {
-    "claude-sonnet-4-6": 200_000,
-    "claude-opus-4-6": 200_000,
-    "claude-haiku-4-5-20251001": 200_000,
-}
-_DEFAULT_CONTEXT_WINDOW = 200_000
-
-
 # ---------------------------------------------------------------------------
 # Result dataclass
 # ---------------------------------------------------------------------------
@@ -157,8 +148,7 @@ class ContextCompressor:
     llm:
         LLM port used to generate compaction documents.
     model:
-        Model identifier (used to look up context window size and for
-        generating compaction documents).
+        Model identifier used for generating compaction documents.
     max_tokens:
         Max tokens for compaction document generation (default 1024).
     protect_first:
@@ -167,11 +157,12 @@ class ContextCompressor:
         Number of messages at the end of history to preserve unchanged
         (the verbatim recent turns).  Defaults to 6 (≈ 3 turns).
     compression_threshold:
-        Fraction of the model's context window that triggers compaction
-        (default 0.8 — fires when <20% of the context window remains).
+        Fraction of the safe prompt budget that triggers compaction.
     context_window:
-        Override context window size in tokens.  When 0 (default), the known
-        table is consulted and falls back to 200 000.
+        Configured context-window size. Zero means unknown.
+    output_reserve:
+        Tokens reserved for model output when deriving a prompt budget from
+        ``context_window``.
     """
 
     def __init__(
@@ -184,6 +175,8 @@ class ContextCompressor:
         protect_last: int = 6,
         compression_threshold: float = 0.8,
         context_window: int = 0,
+        output_reserve: int = 0,
+        token_estimate_safety_factor: float = 1.0,
     ) -> None:
         self._llm = llm
         self._model = model
@@ -191,8 +184,9 @@ class ContextCompressor:
         self._protect_first = protect_first
         self._protect_last = protect_last
         self._threshold = compression_threshold
-        window = context_window or _MODEL_CONTEXT_WINDOWS.get(model, _DEFAULT_CONTEXT_WINDOW)
-        self._context_window = window
+        self._context_window = max(0, context_window)
+        self._output_reserve = max(0, output_reserve)
+        self._token_estimate_safety_factor = max(1.0, token_estimate_safety_factor)
 
     # ------------------------------------------------------------------
     # Public
@@ -203,6 +197,8 @@ class ContextCompressor:
         messages: list[Message],
         *,
         system_tokens: int = 0,
+        tool_tokens: int = 0,
+        prompt_budget_tokens: int = 0,
         todos: list[TodoItem] | None = None,
         memory_summary: str | None = None,
     ) -> tuple[list[Message], CompressionResult]:
@@ -225,9 +221,17 @@ class ContextCompressor:
         list is returned unchanged.
         """
         original_count = len(messages)
-        threshold_tokens = int(self._context_window * self._threshold)
+        configured_budget = max(0, self._context_window - self._output_reserve)
+        budget = prompt_budget_tokens or configured_budget
+        if budget <= 0:
+            return messages, CompressionResult(
+                original_count=original_count, final_count=original_count
+            )
+        threshold_tokens = int(budget * self._threshold)
 
-        estimated = TokenEstimator.rough_messages(messages) + system_tokens
+        estimated = self._estimate(
+            TokenEstimator.rough_messages(messages) + system_tokens + tool_tokens
+        )
         if estimated <= threshold_tokens:
             return messages, CompressionResult(
                 original_count=original_count, final_count=original_count
@@ -247,7 +251,9 @@ class ContextCompressor:
             compression_count += 1
             removed_count += removed
             result_messages = new_messages
-            new_estimated = TokenEstimator.rough_messages(result_messages) + system_tokens
+            new_estimated = self._estimate(
+                TokenEstimator.rough_messages(result_messages) + system_tokens + tool_tokens
+            )
             if new_estimated <= threshold_tokens:
                 break
 
@@ -257,6 +263,9 @@ class ContextCompressor:
             compression_count=compression_count,
             removed_message_count=removed_count,
         )
+
+    def _estimate(self, tokens: int) -> int:
+        return TokenEstimator.conservative(tokens, self._token_estimate_safety_factor)
 
     # ------------------------------------------------------------------
     # Internal

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -784,11 +784,29 @@ class IterationBudgetConfig(BaseModel):
 class ContextManagementConfig(BaseModel):
     """Context compression and prompt-builder configuration."""
 
+    context_window_tokens: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Model context-window size in tokens. The runtime reserves the configured "
+            "maximum output before deriving the safe prompt budget. 0 means the model "
+            "window is unknown, so max_prompt_tokens must provide the prompt ceiling."
+        ),
+    )
+    token_estimate_safety_factor: float = Field(
+        default=1.5,
+        ge=1.0,
+        description=(
+            "Multiplier applied to serialized prompt-size estimates before compression "
+            "and budget enforcement. It covers tokenizer and chat-template overhead "
+            "when the configured provider does not expose preflight token counts."
+        ),
+    )
     compression_threshold: float = Field(
         default=0.8,
         description=(
-            "Fraction of the model's context window that triggers compaction "
-            "(0.0–1.0, default 0.8 — fires when <20% of the context window remains)."
+            "Fraction of the effective safe prompt budget that triggers compaction "
+            "(0.0–1.0, default 0.8)."
         ),
     )
     protect_first_messages: int = Field(
@@ -2926,6 +2944,14 @@ class ResidentStateConfig(BaseModel):
         default=2000,
         ge=100,
         description="Maximum characters persisted from each resident tool result.",
+    )
+    directed_message_context_max_chars: int = Field(
+        default=4000,
+        ge=200,
+        description=(
+            "Maximum characters of prior room content carried into a directed-message "
+            "task. The human's current message is never truncated by this setting."
+        ),
     )
     home_wake_interval_seconds: float = Field(
         default=300.0,

--- a/src/ravn/domain/resident_continuation.py
+++ b/src/ravn/domain/resident_continuation.py
@@ -183,6 +183,7 @@ class ResidentScheduledWakeRecord:
 
 
 RESIDENT_WORKING_STATE_FIELDS = (
+    "objectives",
     "observations",
     "hypotheses",
     "unknowns",
@@ -199,6 +200,8 @@ def validate_resident_working_state(value: Any) -> list[str]:
         return ["working_state must be a mapping"]
     errors: list[str] = []
     for field_name in RESIDENT_WORKING_STATE_FIELDS:
+        if field_name == "objectives" and field_name not in value:
+            continue
         entries = value.get(field_name)
         if not isinstance(entries, list):
             errors.append(f"working_state.{field_name} must be a list")

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -37,10 +37,16 @@ from ravn.adapters.channels.silent import SilentChannel
 from ravn.adapters.channels.skuld_channel import SkuldChannel
 from ravn.adapters.channels.task_context import TaskContextChannel
 from ravn.adapters.events.noop_publisher import NoOpEventPublisher
-from ravn.config import BudgetConfig, HttpChannelConfig, InitiativeConfig, Settings
+from ravn.config import (
+    BudgetConfig,
+    HttpChannelConfig,
+    InitiativeConfig,
+    ResidentStateConfig,
+    Settings,
+)
 from ravn.domain.budget import DailyBudgetTracker, compute_cost
 from ravn.domain.events import RavnEvent, RavnEventType
-from ravn.domain.exceptions import LLMError
+from ravn.domain.exceptions import LLMError, PromptBudgetExceededError
 from ravn.domain.help_needed import build_help_needed_event
 from ravn.domain.models import AgentTask, OutputMode
 from ravn.domain.resident_continuation import validate_resident_working_state
@@ -101,6 +107,7 @@ _A2A_TERMINAL_STATES = frozenset(
     }
 )
 _HTTP_DEFAULTS = HttpChannelConfig()
+_RESIDENT_STATE_DEFAULTS = ResidentStateConfig()
 
 
 def _bounded_hud_text(value: str, limit: int) -> str:
@@ -108,6 +115,14 @@ def _bounded_hud_text(value: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return f"{text[: max(0, limit - 1)].rstrip()}…"
+
+
+def _bounded_room_context(value: str, limit: int) -> str:
+    text = value.strip()
+    if len(text) <= limit:
+        return text
+    dropped = len(text) - limit
+    return f"{text[:limit].rstrip()}\n[prior room context truncated: {dropped} characters omitted]"
 
 
 def _integer_setting(value: object, default: int) -> int:
@@ -174,6 +189,7 @@ def _resident_hud_result(
     *,
     iteration: int | None = None,
     iteration_budget: int | None = None,
+    prompt_budget: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Project one captured task into the stable HUD task shape."""
     metadata = result.metadata
@@ -201,6 +217,13 @@ def _resident_hud_result(
             "warnings": sum(
                 event.type == "error" or "[warning]" in event.summary.casefold()
                 for event in result.events
+            ),
+            "prompt": (
+                dict(prompt_budget)
+                if prompt_budget is not None
+                else dict(metadata["prompt_budget"])
+                if isinstance(metadata.get("prompt_budget"), dict)
+                else {}
             ),
         },
         "events": [
@@ -689,6 +712,7 @@ def _build_resident_valkyrie_schema_repair_prompt(
     ):
         working_state_shape = (
             "working_state:\n"
+            "  objectives: []\n"
             "  observations: []\n"
             "  hypotheses: []\n"
             "  unknowns: []\n"
@@ -1427,6 +1451,7 @@ class DriveLoop:
             result = self._result_store.get(task_id)
             agent = self._active_agents.get(task_id)
             iteration_budget = getattr(agent, "iteration_budget", None)
+            prompt_budget = getattr(agent, "prompt_budget_status", {})
             if result is not None:
                 if task is not None and result.metadata.get("resident_hud") is not True:
                     result.metadata.update(
@@ -1441,6 +1466,9 @@ class DriveLoop:
                         result,
                         iteration=int(getattr(iteration_budget, "consumed", 0) or 0),
                         iteration_budget=int(getattr(iteration_budget, "total", 0) or 0),
+                        prompt_budget=(
+                            dict(prompt_budget) if isinstance(prompt_budget, dict) else {}
+                        ),
                     )
                 )
                 continue
@@ -1473,6 +1501,7 @@ class DriveLoop:
                         "iteration_budget": int(getattr(iteration_budget, "total", 0) or 0),
                         "tool_calls": 0,
                         "warnings": 0,
+                        "prompt": (dict(prompt_budget) if isinstance(prompt_budget, dict) else {}),
                     },
                     "events": [],
                 }
@@ -1884,8 +1913,8 @@ class DriveLoop:
             logger.error("drive_loop: rpc handler raised: %s", exc)
             return {"error": str(exc)}
 
-    @staticmethod
     def _directed_message_context(
+        self,
         content: str,
         metadata: dict[str, Any] | None,
     ) -> str:
@@ -1906,6 +1935,14 @@ class DriveLoop:
         context = metadata.get("help_context")
         reply_context = metadata.get("reply_context")
         recent_room_context = metadata.get("recent_room_context")
+        context_limit = _integer_setting(
+            getattr(
+                getattr(self._settings, "resident_state", None),
+                "directed_message_context_max_chars",
+                None,
+            ),
+            _RESIDENT_STATE_DEFAULTS.directed_message_context_max_chars,
+        )
         has_help_context = bool(
             help_summary
             or help_reason
@@ -1937,7 +1974,7 @@ class DriveLoop:
                 parts.extend(
                     [
                         "The human replied to this prior room message:",
-                        prior_content,
+                        _bounded_room_context(prior_content, context_limit),
                     ]
                 )
         elif isinstance(recent_room_context, dict) and recent_room_context:
@@ -1947,7 +1984,7 @@ class DriveLoop:
                     [
                         "Most recent message from this participant in the room "
                         "(context only; the human did not explicitly reply to it):",
-                        prior_content,
+                        _bounded_room_context(prior_content, context_limit),
                     ]
                 )
         label = "Human reply" if has_help_context or reply_context else "Human message"
@@ -2016,6 +2053,16 @@ class DriveLoop:
 
         import time
 
+        inbox_ref = ""
+        capture = getattr(self._resident_runtime, "capture_directed_message", None)
+        if capture is not None:
+            try:
+                inbox_ref = await capture(content, metadata)
+            except Exception:
+                logger.exception(
+                    "drive_loop: failed to persist directed message; continuing live delivery"
+                )
+
         task_id = f"task_{int(time.time() * 1000):x}_{self._next_counter()}"
         persona = self._persona_config.name if self._persona_config else None
         task = AgentTask(
@@ -2027,6 +2074,7 @@ class DriveLoop:
             persona=persona,
             priority=1,  # high priority — user is waiting
             human_initiated=True,
+            resident_inbox_refs=[inbox_ref] if inbox_ref else [],
         )
         if metadata:
             root_correlation_id = str(metadata.get("root_correlation_id") or "").strip()
@@ -2790,6 +2838,9 @@ class DriveLoop:
                 result.metadata["iteration_budget"] = int(
                     getattr(iteration_budget, "total", 0) or 0
                 )
+                prompt_budget = getattr(agent, "prompt_budget_status", {})
+                if isinstance(prompt_budget, dict) and prompt_budget:
+                    result.metadata["prompt_budget"] = dict(prompt_budget)
             if not success and self._resident_runtime is not None:
                 release = getattr(self._resident_runtime, "release_failed_task", None)
                 if release is not None:
@@ -2810,10 +2861,15 @@ class DriveLoop:
 
     def _format_task_error(self, task: AgentTask, exc: Exception) -> str:
         """Render a user-visible task failure message for live room chat."""
+        if isinstance(exc, PromptBudgetExceededError):
+            return (
+                f"Context limit reached while handling `{task.title}`: {exc}. "
+                "The turn stopped before another model request was sent."
+            )
         if isinstance(exc, LLMError):
             return (
-                f"LLM backend unavailable while handling `{task.title}`: {exc}. "
-                "The task will not make progress until the upstream model/service recovers."
+                f"LLM request failed while handling `{task.title}`: {exc}. "
+                "No successful judgment was recorded for this turn."
             )
         return f"{type(exc).__name__}: {exc}"
 

--- a/src/ravn/resident_runtime.py
+++ b/src/ravn/resident_runtime.py
@@ -43,6 +43,7 @@ that reference scheme; the bounded content needed for this turn is already inclu
 
 In the final structured outcome, include a `working_state` mapping with these lists:
 
+- `objectives`: active operator-given or self-authored outcomes worth pursuing across turns
 - `observations`: evidence-grounded observations with their authoritative references
 - `hypotheses`: revisable interpretations, preserving uncertainty and supporting references
 - `unknowns`: unresolved questions that could change a judgment
@@ -102,6 +103,7 @@ class ResidentRuntime:
         tool_result_max_chars: int = 2000,
         scheduled_wake_default_seconds: float = 3600.0,
         stewardship_interval_seconds: float = 0.0,
+        directed_messages_enabled: bool = True,
     ) -> None:
         self._state = state
         self._inbox = inbox
@@ -114,6 +116,7 @@ class ResidentRuntime:
         self._tool_result_max_chars = max(100, int(tool_result_max_chars))
         self._scheduled_wake_default_seconds = max(1.0, float(scheduled_wake_default_seconds))
         self._stewardship_interval_seconds = max(0.0, float(stewardship_interval_seconds))
+        self._directed_messages_enabled = directed_messages_enabled
         self._enqueue: EnqueueResidentTask | None = None
         self._inflight_cases: set[str] = set()
         self._inflight_refs: set[str] = set()
@@ -183,6 +186,30 @@ class ResidentRuntime:
         if task.resident_case_id:
             self._inflight_cases.add(task.resident_case_id)
         self._inflight_refs.update(task.resident_inbox_refs)
+
+    async def capture_directed_message(
+        self,
+        content: str,
+        metadata: dict[str, Any] | None,
+    ) -> str:
+        """Persist a human message so a failed immediate turn cannot lose it."""
+        if not self._directed_messages_enabled or self._inbox is None:
+            return ""
+        telemetry = get_observability()
+        with telemetry.span(
+            "ravn.port.resident_inbox.write_directed_message",
+            attributes={"ravn.resident.id": self._resident_id},
+        ) as span:
+            ref = await self._inbox.write_directed_message(
+                content=content,
+                metadata=metadata,
+            )
+            span.set_attribute("ravn.resident.inbox_ref", ref)
+        telemetry.count(
+            "ravn.resident.directed_messages.persisted",
+            attributes={"ravn.resident.id": self._resident_id},
+        )
+        return ref
 
     async def handle_completed_turn(
         self,
@@ -895,9 +922,10 @@ class ResidentRuntime:
         context_lines.extend(
             (
                 "Judge, against the charter and your durable working state, whether "
-                "anything in this environment now deserves attention: a stale belief "
-                "worth re-checking, an unknown worth resolving, a risk worth "
-                "investigating, or an improvement worth proposing.",
+                "anything in this environment now deserves attention: an active objective "
+                "worth advancing, a stale belief worth re-checking, an unknown worth "
+                "resolving, a capability gap worth researching, a risk worth investigating, "
+                "or an improvement worth proposing.",
                 "",
                 "Deciding that nothing warrants action is a correct and expected "
                 "outcome. Do not manufacture work to justify this turn. Prefer "

--- a/src/ravn/static/resident-hud.html
+++ b/src/ravn/static/resident-hud.html
@@ -9,7 +9,7 @@
     --bg:#04060a; --panel:#080c12; --panel2:#0b1119;
     --line:#16202e; --line2:#233248;
     --tx:#cfdae6; --dim:#5d7085; --dim2:#3d4c5e;
-    --obs:#2fd6c3; --hyp:#f2b03c; --unk:#a870f5; --gap:#ff5f45; --att:#6d8599;
+    --obj:#62a8ff; --obs:#2fd6c3; --hyp:#f2b03c; --unk:#a870f5; --gap:#ff5f45; --att:#6d8599;
     --mono:"SF Mono",SFMono-Regular,ui-monospace,"JetBrains Mono",Menlo,Consolas,monospace;
   }
   *{box-sizing:border-box;margin:0;padding:0}
@@ -333,6 +333,7 @@
         <div class="live-meta">
           <span>ELAPSED <b id="live-elapsed">—</b></span>
           <span>ITERATION <b id="live-iteration">—</b></span>
+          <span>CONTEXT <b id="live-context">—</b></span>
           <span>TOOLS <b id="live-tools">0</b></span>
           <span>WARNINGS <b id="live-warnings">0</b></span>
         </div>
@@ -394,15 +395,15 @@
   "resident_id": "resident",
   "charter": "",
   "environment": {"name": "Resident"},
-  "fields": ["observations", "hypotheses", "unknowns", "capability_gaps", "attempts"],
+  "fields": ["objectives", "observations", "hypotheses", "unknowns", "capability_gaps", "attempts"],
   "turns": []
 }</script>
 <script>
 // Canonical resident fields get their established colours; anything else a
 // deployment declares still renders, using a rotating palette.
-const KNOWN={observations:"--obs",hypotheses:"--hyp",unknowns:"--unk",
+const KNOWN={objectives:"--obj",observations:"--obs",hypotheses:"--hyp",unknowns:"--unk",
              capability_gaps:"--gap",attempts:"--att"};
-const PALETTE=["--obs","--hyp","--unk","--gap","--att"];
+const PALETTE=["--obj","--obs","--hyp","--unk","--gap","--att"];
 
 const RAW=JSON.parse(document.getElementById("data").textContent);
 // One page may carry several residents, so the same core can be shown against
@@ -852,6 +853,7 @@ function durableTasks(d){
           iteration_budget:0,
           tool_calls:(turn.tools_used||[]).length,
           warnings:0,
+          prompt:{},
         },
         events:[],
         durable:true,
@@ -930,6 +932,11 @@ function renderRuntime(d){
   document.getElementById("live-elapsed").textContent=task?taskDuration(task):"—";
   document.getElementById("live-iteration").textContent=progress.iteration_budget
     ? `${progress.iteration||0} / ${progress.iteration_budget}`:`${progress.iteration||0}`;
+  const prompt=progress.prompt||{}, estimated=prompt.estimated_prompt_tokens||0,
+        budget=prompt.prompt_budget_tokens||0;
+  document.getElementById("live-context").textContent=estimated
+    ? `${estimated.toLocaleString()}${budget?" / "+budget.toLocaleString():""}${prompt.compressed?" · compacted":""}`
+    :"—";
   document.getElementById("live-tools").textContent=progress.tool_calls||0;
   document.getElementById("live-warnings").textContent=progress.warnings||0;
   renderA2A(runtime);

--- a/tests/test_ravn/test_budget.py
+++ b/tests/test_ravn/test_budget.py
@@ -41,20 +41,32 @@ class TestTokenEstimatorRoughMessages:
         assert TokenEstimator.rough_messages(msgs) == total_chars // _CHARS_PER_TOKEN
 
     def test_list_content_message(self):
-        # Counts ALL string values in each block dict (type key values too).
-        # {"type": "text", "text": "abcd"} → "text"(4) + "abcd"(4) = 8 chars
-        # {"type": "other", "value": "efgh"} → "other"(5) + "efgh"(4) = 9 chars
-        # Total 17 chars / 4 = 4 tokens
+        # Structured content is serialized in full, including JSON syntax.
         content = [{"type": "text", "text": "abcd"}, {"type": "other", "value": "efgh"}]
         msgs = [Message(role="user", content=content)]
-        assert TokenEstimator.rough_messages(msgs) == 4
+        assert TokenEstimator.rough_messages(msgs) == 15
 
-    def test_nested_non_string_ignored(self):
-        # {"type": "number", "val": 42} → "number"(6 chars), 42 is int (ignored)
-        # 6 chars / 4 = 1 token
+    def test_nested_non_string_is_counted(self):
         content = [{"type": "number", "val": 42}]
         msgs = [Message(role="user", content=content)]
-        assert TokenEstimator.rough_messages(msgs) == 1
+        assert TokenEstimator.rough_messages(msgs) == 7
+
+    def test_nested_tool_input_is_counted(self):
+        small = Message(
+            role="assistant",
+            content=[{"type": "tool_use", "name": "bash", "input": {"command": "pwd"}}],
+        )
+        large = Message(
+            role="assistant",
+            content=[
+                {
+                    "type": "tool_use",
+                    "name": "bash",
+                    "input": {"command": "x" * 400},
+                }
+            ],
+        )
+        assert TokenEstimator.rough_messages([large]) > TokenEstimator.rough_messages([small]) + 90
 
 
 class TestTokenEstimatorRoughApiMessages:

--- a/tests/test_ravn/test_compression.py
+++ b/tests/test_ravn/test_compression.py
@@ -255,15 +255,15 @@ class TestContextCompressorCompression:
 
 
 class TestContextCompressorContextWindowLookup:
-    def test_known_model_context_window(self):
+    def test_model_name_does_not_imply_context_window(self):
         llm = _make_llm()
         c = ContextCompressor(llm, model="claude-sonnet-4-6")
-        assert c._context_window == 200_000
+        assert c._context_window == 0
 
-    def test_unknown_model_uses_default(self):
+    def test_unknown_model_does_not_get_a_fake_default(self):
         llm = _make_llm()
         c = ContextCompressor(llm, model="gpt-unknown")
-        assert c._context_window == 200_000
+        assert c._context_window == 0
 
     def test_explicit_context_window_override(self):
         llm = _make_llm()

--- a/tests/test_ravn/test_context_management.py
+++ b/tests/test_ravn/test_context_management.py
@@ -260,7 +260,15 @@ class TestAgentContextCompressor:
 
         captured_calls: list[dict] = []
 
-        async def _capture_compress(messages, *, system_tokens=0, todos=None, memory_summary=None):
+        async def _capture_compress(
+            messages,
+            *,
+            system_tokens=0,
+            tool_tokens=0,
+            prompt_budget_tokens=0,
+            todos=None,
+            memory_summary=None,
+        ):
             captured_calls.append({"memory_summary": memory_summary})
             return messages, CompressionResult(
                 original_count=len(messages), final_count=len(messages)

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -8,6 +8,7 @@ correctly when mesh is not available.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -160,6 +161,17 @@ Determine whether the observations require action.
         }
         dl._active_tasks[task.task_id] = MagicMock()
         dl._inflight_tasks[task.task_id] = task
+        dl._active_agents[task.task_id] = SimpleNamespace(
+            iteration_budget=None,
+            prompt_budget_status={
+                "estimated_prompt_tokens": 42_000,
+                "prompt_budget_tokens": 100_000,
+                "output_reserve_tokens": 8_192,
+                "context_window_tokens": 131_072,
+                "token_estimate_safety_factor": 1.5,
+                "compressed": False,
+            },
+        )
         dl._result_store.start(task.task_id, task.triggered_by)
         dl._result_store.append_event(
             task.task_id,
@@ -199,6 +211,14 @@ Determine whether the observations require action.
                     "iteration_budget": 0,
                     "tool_calls": 1,
                     "warnings": 0,
+                    "prompt": {
+                        "estimated_prompt_tokens": 42_000,
+                        "prompt_budget_tokens": 100_000,
+                        "output_reserve_tokens": 8_192,
+                        "context_window_tokens": 131_072,
+                        "token_estimate_safety_factor": 1.5,
+                        "compressed": False,
+                    },
                 },
                 "events": [
                     {
@@ -265,6 +285,7 @@ Determine whether the observations require action.
             "iteration_budget": 8,
             "tool_calls": 1,
             "warnings": 0,
+            "prompt": {},
         }
         assert recent["events"] == [
             {

--- a/tests/test_ravn/test_drive_loop_outcome_contract.py
+++ b/tests/test_ravn/test_drive_loop_outcome_contract.py
@@ -382,7 +382,10 @@ class TestDriveLoopOutcomeContract:
             validation_errors=["working_state.hypotheses must be a list"],
             outcome_fields={"working_state": {"observations": ["signal-a"]}},
         )
-        assert "working_state:\n  observations: []\n  hypotheses: []" in working_state_prompt
+        assert (
+            "working_state:\n  objectives: []\n  observations: []\n  hypotheses: []"
+            in working_state_prompt
+        )
         assert "preserve valid prior entries" in working_state_prompt
 
     def test_free_text_continue_is_not_a_supported_wake_source(self) -> None:
@@ -1410,6 +1413,14 @@ summary: post-mortem source captured
         assert "ignored the transport-only check" in recent_context
         assert recent_context.endswith("Human message: makes sense, ignore")
 
+        dl._settings.resident_state.directed_message_context_max_chars = 200
+        bounded_context = dl._directed_message_context(
+            "current message",
+            {"recent_room_context": {"content": "x" * 500}},
+        )
+        assert "prior room context truncated: 300 characters omitted" in bounded_context
+        assert bounded_context.endswith("Human message: current message")
+
     def test_record_tool_outcome_fields_merges_existing_values(self) -> None:
         dl = _make_drive_loop()
         task = _make_agent_task(task_id="task-tool-outcomes")
@@ -1459,6 +1470,26 @@ summary: post-mortem source captured
         assert enqueued.trace_context == {"traceparent": "00-room-parent-01"}
         assert "The human replied to this prior room message:" in enqueued.initiative_context
         assert "transport check only" in enqueued.initiative_context
+
+    @pytest.mark.asyncio
+    async def test_handle_directed_message_attaches_durable_inbox_ref(self) -> None:
+        dl = _make_drive_loop()
+        dl.enqueue = AsyncMock(return_value=True)
+        resident_runtime = SimpleNamespace(
+            capture_directed_message=AsyncMock(
+                return_value="resident/inbox/signals/operator-message.md"
+            )
+        )
+        dl.set_resident_runtime(resident_runtime)
+
+        assert await dl.handle_directed_message("Please retain this objective.") is True
+
+        task = dl.enqueue.await_args.args[0]
+        assert task.resident_inbox_refs == ["resident/inbox/signals/operator-message.md"]
+        resident_runtime.capture_directed_message.assert_awaited_once_with(
+            "Please retain this objective.",
+            None,
+        )
 
     @pytest.mark.asyncio
     async def test_handle_directed_message_steers_active_agent_when_available(self) -> None:

--- a/tests/test_ravn/test_gateway_http.py
+++ b/tests/test_ravn/test_gateway_http.py
@@ -573,6 +573,8 @@ def test_resident_hud_serves_live_durable_and_inflight_state_without_operator_to
     assert "RESIDENT · HUD" in page.text
     assert "What happened" in page.text
     assert "Current progress" in page.text
+    assert 'id="live-context"' in page.text
+    assert '"objectives", "observations"' in page.text
     assert 'id="progress-status"' in page.text
     assert 'id="task-history"' in page.text
     assert "function durableTasks(d)" in page.text

--- a/tests/test_ravn/test_prompt_budget.py
+++ b/tests/test_ravn/test_prompt_budget.py
@@ -36,6 +36,8 @@ def _agent(
     max_tool_result_chars: int = 0,
     prompt_builder: PromptBuilder | None = None,
     system_prompt: str = "You are a test assistant.",
+    context_window_tokens: int = 0,
+    token_estimate_safety_factor: float = 1.0,
 ) -> RavnAgent:
     return RavnAgent(
         llm=llm,
@@ -48,6 +50,8 @@ def _agent(
         max_iterations=5,
         prompt_builder=prompt_builder,
         max_prompt_tokens=max_prompt_tokens,
+        context_window_tokens=context_window_tokens,
+        token_estimate_safety_factor=token_estimate_safety_factor,
         max_tool_result_chars=max_tool_result_chars,
     )
 
@@ -172,6 +176,46 @@ class TestPromptBudget:
                 await agent.run_turn("word " * 500)
 
         assert any("Prompt budget exceeded" in r.message for r in caplog.records)
+
+    async def test_context_window_reserves_maximum_output(self) -> None:
+        agent = _agent(
+            make_simple_llm("ok"),
+            max_prompt_tokens=5_000,
+            context_window_tokens=2_048,
+        )
+
+        await agent.run_turn("hello")
+
+        assert agent.prompt_budget_status["prompt_budget_tokens"] == 1_024
+        assert agent.prompt_budget_status["output_reserve_tokens"] == 1_024
+        assert agent.prompt_budget_status["context_window_tokens"] == 2_048
+
+    async def test_safety_factor_applies_before_budget_check(self) -> None:
+        baseline = _agent(
+            make_simple_llm("ok"),
+            max_prompt_tokens=100_000,
+            token_estimate_safety_factor=1.0,
+        )
+        conservative = _agent(
+            make_simple_llm("ok"),
+            max_prompt_tokens=100_000,
+            token_estimate_safety_factor=1.5,
+        )
+
+        await baseline.run_turn("hello")
+        await conservative.run_turn("hello")
+
+        assert (
+            conservative.prompt_budget_status["estimated_prompt_tokens"]
+            > baseline.prompt_budget_status["estimated_prompt_tokens"]
+        )
+
+    def test_rejects_output_reserve_larger_than_context_window(self) -> None:
+        with pytest.raises(ValueError, match="max_tokens must be smaller"):
+            _agent(
+                make_simple_llm("ok"),
+                context_window_tokens=1_024,
+            )
 
 
 class TestToolResultCap:

--- a/tests/test_ravn/test_resident_runtime.py
+++ b/tests/test_ravn/test_resident_runtime.py
@@ -298,6 +298,7 @@ async def test_working_state_is_reused_by_a_new_runtime_after_restart(tmp_path) 
                 "continuation": "stop",
                 "signal_refs": ["signal-a"],
                 "working_state": {
+                    "objectives": ["understand and improve device Raven"],
                     "observations": ["signal-a introduced device Raven"],
                     "hypotheses": ["Raven may expose a control surface"],
                     "unknowns": ["how Raven can be inspected"],
@@ -323,6 +324,7 @@ async def test_working_state_is_reused_by_a_new_runtime_after_restart(tmp_path) 
 
     assert "A different generic event arrived." in second_context
     assert "resident/continuation/working-state/resident-alpha.md" in second_context
+    assert "understand and improve device Raven" in second_context
     assert "signal-a introduced device Raven" in second_context
     assert "Raven may expose a control surface" in second_context
     assert "no addressable source capability" in second_context
@@ -332,6 +334,38 @@ async def test_working_state_is_reused_by_a_new_runtime_after_restart(tmp_path) 
     assert "will not turn a prose" in second_context
     assert "Use available tools when they can materially reduce uncertainty" in second_context
     assert "Do not call a tool merely to demonstrate tool use" in second_context
+
+
+@pytest.mark.asyncio
+async def test_directed_message_is_captured_in_the_existing_resident_inbox(tmp_path) -> None:
+    inbox = MimirResidentInbox(MarkdownMimirAdapter(tmp_path / "mimir"))
+    runtime = ResidentRuntime(
+        state=LocalResidentState(tmp_path / "state"),
+        inbox=inbox,
+        resident_id="resident-alpha",
+    )
+
+    ref = await runtime.capture_directed_message(
+        "Keep improving this environment across turns.",
+        {"room_id": "operator-room"},
+    )
+
+    rows = await inbox.list_signals(status=ResidentInboxStatus.NEW.value)
+    assert rows[0][0] == ref
+    assert rows[0][1].summary == "Keep improving this environment across turns."
+
+
+@pytest.mark.asyncio
+async def test_directed_message_capture_can_be_disabled(tmp_path) -> None:
+    inbox = MimirResidentInbox(MarkdownMimirAdapter(tmp_path / "mimir"))
+    runtime = ResidentRuntime(
+        state=LocalResidentState(tmp_path / "state"),
+        inbox=inbox,
+        directed_messages_enabled=False,
+    )
+
+    assert await runtime.capture_directed_message("hello", None) == ""
+    assert await inbox.list_signals(status=ResidentInboxStatus.NEW.value) == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- budget resident prompts against the configured model context window, including nested tool schemas and reserved output tokens
- bound directed-message room context and persist messages through the existing resident inbox for retry after failure or restart
- preserve explicit objectives in resident working state and expose prompt-budget data in traces and the HUD

## Why

Long-running resident context could grow beyond the model window, producing an OpenAI-compatible API 400 and losing progress on directed messages. The runtime also undercounted nested tool arguments and did not show operators how close a turn was to its context ceiling.

## Impact

Ivaldi can compact before crossing Qwen’s configured context limit, retry durable operator messages, keep stewardship objectives visible, and report prompt-budget usage in the HUD and telemetry.

## Validation

- `uv run --extra dev pytest -q tests/test_ravn` — 4558 passed, 7 skipped
- `make lint`
- `git diff --check`
- HUD JavaScript parsed with Node
