### PR TITLE
fix(ravn): reconcile installed tool builds on recovery

### DIFF
--- a/src/ravn/adapters/tool_build/a2a.py
+++ b/src/ravn/adapters/tool_build/a2a.py
@@ -432,6 +432,20 @@ class A2AToolBuildBackend(ToolBuildBackend):
                 raise
             except Exception as exc:
                 telemetry.mark_error(span, type(exc).__name__, str(exc))
+                await self._emit_activity(
+                    {
+                        "agent_id": self._card_url,
+                        "skill_id": workflow_id,
+                        "task_id": task_id,
+                        "state": _task_state(task) or "TASK_STATE_UNSPECIFIED",
+                        "operation": "build",
+                        "input_required": False,
+                        "prompt": request.build_request[:500],
+                        "status_message": str(exc),
+                        "source_tool": "build_tool",
+                        "tracking_state": "error",
+                    }
+                )
                 raise
             last_state = _task_state(task)
             message = (
@@ -446,6 +460,20 @@ class A2AToolBuildBackend(ToolBuildBackend):
                     "a2a.task.state": last_state,
                     "a2a.task.poll_attempt": self._max_poll_attempts,
                 },
+            )
+            await self._emit_activity(
+                {
+                    "agent_id": self._card_url,
+                    "skill_id": workflow_id,
+                    "task_id": task_id,
+                    "state": last_state or "TASK_STATE_UNSPECIFIED",
+                    "operation": "build",
+                    "input_required": False,
+                    "prompt": request.build_request[:500],
+                    "status_message": message,
+                    "source_tool": "build_tool",
+                    "tracking_state": "poll_exhausted",
+                }
             )
             return task, exchanges
 

--- a/src/ravn/adapters/tools/build_tool.py
+++ b/src/ravn/adapters/tools/build_tool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from collections.abc import Callable, Mapping
 from dataclasses import asdict
 from dataclasses import replace as dataclass_replace
@@ -23,10 +24,13 @@ from ravn.tool_observability import publish_learned_tool_inventory
 from ravn.valkyrie_evolution.adapters import PolicyCourtReviewer
 from ravn.valkyrie_evolution.learned_tools import (
     LearnedToolError,
+    learned_tool_artifact_path,
+    learned_tool_path,
     learned_tool_runner_for_backend,
     learned_tool_venvs_dir,
     load_learned_tool,
     manifest_safety_class,
+    read_learned_tool_artifact,
     write_learned_tool,
     write_learned_tool_artifact,
 )
@@ -56,6 +60,7 @@ SELF_REGISTERED_TOOL_CONFIDENCE = 0.74
 DEFAULT_MAX_REPAIR_ATTEMPTS = 3
 
 ToolRegistrar = Callable[[ToolPort], None]
+logger = logging.getLogger(__name__)
 
 
 class BuildTool(ToolPort):
@@ -304,6 +309,28 @@ class BuildTool(ToolPort):
                 "ravn.tool_build.commission.recover",
                 attributes={"ravn.tool_build.operation.id": operation_id},
             ):
+                installed = self._installed_artifact_for_commission(record)
+                if installed is not None:
+                    self._delete_commission(operation_id)
+                    telemetry.event(
+                        "ravn.tool_build.commission.reconciled",
+                        attributes={
+                            "ravn.tool_build.operation.id": operation_id,
+                            "ravn.tool_build.name": installed.manifest.name,
+                            "ravn.tool_build.artifact.id": installed.artifact_id,
+                        },
+                    )
+                    results.append(
+                        ToolResult(
+                            tool_call_id="",
+                            content=(
+                                "Skipped duplicate commissioned build recovery: "
+                                f"verified tool {installed.manifest.name!r} is already installed "
+                                f"as {installed.artifact_id}."
+                            ),
+                        )
+                    )
+                    continue
                 telemetry.event(
                     "ravn.tool_build.commission.recovery_started",
                     attributes={
@@ -486,7 +513,7 @@ class BuildTool(ToolPort):
                 )
 
             tool_path = write_learned_tool(tools_dir=self._tools_dir, artifact=artifact)
-            self._complete_commission(input)
+            self._complete_commission(input, artifact=artifact)
             telemetry.event(
                 "ravn.tool_build.tool.persisted",
                 attributes={
@@ -552,7 +579,27 @@ class BuildTool(ToolPort):
                     "ravn.tool_build.replaced": replace,
                 },
             )
-            await self._publish_flock_proposal(artifact)
+            flock_warning = ""
+            try:
+                await self._publish_flock_proposal(artifact)
+            except Exception as exc:  # noqa: BLE001 — publication follows successful install
+                flock_warning = (
+                    "The tool is installed and registered, but its Flock "
+                    f"proposal could not be published: {type(exc).__name__}: {exc}"
+                )
+                logger.warning(
+                    "Learned tool %s installed, but Flock publication failed",
+                    artifact.manifest.name,
+                    exc_info=True,
+                )
+                telemetry.event(
+                    "ravn.tool_build.flock.failed",
+                    attributes={
+                        "ravn.tool_build.name": artifact.manifest.name,
+                        "error.type": type(exc).__name__,
+                    },
+                    content=str(exc),
+                )
         except ToolBuildInputRequiredError as exc:
             return self._input_required_result(exc)
         except (LearnedToolError, ToolBuildError, TypeError, ValueError) as exc:
@@ -560,7 +607,13 @@ class BuildTool(ToolPort):
 
         return ToolResult(
             tool_call_id="",
-            content=_summary(artifact, tool_path, artifact_path, registered=True),
+            content=_summary(
+                artifact,
+                tool_path,
+                artifact_path,
+                registered=True,
+                flock_warning=flock_warning,
+            ),
         )
 
     async def _maybe_commission(self, input: dict) -> dict:  # noqa: A002
@@ -683,6 +736,8 @@ class BuildTool(ToolPort):
         merged["requirements"] = list(result.requirements)
         provenance = dict(input.get("provenance") or {})
         provenance.update(result.provenance)
+        if operation_id:
+            provenance["build_operation_id"] = operation_id
         if result.build_evidence:
             provenance["build_evidence"] = dict(result.build_evidence)
         merged["provenance"] = provenance
@@ -925,15 +980,71 @@ class BuildTool(ToolPort):
         temporary.chmod(0o600)
         temporary.replace(path)
 
-    def _complete_commission(self, input: dict) -> None:  # noqa: A002
+    def _complete_commission(
+        self,
+        input: dict,  # noqa: A002
+        *,
+        artifact: LearnedToolArtifact | None = None,
+    ) -> None:
         operation_id = str(input.get("_build_operation_id") or "").strip()
-        if not operation_id:
-            return
-        self._delete_commission(operation_id)
-        get_observability().event(
-            "ravn.tool_build.commission.completed",
-            attributes={"ravn.tool_build.operation.id": operation_id},
-        )
+        completed_ids: set[str] = set()
+        if operation_id:
+            self._delete_commission(operation_id)
+            completed_ids.add(operation_id)
+        if artifact is not None:
+            for record in self._commission_records():
+                stale_id = str(record.get("operation_id") or "")
+                if not stale_id or not self._artifact_satisfies_commission(artifact, record):
+                    continue
+                self._delete_commission(stale_id)
+                completed_ids.add(stale_id)
+        for completed_id in completed_ids:
+            get_observability().event(
+                "ravn.tool_build.commission.completed",
+                attributes={"ravn.tool_build.operation.id": completed_id},
+            )
+
+    def _installed_artifact_for_commission(
+        self,
+        record: dict[str, Any],
+    ) -> LearnedToolArtifact | None:
+        tool_name = str(record.get("tool_name") or "").strip()
+        if not tool_name:
+            return None
+        artifact_path = learned_tool_artifact_path(self._artifacts_dir, tool_name)
+        code_path = learned_tool_path(self._tools_dir, tool_name)
+        if not artifact_path.is_file() or not code_path.is_file():
+            return None
+        try:
+            artifact = read_learned_tool_artifact(artifact_path)
+            installed_code = code_path.read_text(encoding="utf-8")
+        except (LearnedToolError, OSError, ValueError):
+            return None
+        if installed_code != artifact.tool_code:
+            return None
+        if not self._artifact_satisfies_commission(artifact, record):
+            return None
+        return artifact
+
+    @staticmethod
+    def _artifact_satisfies_commission(
+        artifact: LearnedToolArtifact,
+        record: dict[str, Any],
+    ) -> bool:
+        if artifact.manifest.name != str(record.get("tool_name") or ""):
+            return False
+        verification = artifact.provenance.get("verification")
+        if not isinstance(verification, dict) or verification.get("ok") is not True:
+            return False
+        operation_id = str(record.get("operation_id") or "")
+        if operation_id and artifact.provenance.get("build_operation_id") == operation_id:
+            return True
+        original = record.get("input")
+        if not isinstance(original, dict):
+            return False
+        if original.get("replace") or str(original.get("build_request") or "").strip():
+            return False
+        return bool(str(original.get("tool_code") or "").strip())
 
     def _delete_commission(self, operation_id: str) -> None:
         try:
@@ -1405,6 +1516,7 @@ def _summary(
     artifact_path: Path,
     *,
     registered: bool,
+    flock_warning: str = "",
 ) -> str:
     payload = {
         "artifact_id": artifact.artifact_id,
@@ -1417,6 +1529,8 @@ def _summary(
         "tests_embedded_in_envelope": bool(artifact.test_code),
         "verification": _verification_payload(artifact),
     }
+    if flock_warning:
+        payload["flock_publication_warning"] = flock_warning
     return json.dumps(payload, indent=2, sort_keys=True)
 
 

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -258,7 +258,11 @@ def _resident_hud_a2a_tasks(
             if not task_id:
                 continue
             state = str(details.get("state") or "TASK_STATE_UNSPECIFIED")
-            if state in _A2A_TERMINAL_STATES:
+            tracking_state = str(details.get("tracking_state") or "")
+            if state in _A2A_TERMINAL_STATES or tracking_state in {
+                "error",
+                "poll_exhausted",
+            }:
                 sessions.pop(task_id, None)
                 continue
             prior = sessions.get(task_id, {})

--- a/tests/test_ravn/test_agent.py
+++ b/tests/test_ravn/test_agent.py
@@ -398,6 +398,61 @@ class TestRavnAgentToolUse:
         assert not second_result.is_error
         assert recovered.requests[0].operation_id == operation_id
         assert list((artifacts_dir / "pending-commissions").glob("*.json")) == []
+        persisted = json.loads((artifacts_dir / "restart_probe.json").read_text())
+        assert persisted["provenance"]["build_operation_id"] == operation_id
+
+    async def test_build_tool_reconciles_stale_commission_when_tool_is_installed(
+        self,
+        tmp_path,
+    ) -> None:
+        agent, _ = make_agent(make_simple_llm("unused"))
+        tools_dir = tmp_path / "tools"
+        artifacts_dir = tmp_path / "artifacts"
+        tool = attach_build_tool(
+            agent,
+            tools_dir=tools_dir,
+            artifacts_dir=artifacts_dir,
+            environment_id="cluster-a",
+            valkyrie_id="resident-a",
+        )
+        tool_code = "def run(input):\n    return {'installed': True}\n"
+        installed = await tool.execute(
+            {
+                "manifest": {
+                    "name": "installed_probe",
+                    "description": "Already installed.",
+                    "input_schema": {"type": "object"},
+                    "required_permission": "probe:read",
+                },
+                "tool_code": tool_code,
+                "canary_input": {},
+            }
+        )
+        assert not installed.is_error
+
+        operation_id = "stale-repair-operation"
+        tool._write_commission(  # noqa: SLF001
+            operation_id,
+            {
+                "version": 1,
+                "operation_id": operation_id,
+                "tool_name": "installed_probe",
+                "environment_id": "cluster-a",
+                "valkyrie_id": "resident-a",
+                "state": "submitting",
+                "input": {
+                    "manifest": {"name": "installed_probe"},
+                    "tool_code": tool_code,
+                },
+            },
+        )
+
+        recovered = await tool.recover_pending()
+
+        assert len(recovered) == 1
+        assert not recovered[0].is_error
+        assert "already installed" in recovered[0].content
+        assert list((artifacts_dir / "pending-commissions").glob("*.json")) == []
 
     async def test_build_tool_rejects_build_request_without_backend(self, tmp_path) -> None:
         agent, _ = make_agent(make_simple_llm("unused"))
@@ -519,6 +574,42 @@ class TestRavnAgentToolUse:
         assert payload["tool_code"].startswith("def run")
         # P5a default preserved: without config the proposal travels at 0.74.
         assert payload["confidence"] == pytest.approx(0.74)
+
+    async def test_build_tool_keeps_success_when_flock_publication_fails(self, tmp_path) -> None:
+        class _UnavailablePublisher:
+            async def publish(self, _event) -> None:
+                raise TimeoutError("NATS publish timed out")
+
+        agent, _ = make_agent(make_simple_llm("unused"))
+        tool = attach_build_tool(
+            agent,
+            tools_dir=tmp_path / "tools",
+            publisher=_UnavailablePublisher(),
+            environment_id="cluster-a",
+            valkyrie_id="resident-a",
+            flock_id="flock-a",
+        )
+
+        result = await tool.execute(
+            {
+                "manifest": {
+                    "name": "resilient_probe",
+                    "description": "Survives optional publication failure.",
+                    "input_schema": {"type": "object"},
+                    "required_permission": "probe:read",
+                },
+                "tool_code": "def run(input):\n    return {'ok': True}\n",
+                "canary_input": {},
+            }
+        )
+
+        assert not result.is_error
+        payload = json.loads(result.content)
+        assert payload["registered"] is True
+        assert "NATS publish timed out" in payload["flock_publication_warning"]
+        registered = next(item for item in agent.tools if item.name == "resilient_probe")
+        run = await registered.execute({})
+        assert json.loads(run.content) == {"ok": True}
 
     async def test_build_tool_custom_flock_confidence_travels_with_proposal(self, tmp_path) -> None:
         """P5a: a configured self_registered_tool_confidence reaches the flock

--- a/tests/test_ravn/test_drive_loop_channel_construction.py
+++ b/tests/test_ravn/test_drive_loop_channel_construction.py
@@ -412,6 +412,21 @@ Determine whether the observations require action.
         assert status["a2a_tasks"][0]["state"] == "TASK_STATE_WORKING"
         assert status["a2a_tasks"][0]["source_tool"] == "build_tool"
 
+        dl.record_a2a_activity(
+            parent_task_id=parent.task_id,
+            activity={
+                "agent_id": "https://ting.example/.well-known/agent-card.json",
+                "skill_id": "tool-builder",
+                "task_id": "task-1",
+                "state": "TASK_STATE_WORKING",
+                "operation": "build",
+                "source_tool": "build_tool",
+                "tracking_state": "poll_exhausted",
+            },
+        )
+
+        assert dl.resident_hud_status()["a2a_tasks"] == []
+
     @pytest.mark.asyncio
     async def test_no_cascade_skuld_and_mesh_uses_composite(self):
         """No cascade, skuld_channel + mesh → direct Skuld stream wins for live activity."""

--- a/tests/test_ravn/test_tool_build_backends.py
+++ b/tests/test_ravn/test_tool_build_backends.py
@@ -912,6 +912,36 @@ async def test_a2a_backend_builds_from_inline_canonical_artifact() -> None:
     }
 
 
+async def test_a2a_backend_closes_local_tracking_when_polling_is_exhausted() -> None:
+    activities: list[dict[str, object]] = []
+
+    async def _capture(activity: dict[str, object]) -> None:
+        activities.append(activity)
+
+    client = _FakeHttpClient(
+        {
+            ("GET", "/.well-known/agent-card.json"): [HttpResponse(200, _a2a_card())],
+            ("POST", "/api/v1/ting/a2a"): [
+                _rpc_result({"task": _a2a_task("TASK_STATE_SUBMITTED")}),
+                _rpc_result(_a2a_task("TASK_STATE_WORKING")),
+            ],
+        }
+    )
+    backend = _a2a_backend(
+        client,
+        workflow_id="wf-1",
+        activity_emitter=_capture,
+        max_poll_attempts=1,
+    )
+
+    with pytest.raises(ToolBuildError, match="did not finish within 1 polls"):
+        await backend.build(_request())
+
+    assert activities[-1]["task_id"] == "task-1"
+    assert activities[-1]["state"] == "TASK_STATE_WORKING"
+    assert activities[-1]["tracking_state"] == "poll_exhausted"
+
+
 async def test_a2a_backend_uses_durable_operation_id_for_message_correlation() -> None:
     artifacts = [
         {


### PR DESCRIPTION
## Summary
- reconcile stale commissioned builds against verified installed artifacts before recovery
- keep successful installation authoritative when optional Flock publication fails
- close local A2A HUD tracking when polling ends without a terminal remote state

## Validation
- `uv run --extra dev ruff check ...`
- `uv run --extra dev pytest -q tests/test_ravn/test_agent.py tests/test_ravn/test_build_tool_verify.py tests/test_ravn/test_tool_build_backends.py tests/test_ravn/test_drive_loop_channel_construction.py` (119 passed)