### PR TITLE
fix(ravn): start shared publisher before producers

### DIFF
--- a/src/ravn/cli/daemon_runtime.py
+++ b/src/ravn/cli/daemon_runtime.py
@@ -106,6 +106,18 @@ async def _run_daemon(
 
             daemon_bus = ObservedSleipnirBus(daemon_bus)
 
+    # This publisher is shared by gateways, the drive loop, and the resident
+    # learning services. Start it before constructing any of those producers so
+    # an immediately-ready trigger cannot publish against an unstarted adapter.
+    environment_signal_publisher_started = False
+    environment_signal_publisher: Any | None = _build_environment_signal_publisher(settings)
+    if environment_signal_publisher is not None and hasattr(
+        environment_signal_publisher,
+        "start",
+    ):
+        await environment_signal_publisher.start()
+        environment_signal_publisher_started = True
+
     def _agent_factory(
         channel: ChannelPort,
         task_id: str | None = None,
@@ -343,8 +355,6 @@ async def _run_daemon(
     odin_court: Any | None = None
     feedback_recorder: Any | None = None
     huddle_archiver: Any | None = None
-    environment_signal_publisher_started = False
-    environment_signal_publisher: Any | None = _build_environment_signal_publisher(settings)
     if settings.initiative.enabled or task_dispatch:
         if settings.sleipnir.enabled:
             event_publisher = RabbitMQEventPublisher(settings.sleipnir)
@@ -459,13 +469,6 @@ async def _run_daemon(
 
         trigger_names = [t.name for t in drive_loop._triggers]
         tasks.append(asyncio.create_task(drive_loop.run(), name="drive_loop"))
-
-    if environment_signal_publisher is not None and hasattr(
-        environment_signal_publisher,
-        "start",
-    ):
-        await environment_signal_publisher.start()
-        environment_signal_publisher_started = True
 
     resident_learning_runtime = _build_resident_learning_runtime(
         settings,

--- a/tests/test_ravn/test_cli_commands.py
+++ b/tests/test_ravn/test_cli_commands.py
@@ -1415,6 +1415,18 @@ class TestDaemonAgentFactory:
 
         recorded: list[dict[str, object]] = []
 
+        class _FakePublisher:
+            def __init__(self) -> None:
+                self.started = False
+
+            async def start(self) -> None:
+                self.started = True
+
+            async def stop(self) -> None:
+                self.started = False
+
+        publisher = _FakePublisher()
+
         class _FakeExecutor:
             def build(self, **kwargs):  # noqa: ANN003
                 recorded.append(kwargs)
@@ -1422,6 +1434,7 @@ class TestDaemonAgentFactory:
 
         class _FakeDriveLoop:
             def __init__(self, *, agent_factory, **kwargs):  # noqa: ANN003
+                assert publisher.started
                 self._triggers: list[object] = []
                 agent_factory(MagicMock(), task_id="task-1", triggered_by="mesh:outcome:test")
                 agent_factory(MagicMock(), task_id="task-2", triggered_by="mesh:outcome:test")
@@ -1440,6 +1453,10 @@ class TestDaemonAgentFactory:
             patch("ravn.cli.commands._build_llm", return_value=MagicMock()),
             patch("ravn.cli.commands._build_memory", return_value=MagicMock()),
             patch("ravn.cli.commands._build_compressor", return_value=MagicMock()),
+            patch(
+                "ravn.cli.commands._build_environment_signal_publisher",
+                return_value=publisher,
+            ),
             patch(
                 "ravn.cli.commands._build_prompt_builder",
                 side_effect=lambda *_args: MagicMock(),


### PR DESCRIPTION
## What changed

Start the daemon shared environment-signal publisher before constructing gateway and drive-loop producers. Add regression coverage that asserts the publisher is ready when the drive loop is built.

## Why

An immediately-ready resident trigger could emit through the NATS adapter before startup completed, causing a real task-start publication to fail with NatsPublisher is not started.

## Validation

- Ruff lint and format checks
- 7,030 Ravn tests passed; 8 skipped
- Focused daemon, NATS transport, and resident-learning suite: 76 passed; 1 skipped