### PR TITLE
feat(ravn): configure private web fetch access

### DIFF
--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -210,6 +210,7 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
         adapter="ravn.adapters.tools.web_fetch.WebFetchTool",
         groups=frozenset({"core"}),
         kwargs_fn=lambda s, ctx: {
+            "allow_private_addresses": s.tools.web.fetch.allow_private_addresses,
             "timeout": s.tools.web.fetch.timeout,
             "user_agent": s.tools.web.fetch.user_agent,
             "content_budget": s.tools.web.fetch.content_budget,

--- a/src/ravn/adapters/tools/web_fetch.py
+++ b/src/ravn/adapters/tools/web_fetch.py
@@ -106,7 +106,7 @@ def truncate_to_budget(text: str, budget: int) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _validate_url(url: str) -> str | None:
+def _validate_url(url: str, *, allow_private_addresses: bool = False) -> str | None:
     """Return an error message if *url* is disallowed, else None.
 
     Blocks:
@@ -121,6 +121,8 @@ def _validate_url(url: str) -> str | None:
     if not hostname:
         return "Blocked: URL has no hostname"
 
+    if allow_private_addresses:
+        return None
     return check_ssrf(hostname)
 
 
@@ -140,10 +142,12 @@ class WebFetchTool(ToolPort):
     def __init__(
         self,
         *,
+        allow_private_addresses: bool = False,
         timeout: float = _DEFAULT_TIMEOUT,
         user_agent: str = _DEFAULT_USER_AGENT,
         content_budget: int = _DEFAULT_CONTENT_BUDGET,
     ) -> None:
+        self._allow_private_addresses = allow_private_addresses
         self._timeout = timeout
         self._user_agent = user_agent
         self._content_budget = content_budget
@@ -183,7 +187,10 @@ class WebFetchTool(ToolPort):
         if not url:
             return ToolResult(tool_call_id="", content="url is required", is_error=True)
 
-        url_error = _validate_url(url)
+        url_error = _validate_url(
+            url,
+            allow_private_addresses=self._allow_private_addresses,
+        )
         if url_error:
             return ToolResult(tool_call_id="", content=url_error, is_error=True)
 

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -204,6 +204,13 @@ class TerminalToolConfig(BaseModel):
 class WebFetchConfig(BaseModel):
     """web_fetch tool configuration."""
 
+    allow_private_addresses: bool = Field(
+        default=False,
+        description=(
+            "Allow web_fetch to connect to hosts that resolve to private or reserved "
+            "addresses. Keep disabled for untrusted workloads."
+        ),
+    )
     timeout: float = Field(
         default=30.0,
         description="HTTP request timeout in seconds.",

--- a/tests/ravn/unit/test_builtin_registry.py
+++ b/tests/ravn/unit/test_builtin_registry.py
@@ -264,6 +264,13 @@ class TestKwargsFn:
         assert "num_results" in kwargs
         assert type(kwargs["provider"]).__name__ == "DuckDuckGoLiteSearchProvider"
 
+    def test_web_fetch_kwargs_include_private_address_policy(
+        self, settings: Settings, tmp_path: Path
+    ) -> None:
+        settings.tools.web.fetch.allow_private_addresses = True
+        kwargs = BUILTIN_TOOLS["web_fetch"].kwargs_fn(settings, _make_runtime_ctx(tmp_path))
+        assert kwargs["allow_private_addresses"] is True
+
     def test_ravn_state_kwargs_tool_names_empty(self, settings: Settings, tmp_path: Path) -> None:
         ctx = _make_runtime_ctx(tmp_path)
         kwargs = BUILTIN_TOOLS["ravn_state"].kwargs_fn(settings, ctx)

--- a/tests/ravn/unit/test_web_fetch.py
+++ b/tests/ravn/unit/test_web_fetch.py
@@ -183,6 +183,10 @@ class TestWebFetchToolProperties:
         tool = WebFetchTool(user_agent="TestAgent/1.0")
         assert tool._user_agent == "TestAgent/1.0"
 
+    def test_private_address_access_can_be_enabled(self) -> None:
+        tool = WebFetchTool(allow_private_addresses=True)
+        assert tool._allow_private_addresses is True
+
 
 # ---------------------------------------------------------------------------
 # WebFetchTool.execute — with mocked httpx
@@ -383,6 +387,21 @@ class TestValidateUrl:
             result = _validate_url("http://internal.example.com")
             assert result is not None
             assert "private" in result.lower() or "reserved" in result.lower()
+
+    def test_private_ip_allowed_when_configured(self) -> None:
+        import socket
+        from unittest.mock import patch
+
+        with patch.object(
+            socket, "getaddrinfo", return_value=[(None, None, None, None, ("192.168.1.1", 0))]
+        ):
+            assert (
+                _validate_url(
+                    "http://internal.example.com",
+                    allow_private_addresses=True,
+                )
+                is None
+            )
 
     def test_localhost_blocked(self) -> None:
         import socket

--- a/tests/test_ravn/test_config.py
+++ b/tests/test_ravn/test_config.py
@@ -31,6 +31,7 @@ from ravn.config import (
     ToolAdapterConfig,
     ToolsConfig,
     TrustGradientConfig,
+    WebFetchConfig,
     resolve_trust_tools,
 )
 
@@ -238,6 +239,14 @@ class TestPermissionConfig:
         assert "write_file" in c.ask
         assert c.rules[0].pattern == "net:*"
         assert c.rules[0].action == "deny"
+
+
+class TestWebFetchConfig:
+    def test_private_addresses_are_blocked_by_default(self) -> None:
+        assert WebFetchConfig().allow_private_addresses is False
+
+    def test_private_addresses_can_be_enabled(self) -> None:
+        assert WebFetchConfig(allow_private_addresses=True).allow_private_addresses is True
 
 
 class TestContextConfig:


### PR DESCRIPTION
## Summary

- add a secure-by-default `tools.web.fetch.allow_private_addresses` setting
- thread the setting through the built-in web-fetch adapter
- retain scheme and hostname validation when private address access is enabled

## Verification

- `uv run --extra dev pytest -q tests/ravn/unit/test_web_fetch.py tests/ravn/unit/test_builtin_registry.py tests/test_ravn/test_config.py` (265 passed)
- focused Ruff checks passed
