### PR TITLE
feat(cli): add Ravn room lifecycle commands

### DIFF
--- a/src/ravn/adapters/discovery/mdns.py
+++ b/src/ravn/adapters/discovery/mdns.py
@@ -155,6 +155,11 @@ class MdnsDiscoveryAdapter:
         self._handshake_listener_task: asyncio.Task | None = None
         self._pending_handshakes: set[str] = set()
 
+        # Zeroconf browse callbacks and the handshake responder both run on
+        # threads with no event loop of their own, so the running loop is
+        # captured at start() and used to hand work back to it.
+        self._loop: asyncio.AbstractEventLoop | None = None
+
     # ------------------------------------------------------------------
     # DiscoveryPort interface
     # ------------------------------------------------------------------
@@ -165,6 +170,7 @@ class MdnsDiscoveryAdapter:
             logger.warning("mdns_discovery: zeroconf not installed — discovery disabled")
             return
 
+        self._loop = asyncio.get_running_loop()
         self._zc = AsyncZeroconf()
         await self._register_service()
         await self._start_browser()
@@ -329,6 +335,21 @@ class MdnsDiscoveryAdapter:
             handlers=handlers,
         )
 
+    def _schedule(self, fn: Any, *args: Any) -> bool:
+        """Run *fn* on the adapter's event loop from any thread.
+
+        Returns False when there is no live loop to schedule onto — which
+        happens only before start() or after stop().
+        """
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            logger.debug(
+                "mdns_discovery: no event loop to schedule %s", getattr(fn, "__name__", fn)
+            )
+            return False
+        loop.call_soon_threadsafe(fn, *args)
+        return True
+
     def _on_service_state_change(
         self,
         zeroconf: object,
@@ -336,11 +357,13 @@ class MdnsDiscoveryAdapter:
         name: str,
         state_change: object,
     ) -> None:
-        """mDNS browse callback — fires on add/remove/update."""
-        asyncio.get_running_loop().call_soon_threadsafe(
-            asyncio.ensure_future,
-            self._handle_service_event(zeroconf, service_type, name, state_change),
-        )
+        """mDNS browse callback — fires on add/remove/update.
+
+        Invoked from a zeroconf thread, which has no running loop of its own.
+        """
+        coro = self._handle_service_event(zeroconf, service_type, name, state_change)
+        if not self._schedule(asyncio.ensure_future, coro):
+            coro.close()
 
     async def _handle_service_event(
         self,
@@ -592,7 +615,8 @@ class MdnsDiscoveryAdapter:
 
             candidate = self._candidates.get(peer_id_a)
             peer = self._peer_from_identity_dict(peer_identity_raw, candidate)
-            asyncio.get_running_loop().call_soon_threadsafe(self._add_peer, peer)
+            # Runs on an executor thread — hand the peer back to the loop.
+            self._schedule(self._add_peer, peer)
         except Exception as exc:
             logger.debug("mdns_discovery: responder error: %s", exc)
 

--- a/src/ravn/adapters/personas/loader.py
+++ b/src/ravn/adapters/personas/loader.py
@@ -976,13 +976,27 @@ class FilesystemPersonaAdapter(PersonaRegistryPort):
 
         return None
 
+    def load_path(self, path: Path) -> PersonaConfig | None:
+        """Load a persona from a path the operator named directly.
+
+        Mirrors :meth:`load` — including outcome instruction injection — for a
+        file addressed by path rather than by registry name, so
+        ``--persona ./reviewer.yaml`` behaves exactly like ``--persona reviewer``.
+        Returns ``None`` when the file is unreadable or malformed.
+        """
+        persona = self.load_from_file(path)
+        if persona is None:
+            return None
+        return _apply_outcome_instruction(persona)
+
     def load_from_file(self, path: Path) -> PersonaConfig | None:
         """Parse a persona YAML file without injecting outcome instructions.
 
         Returns ``None`` when the file is unreadable or malformed rather than
         raising, so callers can treat missing personas as a soft error.
 
-        Note: outcome instruction injection happens in :meth:`load`, not here.
+        Note: outcome instruction injection happens in :meth:`load` and
+        :meth:`load_path`, not here.
         """
         try:
             text = path.read_text(encoding="utf-8", errors="replace")

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -80,6 +80,15 @@ from ravn.cli.flock import flock_app  # noqa: E402 — must be after app is defi
 
 app.add_typer(flock_app, name="flock")
 
+from ravn.cli.registries import personas_app, profiles_app  # noqa: E402
+
+app.add_typer(personas_app, name="personas")
+app.add_typer(profiles_app, name="profiles")
+
+from ravn.cli.room import room_app  # noqa: E402
+
+app.add_typer(room_app, name="room")
+
 
 def approvals_main() -> None:
     approvals_app()
@@ -149,13 +158,32 @@ async def _cli_user_input(question: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _looks_like_path(name: str) -> bool:
+    """Return True when *name* addresses a file rather than a registry name.
+
+    Registry names are bare slugs (``reviewer``), so anything carrying a path
+    separator or a YAML suffix is an explicit file reference.
+    """
+    return os.sep in name or name.endswith((".yaml", ".yml"))
+
+
 def _resolve_persona(
     persona_name: str,
     project_config: ProjectConfig | None,
     settings: Settings | None = None,
     cwd: Path | None = None,
+    warn: bool = True,
 ) -> Any:
-    """Load and merge a persona with optional ProjectConfig overrides."""
+    """Load and merge a persona with optional ProjectConfig overrides.
+
+    *persona_name* is either a registry name resolved through the configured
+    ``persona_source`` adapter, or a path to a persona YAML file.  Returns
+    ``None`` when the name is empty or unresolvable — callers that act on an
+    explicit operator flag should use :func:`_require_persona` instead.
+
+    *warn* suppresses the fallback warning for callers that report the failure
+    themselves, so an operator never sees both a warning and an error.
+    """
     from niuu.utils import import_class, resolve_secret_kwargs  # noqa: PLC0415
     from ravn.adapters.personas.loader import FilesystemPersonaAdapter  # noqa: PLC0415
 
@@ -173,9 +201,15 @@ def _resolve_persona(
     if not name:
         return None
 
-    persona = loader.load(name)
+    if _looks_like_path(name):
+        # A path is inherently a filesystem reference, so it bypasses the
+        # configured registry adapter (which may not be filesystem-backed).
+        persona = FilesystemPersonaAdapter(cwd=cwd).load_path(Path(name).expanduser())
+    else:
+        persona = loader.load(name)
     if persona is None:
-        typer.echo(f"Warning: persona '{name}' not found — using defaults.", err=True)
+        if warn:
+            typer.echo(f"Warning: persona '{name}' not found — using defaults.", err=True)
         return None
 
     # Apply per-sidecar overrides injected by Volundr at flock dispatch time.
@@ -197,16 +231,45 @@ def _resolve_persona(
     return persona
 
 
+def _require_persona(
+    persona_name: str,
+    project_config: ProjectConfig | None,
+    settings: Settings | None = None,
+    cwd: Path | None = None,
+) -> Any:
+    """Resolve a persona, exiting when an explicitly named one does not resolve.
+
+    An operator who passes ``--persona`` has stated which role they want;
+    silently continuing with defaults would run a different agent than asked
+    for.  A persona inherited from ProjectConfig stays a soft fallback, and an
+    empty name still returns ``None``.
+    """
+    name = persona_name.strip()
+    persona = _resolve_persona(
+        persona_name, project_config, settings=settings, cwd=cwd, warn=not name
+    )
+    if persona is not None or not name:
+        return persona
+
+    typer.echo(f"Error: persona '{name}' not found.", err=True)
+    if not _looks_like_path(name):
+        typer.echo("Run 'ravn personas list' to see available personas.", err=True)
+    raise typer.Exit(2)
+
+
 # ---------------------------------------------------------------------------
 # Profile resolution
 # ---------------------------------------------------------------------------
 
 
-def _resolve_profile(profile_name: str) -> RavnProfile | None:
-    """Load a RavnProfile by name from ~/.ravn/profiles/ or the built-in set.
+def _resolve_profile(profile_name: str, warn: bool = True) -> RavnProfile | None:
+    """Load a RavnProfile by name or path.
 
-    Returns ``None`` when *profile_name* is empty or cannot be resolved, so
-    callers can proceed without a profile using Settings defaults.
+    Names resolve from ``~/.ravn/profiles/`` then the built-in set; anything
+    path-shaped is read directly.  Returns ``None`` when *profile_name* is
+    empty or cannot be resolved, so callers can proceed using Settings
+    defaults.  *warn* suppresses the fallback warning for callers that report
+    the failure themselves.
     """
     from ravn.adapters.profiles.loader import ProfileLoader
 
@@ -214,12 +277,34 @@ def _resolve_profile(profile_name: str) -> RavnProfile | None:
     if not name:
         return None
 
-    profile = ProfileLoader().load(name)
+    loader = ProfileLoader()
+    if _looks_like_path(name):
+        profile = loader.load_from_file(Path(name).expanduser())
+    else:
+        profile = loader.load(name)
     if profile is None:
-        typer.echo(f"Warning: profile '{name}' not found — using defaults.", err=True)
+        if warn:
+            typer.echo(f"Warning: profile '{name}' not found — using defaults.", err=True)
         return None
 
     return profile
+
+
+def _require_profile(profile_name: str) -> RavnProfile | None:
+    """Resolve a profile, exiting when an explicitly named one does not resolve.
+
+    Mirrors :func:`_require_persona`: an explicit ``--profile`` that cannot be
+    resolved is an error, not a silent fallback to defaults.
+    """
+    name = profile_name.strip()
+    profile = _resolve_profile(profile_name, warn=False)
+    if profile is not None or not name:
+        return profile
+
+    typer.echo(f"Error: profile '{name}' not found.", err=True)
+    if not _looks_like_path(name):
+        typer.echo("Run 'ravn profiles list' to see available profiles.", err=True)
+    raise typer.Exit(2)
 
 
 def _apply_profile(
@@ -494,11 +579,11 @@ def run(
     settings = Settings()
     _configure_logging(settings)
     project_config = ProjectConfig.discover()
-    ravn_profile = _resolve_profile(profile)
+    ravn_profile = _require_profile(profile)
     # --persona overrides the profile's persona reference; if neither is given
     # the persona is taken from the profile (or ProjectConfig as fallback).
     effective_persona = persona or (ravn_profile.persona if ravn_profile else "")
-    persona_config = _resolve_persona(effective_persona, project_config, settings=settings)
+    persona_config = _require_persona(effective_persona, project_config, settings=settings)
 
     asyncio.run(
         _run_with_signals(
@@ -762,9 +847,9 @@ def tool_mcp(
     )
     try:
         project_config = ProjectConfig.discover()
-        ravn_profile = _resolve_profile(profile)
+        ravn_profile = _require_profile(profile)
         effective_persona = persona or (ravn_profile.persona if ravn_profile else "")
-        persona_config = _resolve_persona(effective_persona, project_config, settings=settings)
+        persona_config = _require_persona(effective_persona, project_config, settings=settings)
         tools = _build_tool_mcp_tools(settings, persona_config=persona_config)
 
         from ravn.adapters.mcp.tool_port_server import ToolPortMcpServer
@@ -1069,9 +1154,9 @@ def gateway(
     settings = Settings()
     _configure_logging(settings)
     project_config = ProjectConfig.discover()
-    ravn_profile = _resolve_profile(profile)
+    ravn_profile = _require_profile(profile)
     effective_persona = persona or (ravn_profile.persona if ravn_profile else "")
-    persona_config = _resolve_persona(effective_persona, project_config, settings=settings)
+    persona_config = _require_persona(effective_persona, project_config, settings=settings)
 
     # CLI flags override config file.
     if telegram:
@@ -1300,9 +1385,9 @@ def daemon(
     _configure_logging(settings)
     _log_effective_config(settings)
     project_config = ProjectConfig.discover()
-    ravn_profile = _resolve_profile(profile)
+    ravn_profile = _require_profile(profile)
     effective_persona = persona or (ravn_profile.persona if ravn_profile else "")
-    persona_config = _resolve_persona(effective_persona, project_config, settings=settings)
+    persona_config = _require_persona(effective_persona, project_config, settings=settings)
 
     asyncio.run(
         _run_daemon(settings, persona_config=persona_config, profile=ravn_profile, resume=resume)
@@ -1337,9 +1422,9 @@ def listen(
     _configure_logging(settings)
     _log_effective_config(settings)
     project_config = ProjectConfig.discover()
-    ravn_profile = _resolve_profile(profile)
+    ravn_profile = _require_profile(profile)
     effective_persona = persona or (ravn_profile.persona if ravn_profile else "")
-    persona_config = _resolve_persona(effective_persona, project_config, settings=settings)
+    persona_config = _require_persona(effective_persona, project_config, settings=settings)
 
     asyncio.run(
         _run_daemon(
@@ -1604,100 +1689,6 @@ def tui(
         mimir_urls=mimir_urls,
     )
     ravn_tui.run()
-
-
-@app.command()
-def room(
-    action: str = typer.Argument(
-        help="Room action: join | leave | message | heartbeat | close | participants."
-    ),
-    broker_url: str = typer.Option(
-        "http://127.0.0.1:9000",
-        "--broker-url",
-        envvar="SKULD_BROKER_URL",
-        help="Skuld broker base URL hosting the Environment room.",
-    ),
-    participant: str = typer.Option("", "--participant", help="Participant id, e.g. human:jozef."),
-    environment: str = typer.Option("", "--environment", help="Environment id to join."),
-    role: str = typer.Option(
-        "observer", "--role", help="Room role: observer|teacher|approver|debugger|owner."
-    ),
-    room_id: str = typer.Option("", "--room", help="Optional huddle room id."),
-    text: str = typer.Option("", "--text", help="Message text (message action)."),
-    reason: str = typer.Option("left", "--reason", help="Reason for leave/close."),
-) -> None:
-    """Join, talk in, and leave a live Valkyrie Environment room from the CLI.
-
-    Wraps the Skuld broker room API so a terminal operator participates in
-    the same live Environment state as the UI (NIU-1023).
-    """
-    import httpx  # noqa: PLC0415
-
-    base = broker_url.rstrip("/")
-
-    def _post(path: str, payload: dict) -> dict:
-        response = httpx.post(f"{base}{path}", json=payload, timeout=10.0)
-        if response.status_code >= 400:
-            typer.echo(f"error {response.status_code}: {response.text[:300]}", err=True)
-            raise typer.Exit(1)
-        return response.json()
-
-    if action == "join":
-        if not participant or not environment:
-            typer.echo("join requires --participant and --environment", err=True)
-            raise typer.Exit(2)
-        result = _post(
-            "/api/room/join",
-            {
-                "participant_id": participant,
-                "display_name": participant,
-                "environment_id": environment,
-                "role": role,
-                "room_id": room_id,
-            },
-        )
-        meta = result.get("participant", result)
-        typer.echo(
-            f"joined {environment} as {participant} ({role}); "
-            f"capabilities: {', '.join(meta.get('capabilities', []))}"
-        )
-        return
-    if action == "leave":
-        _post("/api/room/leave", {"participant_id": participant, "reason": reason})
-        typer.echo(f"left: {participant}")
-        return
-    if action == "message":
-        if not text:
-            typer.echo("message requires --text", err=True)
-            raise typer.Exit(2)
-        _post(
-            "/api/room/message",
-            {"participant_id": participant, "content": text, "room_id": room_id},
-        )
-        typer.echo("sent")
-        return
-    if action == "heartbeat":
-        _post("/api/room/heartbeat", {"participant_id": participant})
-        typer.echo("heartbeat recorded")
-        return
-    if action == "close":
-        result = _post(
-            "/api/room/close",
-            {"room_id": room_id, "reason": reason},
-        )
-        typer.echo(f"closed {room_id}; transcript: {result.get('transcriptRef', '-')}")
-        return
-    if action == "participants":
-        response = httpx.get(f"{base}/api/room/participants", timeout=10.0)
-        response.raise_for_status()
-        for entry in response.json().get("participants", []):
-            typer.echo(
-                f"- {entry.get('peer_id')} [{entry.get('participant_type')}] "
-                f"{entry.get('authority_role') or ''} {entry.get('status') or ''}"
-            )
-        return
-    typer.echo(f"unknown action: {action}", err=True)
-    raise typer.Exit(2)
 
 
 @app.command()

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -90,6 +90,68 @@ from ravn.cli.room import room_app  # noqa: E402
 app.add_typer(room_app, name="room")
 
 
+@app.command("join")
+def join(
+    persona: str = typer.Option(
+        "", "--persona", "-p", help="Persona name, or a path to a persona YAML file."
+    ),
+    room: str = typer.Option("", "--room", "-r", envvar="RAVN_ROOM", help="Room to join."),
+    as_handle: str = typer.Option(
+        "", "--as", help="Member handle in the room. Defaults to the persona name."
+    ),
+    profile: str = typer.Option("", "--profile", help="Profile name or path (deployment wiring)."),
+    base_config: str = typer.Option(
+        "", "--base-config", help="Existing ravn.yaml to layer the membership config over."
+    ),
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+    here: bool = typer.Option(
+        False, "--here", help="Run the member in this terminal instead of detaching."
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Replace an existing member with the same handle."
+    ),
+    autonomous: bool = typer.Option(
+        False,
+        "--autonomous",
+        help="Also enable the self-driving triggers (cron, staleness, wakefulness).",
+    ),
+) -> None:
+    """Put a persona-typed Ravn into a room as an addressable member.
+
+    Persona picks who the member is; profile picks how it is deployed.  The
+    command waits until the member actually registers with the room, so a
+    reported join is a join.
+
+    \b
+    Examples:
+      ravn join --persona reviewer
+      ravn join --persona reviewer --room desk --as second-opinion
+      ravn join --persona ./contrib/red-team.yaml --room desk
+      ravn join --persona coder --room desk --here
+    """
+    from ravn.cli.room import join_room
+
+    join_room(persona, room, as_handle, profile, base_config, rooms_dir, here, force, autonomous)
+
+
+@app.command("leave")
+def leave(
+    as_handle: str = typer.Option(..., "--as", help="Member handle to remove from the room."),
+    room: str = typer.Option("", "--room", "-r", envvar="RAVN_ROOM", help="Room to leave."),
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+) -> None:
+    """Stop a member's daemon and remove it from the room.
+
+    \b
+    Examples:
+      ravn leave --as reviewer
+      ravn leave --as reviewer --room desk
+    """
+    from ravn.cli.room import leave_room
+
+    leave_room(as_handle, room, rooms_dir)
+
+
 def approvals_main() -> None:
     approvals_app()
 

--- a/src/ravn/cli/daemon_config.py
+++ b/src/ravn/cli/daemon_config.py
@@ -100,9 +100,7 @@ def _quiet_overlay() -> dict[str, Any]:
     return overlay
 
 
-def mesh_block(
-    handle: str, *, pub_port: int, rep_port: int, cluster_file: Path
-) -> dict[str, Any]:
+def mesh_block(handle: str, *, pub_port: int, rep_port: int, cluster_file: Path) -> dict[str, Any]:
     """Return the ``mesh:``/``discovery:`` sections that make a member a peer.
 
     Room membership is a surface; peer-to-peer work still travels over the
@@ -146,8 +144,8 @@ def render_cluster_yaml(members: list[dict[str, Any]]) -> str:
                 f"  - peer_id: {member['handle']}",
                 f"    persona: {member['persona']}",
                 f"    display_name: {member['handle']}",
-                f"    pub_address: \"tcp://127.0.0.1:{member['pub_port']}\"",
-                f"    rep_address: \"tcp://127.0.0.1:{member['rep_port']}\"",
+                f'    pub_address: "tcp://127.0.0.1:{member["pub_port"]}"',
+                f'    rep_address: "tcp://127.0.0.1:{member["rep_port"]}"',
             ]
         )
     return "\n".join(lines) + "\n"

--- a/src/ravn/cli/daemon_config.py
+++ b/src/ravn/cli/daemon_config.py
@@ -1,0 +1,246 @@
+"""Daemon config generation shared by ``ravn flock`` and ``ravn room``.
+
+Both supervisors have to answer the same question — what YAML makes a
+``ravn daemon`` join a room — so the Skuld block is rendered in exactly one
+place.  A room member's config is built here too, layered over an optional
+base config so an operator's model/provider settings carry through.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# WebSocket path the broker exposes for Ravn participants; the peer id is
+# appended by the daemon at connect time.
+RAVN_WS_PATH = "/ws/ravn"
+
+
+def room_broker_ws_url(host: str, port: int) -> str:
+    """Return the Ravn-participant WebSocket base URL for a room's broker."""
+    return f"ws://{host}:{port}{RAVN_WS_PATH}"
+
+
+def skuld_block(broker_url: str, *, display_name: str = "") -> dict[str, Any]:
+    """Return the ``skuld:`` config section that makes a daemon join a room.
+
+    This is the single definition of room membership for a Ravn daemon: the
+    drive loop builds its SkuldChannel from it and connects to
+    ``<broker_url>/<peer_id>``.
+    """
+    block: dict[str, Any] = {"enabled": True, "broker_url": broker_url}
+    if display_name:
+        block["display_name"] = display_name
+    return block
+
+
+def render_skuld_yaml(broker_url: str, *, display_name: str = "") -> str:
+    """Render :func:`skuld_block` as a top-level ``skuld:`` YAML section."""
+    return yaml.safe_dump({"skuld": skuld_block(broker_url, display_name=display_name)})
+
+
+def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Merge *overlay* into *base*, recursing into nested mappings."""
+    merged = dict(base)
+    for key, value in overlay.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge(existing, value)
+            continue
+        merged[key] = value
+    return merged
+
+
+def load_base_config(path: Path | None) -> dict[str, Any]:
+    """Load an operator-supplied base config, or return an empty mapping.
+
+    Raises ``ValueError`` when the file exists but is not a YAML mapping —
+    a malformed base config must not silently degrade into defaults.
+    """
+    if path is None:
+        return {}
+    text = path.read_text(encoding="utf-8")
+    data = yaml.safe_load(text)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Base config {path} is not a YAML mapping.")
+    return data
+
+
+# Trigger sources that make a daemon generate its own work. A room member is
+# responsive by default — it answers what is addressed to it — so these are
+# switched off unless the operator asks for an autonomous member.
+_SELF_DRIVING_SECTIONS = (
+    ("mimir", "source_trigger"),
+    ("mimir", "staleness_trigger"),
+    ("resident_wakefulness", None),
+    ("recap", None),
+    ("dream_cycle", None),
+    ("thread", None),
+    ("resident_inbox", None),
+)
+
+
+def quiet_overlay_yaml() -> str:
+    """Render :func:`_quiet_overlay` as top-level YAML sections."""
+    return yaml.safe_dump(_quiet_overlay(), sort_keys=False)
+
+
+def _quiet_overlay() -> dict[str, Any]:
+    """Return the config sections that disable autonomous work generation."""
+    overlay: dict[str, Any] = {}
+    for section, subsection in _SELF_DRIVING_SECTIONS:
+        if subsection is None:
+            overlay[section] = {"enabled": False}
+            continue
+        overlay.setdefault(section, {})[subsection] = {"enabled": False}
+    return overlay
+
+
+def mesh_block(
+    handle: str, *, pub_port: int, rep_port: int, cluster_file: Path
+) -> dict[str, Any]:
+    """Return the ``mesh:``/``discovery:`` sections that make a member a peer.
+
+    Room membership is a surface; peer-to-peer work still travels over the
+    mesh, so a member is wired the same way a flock node is.  Without this a
+    member can be seen in a room but cannot be reached by ``route_work`` or
+    the cascade delegation tools.
+
+    Discovery is static: a room already knows its own roster, so peers are
+    read from a generated cluster file rather than rediscovered over mDNS.
+    """
+    return {
+        "mesh": {
+            "enabled": True,
+            "adapter": "nng",
+            "own_peer_id": handle,
+            "nng": {
+                "pub_sub_address": f"tcp://0.0.0.0:{pub_port}",
+                "req_rep_address": f"tcp://0.0.0.0:{rep_port}",
+            },
+        },
+        "discovery": {
+            "enabled": True,
+            "adapters": [
+                {
+                    "adapter": "ravn.adapters.discovery.static.StaticDiscoveryAdapter",
+                    "cluster_file": str(cluster_file),
+                    "poll_interval_s": 5,
+                }
+            ],
+        },
+        "cascade": {"enabled": True},
+    }
+
+
+def render_cluster_yaml(members: list[dict[str, Any]]) -> str:
+    """Render the static peer table shared by a room's members."""
+    lines = ["# Static peer definitions (auto-generated by ravn join)", "peers:"]
+    for member in members:
+        lines.extend(
+            [
+                f"  - peer_id: {member['handle']}",
+                f"    persona: {member['persona']}",
+                f"    display_name: {member['handle']}",
+                f"    pub_address: \"tcp://127.0.0.1:{member['pub_port']}\"",
+                f"    rep_address: \"tcp://127.0.0.1:{member['rep_port']}\"",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def build_member_config(
+    *,
+    handle: str,
+    broker_url: str,
+    display_name: str = "",
+    memory_db_path: Path | None = None,
+    queue_journal_path: Path | None = None,
+    autonomous: bool = False,
+    mesh_ports: tuple[int, int] | None = None,
+    cluster_file: Path | None = None,
+    base: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the daemon config for one room member.
+
+    The member's *handle* becomes its mesh peer id, which is the identity the
+    broker registers and every other participant addresses.  Room membership
+    and identity are applied last so a base config cannot accidentally
+    override them.
+
+    Unless *autonomous* is set, the self-driving trigger sources are disabled:
+    a member joins to take part in the room, not to start generating its own
+    work the moment it connects.
+    """
+    config = dict(base or {})
+
+    # A detached member's log is its only window, so INFO is the useful floor —
+    # mesh, discovery and tool wiring all report there. Applied as a default so
+    # a base config can still ask for DEBUG.
+    config.setdefault("logging", {}).setdefault("level", "INFO")
+
+    overlay: dict[str, Any] = {
+        "skuld": skuld_block(broker_url, display_name=display_name or handle),
+        "mesh": {"own_peer_id": handle},
+        **(
+            mesh_block(
+                handle,
+                pub_port=mesh_ports[0],
+                rep_port=mesh_ports[1],
+                cluster_file=cluster_file,
+            )
+            if mesh_ports and cluster_file
+            else {}
+        ),
+        # The drive loop owns the room channel's connection, so a member with
+        # initiative disabled would start, find nothing to do, and exit
+        # without ever registering.
+        "initiative": {"enabled": True},
+    }
+    if not autonomous:
+        overlay = _deep_merge(_quiet_overlay(), overlay)
+    if memory_db_path is not None:
+        overlay["memory"] = {"backend": "sqlite", "sqlite": {"path": str(memory_db_path)}}
+    if queue_journal_path is not None:
+        overlay["initiative"]["queue_journal_path"] = str(queue_journal_path)
+
+    return _deep_merge(config, overlay)
+
+
+def render_member_config(
+    *,
+    handle: str,
+    room_name: str,
+    persona: str,
+    broker_url: str,
+    display_name: str = "",
+    memory_db_path: Path | None = None,
+    queue_journal_path: Path | None = None,
+    autonomous: bool = False,
+    mesh_ports: tuple[int, int] | None = None,
+    cluster_file: Path | None = None,
+    base: dict[str, Any] | None = None,
+) -> str:
+    """Render a room member's daemon config as YAML with a provenance header."""
+    config = build_member_config(
+        handle=handle,
+        broker_url=broker_url,
+        display_name=display_name,
+        memory_db_path=memory_db_path,
+        queue_journal_path=queue_journal_path,
+        autonomous=autonomous,
+        mesh_ports=mesh_ports,
+        cluster_file=cluster_file,
+        base=base,
+    )
+    header = (
+        f"# Ravn daemon config — member {handle!r} of room {room_name!r}\n"
+        f"# Persona: {persona}\n"
+        "# Generated by: ravn join\n"
+        "# Edit as needed; 'ravn join' regenerates this file with --force.\n"
+    )
+    return header + yaml.safe_dump(config, sort_keys=False)

--- a/src/ravn/cli/flock.py
+++ b/src/ravn/cli/flock.py
@@ -38,6 +38,11 @@ import typer
 
 from niuu.mesh import nng_gateway_port_for, nng_ports_for
 from niuu.mesh.ipc import cleanup_ravn_mesh_sockets, flock_socket_dir, ravn_mesh_addresses
+from ravn.cli.daemon_config import (
+    quiet_overlay_yaml,
+    render_skuld_yaml,
+    room_broker_ws_url,
+)
 from ravn.cli.process_supervision import (
     DEFAULT_STOP_TIMEOUT_S,
     is_alive,
@@ -264,8 +269,15 @@ def _write_node_config(
     discovery: str = "mdns",
     mesh_transport: str = "tcp",
     http_gateway_enabled: bool = True,
+    room_broker_url: str = "",
+    autonomous: bool = True,
 ) -> None:
-    """Write the per-node ravn daemon config file."""
+    """Write the per-node ravn daemon config file.
+
+    When *room_broker_url* is set, every node also joins that room — the node's
+    ``peer_id`` becomes its member handle, so a flock and a room roster are the
+    same set of ravens rather than two disconnected concepts.
+    """
     config_path = Path(node.config_path)
     config_path.parent.mkdir(parents=True, exist_ok=True)
     flock_socket_dir(flock_dir).mkdir(parents=True, exist_ok=True)
@@ -286,12 +298,15 @@ def _write_node_config(
             f"      poll_interval_s: 5\n"
         )
     else:
+        # The adapters list is the form the discovery builder reads; the older
+        # `adapter: mdns` + `mdns:` shape parsed fine but built nothing, so
+        # nodes never discovered each other.
         discovery_block = (
             f"discovery:\n"
             f"  enabled: true\n"
-            f"  adapter: mdns\n"
-            f"  mdns:\n"
-            f"    handshake_port: {node.handshake_port}\n"
+            f"  adapters:\n"
+            f"    - adapter: ravn.adapters.discovery.mdns.MdnsDiscoveryAdapter\n"
+            f"      handshake_port: {node.handshake_port}\n"
         )
 
     config_path.write_text(
@@ -343,6 +358,8 @@ memory:
 logging:
   level: INFO
 """
+        + (render_skuld_yaml(room_broker_url, display_name=node.persona) if room_broker_url else "")
+        + ("" if autonomous else quiet_overlay_yaml())
     )
 
 
@@ -402,6 +419,30 @@ def _stop_pids(pids: list[int], *, timeout_s: float = DEFAULT_STOP_TIMEOUT_S) ->
 # ---------------------------------------------------------------------------
 
 
+def _resolve_room_broker_url(room: str, rooms_dir: str) -> str:
+    """Return the Ravn WebSocket URL for *room*, or "" when no room was named.
+
+    Resolved against the room registry so a typo fails here rather than
+    producing a flock of nodes that quietly never join anything.
+    """
+    name = room.strip()
+    if not name:
+        return ""
+
+    from ravn.cli.room import _load_room_def, _rooms_dir_default  # noqa: PLC0415
+
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    room_def = _load_room_def(name, resolved_dir)
+    if room_def is None:
+        typer.echo(
+            f"Unknown room {name!r}. Run 'ravn room ls' to see rooms, "
+            f"or 'ravn room create {name}' to make one.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return room_broker_ws_url(room_def.host, room_def.port)
+
+
 @flock_app.command("init")
 def flock_init(
     personas: list[str] = typer.Argument(
@@ -430,6 +471,21 @@ def flock_init(
         "--http-gateway/--no-http-gateway",
         help="Enable per-node HTTP/WebSocket gateways.",
     ),
+    room: str = typer.Option(
+        "",
+        "--room",
+        envvar="RAVN_ROOM",
+        help="Join every node to this room (see 'ravn room ls').",
+    ),
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+    autonomous: bool = typer.Option(
+        False,
+        "--autonomous/--responsive",
+        help=(
+            "With --room, keep the self-driving triggers on. Responsive (the "
+            "default) makes room nodes answer what is addressed to them."
+        ),
+    ),
 ) -> None:
     """Initialise a flock definition without starting any processes.
 
@@ -446,8 +502,10 @@ def flock_init(
       ravn flock init --discovery static   # use cluster.yaml instead of mDNS
       ravn flock init --base-port 8480 coordinator coding-agent
       ravn flock init --force   # regenerate from defaults
+      ravn flock init --room desk reviewer coder   # nodes join room 'desk'
     """
     resolved_dir = Path(flock_dir) if flock_dir else _flock_dir_default()
+    room_broker_url = _resolve_room_broker_url(room, rooms_dir)
     resolved_personas = list(personas) if personas else list(_DEFAULT_PERSONAS)
 
     if mesh_transport not in {"tcp", "ipc"}:
@@ -517,12 +575,16 @@ def flock_init(
             discovery=discovery,
             mesh_transport=mesh_transport,
             http_gateway_enabled=http_gateway,
+            room_broker_url=room_broker_url,
+            autonomous=autonomous or not room_broker_url,
         )
 
     if discovery == "static":
         _write_cluster_yaml(nodes, resolved_dir, mesh_transport=mesh_transport)
 
     typer.echo(f"Flock initialised at {resolved_dir}")
+    if room_broker_url:
+        typer.echo(f"Every node joins room {room!r} at {room_broker_url}")
     typer.echo("")
     for node in nodes:
         summary = f"  [{node.index}] {node.persona:<22} mesh={mesh_transport}"

--- a/src/ravn/cli/flock.py
+++ b/src/ravn/cli/flock.py
@@ -26,8 +26,6 @@ from __future__ import annotations
 import asyncio
 import json
 import os
-import signal
-import socket
 import subprocess
 import sys
 import time
@@ -40,6 +38,12 @@ import typer
 
 from niuu.mesh import nng_gateway_port_for, nng_ports_for
 from niuu.mesh.ipc import cleanup_ravn_mesh_sockets, flock_socket_dir, ravn_mesh_addresses
+from ravn.cli.process_supervision import (
+    DEFAULT_STOP_TIMEOUT_S,
+    is_alive,
+    port_free,
+    stop_pids,
+)
 
 # ---------------------------------------------------------------------------
 # Typer app
@@ -215,9 +219,7 @@ _gateway_port_for = nng_gateway_port_for
 
 
 def _port_free(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        return s.connect_ex(("127.0.0.1", port)) != 0
+    return port_free(port)
 
 
 def _check_ports(flock_def: FlockDef) -> list[int]:
@@ -243,11 +245,7 @@ def _check_ports(flock_def: FlockDef) -> list[int]:
 
 
 def _is_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-        return True
-    except (ProcessLookupError, PermissionError):
-        return False
+    return is_alive(pid)
 
 
 def _any_runtime_alive(runtime: FlockRuntime) -> bool:
@@ -394,23 +392,9 @@ def _spawn_node(node: NodeDef, flock_dir: Path) -> int:
     return proc.pid
 
 
-def _stop_pids(pids: list[int], *, timeout_s: float = 5.0) -> None:
+def _stop_pids(pids: list[int], *, timeout_s: float = DEFAULT_STOP_TIMEOUT_S) -> None:
     """Send SIGTERM to all pids, then SIGKILL stragglers."""
-    for pid in pids:
-        if _is_alive(pid):
-            with suppress(ProcessLookupError):
-                os.kill(pid, signal.SIGTERM)
-
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if not any(_is_alive(pid) for pid in pids):
-            return
-        time.sleep(0.2)
-
-    for pid in pids:
-        if _is_alive(pid):
-            with suppress(ProcessLookupError):
-                os.kill(pid, signal.SIGKILL)
+    stop_pids(pids, timeout_s=timeout_s)
 
 
 # ---------------------------------------------------------------------------

--- a/src/ravn/cli/process_supervision.py
+++ b/src/ravn/cli/process_supervision.py
@@ -1,0 +1,72 @@
+"""Shared supervision helpers for CLI-managed child processes.
+
+``ravn flock`` and ``ravn room`` both supervise detached daemons on this host,
+so port probing, liveness checks, and graceful shutdown live here rather than
+being written twice.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import socket
+import time
+from contextlib import suppress
+
+# Seconds to wait for SIGTERM to be honoured before escalating to SIGKILL.
+DEFAULT_STOP_TIMEOUT_S = 5.0
+
+# Poll interval while waiting for processes to exit.
+_STOP_POLL_INTERVAL_S = 0.2
+
+# Upper bound on the port scan performed by :func:`find_free_port`.
+_PORT_SCAN_LIMIT = 200
+
+
+def port_free(port: int, host: str = "127.0.0.1") -> bool:
+    """Return True when nothing is accepting connections on *port*."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return s.connect_ex((host, port)) != 0
+
+
+def find_free_port(base_port: int, host: str = "127.0.0.1") -> int:
+    """Return the first free port at or above *base_port*.
+
+    Raises ``RuntimeError`` rather than returning a busy port, so a caller
+    never silently binds something already in use.
+    """
+    for candidate in range(base_port, base_port + _PORT_SCAN_LIMIT):
+        if port_free(candidate, host):
+            return candidate
+    raise RuntimeError(
+        f"No free port found in {base_port}..{base_port + _PORT_SCAN_LIMIT - 1} on {host}."
+    )
+
+
+def is_alive(pid: int) -> bool:
+    """Return True when *pid* names a live process."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
+def stop_pids(pids: list[int], *, timeout_s: float = DEFAULT_STOP_TIMEOUT_S) -> None:
+    """Send SIGTERM to all *pids*, then SIGKILL whatever is still running."""
+    for pid in pids:
+        if is_alive(pid):
+            with suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGTERM)
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if not any(is_alive(pid) for pid in pids):
+            return
+        time.sleep(_STOP_POLL_INTERVAL_S)
+
+    for pid in pids:
+        if is_alive(pid):
+            with suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGKILL)

--- a/src/ravn/cli/registries.py
+++ b/src/ravn/cli/registries.py
@@ -1,0 +1,73 @@
+"""ravn personas / ravn profiles — discovery for the two registry flags.
+
+``--persona`` and ``--profile`` are accepted by most Ravn commands, but until
+now the only way to enumerate personas from a terminal was ``ravn flock list``
+— filed under the wrong command — and profiles had no listing at all.  These
+sub-apps make both flags discoverable.
+
+Persona picks *who* a Ravn is (system prompt, tools, event subscriptions);
+profile picks *how* it is deployed (location, MCP servers, Mímir mounts,
+checkpointing).
+"""
+
+from __future__ import annotations
+
+import typer
+
+from ravn.adapters.personas.loader import FilesystemPersonaAdapter
+from ravn.adapters.profiles.loader import ProfileLoader
+
+personas_app = typer.Typer(
+    name="personas",
+    help="Inspect the personas available to --persona.",
+    add_completion=False,
+)
+
+profiles_app = typer.Typer(
+    name="profiles",
+    help="Inspect the profiles available to --profile.",
+    add_completion=False,
+)
+
+
+@personas_app.command("list")
+def personas_list(
+    builtin_only: bool = typer.Option(False, "--builtin", help="List only the bundled personas."),
+) -> None:
+    """List persona names resolvable by ``--persona``.
+
+    \b
+    Examples:
+      ravn personas list            — every resolvable persona
+      ravn personas list --builtin  — only the bundled set
+    """
+    loader = FilesystemPersonaAdapter()
+    names = loader.list_builtin_names() if builtin_only else loader.list_names()
+    if not names:
+        typer.echo("No personas found.", err=True)
+        raise typer.Exit(1)
+
+    for name in names:
+        typer.echo(f"{name:<40} {loader.source(name)}")
+
+
+@profiles_app.command("list")
+def profiles_list(
+    builtin_only: bool = typer.Option(False, "--builtin", help="List only the built-in profiles."),
+) -> None:
+    """List profile names resolvable by ``--profile``.
+
+    \b
+    Examples:
+      ravn profiles list            — every resolvable profile
+      ravn profiles list --builtin  — only the built-in set
+    """
+    loader = ProfileLoader()
+    names = loader.list_builtin_names() if builtin_only else loader.list_names()
+    if not names:
+        typer.echo("No profiles found.", err=True)
+        raise typer.Exit(1)
+
+    builtin = set(loader.list_builtin_names())
+    for name in names:
+        typer.echo(f"{name:<40} {'builtin' if name in builtin else 'user'}")

--- a/src/ravn/cli/room.py
+++ b/src/ravn/cli/room.py
@@ -81,6 +81,22 @@ _REQUEST_TIMEOUT_S = 10.0
 # Longest error body echoed back to the operator.
 _ERROR_BODY_LIMIT = 300
 
+# Suffix marking a member's state record; the handle is everything before it.
+_MEMBER_STATE_SUFFIX = ".member.json"
+
+# First nng port for a room member's mesh sockets. Offset from the flock
+# supervisor's base so a room and a flock can run side by side.
+_MEMBER_MESH_BASE_PORT = 7600
+
+# Turns of history fetched when tailing or resolving the last speaker.
+_HISTORY_SCAN_LIMIT = 50
+
+# Seconds between polls while following a room.
+_TAIL_POLL_INTERVAL_S = 1.0
+
+# Longest message preview rendered on one tail line.
+_TURN_PREVIEW_LIMIT = 120
+
 
 def _rooms_dir_default() -> Path:
     return Path.home() / ".ravn" / "rooms"
@@ -194,6 +210,77 @@ def _live_pid(name: str, rooms_dir: Path) -> int | None:
     if pid is None or not is_alive(pid):
         return None
     return pid
+
+
+# ---------------------------------------------------------------------------
+# Member state  (one subdirectory per joined member)
+# ---------------------------------------------------------------------------
+
+
+def _members_dir(name: str, rooms_dir: Path) -> Path:
+    return _room_dir(name, rooms_dir) / "members"
+
+
+def _member_config_path(name: str, rooms_dir: Path, handle: str) -> Path:
+    return _members_dir(name, rooms_dir) / f"{handle}.yaml"
+
+
+def _member_state_path(name: str, rooms_dir: Path, handle: str) -> Path:
+    return _members_dir(name, rooms_dir) / f"{handle}{_MEMBER_STATE_SUFFIX}"
+
+
+def _member_runtime_dir(name: str, rooms_dir: Path, handle: str) -> Path:
+    """Per-member scratch (queue journal, memory db).
+
+    Kept out of the members directory so a member's runtime files can never be
+    mistaken for another member's state record.
+    """
+    return _room_dir(name, rooms_dir) / "runtime" / handle
+
+
+def _member_log_path(name: str, rooms_dir: Path, handle: str) -> Path:
+    return _room_dir(name, rooms_dir) / "logs" / f"member-{handle}.log"
+
+
+def _list_member_handles(name: str, rooms_dir: Path) -> list[str]:
+    members = _members_dir(name, rooms_dir)
+    if not members.is_dir():
+        return []
+    return sorted(
+        p.name[: -len(_MEMBER_STATE_SUFFIX)] for p in members.glob(f"*{_MEMBER_STATE_SUFFIX}")
+    )
+
+
+def _load_member_state(name: str, rooms_dir: Path, handle: str) -> dict | None:
+    path = _member_state_path(name, rooms_dir, handle)
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _save_member_state(name: str, rooms_dir: Path, handle: str, state: dict) -> None:
+    path = _member_state_path(name, rooms_dir, handle)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _member_live_pid(name: str, rooms_dir: Path, handle: str) -> int | None:
+    state = _load_member_state(name, rooms_dir, handle)
+    if state is None:
+        return None
+    try:
+        pid = int(state["pid"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    return pid if is_alive(pid) else None
 
 
 # ---------------------------------------------------------------------------
@@ -380,7 +467,9 @@ def room_create(
     pid = _start_room(room_def, resolved_dir)
     typer.echo(f"  Broker pid:    {pid}")
     typer.echo("")
-    typer.echo("Join it with:")
+    typer.echo("Put a ravn in it:")
+    typer.echo(f"  ravn join --persona reviewer --room {name}")
+    typer.echo("Join it yourself:")
     typer.echo(f"  ravn room join --participant human:you --environment {name} --role owner")
 
 
@@ -518,7 +607,13 @@ def _resolve_broker_url(broker_url: str, environment: str, rooms_dir: str) -> st
 def _post(base: str, path: str, payload: dict) -> dict:
     import httpx  # noqa: PLC0415
 
-    response = httpx.post(f"{base}{path}", json=payload, timeout=_REQUEST_TIMEOUT_S)
+    try:
+        response = httpx.post(f"{base}{path}", json=payload, timeout=_REQUEST_TIMEOUT_S)
+    except httpx.HTTPError as exc:
+        # A transport-level failure is an operator-facing error, not a stack
+        # trace: report what could not be reached and stop.
+        typer.echo(f"error: {base}{path} unreachable: {exc}", err=True)
+        raise typer.Exit(1) from exc
     if response.status_code >= 400:
         typer.echo(
             f"error {response.status_code}: {response.text[:_ERROR_BODY_LIMIT]}",
@@ -646,3 +741,531 @@ def room_participants(
             f"- {entry.get('peer_id')} [{entry.get('participant_type')}] "
             f"{entry.get('authority_role') or ''} {entry.get('status') or ''}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Membership  (a persona-typed Ravn daemon resident in a room)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_room_for_membership(room: str, rooms_dir: Path) -> RoomDef:
+    """Resolve the target room, defaulting to the only room when unambiguous."""
+    name = room.strip()
+    if not name:
+        names = _list_room_names(rooms_dir)
+        if len(names) == 1:
+            name = names[0]
+        elif not names:
+            typer.echo(
+                "No rooms exist. Create one with 'ravn room create <name>'.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        else:
+            typer.echo(
+                f"Several rooms exist ({', '.join(names)}); pass --room to choose one.",
+                err=True,
+            )
+            raise typer.Exit(2)
+    return _require_room_def(name, rooms_dir)
+
+
+def _await_member_registration(room_def: RoomDef, handle: str, pid: int) -> bool:
+    """Poll the room until *handle* appears among its participants."""
+    import httpx  # noqa: PLC0415
+
+    deadline = time.monotonic() + _STARTUP_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if not is_alive(pid):
+            return False
+        try:
+            response = httpx.get(
+                f"{room_def.broker_url}/api/room/participants",
+                timeout=_REQUEST_TIMEOUT_S,
+            )
+            if response.status_code < 400:
+                peers = {p.get("peer_id") for p in response.json().get("participants", [])}
+                if handle in peers:
+                    return True
+        except httpx.HTTPError:
+            pass
+        time.sleep(_STARTUP_POLL_INTERVAL_S)
+    return False
+
+
+def _spawn_member(
+    room_def: RoomDef, rooms_dir: Path, handle: str, persona: str, config_path: Path
+) -> int:
+    """Start a member's ``ravn daemon`` process detached and return its pid."""
+    log_path = _member_log_path(room_def.name, rooms_dir, handle)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a") as log_fd:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "ravn", "daemon", "--persona", persona],
+            env={**os.environ, "RAVN_CONFIG": str(config_path)},
+            stdout=log_fd,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    return proc.pid
+
+
+@room_app.command("members")
+def room_members(
+    room: str = typer.Option("", "--room", "-r", envvar="RAVN_ROOM", help="Room name."),
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """List the ravens joined to a room and whether each is live.
+
+    Local membership records are cross-checked against the room's live
+    participant roster, so a member whose process died is visible as such
+    rather than silently missing.
+    """
+    import httpx  # noqa: PLC0415
+
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    room_def = _resolve_room_for_membership(room, resolved_dir)
+
+    handles = _list_member_handles(room_def.name, resolved_dir)
+    if not handles:
+        typer.echo(
+            f"No ravens joined to {room_def.name!r}. "
+            f"Add one with 'ravn join --persona <name> --room {room_def.name}'."
+        )
+        return
+
+    registered: set[str] = set()
+    try:
+        response = httpx.get(
+            f"{room_def.broker_url}/api/room/participants", timeout=_REQUEST_TIMEOUT_S
+        )
+        if response.status_code < 400:
+            registered = {p.get("peer_id") for p in response.json().get("participants", [])}
+    except httpx.HTTPError:
+        typer.echo(f"(room broker at {room_def.broker_url} is unreachable)", err=True)
+
+    typer.echo(f"{'HANDLE':<24} {'PERSONA':<24} {'PROCESS':<10} {'IN ROOM':<8} PID")
+    for handle in handles:
+        state = _load_member_state(room_def.name, resolved_dir, handle) or {}
+        pid = _member_live_pid(room_def.name, resolved_dir, handle)
+        process = "running" if pid is not None else "stopped"
+        in_room = "yes" if handle in registered else "no"
+        persona = str(state.get("persona", "-"))
+        typer.echo(f"{handle:<24} {persona:<24} {process:<10} {in_room:<8} {pid or '-'}")
+
+
+def _cluster_file_path(name: str, rooms_dir: Path) -> Path:
+    return _room_dir(name, rooms_dir) / "cluster.yaml"
+
+
+def _allocate_mesh_ports(name: str, rooms_dir: Path, handle: str) -> tuple[int, int]:
+    """Return this member's (pub, rep) nng ports, allocating on first join.
+
+    Ports are persisted with the member rather than derived from its position
+    in the roster: a handle's sort order shifts as others join and leave, and
+    a member whose ports moved underneath it would be unreachable.
+    """
+    from niuu.mesh import nng_ports_for  # noqa: PLC0415
+
+    recorded = _load_member_state(name, rooms_dir, handle) or {}
+    if "pub_port" in recorded and "rep_port" in recorded:
+        return int(recorded["pub_port"]), int(recorded["rep_port"])
+
+    taken = set()
+    for other in _list_member_handles(name, rooms_dir):
+        state = _load_member_state(name, rooms_dir, other) or {}
+        if "pub_port" in state:
+            taken.add(int(state["pub_port"]))
+
+    index = 0
+    while True:
+        pub, rep, _ = nng_ports_for(index, _MEMBER_MESH_BASE_PORT)
+        if pub not in taken:
+            return pub, rep
+        index += 1
+
+
+def _rewrite_cluster_file(name: str, rooms_dir: Path) -> Path:
+    """Regenerate the room's static peer table from its recorded members.
+
+    Every member reads this file, so each join or leave makes the whole room
+    converge on the new roster without any of them being restarted.
+    """
+    from ravn.cli.daemon_config import render_cluster_yaml  # noqa: PLC0415
+
+    members = []
+    for handle in _list_member_handles(name, rooms_dir):
+        state = _load_member_state(name, rooms_dir, handle) or {}
+        if "pub_port" not in state:
+            continue
+        members.append(
+            {
+                "handle": handle,
+                "persona": str(state.get("persona", handle)),
+                "pub_port": int(state["pub_port"]),
+                "rep_port": int(state["rep_port"]),
+            }
+        )
+
+    path = _cluster_file_path(name, rooms_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_cluster_yaml(members), encoding="utf-8")
+    return path
+
+
+def join_room(
+    persona: str,
+    room: str,
+    handle: str,
+    profile: str,
+    base_config: str,
+    rooms_dir: str,
+    here: bool,
+    force: bool,
+    autonomous: bool = False,
+) -> None:
+    """Implementation behind ``ravn join`` — see that command for the contract."""
+    from ravn.cli.commands import _require_persona, _require_profile  # noqa: PLC0415
+    from ravn.cli.daemon_config import (  # noqa: PLC0415
+        load_base_config,
+        render_member_config,
+        room_broker_ws_url,
+    )
+
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    room_def = _resolve_room_for_membership(room, resolved_dir)
+
+    if _live_pid(room_def.name, resolved_dir) is None:
+        typer.echo(
+            f"Room {room_def.name!r} is not running. Start it with "
+            f"'ravn room start {room_def.name}'.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    # Resolve identity before spawning anything: an unknown persona or profile
+    # must fail here, not inside a detached daemon's log.
+    ravn_profile = _require_profile(profile)
+    effective_persona = persona or (ravn_profile.persona if ravn_profile else "")
+    if not effective_persona:
+        typer.echo("Nothing to join as — pass --persona or a --profile that names one.", err=True)
+        raise typer.Exit(2)
+    persona_config = _require_persona(effective_persona, None)
+
+    resolved_handle = (handle or getattr(persona_config, "name", "") or effective_persona).strip()
+    existing_pid = _member_live_pid(room_def.name, resolved_dir, resolved_handle)
+    if existing_pid is not None and not force:
+        typer.echo(
+            f"{resolved_handle!r} is already in {room_def.name!r} (pid {existing_pid}). "
+            f"Use --force to replace it, or --as to pick another handle.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    if existing_pid is not None:
+        stop_pids([existing_pid])
+
+    try:
+        base = load_base_config(Path(base_config).expanduser() if base_config else None)
+    except (OSError, ValueError) as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(2) from exc
+
+    members = _members_dir(room_def.name, resolved_dir)
+    members.mkdir(parents=True, exist_ok=True)
+    mesh_ports = _allocate_mesh_ports(room_def.name, resolved_dir, resolved_handle)
+    runtime = _member_runtime_dir(room_def.name, resolved_dir, resolved_handle)
+    runtime.mkdir(parents=True, exist_ok=True)
+    config_path = _member_config_path(room_def.name, resolved_dir, resolved_handle)
+    config_path.write_text(
+        render_member_config(
+            handle=resolved_handle,
+            room_name=room_def.name,
+            persona=effective_persona,
+            broker_url=room_broker_ws_url(room_def.host, room_def.port),
+            display_name=resolved_handle,
+            memory_db_path=runtime / "memory.db",
+            queue_journal_path=runtime / "queue.json",
+            autonomous=autonomous,
+            mesh_ports=mesh_ports,
+            cluster_file=_cluster_file_path(room_def.name, resolved_dir),
+            base=base,
+        ),
+        encoding="utf-8",
+    )
+
+    if here:
+        # The operator's terminal becomes the member: run in the foreground so
+        # Ctrl+C ends the membership, and record no pid to supervise.
+        typer.echo(
+            f"Joining {room_def.name!r} as {resolved_handle!r} "
+            f"(persona {effective_persona}) in this terminal. Ctrl+C to leave."
+        )
+        os.environ["RAVN_CONFIG"] = str(config_path)
+        from ravn.cli.commands import daemon as _daemon  # noqa: PLC0415
+
+        _daemon(config=str(config_path), persona=effective_persona, profile=profile, resume=True)
+        return
+
+    member_state = {
+        "handle": resolved_handle,
+        "persona": effective_persona,
+        "profile": profile,
+        "pid": 0,
+        "config": str(config_path),
+        "pub_port": mesh_ports[0],
+        "rep_port": mesh_ports[1],
+        "joined_at": datetime.now(UTC).isoformat(),
+    }
+    # Record the member and refresh the roster before starting it, so the
+    # process finds itself and its peers in the cluster file at startup
+    # rather than waiting for the next poll.
+    _save_member_state(room_def.name, resolved_dir, resolved_handle, member_state)
+    _rewrite_cluster_file(room_def.name, resolved_dir)
+
+    pid = _spawn_member(room_def, resolved_dir, resolved_handle, effective_persona, config_path)
+    _save_member_state(room_def.name, resolved_dir, resolved_handle, {**member_state, "pid": pid})
+
+    if not _await_member_registration(room_def, resolved_handle, pid):
+        stop_pids([pid])
+        with suppress(FileNotFoundError):
+            _member_state_path(room_def.name, resolved_dir, resolved_handle).unlink()
+        _rewrite_cluster_file(room_def.name, resolved_dir)
+        log_path = _member_log_path(room_def.name, resolved_dir, resolved_handle)
+        typer.echo(
+            f"{resolved_handle!r} did not register in room {room_def.name!r}.",
+            err=True,
+        )
+        if log_path.is_file():
+            tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-15:]
+            typer.echo(f"--- {log_path} ---", err=True)
+            for line in tail:
+                typer.echo(line, err=True)
+        raise typer.Exit(1)
+
+    typer.echo(
+        f"{resolved_handle!r} joined {room_def.name!r} as persona {effective_persona} (pid {pid})"
+    )
+    typer.echo(f"  Config: {config_path}")
+    typer.echo(f"  Log:    {_member_log_path(room_def.name, resolved_dir, resolved_handle)}")
+
+
+def leave_room(handle: str, room: str, rooms_dir: str) -> None:
+    """Implementation behind ``ravn leave`` — see that command for the contract."""
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    room_def = _resolve_room_for_membership(room, resolved_dir)
+
+    resolved_handle = handle.strip()
+    if not resolved_handle:
+        typer.echo("Pass --as to say which member should leave.", err=True)
+        raise typer.Exit(2)
+
+    state = _load_member_state(room_def.name, resolved_dir, resolved_handle)
+    if state is None:
+        typer.echo(
+            f"{resolved_handle!r} is not a member of {room_def.name!r}. "
+            f"Run 'ravn room members --room {room_def.name}' to see who is.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    pid = _member_live_pid(room_def.name, resolved_dir, resolved_handle)
+    if pid is not None:
+        stop_pids([pid])
+
+    with suppress(FileNotFoundError):
+        _member_state_path(room_def.name, resolved_dir, resolved_handle).unlink()
+    _rewrite_cluster_file(room_def.name, resolved_dir)
+    typer.echo(f"{resolved_handle!r} left {room_def.name!r}.")
+
+
+# ---------------------------------------------------------------------------
+# Addressing  (mention routing over the room's directed-delivery path)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_participants(room_def: RoomDef) -> list[dict]:
+    """Return the room's current participants, or fail with a clear message."""
+    import httpx  # noqa: PLC0415
+
+    try:
+        response = httpx.get(
+            f"{room_def.broker_url}/api/room/participants", timeout=_REQUEST_TIMEOUT_S
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        typer.echo(
+            f"Room {room_def.name!r} is unreachable at {room_def.broker_url}: {exc}", err=True
+        )
+        raise typer.Exit(1) from exc
+    return list(response.json().get("participants", []))
+
+
+@room_app.command("post")
+def room_post(
+    body: str = typer.Argument(help="Message body."),
+    author: str = typer.Option(
+        ..., "--as", help="Participant id posting the message, e.g. human:jozef."
+    ),
+    to: str = typer.Option(
+        "", "--to", help="Deliver to this member. Defaults to whoever spoke last."
+    ),
+    room: str = typer.Option("", "--room", "-r", envvar="RAVN_ROOM", help="Room name."),
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """Post a message into a room, optionally directed at one member.
+
+    This is the human's way into the room. Ravens reach each other over the
+    mesh — ``route_work`` finds a peer by the event types its persona consumes,
+    and the cascade tools delegate to it — so this command deliberately does
+    not decide on their behalf who should act.
+
+    \b
+    Examples:
+      ravn room post --as human:jozef --to reviewer 'take a look at the diff'
+      ravn room post --as human:jozef 'thanks, carry on'
+    """
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    room_def = _resolve_room_for_membership(room, resolved_dir)
+
+    participants = _fetch_participants(room_def)
+    peer_ids = {str(p.get("peer_id")) for p in participants if p.get("peer_id")}
+    if author not in peer_ids:
+        typer.echo(
+            f"{author!r} is not in room {room_def.name!r}. Join first with "
+            f"'ravn room join --participant {author} --environment {room_def.name}'.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    target = to.strip() or _last_speaker(room_def, exclude=author)
+    if target and target not in peer_ids:
+        typer.echo(
+            f"{target!r} is not in room {room_def.name!r}. "
+            f"Run 'ravn room participants --environment {room_def.name}' to see who is.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if not target:
+        _post(
+            room_def.broker_url,
+            "/api/room/message",
+            {"participant_id": author, "content": body, "deliver_to_transport": False},
+        )
+        typer.echo("posted as room commentary (addressed to nobody)")
+        return
+
+    _post(
+        room_def.broker_url,
+        "/api/room/direct",
+        {
+            "target_peer_id": target,
+            "content": body,
+            "participant_id": author,
+            "metadata": {"room": room_def.name},
+        },
+    )
+    typer.echo(f"delivered to {target}")
+
+
+def _last_speaker(room_def: RoomDef, *, exclude: str) -> str:
+    """Return the participant that most recently spoke, if any.
+
+    Used for the untagged-message default so a plain reply lands somewhere
+    sensible instead of becoming a dead letter.
+    """
+    import httpx  # noqa: PLC0415
+
+    try:
+        response = httpx.get(
+            f"{room_def.broker_url}/api/conversation/history",
+            params={"limit": _HISTORY_SCAN_LIMIT},
+            timeout=_REQUEST_TIMEOUT_S,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError:
+        return ""
+
+    turns = _history_turns(response.json())
+    for turn in reversed(turns):
+        speaker = str(turn.get("participant_id") or "")
+        if speaker and speaker != exclude:
+            return speaker
+    return ""
+
+
+def _history_turns(payload: object) -> list[dict]:
+    """Normalise the history endpoint's payload into a list of turns."""
+    if isinstance(payload, list):
+        return [t for t in payload if isinstance(t, dict)]
+    if isinstance(payload, dict):
+        for key in ("turns", "messages", "history"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [t for t in value if isinstance(t, dict)]
+    return []
+
+
+@room_app.command("tail")
+def room_tail(
+    room: str = typer.Option("", "--room", "-r", envvar="RAVN_ROOM", help="Room name."),
+    limit: int = typer.Option(_HISTORY_SCAN_LIMIT, "--limit", "-n", help="Turns of history."),
+    follow: bool = typer.Option(False, "--follow", "-f", help="Keep streaming new turns."),
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """Print a room's recent turns, optionally following new ones.
+
+    \b
+    Examples:
+      ravn room tail
+      ravn room tail --room desk -n 20
+      ravn room tail --follow
+    """
+    import httpx  # noqa: PLC0415
+
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    room_def = _resolve_room_for_membership(room, resolved_dir)
+
+    def _fetch() -> list[dict]:
+        try:
+            response = httpx.get(
+                f"{room_def.broker_url}/api/conversation/history",
+                params={"limit": limit},
+                timeout=_REQUEST_TIMEOUT_S,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            typer.echo(f"Room {room_def.name!r} is unreachable: {exc}", err=True)
+            raise typer.Exit(1) from exc
+        return _history_turns(response.json())
+
+    seen: set[str] = set()
+    for turn in _fetch():
+        seen.add(str(turn.get("id") or ""))
+        typer.echo(_format_turn(turn))
+
+    if not follow:
+        return
+
+    typer.echo("--- following (Ctrl+C to stop) ---", err=True)
+    try:
+        while True:
+            time.sleep(_TAIL_POLL_INTERVAL_S)
+            for turn in _fetch():
+                turn_id = str(turn.get("id") or "")
+                if turn_id in seen:
+                    continue
+                seen.add(turn_id)
+                typer.echo(_format_turn(turn))
+    except KeyboardInterrupt:
+        return
+
+
+def _format_turn(turn: dict) -> str:
+    """Render one conversation turn as a single readable line."""
+    speaker = str(turn.get("participant_id") or turn.get("role") or "?")
+    content = str(turn.get("content") or "").strip().replace("\n", " ")
+    if len(content) > _TURN_PREVIEW_LIMIT:
+        content = content[: _TURN_PREVIEW_LIMIT - 1] + "…"
+    return f"{speaker:<20} {content}"

--- a/src/ravn/cli/room.py
+++ b/src/ravn/cli/room.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -1080,8 +1081,48 @@ def leave_room(handle: str, room: str, rooms_dir: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Addressing  (mention routing over the room's directed-delivery path)
+# Mention parsing  (operator input only)
 # ---------------------------------------------------------------------------
+
+# A handle is a bare slug; colons are allowed because humans are addressed as
+# `human:name`.
+_MENTION_RE = re.compile(r"@([A-Za-z0-9][A-Za-z0-9_:-]*)")
+
+# Code spans are masked so a sample containing an address invokes nobody.
+_FENCED_RE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+
+
+def _parse_mentions(body: str, peer_ids: set[str]) -> tuple[list[str], list[str]]:
+    """Return (resolved peer ids, unresolved handles) addressed in *body*.
+
+    This resolves what a human typed into the same directed delivery that
+    ``--to`` performs — it is input parsing, not routing.  Which peer should
+    pick up a piece of work is Ravn's judgment over the mesh (``route_work``
+    and the cascade tools), and nothing here substitutes for that.
+
+    An unknown handle is reported, never guessed at.
+    """
+    masked = _FENCED_RE.sub(lambda m: " " * len(m.group(0)), body)
+    masked = _INLINE_CODE_RE.sub(lambda m: " " * len(m.group(0)), masked)
+
+    # Humans answer to their bare name too, so `@jozef` reaches `human:jozef`.
+    lookup: dict[str, str] = {}
+    for peer_id in peer_ids:
+        lookup[peer_id.lower()] = peer_id
+        if ":" in peer_id:
+            lookup.setdefault(peer_id.split(":", 1)[1].lower(), peer_id)
+
+    resolved: list[str] = []
+    unresolved: list[str] = []
+    for match in _MENTION_RE.finditer(masked):
+        handle = match.group(1)
+        peer_id = lookup.get(handle.lower())
+        if peer_id is None:
+            unresolved.append(handle)
+        elif peer_id not in resolved:
+            resolved.append(peer_id)
+    return resolved, unresolved
 
 
 def _fetch_participants(room_def: RoomDef) -> list[dict]:
@@ -1103,27 +1144,35 @@ def _fetch_participants(room_def: RoomDef) -> list[dict]:
 
 @room_app.command("post")
 def room_post(
-    body: str = typer.Argument(help="Message body."),
+    body: str = typer.Argument(help="Message body. @handle addresses a member."),
     author: str = typer.Option(
         ..., "--as", help="Participant id posting the message, e.g. human:jozef."
     ),
     to: str = typer.Option(
-        "", "--to", help="Deliver to this member. Defaults to whoever spoke last."
+        "", "--to", help="Deliver to this member, overriding any @mentions in the body."
     ),
     room: str = typer.Option("", "--room", "-r", envvar="RAVN_ROOM", help="Room name."),
     rooms_dir: str = _ROOMS_DIR_OPTION,
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show the resolved recipients without delivering."
+    ),
 ) -> None:
-    """Post a message into a room, optionally directed at one member.
+    """Post a message into a room, addressed with @handle or --to.
 
-    This is the human's way into the room. Ravens reach each other over the
-    mesh — ``route_work`` finds a peer by the event types its persona consumes,
-    and the cascade tools delegate to it — so this command deliberately does
-    not decide on their behalf who should act.
+    Each recipient receives the whole message — parts addressed to different
+    members usually depend on each other, so splitting the body would hide
+    that. With no valid address the message goes to whoever spoke last, and
+    with nobody to address it is recorded as room commentary.
+
+    This resolves what a human typed. Ravens reach each other over the mesh —
+    ``route_work`` finds a peer by the event types its persona consumes — so
+    this never decides on their behalf who should act.
 
     \b
     Examples:
-      ravn room post --as human:jozef --to reviewer 'take a look at the diff'
-      ravn room post --as human:jozef 'thanks, carry on'
+      ravn room post --as human:jozef '@reviewer take a look at the diff'
+      ravn room post --as human:jozef '@builder build it then @reviewer check it'
+      ravn room post --as human:jozef --to reviewer 'take a look'
     """
     resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
     room_def = _resolve_room_for_membership(room, resolved_dir)
@@ -1138,16 +1187,42 @@ def room_post(
         )
         raise typer.Exit(1)
 
-    target = to.strip() or _last_speaker(room_def, exclude=author)
-    if target and target not in peer_ids:
+    unresolved: list[str] = []
+    if to.strip():
+        recipients = [to.strip()]
+    else:
+        recipients, unresolved = _parse_mentions(body, peer_ids)
+        # A self-mention does not re-invoke the author.
+        recipients = [peer for peer in recipients if peer != author]
+        if not recipients:
+            last = _last_speaker(room_def, exclude=author)
+            recipients = [last] if last else []
+
+    if unresolved:
         typer.echo(
-            f"{target!r} is not in room {room_def.name!r}. "
+            "warning: no member matches "
+            + ", ".join("@" + handle for handle in unresolved)
+            + " — treated as plain text.",
+            err=True,
+        )
+
+    unknown = [peer for peer in recipients if peer not in peer_ids]
+    if unknown:
+        typer.echo(
+            f"{unknown[0]!r} is not in room {room_def.name!r}. "
             f"Run 'ravn room participants --environment {room_def.name}' to see who is.",
             err=True,
         )
         raise typer.Exit(1)
 
-    if not target:
+    if dry_run:
+        typer.echo(f"author:     {author}")
+        typer.echo(
+            "recipients: " + (", ".join(recipients) if recipients else "(nobody — commentary)")
+        )
+        return
+
+    if not recipients:
         _post(
             room_def.broker_url,
             "/api/room/message",
@@ -1156,17 +1231,18 @@ def room_post(
         typer.echo("posted as room commentary (addressed to nobody)")
         return
 
-    _post(
-        room_def.broker_url,
-        "/api/room/direct",
-        {
-            "target_peer_id": target,
-            "content": body,
-            "participant_id": author,
-            "metadata": {"room": room_def.name},
-        },
-    )
-    typer.echo(f"delivered to {target}")
+    for recipient in recipients:
+        _post(
+            room_def.broker_url,
+            "/api/room/direct",
+            {
+                "target_peer_id": recipient,
+                "content": body,
+                "participant_id": author,
+                "metadata": {"room": room_def.name, "recipients": recipients},
+            },
+        )
+    typer.echo(f"delivered to {', '.join(recipients)}")
 
 
 def _last_speaker(room_def: RoomDef, *, exclude: str) -> str:

--- a/src/ravn/cli/room.py
+++ b/src/ravn/cli/room.py
@@ -1,0 +1,648 @@
+"""ravn room — create and talk to local collaboration rooms.
+
+A room is a Skuld broker running in room mode, bound to one environment id
+that doubles as the room's name.  ``ravn room create`` writes the broker
+config, supervises the process, and records enough state for the other
+subcommands to find it — so a room needs no Volundr, no Postgres, and no
+hand-written YAML.
+
+Lifecycle
+---------
+  ravn room create NAME   — write config, start the broker, verify it answers
+  ravn room ls            — list known rooms and whether they are live
+  ravn room show NAME     — print one room's definition and status
+  ravn room start NAME    — start a stopped room
+  ravn room stop NAME     — graceful shutdown; preserves the definition
+  ravn room rm NAME       — stop and delete the room directory
+
+Participation (Skuld broker room API)
+-------------------------------------
+  ravn room join --participant ID --environment NAME [--role owner]
+  ravn room message --participant ID --text "..."
+  ravn room participants [--environment NAME]
+  ravn room heartbeat --participant ID
+  ravn room leave --participant ID
+  ravn room close --room ROOM_ID
+
+State files (under ~/.ravn/rooms/NAME/)
+---------------------------------------
+  room.yaml    — room definition (created by create, read by everything else)
+  broker.yaml  — generated Skuld broker config
+  state.json   — runtime pid (created by start, removed by stop)
+  logs/        — broker log
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import typer
+import yaml
+
+from ravn.cli.process_supervision import find_free_port, is_alive, port_free, stop_pids
+
+room_app = typer.Typer(
+    name="room",
+    help="Create, supervise, and join local Ravn collaboration rooms.",
+    add_completion=False,
+)
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+# First port tried when allocating a room broker; scans upward from here.
+_DEFAULT_BASE_PORT = 7500
+
+# Loopback by default: a room is private to this host until deliberately bound
+# wider, matching the flock supervisor's posture.
+_DEFAULT_HOST = "127.0.0.1"
+
+# Fallback broker URL for participation subcommands when no room is registered
+# locally — preserves the pre-existing `ravn room` default.
+_DEFAULT_BROKER_URL = "http://127.0.0.1:9000"
+
+# How long `create`/`start` wait for the broker to answer before reporting
+# failure, and how often they poll while waiting.
+_STARTUP_TIMEOUT_S = 30.0
+_STARTUP_POLL_INTERVAL_S = 0.25
+
+# HTTP timeout for the participation subcommands.
+_REQUEST_TIMEOUT_S = 10.0
+
+# Longest error body echoed back to the operator.
+_ERROR_BODY_LIMIT = 300
+
+
+def _rooms_dir_default() -> Path:
+    return Path.home() / ".ravn" / "rooms"
+
+
+# ---------------------------------------------------------------------------
+# Room definition  (persisted in room.yaml — the source of truth)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RoomDef:
+    """Static room definition — created by create, read by every other command."""
+
+    name: str
+    environment_id: str
+    host: str
+    port: int
+    created_at: str
+
+    @property
+    def broker_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def to_yaml(self) -> str:
+        return yaml.safe_dump(asdict(self), sort_keys=False)
+
+    @classmethod
+    def from_yaml(cls, text: str) -> RoomDef:
+        data = yaml.safe_load(text) or {}
+        return cls(
+            name=str(data["name"]),
+            environment_id=str(data["environment_id"]),
+            host=str(data.get("host", _DEFAULT_HOST)),
+            port=int(data["port"]),
+            created_at=str(data.get("created_at", "")),
+        )
+
+
+def _room_dir(name: str, rooms_dir: Path) -> Path:
+    return rooms_dir / name
+
+
+def _room_def_path(name: str, rooms_dir: Path) -> Path:
+    return _room_dir(name, rooms_dir) / "room.yaml"
+
+
+def _broker_config_path(name: str, rooms_dir: Path) -> Path:
+    return _room_dir(name, rooms_dir) / "broker.yaml"
+
+
+def _state_path(name: str, rooms_dir: Path) -> Path:
+    return _room_dir(name, rooms_dir) / "state.json"
+
+
+def _log_path(name: str, rooms_dir: Path) -> Path:
+    return _room_dir(name, rooms_dir) / "logs" / "broker.log"
+
+
+def _load_room_def(name: str, rooms_dir: Path) -> RoomDef | None:
+    path = _room_def_path(name, rooms_dir)
+    if not path.is_file():
+        return None
+    return RoomDef.from_yaml(path.read_text(encoding="utf-8"))
+
+
+def _require_room_def(name: str, rooms_dir: Path) -> RoomDef:
+    room_def = _load_room_def(name, rooms_dir)
+    if room_def is None:
+        typer.echo(
+            f"Unknown room {name!r}. Run 'ravn room ls' to see rooms, "
+            f"or 'ravn room create {name}' to make one.",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return room_def
+
+
+def _list_room_names(rooms_dir: Path) -> list[str]:
+    if not rooms_dir.is_dir():
+        return []
+    return sorted(p.name for p in rooms_dir.iterdir() if (p / "room.yaml").is_file())
+
+
+def _load_pid(name: str, rooms_dir: Path) -> int | None:
+    path = _state_path(name, rooms_dir)
+    if not path.is_file():
+        return None
+    try:
+        pid = int(json.loads(path.read_text(encoding="utf-8"))["pid"])
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return None
+    return pid
+
+
+def _save_pid(name: str, rooms_dir: Path, pid: int) -> None:
+    path = _state_path(name, rooms_dir)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps({"pid": pid}), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _clear_pid(name: str, rooms_dir: Path) -> None:
+    with suppress(FileNotFoundError):
+        _state_path(name, rooms_dir).unlink()
+
+
+def _live_pid(name: str, rooms_dir: Path) -> int | None:
+    """Return the recorded pid when it is still running, else None."""
+    pid = _load_pid(name, rooms_dir)
+    if pid is None or not is_alive(pid):
+        return None
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Broker config generation
+# ---------------------------------------------------------------------------
+
+
+def _write_broker_config(room_def: RoomDef, rooms_dir: Path) -> Path:
+    """Write the Skuld broker config that puts the broker in room mode.
+
+    ``room.environment_id`` is the room name, which is what the participation
+    subcommands and every joining Ravn address.
+    """
+    room_dir = _room_dir(room_def.name, rooms_dir)
+    workspace = room_dir / "workspace"
+    persist = room_dir / "persist"
+    workspace.mkdir(parents=True, exist_ok=True)
+    persist.mkdir(parents=True, exist_ok=True)
+
+    config = {
+        "host": room_def.host,
+        "port": room_def.port,
+        "persistence_mount_path": str(persist),
+        "session": {
+            "id": room_def.name,
+            "workspace_dir": str(workspace),
+        },
+        "room": {
+            "enabled": True,
+            "environment_id": room_def.environment_id,
+        },
+    }
+    path = _broker_config_path(room_def.name, rooms_dir)
+    path.write_text(
+        "# Skuld broker config — room "
+        f"{room_def.name}\n"
+        "# Generated by: ravn room create\n"
+        "# Edit as needed; 'ravn room start' re-reads this file.\n"
+        + yaml.safe_dump(config, sort_keys=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _spawn_broker(room_def: RoomDef, rooms_dir: Path) -> int:
+    """Start the room's broker process detached and return its pid."""
+    log_path = _log_path(room_def.name, rooms_dir)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path = _broker_config_path(room_def.name, rooms_dir)
+    with open(log_path, "a") as log_fd:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "skuld"],
+            env={**os.environ, "NIUU_CONFIG": str(config_path)},
+            stdout=log_fd,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    return proc.pid
+
+
+def _broker_responding(room_def: RoomDef) -> bool:
+    """Return True when the room API answers on the room's broker URL."""
+    import httpx  # noqa: PLC0415
+
+    try:
+        response = httpx.get(
+            f"{room_def.broker_url}/api/room/participants",
+            timeout=_STARTUP_POLL_INTERVAL_S * 4,
+        )
+    except httpx.HTTPError:
+        return False
+    return response.status_code < 400
+
+
+def _wait_for_broker(room_def: RoomDef, pid: int, rooms_dir: Path) -> None:
+    """Block until the broker answers, or fail with its log tail.
+
+    Reports the concrete failure rather than leaving a half-started room
+    looking healthy.
+    """
+    deadline = time.monotonic() + _STARTUP_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if _broker_responding(room_def):
+            return
+        if not is_alive(pid):
+            break
+        time.sleep(_STARTUP_POLL_INTERVAL_S)
+
+    _clear_pid(room_def.name, rooms_dir)
+    stop_pids([pid])
+    log_path = _log_path(room_def.name, rooms_dir)
+    typer.echo(f"Room {room_def.name!r} broker did not come up on {room_def.broker_url}.", err=True)
+    if log_path.is_file():
+        tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()[-15:]
+        typer.echo(f"--- {log_path} ---", err=True)
+        for line in tail:
+            typer.echo(line, err=True)
+    raise typer.Exit(1)
+
+
+def _start_room(room_def: RoomDef, rooms_dir: Path) -> int:
+    """Start the room's broker and return its pid once it answers."""
+    if not port_free(room_def.port, room_def.host):
+        typer.echo(
+            f"Port {room_def.port} on {room_def.host} is already in use. "
+            f"Stop whatever holds it, or recreate the room with --port.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    pid = _spawn_broker(room_def, rooms_dir)
+    _save_pid(room_def.name, rooms_dir, pid)
+    _wait_for_broker(room_def, pid, rooms_dir)
+    return pid
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle commands
+# ---------------------------------------------------------------------------
+
+
+@room_app.command("create")
+def room_create(
+    name: str = typer.Argument(help="Room name. Doubles as the environment id."),
+    host: str = typer.Option(_DEFAULT_HOST, "--host", help="Bind address for the room broker."),
+    port: int = typer.Option(
+        0, "--port", help="Broker port. 0 allocates the first free port from 7500."
+    ),
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+    force: bool = typer.Option(False, "--force", "-f", help="Overwrite an existing definition."),
+    start: bool = typer.Option(
+        True, "--start/--no-start", help="Start the broker after writing the definition."
+    ),
+) -> None:
+    """Create a room and start its broker.
+
+    \b
+    Examples:
+      ravn room create desk
+      ravn room create desk --port 7500
+      ravn room create desk --no-start   # write the definition only
+    """
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    existing = _load_room_def(name, resolved_dir)
+    if existing is not None and not force:
+        typer.echo(
+            f"Room {name!r} already exists at {_room_dir(name, resolved_dir)}. "
+            "Use --force to overwrite, or edit room.yaml directly.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    if existing is not None and _live_pid(name, resolved_dir) is not None:
+        typer.echo(
+            f"Room {name!r} is running. Run 'ravn room stop {name}' before recreating it.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    resolved_port = port if port > 0 else find_free_port(_DEFAULT_BASE_PORT, host)
+    room_def = RoomDef(
+        name=name,
+        environment_id=name,
+        host=host,
+        port=resolved_port,
+        created_at=datetime.now(UTC).isoformat(),
+    )
+
+    _room_dir(name, resolved_dir).mkdir(parents=True, exist_ok=True)
+    _room_def_path(name, resolved_dir).write_text(room_def.to_yaml(), encoding="utf-8")
+    config_path = _write_broker_config(room_def, resolved_dir)
+
+    typer.echo(f"Room {name!r} created at {_room_dir(name, resolved_dir)}")
+    typer.echo(f"  Definition:    {_room_def_path(name, resolved_dir)}")
+    typer.echo(f"  Broker config: {config_path}")
+    typer.echo(f"  Broker URL:    {room_def.broker_url}")
+
+    if not start:
+        typer.echo("")
+        typer.echo(f"Start it with:  ravn room start {name}")
+        return
+
+    pid = _start_room(room_def, resolved_dir)
+    typer.echo(f"  Broker pid:    {pid}")
+    typer.echo("")
+    typer.echo("Join it with:")
+    typer.echo(f"  ravn room join --participant human:you --environment {name} --role owner")
+
+
+@room_app.command("ls")
+def room_ls(
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+) -> None:
+    """List known rooms and whether their brokers are live."""
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    names = _list_room_names(resolved_dir)
+    if not names:
+        typer.echo(f"No rooms in {resolved_dir}. Create one with 'ravn room create <name>'.")
+        return
+
+    typer.echo(f"{'NAME':<24} {'STATUS':<10} {'PID':<8} URL")
+    for name in names:
+        room_def = _load_room_def(name, resolved_dir)
+        if room_def is None:
+            continue
+        pid = _live_pid(name, resolved_dir)
+        status = "running" if pid is not None else "stopped"
+        typer.echo(f"{name:<24} {status:<10} {str(pid or '-'):<8} {room_def.broker_url}")
+
+
+@room_app.command("show")
+def room_show(
+    name: str = typer.Argument(help="Room name."),
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+) -> None:
+    """Show one room's definition, status, and file locations."""
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    room_def = _require_room_def(name, resolved_dir)
+    pid = _live_pid(name, resolved_dir)
+
+    typer.echo(f"name:           {room_def.name}")
+    typer.echo(f"environment_id: {room_def.environment_id}")
+    typer.echo(f"broker_url:     {room_def.broker_url}")
+    typer.echo(f"created_at:     {room_def.created_at}")
+    typer.echo(f"status:         {'running' if pid is not None else 'stopped'}")
+    typer.echo(f"pid:            {pid if pid is not None else '-'}")
+    typer.echo(f"definition:     {_room_def_path(name, resolved_dir)}")
+    typer.echo(f"broker config:  {_broker_config_path(name, resolved_dir)}")
+    typer.echo(f"log:            {_log_path(name, resolved_dir)}")
+
+
+@room_app.command("start")
+def room_start(
+    name: str = typer.Argument(help="Room name."),
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+) -> None:
+    """Start a stopped room's broker."""
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    room_def = _require_room_def(name, resolved_dir)
+
+    running = _live_pid(name, resolved_dir)
+    if running is not None:
+        typer.echo(f"Room {name!r} is already running (pid {running}).")
+        return
+
+    pid = _start_room(room_def, resolved_dir)
+    typer.echo(f"Room {name!r} started (pid {pid}) at {room_def.broker_url}")
+
+
+@room_app.command("stop")
+def room_stop(
+    name: str = typer.Argument(help="Room name."),
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+) -> None:
+    """Stop a room's broker. Preserves the definition."""
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    _require_room_def(name, resolved_dir)
+
+    pid = _live_pid(name, resolved_dir)
+    if pid is None:
+        _clear_pid(name, resolved_dir)
+        typer.echo(f"Room {name!r} is not running.")
+        return
+
+    stop_pids([pid])
+    _clear_pid(name, resolved_dir)
+    typer.echo(f"Room {name!r} stopped.")
+
+
+@room_app.command("rm")
+def room_rm(
+    name: str = typer.Argument(help="Room name."),
+    rooms_dir: str = typer.Option("", "--rooms-dir", help="Override the rooms state directory."),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Delete without the interactive confirmation."
+    ),
+) -> None:
+    """Stop a room and delete its directory, including its transcript logs."""
+    import shutil  # noqa: PLC0415
+
+    resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+    _require_room_def(name, resolved_dir)
+    room_dir = _room_dir(name, resolved_dir)
+
+    if not force:
+        typer.confirm(f"Delete room {name!r} and everything under {room_dir}?", abort=True)
+
+    pid = _live_pid(name, resolved_dir)
+    if pid is not None:
+        stop_pids([pid])
+
+    shutil.rmtree(room_dir)
+    typer.echo(f"Room {name!r} removed.")
+
+
+# ---------------------------------------------------------------------------
+# Participation commands  (Skuld broker room API)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_broker_url(broker_url: str, environment: str, rooms_dir: str) -> str:
+    """Resolve the broker URL for a participation subcommand.
+
+    An explicit ``--broker-url`` always wins.  Otherwise a locally registered
+    room whose name matches ``--environment`` supplies its own URL, so
+    ``--environment desk`` alone is enough once the room exists.
+    """
+    if broker_url:
+        return broker_url.rstrip("/")
+
+    name = environment.strip()
+    if name:
+        resolved_dir = Path(rooms_dir) if rooms_dir else _rooms_dir_default()
+        room_def = _load_room_def(name, resolved_dir)
+        if room_def is not None:
+            return room_def.broker_url
+
+    return _DEFAULT_BROKER_URL
+
+
+def _post(base: str, path: str, payload: dict) -> dict:
+    import httpx  # noqa: PLC0415
+
+    response = httpx.post(f"{base}{path}", json=payload, timeout=_REQUEST_TIMEOUT_S)
+    if response.status_code >= 400:
+        typer.echo(
+            f"error {response.status_code}: {response.text[:_ERROR_BODY_LIMIT]}",
+            err=True,
+        )
+        raise typer.Exit(1)
+    return response.json()
+
+
+_BROKER_URL_OPTION = typer.Option(
+    "",
+    "--broker-url",
+    envvar="SKULD_BROKER_URL",
+    help="Skuld broker base URL. Defaults to the named room's broker.",
+)
+_ROOMS_DIR_OPTION = typer.Option("", "--rooms-dir", help="Override the rooms state directory.")
+
+
+@room_app.command("join")
+def room_join(
+    participant: str = typer.Option(..., "--participant", help="Participant id, e.g. human:jozef."),
+    environment: str = typer.Option(..., "--environment", help="Environment (room) id to join."),
+    role: str = typer.Option(
+        "observer", "--role", help="Room role: observer|teacher|approver|debugger|owner."
+    ),
+    room_id: str = typer.Option("", "--room", help="Optional huddle room id."),
+    broker_url: str = _BROKER_URL_OPTION,
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """Join a live room as a human participant."""
+    base = _resolve_broker_url(broker_url, environment, rooms_dir)
+    result = _post(
+        base,
+        "/api/room/join",
+        {
+            "participant_id": participant,
+            "display_name": participant,
+            "environment_id": environment,
+            "role": role,
+            "room_id": room_id,
+        },
+    )
+    meta = result.get("participant", result)
+    typer.echo(
+        f"joined {environment} as {participant} ({role}); "
+        f"capabilities: {', '.join(meta.get('capabilities', []))}"
+    )
+
+
+@room_app.command("leave")
+def room_leave(
+    participant: str = typer.Option(..., "--participant", help="Participant id."),
+    environment: str = typer.Option("", "--environment", help="Environment (room) id."),
+    reason: str = typer.Option("left", "--reason", help="Reason recorded for the departure."),
+    broker_url: str = _BROKER_URL_OPTION,
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """Leave a live room."""
+    base = _resolve_broker_url(broker_url, environment, rooms_dir)
+    _post(base, "/api/room/leave", {"participant_id": participant, "reason": reason})
+    typer.echo(f"left: {participant}")
+
+
+@room_app.command("message")
+def room_message(
+    participant: str = typer.Option(..., "--participant", help="Participant id."),
+    text: str = typer.Option(..., "--text", help="Message text."),
+    environment: str = typer.Option("", "--environment", help="Environment (room) id."),
+    room_id: str = typer.Option("", "--room", help="Optional huddle room id."),
+    broker_url: str = _BROKER_URL_OPTION,
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """Post a message into a live room."""
+    base = _resolve_broker_url(broker_url, environment, rooms_dir)
+    _post(
+        base,
+        "/api/room/message",
+        {"participant_id": participant, "content": text, "room_id": room_id},
+    )
+    typer.echo("sent")
+
+
+@room_app.command("heartbeat")
+def room_heartbeat(
+    participant: str = typer.Option(..., "--participant", help="Participant id."),
+    environment: str = typer.Option("", "--environment", help="Environment (room) id."),
+    broker_url: str = _BROKER_URL_OPTION,
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """Refresh a participant's presence so it is not swept as expired."""
+    base = _resolve_broker_url(broker_url, environment, rooms_dir)
+    _post(base, "/api/room/heartbeat", {"participant_id": participant})
+    typer.echo("heartbeat recorded")
+
+
+@room_app.command("close")
+def room_close(
+    room_id: str = typer.Option(..., "--room", help="Huddle room id to close."),
+    environment: str = typer.Option("", "--environment", help="Environment (room) id."),
+    reason: str = typer.Option("closed", "--reason", help="Reason recorded for the closure."),
+    broker_url: str = _BROKER_URL_OPTION,
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """Close a huddle, publishing its transcript for archival."""
+    base = _resolve_broker_url(broker_url, environment, rooms_dir)
+    result = _post(base, "/api/room/close", {"room_id": room_id, "reason": reason})
+    typer.echo(f"closed {room_id}; transcript: {result.get('transcriptRef', '-')}")
+
+
+@room_app.command("participants")
+def room_participants(
+    environment: str = typer.Option("", "--environment", help="Environment (room) id."),
+    broker_url: str = _BROKER_URL_OPTION,
+    rooms_dir: str = _ROOMS_DIR_OPTION,
+) -> None:
+    """List the participants currently in a room."""
+    import httpx  # noqa: PLC0415
+
+    base = _resolve_broker_url(broker_url, environment, rooms_dir)
+    params = {"environment_id": environment} if environment else None
+    response = httpx.get(f"{base}/api/room/participants", params=params, timeout=_REQUEST_TIMEOUT_S)
+    response.raise_for_status()
+    for entry in response.json().get("participants", []):
+        typer.echo(
+            f"- {entry.get('peer_id')} [{entry.get('participant_type')}] "
+            f"{entry.get('authority_role') or ''} {entry.get('status') or ''}"
+        )

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -1003,8 +1003,10 @@ class DriveLoop:
         # today so ordering and correlation remain consistent for all consumers.
         self._skuld_channel: SkuldChannel | None = None
         if settings.skuld.enabled:
-            # peer_id is appended to the broker_url
-            peer_id = settings.mesh.own_peer_id if settings.mesh.enabled else "ravn-daemon"
+            # peer_id is appended to the broker_url. An explicitly configured
+            # peer id is the daemon's room identity whether or not the nng
+            # mesh is running — a room member sets it without needing a mesh.
+            peer_id = settings.mesh.own_peer_id.strip() or "ravn-daemon"
             broker_url = f"{settings.skuld.broker_url.rstrip('/')}/{peer_id}"
             self._skuld_channel = SkuldChannel(
                 broker_url=broker_url,

--- a/src/skuld/broker_api.py
+++ b/src/skuld/broker_api.py
@@ -685,6 +685,14 @@ class _RoomMessageRequest(BaseModel):
     source: str = "external"
     participant_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    deliver_to_transport: bool = Field(
+        default=True,
+        description=(
+            "Also hand the message to the broker's own CLI transport. Set false "
+            "for room commentary addressed to no member, which would otherwise "
+            "lazy-start a transport that has nothing to answer."
+        ),
+    )
 
 
 class _DirectedRoomMessageRequest(BaseModel):
@@ -788,6 +796,7 @@ async def send_room_message(body: _RoomMessageRequest) -> dict:
             source=body.source,
             participant_id=body.participant_id,
             metadata=body.metadata,
+            deliver_to_transport=body.deliver_to_transport,
         )
     except ValueError as exc:
         raise HTTPException(400, str(exc))

--- a/tests/test_ravn/test_cli_daemon_config.py
+++ b/tests/test_ravn/test_cli_daemon_config.py
@@ -1,0 +1,231 @@
+"""Tests for the shared daemon config generator used by flock and room."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ravn.cli.daemon_config import (
+    build_member_config,
+    load_base_config,
+    render_cluster_yaml,
+    render_member_config,
+    render_skuld_yaml,
+    room_broker_ws_url,
+    skuld_block,
+)
+
+
+class TestBrokerUrl:
+    def test_points_at_the_ravn_participant_endpoint(self) -> None:
+        assert room_broker_ws_url("127.0.0.1", 7500) == "ws://127.0.0.1:7500/ws/ravn"
+
+
+class TestSkuldBlock:
+    def test_enables_the_room_channel(self) -> None:
+        block = skuld_block("ws://x/ws/ravn", display_name="reviewer")
+
+        assert block == {
+            "enabled": True,
+            "broker_url": "ws://x/ws/ravn",
+            "display_name": "reviewer",
+        }
+
+    def test_display_name_is_optional(self) -> None:
+        assert "display_name" not in skuld_block("ws://x/ws/ravn")
+
+    def test_renders_as_a_top_level_section(self) -> None:
+        parsed = yaml.safe_load(render_skuld_yaml("ws://x/ws/ravn"))
+
+        assert parsed["skuld"]["enabled"] is True
+
+
+class TestMemberConfig:
+    def test_handle_becomes_the_mesh_peer_id(self) -> None:
+        """The peer id is the member's room identity — it must be the handle."""
+        config = build_member_config(handle="reviewer", broker_url="ws://x/ws/ravn")
+
+        assert config["mesh"]["own_peer_id"] == "reviewer"
+
+    def test_initiative_is_enabled(self) -> None:
+        """The drive loop owns the room connection; without it nothing registers."""
+        config = build_member_config(handle="reviewer", broker_url="ws://x/ws/ravn")
+
+        assert config["initiative"]["enabled"] is True
+
+    def test_self_driving_triggers_are_off_by_default(self) -> None:
+        config = build_member_config(handle="reviewer", broker_url="ws://x/ws/ravn")
+
+        assert config["mimir"]["source_trigger"]["enabled"] is False
+        assert config["mimir"]["staleness_trigger"]["enabled"] is False
+        assert config["resident_wakefulness"]["enabled"] is False
+        assert config["dream_cycle"]["enabled"] is False
+
+    def test_autonomous_leaves_triggers_alone(self) -> None:
+        config = build_member_config(
+            handle="reviewer", broker_url="ws://x/ws/ravn", autonomous=True
+        )
+
+        assert "resident_wakefulness" not in config
+        assert "dream_cycle" not in config
+
+    def test_paths_are_threaded_through(self, tmp_path: Path) -> None:
+        config = build_member_config(
+            handle="reviewer",
+            broker_url="ws://x/ws/ravn",
+            memory_db_path=tmp_path / "memory.db",
+            queue_journal_path=tmp_path / "queue.json",
+        )
+
+        assert config["memory"]["sqlite"]["path"] == str(tmp_path / "memory.db")
+        assert config["initiative"]["queue_journal_path"] == str(tmp_path / "queue.json")
+        # The queue path must not clobber the enabled flag it shares a section with.
+        assert config["initiative"]["enabled"] is True
+
+
+class TestBaseLayering:
+    def test_base_settings_survive(self) -> None:
+        base = {"llm": {"model": "some-model", "max_tokens": 4096}}
+
+        config = build_member_config(handle="r", broker_url="ws://x/ws/ravn", base=base)
+
+        assert config["llm"] == {"model": "some-model", "max_tokens": 4096}
+
+    def test_nested_base_sections_merge_rather_than_replace(self) -> None:
+        base = {"memory": {"backend": "sqlite", "sqlite": {"pragma": "WAL"}}}
+
+        config = build_member_config(
+            handle="r",
+            broker_url="ws://x/ws/ravn",
+            memory_db_path=Path("/tmp/m.db"),
+            base=base,
+        )
+
+        assert config["memory"]["sqlite"]["pragma"] == "WAL"
+        assert config["memory"]["sqlite"]["path"] == "/tmp/m.db"
+
+    def test_membership_wins_over_a_conflicting_base(self) -> None:
+        """A base config must not be able to point a member at another room."""
+        base = {"skuld": {"enabled": False, "broker_url": "ws://elsewhere/ws/ravn"}}
+
+        config = build_member_config(handle="r", broker_url="ws://x/ws/ravn", base=base)
+
+        assert config["skuld"]["enabled"] is True
+        assert config["skuld"]["broker_url"] == "ws://x/ws/ravn"
+
+
+class TestLoadBaseConfig:
+    def test_none_yields_empty(self) -> None:
+        assert load_base_config(None) == {}
+
+    def test_empty_file_yields_empty(self, tmp_path: Path) -> None:
+        path = tmp_path / "base.yaml"
+        path.write_text("", encoding="utf-8")
+
+        assert load_base_config(path) == {}
+
+    def test_mapping_is_returned(self, tmp_path: Path) -> None:
+        path = tmp_path / "base.yaml"
+        path.write_text("llm:\n  model: x\n", encoding="utf-8")
+
+        assert load_base_config(path) == {"llm": {"model": "x"}}
+
+    def test_non_mapping_raises_rather_than_degrading(self, tmp_path: Path) -> None:
+        path = tmp_path / "base.yaml"
+        path.write_text("- just\n- a list\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="not a YAML mapping"):
+            load_base_config(path)
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(OSError):
+            load_base_config(tmp_path / "absent.yaml")
+
+
+class TestRenderMemberConfig:
+    def test_output_is_parseable_yaml_with_provenance(self) -> None:
+        rendered = render_member_config(
+            handle="reviewer",
+            room_name="desk",
+            persona="reviewer",
+            broker_url="ws://x/ws/ravn",
+        )
+
+        assert "# Generated by: ravn join" in rendered
+        assert "member 'reviewer' of room 'desk'" in rendered
+        parsed = yaml.safe_load(rendered)
+        assert parsed["skuld"]["broker_url"] == "ws://x/ws/ravn"
+        assert parsed["mesh"]["own_peer_id"] == "reviewer"
+
+
+class TestMemberMeshWiring:
+    """A room member must be a real mesh peer, not just a seat in a room."""
+
+    def _config(self, tmp_path: Path) -> dict:
+        return build_member_config(
+            handle="reviewer",
+            broker_url="ws://x/ws/ravn",
+            mesh_ports=(7600, 7601),
+            cluster_file=tmp_path / "cluster.yaml",
+        )
+
+    def test_mesh_is_enabled_with_allocated_sockets(self, tmp_path: Path) -> None:
+        config = self._config(tmp_path)
+
+        assert config["mesh"]["enabled"] is True
+        assert config["mesh"]["adapter"] == "nng"
+        assert config["mesh"]["own_peer_id"] == "reviewer"
+        assert config["mesh"]["nng"]["pub_sub_address"] == "tcp://0.0.0.0:7600"
+        assert config["mesh"]["nng"]["req_rep_address"] == "tcp://0.0.0.0:7601"
+
+    def test_discovery_uses_the_adapters_list(self, tmp_path: Path) -> None:
+        """The builder only reads `adapters`; the legacy `adapter` key builds nothing."""
+        config = self._config(tmp_path)
+
+        adapters = config["discovery"]["adapters"]
+        assert config["discovery"]["enabled"] is True
+        assert adapters[0]["adapter"].endswith("StaticDiscoveryAdapter")
+        assert adapters[0]["cluster_file"] == str(tmp_path / "cluster.yaml")
+        assert "adapter" not in config["discovery"]
+
+    def test_cascade_is_enabled_for_delegation(self, tmp_path: Path) -> None:
+        assert self._config(tmp_path)["cascade"]["enabled"] is True
+
+    def test_without_ports_no_mesh_is_configured(self) -> None:
+        config = build_member_config(handle="reviewer", broker_url="ws://x/ws/ravn")
+
+        assert config["mesh"] == {"own_peer_id": "reviewer"}
+        assert "discovery" not in config
+
+    def test_logging_defaults_to_info_but_base_wins(self) -> None:
+        """A detached member needs a readable log, without overriding the operator."""
+        default = build_member_config(handle="r", broker_url="ws://x/ws/ravn")
+        overridden = build_member_config(
+            handle="r", broker_url="ws://x/ws/ravn", base={"logging": {"level": "DEBUG"}}
+        )
+
+        assert default["logging"]["level"] == "INFO"
+        assert overridden["logging"]["level"] == "DEBUG"
+
+
+class TestClusterYaml:
+    def test_renders_every_member_as_a_peer(self) -> None:
+        rendered = render_cluster_yaml(
+            [
+                {"handle": "reviewer", "persona": "reviewer", "pub_port": 7600, "rep_port": 7601},
+                {"handle": "builder", "persona": "coder", "pub_port": 7602, "rep_port": 7603},
+            ]
+        )
+
+        assert "peer_id: reviewer" in rendered
+        assert "peer_id: builder" in rendered
+        assert 'pub_address: "tcp://127.0.0.1:7600"' in rendered
+        assert 'rep_address: "tcp://127.0.0.1:7603"' in rendered
+
+    def test_an_empty_room_renders_an_empty_table(self) -> None:
+        rendered = render_cluster_yaml([])
+
+        assert "peers:" in rendered
+        assert "peer_id" not in rendered

--- a/tests/test_ravn/test_cli_process_supervision.py
+++ b/tests/test_ravn/test_cli_process_supervision.py
@@ -1,0 +1,125 @@
+"""Tests for the shared CLI process-supervision helpers.
+
+These run against real sockets and real short-lived child processes — the
+helpers exist to be correct about liveness and port availability, which a
+mock cannot demonstrate.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+
+import pytest
+
+from ravn.cli.process_supervision import (
+    find_free_port,
+    is_alive,
+    port_free,
+    stop_pids,
+)
+
+
+class TestPortFree:
+    def test_unbound_port_is_free(self) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            port = probe.getsockname()[1]
+        # Socket closed — nothing is listening on that port now.
+        assert port_free(port) is True
+
+    def test_listening_port_is_not_free(self) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            port = listener.getsockname()[1]
+
+            assert port_free(port) is False
+
+
+class TestFindFreePort:
+    def test_returns_the_base_port_when_free(self) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            base = probe.getsockname()[1]
+
+        assert find_free_port(base) == base
+
+    def test_skips_a_busy_port(self) -> None:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(1)
+            base = listener.getsockname()[1]
+
+            assert find_free_port(base) > base
+
+    def test_raises_rather_than_returning_a_busy_port(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail loudly: silently handing back a used port would bind a broker onto it."""
+        monkeypatch.setattr(
+            "ravn.cli.process_supervision.port_free", lambda port, host="127.0.0.1": False
+        )
+
+        with pytest.raises(RuntimeError, match="No free port"):
+            find_free_port(7500)
+
+
+class TestIsAlive:
+    def test_current_process_is_alive(self) -> None:
+        assert is_alive(os.getpid()) is True
+
+    def test_reaped_child_is_not_alive(self) -> None:
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait()
+
+        assert is_alive(proc.pid) is False
+
+
+class TestStopPids:
+    def test_terminates_a_running_child(self) -> None:
+        proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        try:
+            assert is_alive(proc.pid) is True
+
+            stop_pids([proc.pid])
+            proc.wait(timeout=10)
+
+            assert proc.poll() is not None
+        finally:
+            if proc.poll() is None:  # pragma: no cover - only on an unexpected survival
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_escalates_to_sigkill_when_sigterm_is_ignored(self) -> None:
+        script = (
+            "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(30)"
+        )
+        proc = subprocess.Popen([sys.executable, "-c", script])
+        try:
+            # Give the child time to install its SIGTERM handler.
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and proc.poll() is None:
+                time.sleep(0.05)
+                break
+
+            stop_pids([proc.pid], timeout_s=0.5)
+            proc.wait(timeout=10)
+
+            assert proc.poll() is not None
+        finally:
+            if proc.poll() is None:  # pragma: no cover - only on an unexpected survival
+                proc.kill()
+                proc.wait(timeout=5)
+
+    def test_dead_pids_are_a_no_op(self) -> None:
+        proc = subprocess.Popen([sys.executable, "-c", "pass"])
+        proc.wait()
+
+        stop_pids([proc.pid])  # must not raise
+
+    def test_empty_list_is_a_no_op(self) -> None:
+        stop_pids([])

--- a/tests/test_ravn/test_cli_registries.py
+++ b/tests/test_ravn/test_cli_registries.py
@@ -1,0 +1,208 @@
+"""Tests for persona/profile resolution by path and the strict CLI resolvers.
+
+``--persona`` and ``--profile`` accept a registry name or a file path, and an
+explicitly named one that does not resolve is an error rather than a silent
+fallback to defaults.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from ravn.adapters.personas.loader import FilesystemPersonaAdapter
+from ravn.cli.commands import (
+    _looks_like_path,
+    _require_persona,
+    _require_profile,
+    _resolve_persona,
+    _resolve_profile,
+    app,
+)
+
+runner = CliRunner()
+
+
+class TestLooksLikePath:
+    @pytest.mark.parametrize("name", ["reviewer", "coding-agent", "local"])
+    def test_bare_names_are_registry_names(self, name: str) -> None:
+        assert _looks_like_path(name) is False
+
+    @pytest.mark.parametrize(
+        "name", ["./reviewer.yaml", "/tmp/a.yaml", "dir/x.yml", "custom.yaml", "custom.yml"]
+    )
+    def test_path_shaped_names_are_paths(self, name: str) -> None:
+        assert _looks_like_path(name) is True
+
+
+class TestPersonaByPath:
+    def test_path_load_matches_name_load(self, tmp_path: Path) -> None:
+        """A persona addressed by path behaves exactly like one addressed by name."""
+        loader = FilesystemPersonaAdapter()
+        by_name = loader.load("reviewer")
+        assert by_name is not None, "bundled 'reviewer' persona is expected to exist"
+
+        source = Path(loader.source("reviewer"))
+        copied = tmp_path / "custom-reviewer.yaml"
+        copied.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+        by_path = _resolve_persona(str(copied), None)
+
+        assert by_path is not None
+        assert by_path.name == by_name.name
+        assert by_path.system_prompt_template == by_name.system_prompt_template
+        assert by_path.allowed_tools == by_name.allowed_tools
+
+    def test_load_path_injects_outcome_instruction_like_load(self, tmp_path: Path) -> None:
+        """load_path mirrors load — otherwise a file persona would lose its outcome block."""
+        loader = FilesystemPersonaAdapter()
+        source = Path(loader.source("reviewer"))
+        copied = tmp_path / "copy.yaml"
+        copied.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+        assert loader.load_path(copied) == loader.load("reviewer")
+
+    def test_missing_file_resolves_to_none(self, tmp_path: Path) -> None:
+        assert _resolve_persona(str(tmp_path / "absent.yaml"), None) is None
+
+    def test_malformed_file_resolves_to_none(self, tmp_path: Path) -> None:
+        broken = tmp_path / "broken.yaml"
+        broken.write_text("::: not valid yaml :::", encoding="utf-8")
+
+        assert _resolve_persona(str(broken), None) is None
+
+    def test_warn_false_suppresses_the_fallback_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _resolve_persona(str(tmp_path / "absent.yaml"), None, warn=False)
+
+        assert capsys.readouterr().err == ""
+
+
+class TestRequirePersona:
+    def test_unresolvable_explicit_persona_exits(self) -> None:
+        with pytest.raises(typer.Exit) as exc:
+            _require_persona("does-not-exist", None)
+
+        assert exc.value.exit_code == 2
+
+    def test_empty_persona_stays_a_soft_none(self) -> None:
+        assert _require_persona("", None) is None
+
+    def test_resolvable_persona_is_returned(self) -> None:
+        persona = _require_persona("reviewer", None)
+
+        assert persona is not None
+        assert persona.name == "reviewer"
+
+    def test_error_is_reported_once(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """The operator sees an error, not an error preceded by a warning."""
+        with pytest.raises(typer.Exit):
+            _require_persona("does-not-exist", None)
+
+        err = capsys.readouterr().err
+        assert "Warning:" not in err
+        assert "Error: persona 'does-not-exist' not found." in err
+
+    def test_path_error_omits_the_registry_hint(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(typer.Exit):
+            _require_persona(str(tmp_path / "absent.yaml"), None)
+
+        assert "ravn personas list" not in capsys.readouterr().err
+
+
+class TestProfileByPathAndRequire:
+    def test_profile_loads_from_path(self, tmp_path: Path) -> None:
+        profile_file = tmp_path / "custom.yaml"
+        profile_file.write_text(
+            "name: custom\npersona: reviewer\ndeployment: ephemeral\n", encoding="utf-8"
+        )
+
+        profile = _resolve_profile(str(profile_file))
+
+        assert profile is not None
+        assert profile.name == "custom"
+        assert profile.persona == "reviewer"
+
+    def test_builtin_profile_still_loads_by_name(self) -> None:
+        profile = _resolve_profile("local")
+
+        assert profile is not None
+        assert profile.name == "local"
+
+    def test_unresolvable_explicit_profile_exits(self) -> None:
+        with pytest.raises(typer.Exit) as exc:
+            _require_profile("does-not-exist")
+
+        assert exc.value.exit_code == 2
+
+    def test_empty_profile_stays_a_soft_none(self) -> None:
+        assert _require_profile("") is None
+
+    def test_missing_profile_file_resolves_to_none(self, tmp_path: Path) -> None:
+        assert _resolve_profile(str(tmp_path / "absent.yaml")) is None
+
+
+class TestRegistryListings:
+    """Exercised through the top-level app — the surface an operator actually types."""
+
+    def test_personas_list_includes_a_known_persona(self) -> None:
+        result = runner.invoke(app, ["personas", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "reviewer" in result.output
+
+    def test_personas_builtin_listing_is_a_subset(self) -> None:
+        full = runner.invoke(app, ["personas", "list"])
+        builtin = runner.invoke(app, ["personas", "list", "--builtin"])
+
+        assert builtin.exit_code == 0, builtin.output
+        builtin_names = {line.split()[0] for line in builtin.output.splitlines() if line.strip()}
+        full_names = {line.split()[0] for line in full.output.splitlines() if line.strip()}
+        assert builtin_names
+        assert builtin_names <= full_names
+
+    def test_profiles_list_reports_builtins(self) -> None:
+        result = runner.invoke(app, ["profiles", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "local" in result.output
+        assert "builtin" in result.output
+
+    def test_profiles_builtin_only_listing(self) -> None:
+        result = runner.invoke(app, ["profiles", "list", "--builtin"])
+
+        assert result.exit_code == 0, result.output
+        assert "local" in result.output
+
+    def test_empty_persona_registry_is_an_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty registry means a broken install, not an empty success."""
+        monkeypatch.setattr(FilesystemPersonaAdapter, "list_names", lambda self: [])
+
+        result = runner.invoke(app, ["personas", "list"])
+
+        assert result.exit_code == 1
+        assert "No personas found" in result.output
+
+    def test_empty_profile_registry_is_an_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ravn.adapters.profiles.loader import ProfileLoader
+
+        monkeypatch.setattr(ProfileLoader, "list_names", lambda self: [])
+
+        result = runner.invoke(app, ["profiles", "list"])
+
+        assert result.exit_code == 1
+        assert "No profiles found" in result.output
+
+    def test_room_subcommands_are_mounted(self) -> None:
+        """`room` moved from an action argument to a sub-app; the verbs must survive."""
+        result = runner.invoke(app, ["room", "--help"])
+
+        assert result.exit_code == 0, result.output
+        for verb in ("create", "ls", "show", "start", "stop", "rm", "join", "participants"):
+            assert verb in result.output

--- a/tests/test_ravn/test_cli_room.py
+++ b/tests/test_ravn/test_cli_room.py
@@ -1,0 +1,592 @@
+"""Tests for ``ravn room`` — room lifecycle and broker-URL resolution.
+
+The broker process itself is never spawned here: ``_spawn_broker`` and the
+readiness probe are the seams, so these tests cover the state machine (define,
+start, stop, remove) and the resolution rules without binding ports.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import typer
+from typer.testing import CliRunner
+
+from ravn.cli import room as room_mod
+from ravn.cli.room import RoomDef, room_app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def rooms_dir(tmp_path: Path) -> Path:
+    return tmp_path / "rooms"
+
+
+@pytest.fixture
+def fake_broker(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Replace process spawning and readiness probing with recorded fakes."""
+    state: dict = {"spawned": [], "responding": True, "pid": 4242}
+
+    def _spawn(room_def: RoomDef, dirs: Path) -> int:
+        state["spawned"].append(room_def.name)
+        return int(state["pid"])
+
+    monkeypatch.setattr(room_mod, "_spawn_broker", _spawn)
+    monkeypatch.setattr(room_mod, "_broker_responding", lambda room_def: state["responding"])
+    monkeypatch.setattr(room_mod, "port_free", lambda port, host="127.0.0.1": True)
+    monkeypatch.setattr(room_mod, "is_alive", lambda pid: pid == state["pid"])
+    monkeypatch.setattr(room_mod, "stop_pids", lambda pids, **kw: None)
+    return state
+
+
+def _create(rooms_dir: Path, name: str = "desk", *extra: str):
+    return runner.invoke(room_app, ["create", name, "--rooms-dir", str(rooms_dir), *extra])
+
+
+class TestRoomCreate:
+    def test_create_writes_definition_and_broker_config(
+        self, rooms_dir: Path, fake_broker: dict
+    ) -> None:
+        result = _create(rooms_dir, "desk", "--port", "7501")
+
+        assert result.exit_code == 0, result.output
+        room_def = room_mod._load_room_def("desk", rooms_dir)
+        assert room_def is not None
+        assert room_def.environment_id == "desk"
+        assert room_def.port == 7501
+        assert room_def.broker_url == "http://127.0.0.1:7501"
+        assert fake_broker["spawned"] == ["desk"]
+
+    def test_broker_config_enables_room_mode(self, rooms_dir: Path, fake_broker: dict) -> None:
+        import yaml
+
+        _create(rooms_dir, "desk", "--port", "7501")
+
+        config = yaml.safe_load(
+            room_mod._broker_config_path("desk", rooms_dir).read_text(encoding="utf-8")
+        )
+        assert config["room"] == {"enabled": True, "environment_id": "desk"}
+        assert config["port"] == 7501
+        # The broker refuses to start without a writable workspace, so the
+        # generated config must point at the room's own directory.
+        assert config["session"]["workspace_dir"].startswith(str(rooms_dir))
+        assert config["persistence_mount_path"].startswith(str(rooms_dir))
+
+    def test_no_start_skips_the_broker(self, rooms_dir: Path, fake_broker: dict) -> None:
+        result = _create(rooms_dir, "desk", "--no-start")
+
+        assert result.exit_code == 0, result.output
+        assert fake_broker["spawned"] == []
+        assert room_mod._load_pid("desk", rooms_dir) is None
+
+    def test_duplicate_create_is_refused_without_force(
+        self, rooms_dir: Path, fake_broker: dict
+    ) -> None:
+        _create(rooms_dir, "desk", "--no-start")
+        result = _create(rooms_dir, "desk", "--no-start")
+
+        assert result.exit_code == 1
+        assert "already exists" in result.output
+
+    def test_force_recreates_a_stopped_room(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--no-start", "--port", "7501")
+        result = _create(rooms_dir, "desk", "--no-start", "--force", "--port", "7502")
+
+        assert result.exit_code == 0, result.output
+        room_def = room_mod._load_room_def("desk", rooms_dir)
+        assert room_def is not None
+        assert room_def.port == 7502
+
+    def test_force_is_refused_while_the_room_runs(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--port", "7501")
+        result = _create(rooms_dir, "desk", "--force", "--port", "7502")
+
+        assert result.exit_code == 1
+        assert "is running" in result.output
+
+    def test_port_in_use_fails_loudly(
+        self, rooms_dir: Path, fake_broker: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(room_mod, "port_free", lambda port, host="127.0.0.1": False)
+
+        result = _create(rooms_dir, "desk", "--port", "7501")
+
+        assert result.exit_code == 1
+        assert "already in use" in result.output
+        assert fake_broker["spawned"] == []
+
+    def test_unresponsive_broker_reports_failure_and_clears_state(
+        self, rooms_dir: Path, fake_broker: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_broker["responding"] = False
+        # A dead child short-circuits the wait instead of burning the timeout.
+        monkeypatch.setattr(room_mod, "is_alive", lambda pid: False)
+
+        result = _create(rooms_dir, "desk", "--port", "7501")
+
+        assert result.exit_code == 1
+        assert "did not come up" in result.output
+        assert room_mod._load_pid("desk", rooms_dir) is None
+
+
+class TestRoomLifecycle:
+    def test_ls_reports_running_and_stopped(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--port", "7501")
+        _create(rooms_dir, "lab", "--no-start", "--port", "7502")
+
+        result = runner.invoke(room_app, ["ls", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert "desk" in result.output
+        assert "running" in result.output
+        assert "lab" in result.output
+        assert "stopped" in result.output
+
+    def test_ls_on_empty_directory_is_not_an_error(self, rooms_dir: Path) -> None:
+        result = runner.invoke(room_app, ["ls", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0
+        assert "No rooms" in result.output
+
+    def test_show_reports_status(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--port", "7501")
+
+        result = runner.invoke(room_app, ["show", "desk", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert "environment_id: desk" in result.output
+        assert "status:         running" in result.output
+
+    def test_show_unknown_room_fails(self, rooms_dir: Path) -> None:
+        result = runner.invoke(room_app, ["show", "ghost", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 1
+        assert "Unknown room" in result.output
+
+    def test_stop_clears_recorded_pid(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--port", "7501")
+        assert room_mod._load_pid("desk", rooms_dir) is not None
+
+        result = runner.invoke(room_app, ["stop", "desk", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert room_mod._load_pid("desk", rooms_dir) is None
+
+    def test_stop_when_not_running_is_idempotent(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--no-start")
+
+        result = runner.invoke(room_app, ["stop", "desk", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0
+        assert "not running" in result.output
+
+    def test_start_is_a_no_op_when_already_running(
+        self, rooms_dir: Path, fake_broker: dict
+    ) -> None:
+        _create(rooms_dir, "desk", "--port", "7501")
+        result = runner.invoke(room_app, ["start", "desk", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert "already running" in result.output
+        assert fake_broker["spawned"] == ["desk"]
+
+    def test_start_after_stop_respawns(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--no-start", "--port", "7501")
+
+        result = runner.invoke(room_app, ["start", "desk", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert fake_broker["spawned"] == ["desk"]
+
+    def test_rm_deletes_the_room_directory(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--port", "7501")
+
+        result = runner.invoke(room_app, ["rm", "desk", "--force", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert not room_mod._room_dir("desk", rooms_dir).exists()
+
+    def test_rm_unknown_room_fails(self, rooms_dir: Path) -> None:
+        result = runner.invoke(room_app, ["rm", "ghost", "--force", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 1
+
+
+class TestPidState:
+    def test_corrupt_state_file_reads_as_no_pid(self, rooms_dir: Path) -> None:
+        room_dir = room_mod._room_dir("desk", rooms_dir)
+        room_dir.mkdir(parents=True)
+        room_mod._state_path("desk", rooms_dir).write_text("not json", encoding="utf-8")
+
+        assert room_mod._load_pid("desk", rooms_dir) is None
+
+    def test_state_file_without_pid_key_reads_as_no_pid(self, rooms_dir: Path) -> None:
+        room_dir = room_mod._room_dir("desk", rooms_dir)
+        room_dir.mkdir(parents=True)
+        room_mod._state_path("desk", rooms_dir).write_text(json.dumps({}), encoding="utf-8")
+
+        assert room_mod._load_pid("desk", rooms_dir) is None
+
+
+class TestBrokerUrlResolution:
+    def test_explicit_broker_url_wins(self, rooms_dir: Path, fake_broker: dict) -> None:
+        _create(rooms_dir, "desk", "--no-start", "--port", "7501")
+
+        resolved = room_mod._resolve_broker_url("http://elsewhere:9999/", "desk", str(rooms_dir))
+
+        assert resolved == "http://elsewhere:9999"
+
+    def test_environment_name_resolves_to_the_registered_room(
+        self, rooms_dir: Path, fake_broker: dict
+    ) -> None:
+        _create(rooms_dir, "desk", "--no-start", "--port", "7501")
+
+        resolved = room_mod._resolve_broker_url("", "desk", str(rooms_dir))
+
+        assert resolved == "http://127.0.0.1:7501"
+
+    def test_unknown_environment_falls_back_to_the_default_broker(self, rooms_dir: Path) -> None:
+        resolved = room_mod._resolve_broker_url("", "ghost", str(rooms_dir))
+
+        assert resolved == room_mod._DEFAULT_BROKER_URL
+
+    def test_no_environment_falls_back_to_the_default_broker(self, rooms_dir: Path) -> None:
+        resolved = room_mod._resolve_broker_url("", "", str(rooms_dir))
+
+        assert resolved == room_mod._DEFAULT_BROKER_URL
+
+
+class TestRoomDefSerialisation:
+    def test_round_trips_through_yaml(self) -> None:
+        original = RoomDef(
+            name="desk",
+            environment_id="desk",
+            host="127.0.0.1",
+            port=7501,
+            created_at="2026-07-26T00:00:00+00:00",
+        )
+
+        restored = RoomDef.from_yaml(original.to_yaml())
+
+        assert restored == original
+
+    def test_host_defaults_when_absent(self) -> None:
+        restored = RoomDef.from_yaml("name: desk\nenvironment_id: desk\nport: 7501\n")
+
+        assert restored.host == room_mod._DEFAULT_HOST
+        assert restored.created_at == ""
+
+
+class TestParticipationCommands:
+    """The participation subcommands are thin wrappers over the broker API."""
+
+    def test_join_posts_the_expected_payload(
+        self, rooms_dir: Path, fake_broker: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _create(rooms_dir, "desk", "--no-start", "--port", "7501")
+        calls: list[tuple[str, str, dict]] = []
+
+        def _fake_post(base: str, path: str, payload: dict) -> dict:
+            calls.append((base, path, payload))
+            return {"participant": {"capabilities": ["view", "reply"]}}
+
+        monkeypatch.setattr(room_mod, "_post", _fake_post)
+
+        result = runner.invoke(
+            room_app,
+            [
+                "join",
+                "--participant",
+                "human:jozef",
+                "--environment",
+                "desk",
+                "--role",
+                "owner",
+                "--rooms-dir",
+                str(rooms_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        base, path, payload = calls[0]
+        assert base == "http://127.0.0.1:7501"
+        assert path == "/api/room/join"
+        assert payload["participant_id"] == "human:jozef"
+        assert payload["environment_id"] == "desk"
+        assert payload["role"] == "owner"
+
+    def test_message_requires_text(self, rooms_dir: Path) -> None:
+        result = runner.invoke(
+            room_app,
+            ["message", "--participant", "human:jozef", "--rooms-dir", str(rooms_dir)],
+        )
+
+        assert result.exit_code != 0
+
+    def test_message_posts_content(
+        self, rooms_dir: Path, fake_broker: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _create(rooms_dir, "desk", "--no-start", "--port", "7501")
+        calls: list[tuple[str, str, dict]] = []
+        monkeypatch.setattr(
+            room_mod,
+            "_post",
+            lambda base, path, payload: (calls.append((base, path, payload)), {})[1],
+        )
+
+        result = runner.invoke(
+            room_app,
+            [
+                "message",
+                "--participant",
+                "human:jozef",
+                "--environment",
+                "desk",
+                "--text",
+                "hello room",
+                "--rooms-dir",
+                str(rooms_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        _, path, payload = calls[0]
+        assert path == "/api/room/message"
+        assert payload["content"] == "hello room"
+
+
+class TestStartupFailureReporting:
+    def test_failure_echoes_the_broker_log_tail(
+        self, rooms_dir: Path, fake_broker: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A room that won't start must show why, not just that it didn't."""
+        fake_broker["responding"] = False
+        monkeypatch.setattr(room_mod, "is_alive", lambda pid: False)
+
+        def _spawn_and_log(room_def: RoomDef, dirs: Path) -> int:
+            log = room_mod._log_path(room_def.name, dirs)
+            log.parent.mkdir(parents=True, exist_ok=True)
+            log.write_text("OSError: Read-only file system: '/volundr'\n", encoding="utf-8")
+            return int(fake_broker["pid"])
+
+        monkeypatch.setattr(room_mod, "_spawn_broker", _spawn_and_log)
+
+        result = _create(rooms_dir, "desk", "--port", "7501")
+
+        assert result.exit_code == 1
+        assert "Read-only file system" in result.output
+
+    def test_rm_requires_confirmation_without_force(
+        self, rooms_dir: Path, fake_broker: dict
+    ) -> None:
+        _create(rooms_dir, "desk", "--no-start")
+
+        result = runner.invoke(room_app, ["rm", "desk", "--rooms-dir", str(rooms_dir)], input="n\n")
+
+        assert result.exit_code != 0
+        assert room_mod._room_dir("desk", rooms_dir).exists()
+
+
+class TestRemainingParticipationCommands:
+    @pytest.fixture
+    def posted(self, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, dict]]:
+        calls: list[tuple[str, str, dict]] = []
+
+        def _fake_post(base: str, path: str, payload: dict) -> dict:
+            calls.append((base, path, payload))
+            return {"transcriptRef": "mimir://t/1"}
+
+        monkeypatch.setattr(room_mod, "_post", _fake_post)
+        return calls
+
+    def test_leave(self, rooms_dir: Path, posted: list) -> None:
+        result = runner.invoke(
+            room_app,
+            ["leave", "--participant", "human:jozef", "--rooms-dir", str(rooms_dir)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert posted[0][1] == "/api/room/leave"
+        assert posted[0][2]["reason"] == "left"
+
+    def test_heartbeat(self, rooms_dir: Path, posted: list) -> None:
+        result = runner.invoke(
+            room_app,
+            ["heartbeat", "--participant", "human:jozef", "--rooms-dir", str(rooms_dir)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert posted[0][1] == "/api/room/heartbeat"
+
+    def test_close_reports_the_transcript(self, rooms_dir: Path, posted: list) -> None:
+        result = runner.invoke(
+            room_app, ["close", "--room", "huddle-1", "--rooms-dir", str(rooms_dir)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert posted[0][1] == "/api/room/close"
+        assert "mimir://t/1" in result.output
+
+    def test_participants_lists_each_peer(
+        self, rooms_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class _Response:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {
+                    "participants": [
+                        {
+                            "peer_id": "human:jozef",
+                            "participant_type": "human",
+                            "authority_role": "owner",
+                            "status": "idle",
+                        },
+                        {
+                            "peer_id": "ravn-reviewer",
+                            "participant_type": "ravn",
+                            "authority_role": "",
+                            "status": "running",
+                        },
+                    ]
+                }
+
+        monkeypatch.setattr(
+            room_mod.httpx if hasattr(room_mod, "httpx") else __import__("httpx"),
+            "get",
+            lambda *a, **kw: _Response(),
+        )
+
+        result = runner.invoke(
+            room_app, ["participants", "--environment", "desk", "--rooms-dir", str(rooms_dir)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "human:jozef" in result.output
+        assert "ravn-reviewer" in result.output
+
+
+class TestPostErrorHandling:
+    def test_http_error_status_exits_with_the_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A broker rejection must surface, not be swallowed into a success message."""
+        import httpx
+
+        class _Response:
+            status_code = 403
+            text = "participant lacks capability"
+
+        monkeypatch.setattr(httpx, "post", lambda *a, **kw: _Response())
+
+        with pytest.raises(typer.Exit) as exc:
+            room_mod._post("http://127.0.0.1:7500", "/api/room/message", {})
+
+        assert exc.value.exit_code == 1
+
+    def test_success_returns_the_decoded_body(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import httpx
+
+        class _Response:
+            status_code = 200
+
+            def json(self) -> dict:
+                return {"status": "ok"}
+
+        monkeypatch.setattr(httpx, "post", lambda *a, **kw: _Response())
+
+        assert room_mod._post("http://x", "/p", {}) == {"status": "ok"}
+
+
+class TestBrokerProbe:
+    def test_connection_error_reads_as_not_responding(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import httpx
+
+        def _raise(*args, **kwargs):
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(httpx, "get", _raise)
+        room_def = RoomDef("desk", "desk", "127.0.0.1", 7501, "")
+
+        assert room_mod._broker_responding(room_def) is False
+
+    def test_ok_status_reads_as_responding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import httpx
+
+        class _Response:
+            status_code = 200
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _Response())
+        room_def = RoomDef("desk", "desk", "127.0.0.1", 7501, "")
+
+        assert room_mod._broker_responding(room_def) is True
+
+    def test_error_status_reads_as_not_responding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import httpx
+
+        class _Response:
+            status_code = 500
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _Response())
+        room_def = RoomDef("desk", "desk", "127.0.0.1", 7501, "")
+
+        assert room_mod._broker_responding(room_def) is False
+
+
+class TestSpawnBroker:
+    def test_spawns_the_broker_with_its_own_config(
+        self, rooms_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The child must be pointed at the room's generated config, detached."""
+        recorded: dict = {}
+
+        class _Proc:
+            pid = 5150
+
+        def _fake_popen(cmd, **kwargs):
+            recorded["cmd"] = cmd
+            recorded["env"] = kwargs["env"]
+            recorded["start_new_session"] = kwargs["start_new_session"]
+            return _Proc()
+
+        monkeypatch.setattr(room_mod.subprocess, "Popen", _fake_popen)
+
+        room_def = RoomDef("desk", "desk", "127.0.0.1", 7501, "")
+        room_mod._room_dir("desk", rooms_dir).mkdir(parents=True)
+        room_mod._write_broker_config(room_def, rooms_dir)
+
+        pid = room_mod._spawn_broker(room_def, rooms_dir)
+
+        assert pid == 5150
+        assert recorded["cmd"][1:] == ["-m", "skuld"]
+        assert recorded["env"]["NIUU_CONFIG"] == str(
+            room_mod._broker_config_path("desk", rooms_dir)
+        )
+        assert recorded["start_new_session"] is True
+
+
+class TestDefaultRoomsDir:
+    def test_defaults_under_the_ravn_home(self) -> None:
+        assert room_mod._rooms_dir_default() == Path.home() / ".ravn" / "rooms"
+
+
+def test_room_dir_layout_is_contained(tmp_path: Path, fake_broker: dict) -> None:
+    """Everything a room owns lives under its own directory, so rm is total."""
+    rooms = tmp_path / "rooms"
+    _create(rooms, "desk", "--port", "7501")
+
+    room_dir = rooms / "desk"
+    for path in (
+        room_mod._room_def_path("desk", rooms),
+        room_mod._broker_config_path("desk", rooms),
+        room_mod._state_path("desk", rooms),
+        room_mod._log_path("desk", rooms).parent,
+    ):
+        assert os.path.commonpath([str(room_dir), str(path)]) == str(room_dir)

--- a/tests/test_ravn/test_cli_room_membership.py
+++ b/tests/test_ravn/test_cli_room_membership.py
@@ -1,0 +1,613 @@
+"""Tests for room membership (``ravn join`` / ``leave``) and mention routing.
+
+Daemon processes are never spawned: ``_spawn_member`` and the registration
+probe are the seams, so these cover the decisions — identity resolution,
+handle collisions, routing — rather than process management.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from ravn.cli import room as room_mod
+from ravn.cli.commands import app
+from ravn.cli.room import RoomDef, room_app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def rooms_dir(tmp_path: Path) -> Path:
+    return tmp_path / "rooms"
+
+
+@pytest.fixture
+def live_room(rooms_dir: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    """A created, running room whose members register successfully."""
+    state: dict = {"spawned": [], "registered": True, "broker_pid": 4242, "member_pid": 5150}
+
+    monkeypatch.setattr(room_mod, "_spawn_broker", lambda rd, d: int(state["broker_pid"]))
+    monkeypatch.setattr(room_mod, "_broker_responding", lambda rd: True)
+    monkeypatch.setattr(room_mod, "port_free", lambda port, host="127.0.0.1": True)
+    monkeypatch.setattr(room_mod, "stop_pids", lambda pids, **kw: None)
+    monkeypatch.setattr(
+        room_mod, "is_alive", lambda pid: pid in (state["broker_pid"], state["member_pid"])
+    )
+
+    def _spawn_member(rd: RoomDef, d: Path, handle: str, persona: str, cfg: Path) -> int:
+        state["spawned"].append((handle, persona))
+        return int(state["member_pid"])
+
+    monkeypatch.setattr(room_mod, "_spawn_member", _spawn_member)
+    monkeypatch.setattr(
+        room_mod, "_await_member_registration", lambda rd, handle, pid: state["registered"]
+    )
+
+    result = runner.invoke(
+        room_app, ["create", "desk", "--rooms-dir", str(rooms_dir), "--port", "7500"]
+    )
+    assert result.exit_code == 0, result.output
+    return state
+
+
+def _join(rooms_dir: Path, *args: str):
+    return runner.invoke(app, ["join", "--rooms-dir", str(rooms_dir), *args])
+
+
+class TestJoin:
+    def test_persona_becomes_the_default_handle(self, rooms_dir: Path, live_room: dict) -> None:
+        result = _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+
+        assert result.exit_code == 0, result.output
+        assert live_room["spawned"] == [("reviewer", "reviewer")]
+        assert room_mod._load_member_state("desk", rooms_dir, "reviewer") is not None
+
+    def test_as_overrides_the_handle(self, rooms_dir: Path, live_room: dict) -> None:
+        result = _join(rooms_dir, "--persona", "coder", "--room", "desk", "--as", "builder")
+
+        assert result.exit_code == 0, result.output
+        assert live_room["spawned"] == [("builder", "coder")]
+
+    def test_member_config_targets_the_rooms_broker(self, rooms_dir: Path, live_room: dict) -> None:
+        import yaml
+
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+
+        config = yaml.safe_load(
+            room_mod._member_config_path("desk", rooms_dir, "reviewer").read_text(encoding="utf-8")
+        )
+        assert config["skuld"]["broker_url"] == "ws://127.0.0.1:7500/ws/ravn"
+        assert config["mesh"]["own_peer_id"] == "reviewer"
+
+    def test_unknown_persona_fails_before_spawning(self, rooms_dir: Path, live_room: dict) -> None:
+        """Identity is resolved up front so failures surface here, not in a log."""
+        result = _join(rooms_dir, "--persona", "does-not-exist", "--room", "desk")
+
+        assert result.exit_code == 2
+        assert live_room["spawned"] == []
+
+    def test_duplicate_handle_is_refused(self, rooms_dir: Path, live_room: dict) -> None:
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+        result = _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+
+        assert result.exit_code == 1
+        assert "already in" in result.output
+
+    def test_force_replaces_an_existing_member(self, rooms_dir: Path, live_room: dict) -> None:
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+        result = _join(rooms_dir, "--persona", "reviewer", "--room", "desk", "--force")
+
+        assert result.exit_code == 0, result.output
+        assert len(live_room["spawned"]) == 2
+
+    def test_joining_a_stopped_room_fails(self, rooms_dir: Path, live_room: dict) -> None:
+        runner.invoke(room_app, ["stop", "desk", "--rooms-dir", str(rooms_dir)])
+
+        result = _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+
+        assert result.exit_code == 1
+        assert "not running" in result.output
+
+    def test_failed_registration_cleans_up(self, rooms_dir: Path, live_room: dict) -> None:
+        """A member that never registers must not be left recorded as joined."""
+        live_room["registered"] = False
+
+        result = _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+
+        assert result.exit_code == 1
+        assert "did not register" in result.output
+        assert room_mod._load_member_state("desk", rooms_dir, "reviewer") is None
+
+    def test_no_persona_and_no_profile_is_an_error(self, rooms_dir: Path, live_room: dict) -> None:
+        result = _join(rooms_dir, "--room", "desk")
+
+        assert result.exit_code == 2
+        assert "Nothing to join as" in result.output
+
+    def test_single_room_is_inferred(self, rooms_dir: Path, live_room: dict) -> None:
+        result = _join(rooms_dir, "--persona", "reviewer")
+
+        assert result.exit_code == 0, result.output
+
+    def test_ambiguous_room_requires_an_explicit_choice(
+        self, rooms_dir: Path, live_room: dict
+    ) -> None:
+        runner.invoke(
+            room_app,
+            ["create", "lab", "--rooms-dir", str(rooms_dir), "--port", "7502", "--no-start"],
+        )
+
+        result = _join(rooms_dir, "--persona", "reviewer")
+
+        assert result.exit_code == 2
+        assert "pass --room" in result.output
+
+
+class TestLeave:
+    def test_leave_removes_the_member(self, rooms_dir: Path, live_room: dict) -> None:
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+
+        result = runner.invoke(
+            app, ["leave", "--as", "reviewer", "--room", "desk", "--rooms-dir", str(rooms_dir)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert room_mod._load_member_state("desk", rooms_dir, "reviewer") is None
+
+    def test_leaving_a_non_member_fails(self, rooms_dir: Path, live_room: dict) -> None:
+        result = runner.invoke(
+            app, ["leave", "--as", "ghost", "--room", "desk", "--rooms-dir", str(rooms_dir)]
+        )
+
+        assert result.exit_code == 1
+        assert "not a member" in result.output
+
+
+class TestMembersListing:
+    def test_runtime_files_are_not_mistaken_for_members(
+        self, rooms_dir: Path, live_room: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A member's queue journal must never appear as a second member."""
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+        monkeypatch.setattr(room_mod, "_fetch_participants", lambda rd: [])
+
+        assert room_mod._list_member_handles("desk", rooms_dir) == ["reviewer"]
+
+    def test_members_reports_process_and_room_state(
+        self, rooms_dir: Path, live_room: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+
+        class _Response:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {"participants": [{"peer_id": "reviewer"}]}
+
+        import httpx
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _Response())
+
+        result = runner.invoke(
+            room_app, ["members", "--room", "desk", "--rooms-dir", str(rooms_dir)]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "reviewer" in result.output
+        assert "running" in result.output
+
+    def test_empty_room_says_so(self, rooms_dir: Path, live_room: dict) -> None:
+        result = runner.invoke(
+            room_app, ["members", "--room", "desk", "--rooms-dir", str(rooms_dir)]
+        )
+
+        assert result.exit_code == 0
+        assert "No ravens joined" in result.output
+
+
+class TestPostRouting:
+    @pytest.fixture
+    def posted(self, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, dict]]:
+        calls: list[tuple[str, str, dict]] = []
+        monkeypatch.setattr(
+            room_mod,
+            "_post",
+            lambda base, path, payload: (calls.append((base, path, payload)), {})[1],
+        )
+        monkeypatch.setattr(
+            room_mod,
+            "_fetch_participants",
+            lambda rd: [
+                {"peer_id": "reviewer"},
+                {"peer_id": "builder"},
+                {"peer_id": "human:jozef"},
+            ],
+        )
+        monkeypatch.setattr(room_mod, "_last_speaker", lambda rd, exclude: "")
+        return calls
+
+    def _post_cmd(self, rooms_dir: Path, body: str, *extra: str):
+        return runner.invoke(
+            room_app,
+            [
+                "post",
+                body,
+                "--as",
+                "human:jozef",
+                "--room",
+                "desk",
+                "--rooms-dir",
+                str(rooms_dir),
+                *extra,
+            ],
+        )
+
+    def test_explicit_target_is_delivered_directly(
+        self, rooms_dir: Path, live_room: dict, posted: list
+    ) -> None:
+        result = self._post_cmd(rooms_dir, "take a look", "--to", "reviewer")
+
+        assert result.exit_code == 0, result.output
+        _, path, payload = posted[0]
+        assert path == "/api/room/direct"
+        assert payload["target_peer_id"] == "reviewer"
+
+    def test_untagged_message_falls_back_to_the_last_speaker(
+        self, rooms_dir: Path, live_room: dict, posted: list, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(room_mod, "_last_speaker", lambda rd, exclude: "reviewer")
+
+        result = self._post_cmd(rooms_dir, "carry on")
+
+        assert result.exit_code == 0, result.output
+        assert posted[0][2]["target_peer_id"] == "reviewer"
+
+    def test_no_target_becomes_commentary_without_transport_delivery(
+        self, rooms_dir: Path, live_room: dict, posted: list
+    ) -> None:
+        result = self._post_cmd(rooms_dir, "thinking out loud")
+
+        assert result.exit_code == 0, result.output
+        _, path, payload = posted[0]
+        assert path == "/api/room/message"
+        assert payload["deliver_to_transport"] is False
+
+    def test_unknown_target_is_refused(
+        self, rooms_dir: Path, live_room: dict, posted: list
+    ) -> None:
+        """A typo must not be silently delivered somewhere else."""
+        result = self._post_cmd(rooms_dir, "hello", "--to", "reviwer")
+
+        assert result.exit_code == 1
+        assert "is not in room" in result.output
+        assert posted == []
+
+    def test_a_non_participant_cannot_post(
+        self, rooms_dir: Path, live_room: dict, posted: list
+    ) -> None:
+        result = runner.invoke(
+            room_app,
+            [
+                "post",
+                "hello",
+                "--as",
+                "human:stranger",
+                "--room",
+                "desk",
+                "--rooms-dir",
+                str(rooms_dir),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "is not in room" in result.output
+        assert posted == []
+
+
+class TestHistoryHelpers:
+    def test_turns_from_a_bare_list(self) -> None:
+        assert room_mod._history_turns([{"id": "1"}]) == [{"id": "1"}]
+
+    @pytest.mark.parametrize("key", ["turns", "messages", "history"])
+    def test_turns_from_a_wrapped_payload(self, key: str) -> None:
+        assert room_mod._history_turns({key: [{"id": "1"}]}) == [{"id": "1"}]
+
+    def test_unknown_shape_yields_nothing(self) -> None:
+        assert room_mod._history_turns({"unexpected": 1}) == []
+        assert room_mod._history_turns("nonsense") == []
+
+    def test_turn_formatting_truncates_long_bodies(self) -> None:
+        line = room_mod._format_turn({"participant_id": "reviewer", "content": "x" * 500})
+
+        assert line.startswith("reviewer")
+        assert line.endswith("…")
+        assert len(line) < 200
+
+    def test_turn_formatting_collapses_newlines(self) -> None:
+        line = room_mod._format_turn({"participant_id": "r", "content": "one\ntwo"})
+
+        assert "\n" not in line
+        assert "one two" in line
+
+
+class TestFetchParticipants:
+    def test_unreachable_room_fails_cleanly(
+        self, rooms_dir: Path, live_room: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dead broker is an operator-facing error, never a stack trace."""
+        import httpx
+        import typer
+
+        def _raise(*args, **kwargs):
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(httpx, "get", _raise)
+        room_def = room_mod._require_room_def("desk", rooms_dir)
+
+        with pytest.raises(typer.Exit) as exc:
+            room_mod._fetch_participants(room_def)
+
+        assert exc.value.exit_code == 1
+
+    def test_returns_the_roster(
+        self, rooms_dir: Path, live_room: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import httpx
+
+        class _Response:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {"participants": [{"peer_id": "reviewer"}]}
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _Response())
+        room_def = room_mod._require_room_def("desk", rooms_dir)
+
+        assert room_mod._fetch_participants(room_def) == [{"peer_id": "reviewer"}]
+
+
+class TestLastSpeaker:
+    def _room_def(self) -> RoomDef:
+        return RoomDef("desk", "desk", "127.0.0.1", 7500, "")
+
+    def _history(self, monkeypatch: pytest.MonkeyPatch, turns: list[dict]) -> None:
+        import httpx
+
+        class _Response:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {"turns": turns}
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _Response())
+
+    def test_picks_the_most_recent_other_speaker(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._history(
+            monkeypatch,
+            [
+                {"participant_id": "human:jozef"},
+                {"participant_id": "reviewer"},
+                {"participant_id": "builder"},
+            ],
+        )
+
+        assert room_mod._last_speaker(self._room_def(), exclude="human:jozef") == "builder"
+
+    def test_skips_the_author(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._history(
+            monkeypatch,
+            [{"participant_id": "reviewer"}, {"participant_id": "human:jozef"}],
+        )
+
+        assert room_mod._last_speaker(self._room_def(), exclude="human:jozef") == "reviewer"
+
+    def test_empty_history_yields_nobody(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._history(monkeypatch, [])
+
+        assert room_mod._last_speaker(self._room_def(), exclude="human:jozef") == ""
+
+    def test_unreachable_history_yields_nobody(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A default recipient is a convenience; losing it must not fail the post."""
+        import httpx
+
+        def _raise(*args, **kwargs):
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(httpx, "get", _raise)
+
+        assert room_mod._last_speaker(self._room_def(), exclude="human:jozef") == ""
+
+
+class TestTail:
+    def _history(self, monkeypatch: pytest.MonkeyPatch, turns: list[dict]) -> None:
+        import httpx
+
+        class _Response:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {"turns": turns}
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _Response())
+
+    def test_prints_recent_turns(
+        self, rooms_dir: Path, live_room: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._history(
+            monkeypatch,
+            [
+                {"id": "1", "participant_id": "human:jozef", "content": "@reviewer look"},
+                {"id": "2", "participant_id": "reviewer", "content": "on it"},
+            ],
+        )
+
+        result = runner.invoke(room_app, ["tail", "--room", "desk", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 0, result.output
+        assert "@reviewer look" in result.output
+        assert "on it" in result.output
+
+    def test_unreachable_room_fails_cleanly(
+        self, rooms_dir: Path, live_room: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import httpx
+
+        def _raise(*args, **kwargs):
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(httpx, "get", _raise)
+
+        result = runner.invoke(room_app, ["tail", "--room", "desk", "--rooms-dir", str(rooms_dir)])
+
+        assert result.exit_code == 1
+        assert "unreachable" in result.output
+
+    def test_follow_prints_only_new_turns_then_stops(
+        self, rooms_dir: Path, live_room: dict, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Following must not reprint history on every poll."""
+        batches = [
+            [{"id": "1", "participant_id": "human:jozef", "content": "first"}],
+            [
+                {"id": "1", "participant_id": "human:jozef", "content": "first"},
+                {"id": "2", "participant_id": "reviewer", "content": "second"},
+            ],
+        ]
+        calls = {"n": 0}
+
+        def _fetch_turns(*args, **kwargs):
+            index = min(calls["n"], len(batches) - 1)
+            calls["n"] += 1
+            return batches[index]
+
+        import httpx
+
+        class _Response:
+            def __init__(self, turns: list[dict]) -> None:
+                self._turns = turns
+
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return {"turns": self._turns}
+
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _Response(_fetch_turns()))
+        monkeypatch.setattr(room_mod, "_TAIL_POLL_INTERVAL_S", 0.01)
+
+        def _sleep_then_interrupt(_seconds: float) -> None:
+            if calls["n"] >= 2:
+                raise KeyboardInterrupt
+            return None
+
+        monkeypatch.setattr(room_mod.time, "sleep", _sleep_then_interrupt)
+
+        result = runner.invoke(
+            room_app, ["tail", "--room", "desk", "--rooms-dir", str(rooms_dir), "--follow"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert result.output.count("first") == 1
+        assert "second" in result.output
+
+
+class TestAwaitRegistration:
+    def test_returns_false_when_the_process_dies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(room_mod, "is_alive", lambda pid: False)
+        room_def = RoomDef("desk", "desk", "127.0.0.1", 7500, "")
+
+        assert room_mod._await_member_registration(room_def, "reviewer", 1234) is False
+
+    def test_returns_true_once_the_handle_appears(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import httpx
+
+        class _Response:
+            status_code = 200
+
+            def json(self) -> dict:
+                return {"participants": [{"peer_id": "reviewer"}]}
+
+        monkeypatch.setattr(room_mod, "is_alive", lambda pid: True)
+        monkeypatch.setattr(httpx, "get", lambda *a, **kw: _Response())
+        room_def = RoomDef("desk", "desk", "127.0.0.1", 7500, "")
+
+        assert room_mod._await_member_registration(room_def, "reviewer", 1234) is True
+
+
+class TestMemberPortAllocation:
+    def test_ports_are_persisted_not_derived_from_sort_order(
+        self, rooms_dir: Path, live_room: dict
+    ) -> None:
+        """A handle's roster position shifts; its ports must not move with it."""
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+        reviewer = room_mod._load_member_state("desk", rooms_dir, "reviewer")
+        assert reviewer is not None
+        first_ports = (reviewer["pub_port"], reviewer["rep_port"])
+
+        # 'builder' sorts before 'reviewer' — a derived index would move it.
+        _join(rooms_dir, "--persona", "coder", "--room", "desk", "--as", "builder")
+
+        reviewer_after = room_mod._load_member_state("desk", rooms_dir, "reviewer")
+        assert reviewer_after is not None
+        assert (reviewer_after["pub_port"], reviewer_after["rep_port"]) == first_ports
+
+    def test_members_do_not_share_ports(self, rooms_dir: Path, live_room: dict) -> None:
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+        _join(rooms_dir, "--persona", "coder", "--room", "desk", "--as", "builder")
+
+        ports = {
+            room_mod._load_member_state("desk", rooms_dir, handle)["pub_port"]
+            for handle in ("reviewer", "builder")
+        }
+        assert len(ports) == 2
+
+
+class TestClusterFile:
+    def test_roster_lists_every_member(self, rooms_dir: Path, live_room: dict) -> None:
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+        _join(rooms_dir, "--persona", "coder", "--room", "desk", "--as", "builder")
+
+        cluster = room_mod._cluster_file_path("desk", rooms_dir).read_text(encoding="utf-8")
+
+        assert "peer_id: reviewer" in cluster
+        assert "peer_id: builder" in cluster
+
+    def test_leaving_removes_the_peer_from_the_roster(
+        self, rooms_dir: Path, live_room: dict
+    ) -> None:
+        """Remaining members must converge on the new roster without a restart."""
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+        _join(rooms_dir, "--persona", "coder", "--room", "desk", "--as", "builder")
+
+        runner.invoke(
+            app, ["leave", "--as", "builder", "--room", "desk", "--rooms-dir", str(rooms_dir)]
+        )
+
+        cluster = room_mod._cluster_file_path("desk", rooms_dir).read_text(encoding="utf-8")
+        assert "peer_id: reviewer" in cluster
+        assert "peer_id: builder" not in cluster
+
+    def test_a_failed_join_leaves_no_ghost_peer(self, rooms_dir: Path, live_room: dict) -> None:
+        live_room["registered"] = False
+
+        _join(rooms_dir, "--persona", "reviewer", "--room", "desk")
+
+        cluster = room_mod._cluster_file_path("desk", rooms_dir).read_text(encoding="utf-8")
+        assert "peer_id: reviewer" not in cluster

--- a/tests/test_ravn/test_cli_room_membership.py
+++ b/tests/test_ravn/test_cli_room_membership.py
@@ -611,3 +611,132 @@ class TestClusterFile:
 
         cluster = room_mod._cluster_file_path("desk", rooms_dir).read_text(encoding="utf-8")
         assert "peer_id: reviewer" not in cluster
+
+
+class TestMentionParsing:
+    """Operator input parsing — resolves what a human typed, nothing more."""
+
+    PEERS = {"reviewer", "builder", "human:jozef"}
+
+    def test_resolves_a_known_handle(self) -> None:
+        assert room_mod._parse_mentions("@reviewer look", self.PEERS) == (["reviewer"], [])
+
+    def test_resolves_several_in_order(self) -> None:
+        resolved, _ = room_mod._parse_mentions(
+            "@builder build it then @reviewer check it", self.PEERS
+        )
+        assert resolved == ["builder", "reviewer"]
+
+    def test_duplicates_collapse(self) -> None:
+        resolved, _ = room_mod._parse_mentions("@reviewer and @reviewer", self.PEERS)
+        assert resolved == ["reviewer"]
+
+    def test_matching_is_case_insensitive(self) -> None:
+        assert room_mod._parse_mentions("@Reviewer", self.PEERS)[0] == ["reviewer"]
+
+    def test_humans_answer_to_their_bare_name(self) -> None:
+        assert room_mod._parse_mentions("@jozef ping", self.PEERS)[0] == ["human:jozef"]
+
+    def test_unknown_handle_is_reported_not_guessed(self) -> None:
+        resolved, unresolved = room_mod._parse_mentions("@reviwer look", self.PEERS)
+        assert resolved == []
+        assert unresolved == ["reviwer"]
+
+    def test_inline_code_does_not_address(self) -> None:
+        assert room_mod._parse_mentions("use `@reviewer` here", self.PEERS) == ([], [])
+
+    def test_fenced_block_does_not_address(self) -> None:
+        body = "look:\n```python\n@reviewer\n```\nthoughts?"
+        assert room_mod._parse_mentions(body, self.PEERS) == ([], [])
+
+    def test_mention_outside_a_fence_still_resolves(self) -> None:
+        body = "```\n@builder\n```\n@reviewer please review it"
+        assert room_mod._parse_mentions(body, self.PEERS)[0] == ["reviewer"]
+
+
+class TestPostMentionRouting:
+    @pytest.fixture
+    def posted(self, monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str, dict]]:
+        calls: list[tuple[str, str, dict]] = []
+        monkeypatch.setattr(
+            room_mod,
+            "_post",
+            lambda base, path, payload: (calls.append((base, path, payload)), {})[1],
+        )
+        monkeypatch.setattr(
+            room_mod,
+            "_fetch_participants",
+            lambda rd: [
+                {"peer_id": "reviewer"},
+                {"peer_id": "builder"},
+                {"peer_id": "human:jozef"},
+            ],
+        )
+        monkeypatch.setattr(room_mod, "_last_speaker", lambda rd, exclude: "")
+        return calls
+
+    def _cmd(self, rooms_dir: Path, body: str, *extra: str):
+        return runner.invoke(
+            room_app,
+            [
+                "post",
+                body,
+                "--as",
+                "human:jozef",
+                "--room",
+                "desk",
+                "--rooms-dir",
+                str(rooms_dir),
+                *extra,
+            ],
+        )
+
+    def test_mention_delivers_to_that_member(
+        self, rooms_dir: Path, live_room: dict, posted: list
+    ) -> None:
+        result = self._cmd(rooms_dir, "@reviewer take a look")
+
+        assert result.exit_code == 0, result.output
+        assert posted[0][1] == "/api/room/direct"
+        assert posted[0][2]["target_peer_id"] == "reviewer"
+
+    def test_two_mentions_fan_out_with_the_whole_body(
+        self, rooms_dir: Path, live_room: dict, posted: list
+    ) -> None:
+        """Each recipient gets the full message, not a per-mention slice."""
+        body = "@builder build it then @reviewer check it"
+        result = self._cmd(rooms_dir, body)
+
+        assert result.exit_code == 0, result.output
+        assert [p["target_peer_id"] for _, _, p in posted] == ["builder", "reviewer"]
+        assert all(p["content"] == body for _, _, p in posted)
+
+    def test_self_mention_does_not_reinvoke_the_author(
+        self, rooms_dir: Path, live_room: dict, posted: list
+    ) -> None:
+        result = self._cmd(rooms_dir, "@jozef noting for myself")
+
+        assert result.exit_code == 0, result.output
+        assert posted[0][1] == "/api/room/message"
+
+    def test_to_overrides_mentions(self, rooms_dir: Path, live_room: dict, posted: list) -> None:
+        result = self._cmd(rooms_dir, "@reviewer look", "--to", "builder")
+
+        assert result.exit_code == 0, result.output
+        assert posted[0][2]["target_peer_id"] == "builder"
+
+    def test_misaddress_warns_and_falls_back(
+        self, rooms_dir: Path, live_room: dict, posted: list
+    ) -> None:
+        result = self._cmd(rooms_dir, "@reviwer look")
+
+        assert result.exit_code == 0, result.output
+        assert "no member matches @reviwer" in result.output
+        assert posted[0][1] == "/api/room/message"
+
+    def test_dry_run_delivers_nothing(self, rooms_dir: Path, live_room: dict, posted: list) -> None:
+        result = self._cmd(rooms_dir, "@reviewer look", "--dry-run")
+
+        assert result.exit_code == 0, result.output
+        assert posted == []
+        assert "recipients: reviewer" in result.output

--- a/tests/test_ravn/test_flock_cli.py
+++ b/tests/test_ravn/test_flock_cli.py
@@ -153,3 +153,21 @@ def test_runtime_helpers_round_trip_and_delete_state(tmp_path: Path) -> None:
 
     _delete_runtime(tmp_path)
     assert _load_runtime(tmp_path) is None
+
+
+def test_mdns_discovery_uses_the_adapters_list(tmp_path: Path) -> None:
+    """Regression: the legacy `adapter: mdns` shape parsed but built nothing.
+
+    `_build_discovery` reads `settings.discovery.adapters`, so a node written
+    with the old single-`adapter` key started with discovery disabled and no
+    mesh-routing tools — peers never found each other.
+    """
+    node = _node(tmp_path)
+
+    _write_node_config(node, tmp_path, discovery="mdns", mesh_transport="tcp")
+
+    config = Path(node.config_path).read_text(encoding="utf-8")
+    assert "adapters:" in config
+    assert "ravn.adapters.discovery.mdns.MdnsDiscoveryAdapter" in config
+    assert f"handshake_port: {node.handshake_port}" in config
+    assert "adapter: mdns" not in config

--- a/tests/test_ravn/test_flock_cli_commands.py
+++ b/tests/test_ravn/test_flock_cli_commands.py
@@ -415,3 +415,124 @@ def test_python_tail_prints_last_lines_without_following(tmp_path: Path) -> None
 
     # follow=False prints the last *lines* and returns; a missing path is skipped.
     _python_tail([str(log), str(tmp_path / "missing.log")], lines=3, follow=False)
+
+
+class TestFlockRoomMembership:
+    """`flock init --room` makes a flock and a room roster the same ravens."""
+
+    def _room(self, tmp_path: Path) -> Path:
+        from ravn.cli.room import RoomDef, _room_def_path
+
+        rooms = tmp_path / "rooms"
+        (rooms / "desk").mkdir(parents=True)
+        room_def = RoomDef(
+            name="desk",
+            environment_id="desk",
+            host="127.0.0.1",
+            port=7500,
+            created_at="2026-07-26T00:00:00+00:00",
+        )
+        _room_def_path("desk", rooms).write_text(room_def.to_yaml(), encoding="utf-8")
+        return rooms
+
+    def test_nodes_get_the_room_channel(self, tmp_path: Path) -> None:
+        rooms = self._room(tmp_path)
+
+        result = runner.invoke(
+            flock_app,
+            [
+                "init",
+                "coordinator",
+                "--flock-dir",
+                str(tmp_path / "flock"),
+                "--room",
+                "desk",
+                "--rooms-dir",
+                str(rooms),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        config = (tmp_path / "flock" / "node-coordinator.yaml").read_text()
+        assert "skuld:" in config
+        assert "broker_url: ws://127.0.0.1:7500/ws/ravn" in config
+
+    def test_without_room_no_skuld_block_is_added(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            flock_app, ["init", "coordinator", "--flock-dir", str(tmp_path / "flock")]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "skuld:" not in (tmp_path / "flock" / "node-coordinator.yaml").read_text()
+
+    def test_unknown_room_fails_before_writing_configs(self, tmp_path: Path) -> None:
+        """A typo must not produce a flock that quietly joins nothing."""
+        rooms = self._room(tmp_path)
+
+        result = runner.invoke(
+            flock_app,
+            [
+                "init",
+                "coordinator",
+                "--flock-dir",
+                str(tmp_path / "flock"),
+                "--room",
+                "ghost",
+                "--rooms-dir",
+                str(rooms),
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Unknown room 'ghost'" in result.output
+        assert not (tmp_path / "flock" / "node-coordinator.yaml").exists()
+
+    def test_room_nodes_are_responsive_by_default(self, tmp_path: Path) -> None:
+        """A room node answers what is addressed to it instead of self-driving."""
+        rooms = self._room(tmp_path)
+
+        runner.invoke(
+            flock_app,
+            [
+                "init",
+                "coordinator",
+                "--flock-dir",
+                str(tmp_path / "flock"),
+                "--room",
+                "desk",
+                "--rooms-dir",
+                str(rooms),
+            ],
+        )
+
+        config = (tmp_path / "flock" / "node-coordinator.yaml").read_text()
+        assert "dream_cycle" in config
+        assert "resident_wakefulness" in config
+
+    def test_autonomous_room_nodes_keep_their_triggers(self, tmp_path: Path) -> None:
+        rooms = self._room(tmp_path)
+
+        runner.invoke(
+            flock_app,
+            [
+                "init",
+                "coordinator",
+                "--flock-dir",
+                str(tmp_path / "flock"),
+                "--room",
+                "desk",
+                "--rooms-dir",
+                str(rooms),
+                "--autonomous",
+            ],
+        )
+
+        config = (tmp_path / "flock" / "node-coordinator.yaml").read_text()
+        assert "dream_cycle" not in config
+
+    def test_a_roomless_flock_is_unchanged(self, tmp_path: Path) -> None:
+        """Plain `flock init` keeps its long-standing autonomous behaviour."""
+        runner.invoke(flock_app, ["init", "coordinator", "--flock-dir", str(tmp_path / "flock")])
+
+        config = (tmp_path / "flock" / "node-coordinator.yaml").read_text()
+        assert "dream_cycle" not in config


### PR DESCRIPTION
## What changed

- add ravn room lifecycle and participant commands
- add top-level ravn join and ravn leave membership supervision
- keep room members on the existing shared mesh/discovery path
- address room messages through explicit participant mentions
- extract process supervision, daemon config, and persona/profile registries into focused CLI modules
- resolve persona paths consistently for flock and room operations

## Why

Ravn needs a direct local room surface that uses the existing shared Niuu collaboration contract without placing room ownership inside Skuld or introducing a second collaboration stack.

## Validation

- Ruff passes for all touched runtime and test modules
- 214 focused room, membership, supervision, daemon-config, and flock tests pass
- branch includes current dev after Observatory workload-identity PR #866
- git diff check passes
