### PR TITLE
fix(ravn): expose active A2A tasks in resident HUD

### DIFF
--- a/src/ravn/adapters/tool_build/a2a.py
+++ b/src/ravn/adapters/tool_build/a2a.py
@@ -82,6 +82,7 @@ class A2AToolBuildBackend(ToolBuildBackend):
         poll_interval_seconds: float = 5.0,
         gate_reviewer: GateReviewer | None = None,
         question_answerer: QuestionAnswerer | None = None,
+        activity_emitter: Callable[[dict[str, object]], Awaitable[None]] | None = None,
         max_gate_rounds: int = 3,
         sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     ) -> None:
@@ -116,6 +117,7 @@ class A2AToolBuildBackend(ToolBuildBackend):
         # silently auto-approved or guessed.
         self._gate_reviewer = gate_reviewer
         self._question_answerer = question_answerer
+        self._activity_emitter = activity_emitter
         self._max_gate_rounds = max_gate_rounds
         self._sleep = sleep
 
@@ -275,6 +277,7 @@ class A2AToolBuildBackend(ToolBuildBackend):
             endpoint,
             task_id,
             request,
+            workflow_id=workflow_id,
             exchanges=exchanges,
             rounds=rounds,
         )
@@ -319,6 +322,7 @@ class A2AToolBuildBackend(ToolBuildBackend):
         task_id: str,
         request: ToolBuildRequest,
         *,
+        workflow_id: str,
         exchanges: list[dict[str, Any]] | None = None,
         rounds: int = 0,
     ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
@@ -337,11 +341,31 @@ class A2AToolBuildBackend(ToolBuildBackend):
             "a2a.endpoint": endpoint,
             "a2a.task.max_poll_attempts": self._max_poll_attempts,
         }
+        last_activity: tuple[str, str, str] | None = None
         with telemetry.span("ravn.a2a.task.wait", attributes=attributes) as span:
             try:
                 for attempt in range(self._max_poll_attempts):
                     task = await self._get_task(endpoint, task_id)
                     state = _task_state(task)
+                    question = _activity_question(task)
+                    status_message = _task_status_message(task)
+                    activity = (state, question, status_message)
+                    if activity != last_activity:
+                        await self._emit_activity(
+                            {
+                                "agent_id": self._card_url,
+                                "skill_id": workflow_id,
+                                "task_id": task_id,
+                                "state": state or "TASK_STATE_UNSPECIFIED",
+                                "operation": "build",
+                                "input_required": state == _INPUT_REQUIRED_STATE,
+                                "question": question,
+                                "prompt": request.build_request[:500],
+                                "status_message": status_message,
+                                "source_tool": "build_tool",
+                            }
+                        )
+                        last_activity = activity
                     span.set_attribute("a2a.task.state", state)
                     span.set_attribute("a2a.task.poll_attempt", attempt + 1)
                     telemetry.event(
@@ -424,6 +448,14 @@ class A2AToolBuildBackend(ToolBuildBackend):
                 },
             )
             return task, exchanges
+
+    async def _emit_activity(self, activity: dict[str, object]) -> None:
+        if self._activity_emitter is None:
+            return
+        try:
+            await self._activity_emitter(activity)
+        except Exception:
+            logger.exception("Failed to capture A2A tool-build activity")
 
     async def _resume_task_input(
         self,
@@ -1044,6 +1076,27 @@ def _task_state(task: Any) -> str:
     if not isinstance(status, dict):
         return ""
     return str(status.get("state") or "")
+
+
+def _task_status_message(task: dict[str, Any]) -> str:
+    status = task.get("status")
+    if not isinstance(status, dict):
+        return ""
+    return str(status.get("message") or status.get("update") or "")[:500]
+
+
+def _activity_question(task: dict[str, Any]) -> str:
+    question = _first_pending_question(task)
+    if question:
+        return str(question.get("question") or question.get("summary") or "")[:500]
+    gate = _first_pending_gate(task)
+    if not gate:
+        return ""
+    return " — ".join(
+        str(gate.get(key) or "").strip()
+        for key in ("label", "condition", "instructions", "summary")
+        if str(gate.get(key) or "").strip()
+    )[:500]
 
 
 def _continuation_exchanges(continuation: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/ravn/adapters/tools/a2a_task.py
+++ b/src/ravn/adapters/tools/a2a_task.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 from uuid import uuid4
 
@@ -19,6 +21,8 @@ _INPUT_REQUIRED_STATE = "TASK_STATE_INPUT_REQUIRED"
 _DEFAULT_RESULT_MAX_CHARS = 12_000
 _DEFAULT_MESSAGE_MAX_CHARS = 12_000
 
+logger = logging.getLogger(__name__)
+
 
 class A2ATaskTool(ToolPort):
     """Start, inspect, answer, or cancel a task on a discovered peer agent."""
@@ -31,6 +35,7 @@ class A2ATaskTool(ToolPort):
         trusted_origins: list[str] | None = None,
         result_max_chars: int = _DEFAULT_RESULT_MAX_CHARS,
         message_max_chars: int = _DEFAULT_MESSAGE_MAX_CHARS,
+        activity_emitter: Callable[[dict[str, object]], Awaitable[None]] | None = None,
     ) -> None:
         self._directory = agent_directory
         self._client = client
@@ -39,6 +44,7 @@ class A2ATaskTool(ToolPort):
         )
         self._result_max_chars = max(1_000, result_max_chars)
         self._message_max_chars = max(1_000, message_max_chars)
+        self._activity_emitter = activity_emitter
 
     @property
     def name(self) -> str:
@@ -196,6 +202,23 @@ class A2ATaskTool(ToolPort):
                 "a2a.task.state": state or "unknown",
             },
         )
+        await self._emit_activity(
+            {
+                "agent_id": agent.id,
+                "skill_id": str(input.get("skill_id") or ""),
+                "task_id": task_id,
+                "state": state or "TASK_STATE_UNSPECIFIED",
+                "operation": operation,
+                "input_required": state == _INPUT_REQUIRED_STATE,
+                "question": _pending_question(task),
+                "prompt": _truncate(str(input.get("prompt") or ""), 500),
+                "status_message": _truncate(
+                    str(status.get("message") or status.get("update") or ""),
+                    500,
+                ),
+                "source_tool": self.name,
+            }
+        )
         return ToolResult(
             tool_call_id="",
             content=_render_response_payload(
@@ -206,6 +229,14 @@ class A2ATaskTool(ToolPort):
                 max_chars=self._result_max_chars,
             ),
         )
+
+    async def _emit_activity(self, activity: dict[str, object]) -> None:
+        if self._activity_emitter is None or not activity.get("task_id"):
+            return
+        try:
+            await self._activity_emitter(activity)
+        except Exception:
+            logger.exception("Failed to capture A2A task activity")
 
     async def _execute_operation(
         self,
@@ -356,6 +387,19 @@ def _jsonrpc_endpoint(agent: AgentDirectoryEntry) -> str:
             continue
         if interface.url:
             return interface.url
+    return ""
+
+
+def _pending_question(task: dict[str, Any]) -> str:
+    metadata = task.get("metadata")
+    if not isinstance(metadata, dict):
+        return ""
+    questions = metadata.get("pendingQuestions")
+    if not isinstance(questions, list):
+        return ""
+    for item in questions:
+        if isinstance(item, dict):
+            return _truncate(str(item.get("question") or item.get("summary") or ""), 500)
     return ""
 
 

--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -392,6 +392,7 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
             "trusted_origins": ctx["a2a_trusted_origins"],
             "message_max_chars": s.gateway.platform.a2a_message_max_chars,
             "result_max_chars": s.gateway.platform.a2a_result_max_chars,
+            "activity_emitter": ctx.get("a2a_activity_emitter"),
         },
     ),
     "ting_plan": BuiltinToolDef(

--- a/src/ravn/cli/daemon_runtime.py
+++ b/src/ravn/cli/daemon_runtime.py
@@ -169,6 +169,18 @@ async def _run_daemon(
                 fields=fields,
             )
 
+        async def _emit_a2a_activity(activity: dict[str, object]) -> None:
+            if drive_loop is None:
+                return
+            current_task = drive_loop.resolve_task_context(task_id)
+            if current_task is None:
+                logger.warning("a2a_activity: no task context available for task_id=%s", task_id)
+                return
+            drive_loop.record_a2a_activity(
+                parent_task_id=current_task.task_id,
+                activity=activity,
+            )
+
         tools = _build_tools(
             settings,
             workspace,
@@ -187,6 +199,7 @@ async def _run_daemon(
                 drive_loop._session_join_manager if drive_loop is not None else None
             ),
             permission=permission,
+            a2a_activity_emitter=_emit_a2a_activity,
         )
         if profile_cfg.include_mcp:
             tools.extend(_filter_tools(mcp_tools, settings, resolved_persona))
@@ -266,6 +279,7 @@ async def _run_daemon(
             settings=settings,
             publisher=environment_signal_publisher or sleipnir_catalog_publisher or daemon_bus,
             drive_loop=drive_loop,
+            a2a_activity_emitter=_emit_a2a_activity,
         )
 
     tasks: list[asyncio.Task] = []

--- a/src/ravn/cli/runtime_builders.py
+++ b/src/ravn/cli/runtime_builders.py
@@ -59,6 +59,7 @@ def _attach_agent_build_tool(
     settings: Settings,
     publisher: Any | None = None,
     drive_loop: Any | None = None,
+    a2a_activity_emitter: Any | None = None,
 ) -> Any:
     """Attach build_tool when the active persona explicitly allows it."""
     if not enabled:
@@ -137,6 +138,7 @@ def _attach_agent_build_tool(
                 workflow_selector=realm_config.workflow_selector,
                 gate_reviewer=gate_reviewer,
                 question_answerer=question_answerer,
+                activity_emitter=a2a_activity_emitter,
             ),
             investigation_context=_investigation_context,
             max_repair_attempts=settings.resident_evolution.build_repair_attempts,
@@ -155,6 +157,7 @@ def _build_tool_build_backend(
     workflow_selector: dict[str, Any] | None = None,
     gate_reviewer: Any | None = None,
     question_answerer: Any | None = None,
+    activity_emitter: Any | None = None,
 ) -> Any | None:
     """Construct the configured tool build adapter, or None for inline authoring.
 
@@ -180,6 +183,8 @@ def _build_tool_build_backend(
         kwargs["gate_reviewer"] = gate_reviewer
     if question_answerer is not None and _constructor_accepts_kwarg(cls, "question_answerer"):
         kwargs["question_answerer"] = question_answerer
+    if activity_emitter is not None and _constructor_accepts_kwarg(cls, "activity_emitter"):
+        kwargs["activity_emitter"] = activity_emitter
     return cls(**kwargs)
 
 

--- a/src/ravn/cli/tool_builders.py
+++ b/src/ravn/cli/tool_builders.py
@@ -37,6 +37,7 @@ def _build_tools(
     mimir_event_emitter: Callable[[str, dict[str, Any]], Awaitable[None]] | None = None,
     session_join_manager: Any | None = None,
     permission: Any | None = None,
+    a2a_activity_emitter: Callable[[dict[str, object]], Awaitable[None]] | None = None,
 ) -> list[Any]:
     """Build the tool list from the built-in registry, filtered by profile.
 
@@ -81,6 +82,7 @@ def _build_tools(
         "persona_prefix": persona_prefix,
         "discovery": discovery,
         "permission": permission,
+        "a2a_activity_emitter": a2a_activity_emitter,
     }
     runtime_ctx["capability_tools_provider"] = lambda: runtime_ctx.get("capability_tools", [])
 

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -30,7 +30,12 @@ from niuu.domain.mimir import ThreadState
 from niuu.domain.outcome import OutcomeSchema, parse_outcome_block
 from niuu.observability import get_observability
 from niuu.ports.mimir import MimirPort
-from ravn.adapters.channels.capture import CaptureChannel, TaskResult, TaskResultStore
+from ravn.adapters.channels.capture import (
+    CaptureChannel,
+    CapturedEvent,
+    TaskResult,
+    TaskResultStore,
+)
 from ravn.adapters.channels.composite import CompositeChannel
 from ravn.adapters.channels.mesh_channel import MeshActivityChannel
 from ravn.adapters.channels.silent import SilentChannel
@@ -245,105 +250,40 @@ def _resident_hud_a2a_tasks(
     """Project the latest observed state of non-terminal A2A tasks."""
     sessions: dict[str, dict[str, object]] = {}
     for result in results:
-        pending_input: dict[str, object] | None = None
-        pending_started_at: datetime | None = None
         for event in result.events:
+            if event.type != "a2a_task":
+                continue
             details = event.details if isinstance(event.details, dict) else {}
-            if details.get("tool_name") != "a2a_task":
+            task_id = str(details.get("task_id") or "")
+            if not task_id:
                 continue
-            if event.type == "tool_start":
-                supplied = details.get("input")
-                pending_input = dict(supplied) if isinstance(supplied, dict) else {}
-                pending_started_at = event.timestamp
-                continue
-            if event.type != "tool_result":
-                continue
-            payload = details.get("result")
-            if isinstance(payload, str):
-                try:
-                    payload = json.loads(payload)
-                except ValueError:
-                    payload = {}
-            if not isinstance(payload, dict):
-                pending_input = None
-                pending_started_at = None
-                continue
-
-            agent_id = str(payload.get("agent_id") or (pending_input or {}).get("agent_id") or "")
-            task_id = str(payload.get("task_id") or (pending_input or {}).get("task_id") or "")
-            if not agent_id or not task_id:
-                pending_input = None
-                pending_started_at = None
-                continue
-            state = str(payload.get("state") or "TASK_STATE_UNSPECIFIED")
-            key = f"{agent_id}:{task_id}"
+            state = str(details.get("state") or "TASK_STATE_UNSPECIFIED")
             if state in _A2A_TERMINAL_STATES:
-                sessions.pop(key, None)
-            else:
-                prior = sessions.get(key, {})
-                questions = payload.get("pending_questions")
-                if isinstance(questions, str):
-                    try:
-                        questions = json.loads(questions)
-                    except ValueError:
-                        questions = []
-                question = ""
-                if isinstance(questions, list) and questions and isinstance(questions[0], dict):
-                    question = str(questions[0].get("question") or "")
-                task_input = pending_input or {}
-                sessions[key] = {
-                    "agent_id": agent_id,
-                    "skill_id": str(task_input.get("skill_id") or prior.get("skill_id") or ""),
-                    "task_id": task_id,
-                    "state": state,
-                    "operation": str(payload.get("operation") or task_input.get("operation") or ""),
-                    "input_required": bool(payload.get("input_required")),
-                    "question": _bounded_hud_text(question, 500),
-                    "prompt": _bounded_hud_text(
-                        str(task_input.get("prompt") or prior.get("prompt") or ""),
-                        500,
-                    ),
-                    "status_message": _bounded_hud_text(
-                        str(payload.get("status_message") or ""),
-                        500,
-                    ),
-                    "parent_task_id": result.task_id,
-                    "parent_active": result.task_id in active_parent_ids,
-                    "started_at": prior.get("started_at")
-                    or (pending_started_at or event.timestamp).isoformat(),
-                    "observed_at": event.timestamp.isoformat(),
-                }
-            pending_input = None
-            pending_started_at = None
-
-        if pending_input is not None and pending_started_at is not None:
-            agent_id = str(pending_input.get("agent_id") or "")
-            if agent_id:
-                supplied_task_id = str(pending_input.get("task_id") or "")
-                key = (
-                    supplied_task_id
-                    and f"{agent_id}:{supplied_task_id}"
-                    or (f"call:{result.task_id}:{pending_started_at.isoformat()}")
-                )
-                prior = sessions.get(key, {})
-                sessions[key] = {
-                    "agent_id": agent_id,
-                    "skill_id": str(pending_input.get("skill_id") or prior.get("skill_id") or ""),
-                    "task_id": supplied_task_id,
-                    "state": "CALL_IN_PROGRESS",
-                    "operation": str(pending_input.get("operation") or ""),
-                    "input_required": False,
-                    "question": "",
-                    "prompt": _bounded_hud_text(
-                        str(pending_input.get("prompt") or prior.get("prompt") or ""),
-                        500,
-                    ),
-                    "status_message": "",
-                    "parent_task_id": result.task_id,
-                    "parent_active": result.task_id in active_parent_ids,
-                    "started_at": prior.get("started_at") or pending_started_at.isoformat(),
-                    "observed_at": pending_started_at.isoformat(),
-                }
+                sessions.pop(task_id, None)
+                continue
+            prior = sessions.get(task_id, {})
+            sessions[task_id] = {
+                "agent_id": str(details.get("agent_id") or prior.get("agent_id") or ""),
+                "skill_id": str(details.get("skill_id") or prior.get("skill_id") or ""),
+                "task_id": task_id,
+                "state": state,
+                "operation": str(details.get("operation") or prior.get("operation") or ""),
+                "input_required": bool(details.get("input_required")),
+                "question": _bounded_hud_text(str(details.get("question") or ""), 500),
+                "prompt": _bounded_hud_text(
+                    str(details.get("prompt") or prior.get("prompt") or ""),
+                    500,
+                ),
+                "status_message": _bounded_hud_text(
+                    str(details.get("status_message") or ""),
+                    500,
+                ),
+                "source_tool": str(details.get("source_tool") or prior.get("source_tool") or ""),
+                "parent_task_id": result.task_id,
+                "parent_active": result.task_id in active_parent_ids,
+                "started_at": prior.get("started_at") or event.timestamp.isoformat(),
+                "observed_at": event.timestamp.isoformat(),
+            }
     return sorted(
         sessions.values(),
         key=lambda item: str(item.get("observed_at") or ""),
@@ -1699,6 +1639,27 @@ class DriveLoop:
         merged = dict(existing)
         merged.update(fields)
         task.tool_outcomes[event_type] = merged
+
+    def record_a2a_activity(
+        self,
+        *,
+        parent_task_id: str,
+        activity: dict[str, object],
+    ) -> None:
+        """Capture an A2A task state already observed by a resident tool."""
+        task_id = str(activity.get("task_id") or "").strip()
+        if not parent_task_id or not task_id:
+            return
+        state = str(activity.get("state") or "TASK_STATE_UNSPECIFIED")
+        self._result_store.append_event(
+            parent_task_id,
+            CapturedEvent(
+                type="a2a_task",
+                summary=f"A2A task {task_id}: {state}",
+                timestamp=datetime.now(UTC),
+                details=dict(activity),
+            ),
+        )
 
     def _authoritative_valkyrie_fields(self, task: AgentTask) -> dict[str, object]:
         """Return identity/correlation data owned by runtime configuration."""

--- a/tests/test_ravn/test_a2a_task_tool.py
+++ b/tests/test_ravn/test_a2a_task_tool.py
@@ -104,6 +104,11 @@ class _Client:
 
 @pytest.mark.asyncio
 async def test_a2a_task_preserves_task_state_questions_artifacts_and_provenance() -> None:
+    activities: list[dict[str, object]] = []
+
+    async def _capture(activity: dict[str, object]) -> None:
+        activities.append(activity)
+
     client = _Client(
         [
             {"task": {"id": "task-1", "status": {"state": "TASK_STATE_SUBMITTED"}}},
@@ -117,7 +122,11 @@ async def test_a2a_task_preserves_task_state_questions_artifacts_and_provenance(
             {"id": "task-1", "status": {"state": "TASK_STATE_CANCELED"}},
         ]
     )
-    tool = A2ATaskTool(agent_directory=_Directory(_agent()), client=client)
+    tool = A2ATaskTool(
+        agent_directory=_Directory(_agent()),
+        client=client,
+        activity_emitter=_capture,
+    )
 
     started = json.loads(
         (
@@ -178,6 +187,14 @@ async def test_a2a_task_preserves_task_state_questions_artifacts_and_provenance(
     assert reply_message["taskId"] == "task-1"
     assert reply_message["metadata"] == {"requestId": "question-1"}
     assert all(url == "https://peer.example/a2a" for url, _, _ in client.posts)
+    assert [activity["state"] for activity in activities] == [
+        "TASK_STATE_SUBMITTED",
+        "TASK_STATE_INPUT_REQUIRED",
+        "TASK_STATE_WORKING",
+        "TASK_STATE_CANCELED",
+    ]
+    assert activities[0]["source_tool"] == "a2a_task"
+    assert activities[1]["question"] == "Which branch?"
 
 
 @pytest.mark.asyncio

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -325,42 +325,23 @@ Determine whether the observations require action.
         dl._active_tasks[parent.task_id] = MagicMock()
         dl._inflight_tasks[parent.task_id] = parent
         dl._result_store.start(parent.task_id, parent.triggered_by)
-        started_at = datetime(2026, 7, 25, 10, 0, tzinfo=UTC)
         observed_at = datetime(2026, 7, 25, 10, 1, tzinfo=UTC)
         dl._result_store.append_event(
             parent.task_id,
             CapturedEvent(
-                type="tool_start",
-                summary="tool: a2a_task(...)",
-                timestamp=started_at,
-                details={
-                    "tool_name": "a2a_task",
-                    "input": {
-                        "operation": "start",
-                        "agent_id": "agent-1",
-                        "skill_id": "research",
-                        "prompt": "Investigate the observed fault.",
-                    },
-                },
-            ),
-        )
-        dl._result_store.append_event(
-            parent.task_id,
-            CapturedEvent(
-                type="tool_result",
-                summary="→ working",
+                type="a2a_task",
+                summary="A2A task task-1: TASK_STATE_INPUT_REQUIRED",
                 timestamp=observed_at,
                 details={
-                    "tool_name": "a2a_task",
-                    "result": {
-                        "operation": "start",
-                        "agent_id": "agent-1",
-                        "task_id": "task-1",
-                        "state": "TASK_STATE_INPUT_REQUIRED",
-                        "input_required": True,
-                        "pending_questions": [{"question": "Which firmware version?"}],
-                    },
-                    "is_error": False,
+                    "operation": "build",
+                    "agent_id": "agent-1",
+                    "skill_id": "research",
+                    "task_id": "task-1",
+                    "state": "TASK_STATE_INPUT_REQUIRED",
+                    "input_required": True,
+                    "question": "Which firmware version?",
+                    "prompt": "Investigate the observed fault.",
+                    "source_tool": "build_tool",
                 },
             ),
         )
@@ -374,14 +355,15 @@ Determine whether the observations require action.
                 "skill_id": "research",
                 "task_id": "task-1",
                 "state": "TASK_STATE_INPUT_REQUIRED",
-                "operation": "start",
+                "operation": "build",
                 "input_required": True,
                 "question": "Which firmware version?",
                 "prompt": "Investigate the observed fault.",
                 "status_message": "",
+                "source_tool": "build_tool",
                 "parent_task_id": "parent-task",
                 "parent_active": True,
-                "started_at": started_at.isoformat(),
+                "started_at": observed_at.isoformat(),
                 "observed_at": observed_at.isoformat(),
             }
         ]
@@ -389,39 +371,46 @@ Determine whether the observations require action.
         dl._result_store.append_event(
             parent.task_id,
             CapturedEvent(
-                type="tool_start",
-                summary="tool: a2a_task(...)",
-                timestamp=observed_at,
-                details={
-                    "tool_name": "a2a_task",
-                    "input": {
-                        "operation": "get",
-                        "agent_id": "agent-1",
-                        "task_id": "task-1",
-                    },
-                },
-            ),
-        )
-        dl._result_store.append_event(
-            parent.task_id,
-            CapturedEvent(
-                type="tool_result",
-                summary="→ complete",
+                type="a2a_task",
+                summary="A2A task task-1: TASK_STATE_COMPLETED",
                 timestamp=datetime(2026, 7, 25, 10, 2, tzinfo=UTC),
                 details={
-                    "tool_name": "a2a_task",
-                    "result": {
-                        "operation": "get",
-                        "agent_id": "agent-1",
-                        "task_id": "task-1",
-                        "state": "TASK_STATE_COMPLETED",
-                    },
-                    "is_error": False,
+                    "operation": "build",
+                    "agent_id": "agent-1",
+                    "task_id": "task-1",
+                    "state": "TASK_STATE_COMPLETED",
+                    "source_tool": "build_tool",
                 },
             ),
         )
 
         assert dl.resident_hud_status()["a2a_tasks"] == []
+
+    def test_record_a2a_activity_captures_the_polled_remote_state(self):
+        dl, _ = _make_drive_loop_with_mesh(cascade_enabled=True)
+        parent = _make_task("parent-task")
+        dl._active_tasks[parent.task_id] = MagicMock()
+        dl._inflight_tasks[parent.task_id] = parent
+        dl._result_store.start(parent.task_id, parent.triggered_by)
+
+        dl.record_a2a_activity(
+            parent_task_id=parent.task_id,
+            activity={
+                "agent_id": "https://ting.example/.well-known/agent-card.json",
+                "skill_id": "tool-builder",
+                "task_id": "task-1",
+                "state": "TASK_STATE_WORKING",
+                "operation": "build",
+                "source_tool": "build_tool",
+            },
+        )
+
+        status = dl.resident_hud_status()
+
+        assert status["a2a_count"] == 1
+        assert status["a2a_tasks"][0]["task_id"] == "task-1"
+        assert status["a2a_tasks"][0]["state"] == "TASK_STATE_WORKING"
+        assert status["a2a_tasks"][0]["source_tool"] == "build_tool"
 
     @pytest.mark.asyncio
     async def test_no_cascade_skuld_and_mesh_uses_composite(self):

--- a/tests/test_ravn/test_signal_build_tool_wiring.py
+++ b/tests/test_ravn/test_signal_build_tool_wiring.py
@@ -179,6 +179,21 @@ def test_build_tool_build_backend_applies_realm_selector_override() -> None:
     assert backend._workflow_selector.tags == []
 
 
+def test_build_tool_build_backend_injects_a2a_activity_emitter() -> None:
+    configured = Settings(
+        resident_evolution={
+            "tool_build_adapter": "ravn.adapters.tool_build.A2AToolBuildBackend",
+            "tool_build_kwargs": {"card_url": "https://ting.example/.well-known/agent-card.json"},
+        }
+    )
+    emitter = AsyncMock()
+
+    backend = _build_tool_build_backend(configured, activity_emitter=emitter)
+
+    assert backend is not None
+    assert backend._activity_emitter is emitter
+
+
 # ---------------------------------------------------------------------------
 # _resolve_realm_build_config — realm grant resolution + fallbacks
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_tool_build_backends.py
+++ b/tests/test_ravn/test_tool_build_backends.py
@@ -852,6 +852,11 @@ def _a2a_backend(client: _FakeHttpClient, **kwargs) -> A2AToolBuildBackend:
 
 
 async def test_a2a_backend_builds_from_inline_canonical_artifact() -> None:
+    activities: list[dict[str, object]] = []
+
+    async def _capture(activity: dict[str, object]) -> None:
+        activities.append(activity)
+
     artifacts = [
         {
             "artifactId": "research/campaigns/task-1/learned_tool.json",
@@ -868,7 +873,7 @@ async def test_a2a_backend_builds_from_inline_canonical_artifact() -> None:
             ],
         }
     )
-    backend = _a2a_backend(client, workflow_id="wf-1")
+    backend = _a2a_backend(client, workflow_id="wf-1", activity_emitter=_capture)
 
     result = await backend.build(_request())
 
@@ -889,6 +894,22 @@ async def test_a2a_backend_builds_from_inline_canonical_artifact() -> None:
     assert message["parts"][0]["text"]
     assert client.post_bodies[1]["method"] == "GetTask"
     assert all(headers.get("A2A-Version") == "1.0" for headers in client.headers_seen)
+    assert [activity["state"] for activity in activities] == [
+        "TASK_STATE_WORKING",
+        "TASK_STATE_COMPLETED",
+    ]
+    assert activities[0] == {
+        "agent_id": "https://ting.example/.well-known/agent-card.json",
+        "skill_id": "wf-1",
+        "task_id": "task-1",
+        "state": "TASK_STATE_WORKING",
+        "operation": "build",
+        "input_required": False,
+        "question": "",
+        "prompt": "Build a tool that queries a bounded metric window and summarizes it.",
+        "status_message": "",
+        "source_tool": "build_tool",
+    }
 
 
 async def test_a2a_backend_uses_durable_operation_id_for_message_correlation() -> None:


### PR DESCRIPTION
## What changed
- capture the real A2A task id/state already returned by direct A2A calls and nested tool-build polling
- project those lifecycle facts through the existing resident task result store
- show nested `build_tool` A2A activity in `a2a_tasks`/`a2a_count` without forwarding poll noise to operator channels
- remove terminal tasks from the active HUD projection

## Validation
- `uv run --extra dev ruff check` on all changed files
- `uv run --extra dev pytest -q`
- 17,572 passed, 33 skipped, 129 deselected, 1 xfailed