### PR TITLE
fix(ravn): reconnect and trace learned tool lifecycle

### DIFF
--- a/src/ravn/adapters/tools/build_tool.py
+++ b/src/ravn/adapters/tools/build_tool.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import asdict
 from dataclasses import replace as dataclass_replace
 from pathlib import Path
@@ -60,6 +60,7 @@ SELF_REGISTERED_TOOL_CONFIDENCE = 0.74
 DEFAULT_MAX_REPAIR_ATTEMPTS = 3
 
 ToolRegistrar = Callable[[ToolPort], None]
+InstalledArtifactRecorder = Callable[[ResidentLearningArtifact], Awaitable[None]]
 logger = logging.getLogger(__name__)
 
 
@@ -89,6 +90,7 @@ class BuildTool(ToolPort):
         investigation_context: Callable[[], str] | None = None,
         max_repair_attempts: int = DEFAULT_MAX_REPAIR_ATTEMPTS,
         flock_confidence: float = SELF_REGISTERED_TOOL_CONFIDENCE,
+        installed_artifact_recorder: InstalledArtifactRecorder | None = None,
     ) -> None:
         self._tools_dir = Path(tools_dir)
         self._artifacts_dir = (
@@ -112,6 +114,7 @@ class BuildTool(ToolPort):
         self._investigation_context = investigation_context
         self._max_repair_attempts = max_repair_attempts
         self._flock_confidence = flock_confidence
+        self._installed_artifact_recorder = installed_artifact_recorder
 
     def _investigation_prompt(self) -> str:
         """The investigation prompt that drove this build, for review provenance."""
@@ -571,6 +574,20 @@ class BuildTool(ToolPort):
 
             replace = bool(input.get("replace"))
             self._register_tool(learned_tool, replace=replace)  # type: ignore[call-arg]
+            lifecycle_warning = ""
+            if self._installed_artifact_recorder is not None:
+                try:
+                    await self._installed_artifact_recorder(resident_artifact)
+                except Exception as exc:  # noqa: BLE001 — installation already succeeded
+                    lifecycle_warning = (
+                        "The tool is installed, but its lifecycle record could not be "
+                        f"updated: {type(exc).__name__}: {exc}"
+                    )
+                    logger.warning(
+                        "Learned tool %s installed, but lifecycle registration failed",
+                        artifact.manifest.name,
+                        exc_info=True,
+                    )
             publish_learned_tool_inventory([artifact])
             telemetry.event(
                 "ravn.tool_build.registered",
@@ -613,6 +630,7 @@ class BuildTool(ToolPort):
                 artifact_path,
                 registered=True,
                 flock_warning=flock_warning,
+                lifecycle_warning=lifecycle_warning,
             ),
         )
 
@@ -1380,6 +1398,7 @@ def attach_build_tool(
     investigation_context: Callable[[], str] | None = None,
     max_repair_attempts: int = DEFAULT_MAX_REPAIR_ATTEMPTS,
     flock_confidence: float = SELF_REGISTERED_TOOL_CONFIDENCE,
+    installed_artifact_recorder: InstalledArtifactRecorder | None = None,
 ) -> BuildTool:
     """Attach build_tool to an agent supporting register_tool()."""
     registrar = getattr(agent, "register_tool", None)
@@ -1405,6 +1424,7 @@ def attach_build_tool(
         investigation_context=investigation_context,
         max_repair_attempts=max_repair_attempts,
         flock_confidence=flock_confidence,
+        installed_artifact_recorder=installed_artifact_recorder,
     )
     registrar(tool, replace=replace)
     return tool
@@ -1517,6 +1537,7 @@ def _summary(
     *,
     registered: bool,
     flock_warning: str = "",
+    lifecycle_warning: str = "",
 ) -> str:
     payload = {
         "artifact_id": artifact.artifact_id,
@@ -1531,6 +1552,8 @@ def _summary(
     }
     if flock_warning:
         payload["flock_publication_warning"] = flock_warning
+    if lifecycle_warning:
+        payload["lifecycle_warning"] = lifecycle_warning
     return json.dumps(payload, indent=2, sort_keys=True)
 
 

--- a/src/ravn/adapters/tools/build_tool.py
+++ b/src/ravn/adapters/tools/build_tool.py
@@ -576,18 +576,36 @@ class BuildTool(ToolPort):
             self._register_tool(learned_tool, replace=replace)  # type: ignore[call-arg]
             lifecycle_warning = ""
             if self._installed_artifact_recorder is not None:
-                try:
-                    await self._installed_artifact_recorder(resident_artifact)
-                except Exception as exc:  # noqa: BLE001 — installation already succeeded
-                    lifecycle_warning = (
-                        "The tool is installed, but its lifecycle record could not be "
-                        f"updated: {type(exc).__name__}: {exc}"
-                    )
-                    logger.warning(
-                        "Learned tool %s installed, but lifecycle registration failed",
-                        artifact.manifest.name,
-                        exc_info=True,
-                    )
+                lifecycle_attributes = {
+                    "ravn.learned_tool.name": artifact.manifest.name,
+                    "ravn.learned_tool.artifact_id": artifact.artifact_id,
+                    "ravn.skill.lifecycle.action": "register",
+                }
+                with telemetry.span(
+                    "ravn.learned_tool.lifecycle.register",
+                    attributes=lifecycle_attributes,
+                ) as lifecycle_span:
+                    try:
+                        await self._installed_artifact_recorder(resident_artifact)
+                        telemetry.event(
+                            "ravn.learned_tool.lifecycle.registered",
+                            attributes=lifecycle_attributes,
+                        )
+                    except Exception as exc:  # noqa: BLE001 — installation already succeeded
+                        lifecycle_warning = (
+                            "The tool is installed, but its lifecycle record could not be "
+                            f"updated: {type(exc).__name__}: {exc}"
+                        )
+                        telemetry.mark_error(
+                            lifecycle_span,
+                            type(exc).__name__,
+                            str(exc),
+                        )
+                        logger.warning(
+                            "Learned tool %s installed, but lifecycle registration failed",
+                            artifact.manifest.name,
+                            exc_info=True,
+                        )
             publish_learned_tool_inventory([artifact])
             telemetry.event(
                 "ravn.tool_build.registered",

--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -303,21 +303,30 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
         groups=frozenset({"skill"}),
         condition=lambda s: s.skill.enabled,
         required_context=frozenset({"skill_port"}),
-        kwargs_fn=lambda s, ctx: {"skill_port": ctx["skill_port"]},
+        kwargs_fn=lambda s, ctx: {
+            "skill_port": ctx["skill_port"],
+            "manager": ctx.get("skill_manager"),
+        },
     ),
     "skill_run": BuiltinToolDef(
         adapter="ravn.adapters.tools.skill_tools.SkillRunTool",
         groups=frozenset({"skill"}),
         condition=lambda s: s.skill.enabled,
         required_context=frozenset({"skill_port"}),
-        kwargs_fn=lambda s, ctx: {"skill_port": ctx["skill_port"]},
+        kwargs_fn=lambda s, ctx: {
+            "skill_port": ctx["skill_port"],
+            "manager": ctx.get("skill_manager"),
+        },
     ),
     "skill_manage": BuiltinToolDef(
         adapter="ravn.adapters.tools.skill_tools.SkillManageTool",
         groups=frozenset({"skill"}),
         condition=lambda s: s.skill.enabled,
         required_context=frozenset({"skill_port"}),
-        kwargs_fn=lambda s, ctx: {"skill_port": ctx["skill_port"]},
+        kwargs_fn=lambda s, ctx: {
+            "skill_port": ctx["skill_port"],
+            "manager": ctx.get("skill_manager"),
+        },
     ),
     # =========================================================================
     # kubernetes — read-only resident Environment inspection
@@ -470,6 +479,7 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
         kwargs_fn=lambda _s, ctx: {
             "tools_provider": ctx["capability_tools_provider"],
             "skill_port": ctx.get("skill_port"),
+            "skill_manager": ctx.get("skill_manager"),
             "workflow_sources": ctx.get("workflow_sources") or [],
             "learned_tools_provider": ctx.get("learned_tools_provider"),
             "agent_directory": ctx.get("agent_directory"),
@@ -485,6 +495,7 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
         kwargs_fn=lambda _s, ctx: {
             "resolver": ctx["learned_tool_resolver"],
             "permission": ctx["permission"],
+            "skill_manager": ctx.get("skill_manager"),
         },
     ),
 }

--- a/src/ravn/adapters/tools/capability_catalog.py
+++ b/src/ravn/adapters/tools/capability_catalog.py
@@ -22,6 +22,7 @@ from ravn.ports.agent_directory import PeerAgentDirectoryPort
 from ravn.ports.capability import WorkflowCapabilityPort
 from ravn.ports.skill import SkillPort
 from ravn.ports.tool import ToolPort
+from ravn.skills.management import SkillManagementRegistry
 from ravn.tool_observability import publish_learned_tool_inventory
 
 _PERMISSION = "introspect:read"
@@ -35,12 +36,14 @@ class CapabilityListTool(ToolPort):
         *,
         tools_provider: Callable[[], Sequence[ToolPort]],
         skill_port: SkillPort | None = None,
+        skill_manager: SkillManagementRegistry | None = None,
         workflow_sources: Sequence[WorkflowCapabilityPort] | None = None,
         learned_tools_provider: Callable[[], Sequence[Any]] | None = None,
         agent_directory: PeerAgentDirectoryPort | None = None,
     ) -> None:
         self._tools_provider = tools_provider
         self._skill_port = skill_port
+        self._skill_manager = skill_manager
         self._workflow_sources = list(workflow_sources or [])
         # Returns learned-tool artifact envelopes (manifest name/description/
         # schema) read from disk — never loaded as callables here (NIU-1118).
@@ -199,6 +202,12 @@ class CapabilityListTool(ToolPort):
             before = len(capabilities)
             try:
                 learned_artifacts = list(self._learned_tools_provider())
+                if self._skill_manager is not None:
+                    learned_artifacts = [
+                        artifact
+                        for artifact in learned_artifacts
+                        if self._skill_manager.status(artifact.manifest.name) != "archived"
+                    ]
                 publish_learned_tool_inventory(learned_artifacts)
                 for artifact in learned_artifacts:
                     manifest = artifact.manifest
@@ -244,7 +253,11 @@ class CapabilityListTool(ToolPort):
         if self._skill_port is not None:
             before = len(capabilities)
             try:
-                for skill in await self._skill_port.list_skills():
+                if self._skill_manager is None:
+                    skills = await self._skill_port.list_skills()
+                else:
+                    skills = await self._skill_manager.list_runnable_skills()
+                for skill in skills:
                     capabilities.append(
                         capability_from_skill(
                             skill_id=skill.skill_id,

--- a/src/ravn/adapters/tools/learned_tool_run.py
+++ b/src/ravn/adapters/tools/learned_tool_run.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 
+from niuu.observability import get_observability
 from ravn.domain.models import ToolResult
 from ravn.ports.permission import PermissionPort
 from ravn.ports.tool import ToolPort
@@ -101,50 +102,91 @@ class LearnedToolRunTool(ToolPort):
                 is_error=True,
             )
 
-        if self._skill_manager is not None and self._skill_manager.status(name) == "archived":
-            return ToolResult(
-                tool_call_id="",
-                content=f"Learned tool {name!r} is archived and cannot be run.",
-                is_error=True,
-            )
-
-        try:
-            tool = self._resolver.load(name)
-        except LearnedToolError as exc:
-            return ToolResult(
-                tool_call_id="",
-                content=(
-                    f"{exc} — use capability_list (kind='tool', tag 'learned') to "
-                    "discover installed learned tools."
-                ),
-                is_error=True,
-            )
-
-        granted = await self._permission.check(tool.required_permission)
-        if not granted:
-            return ToolResult(
-                tool_call_id="",
-                content=(
-                    f"Permission {tool.required_permission!r} denied for learned tool {name!r}."
-                ),
-                is_error=True,
-            )
-
-        try:
-            result = await tool.execute(payload)
-        except Exception as exc:
-            logger.warning("learned_tool_run: %r raised: %s", name, exc)
-            result = ToolResult(
-                tool_call_id="",
-                content=f"Learned tool {name!r} error: {exc}",
-                is_error=True,
-            )
-        if self._skill_manager is not None:
-            try:
-                await self._skill_manager.record_usage(name, success=not result.is_error)
-            except LookupError:
-                logger.warning(
-                    "learned_tool_run: %r has no managed lifecycle record",
-                    name,
+        telemetry = get_observability()
+        lifecycle_status = (
+            self._skill_manager.status(name) if self._skill_manager is not None else None
+        )
+        attributes = {
+            "ravn.learned_tool.name": name,
+            "ravn.skill.lifecycle.status": lifecycle_status or "unmanaged",
+        }
+        with telemetry.span("ravn.learned_tool.lifecycle.run", attributes=attributes) as span:
+            if lifecycle_status == "archived":
+                span.set_attribute("ravn.learned_tool.outcome", "archived")
+                return ToolResult(
+                    tool_call_id="",
+                    content=f"Learned tool {name!r} is archived and cannot be run.",
+                    is_error=True,
                 )
-        return result
+
+            try:
+                tool = self._resolver.load(name)
+            except LearnedToolError as exc:
+                span.set_attribute("ravn.learned_tool.outcome", "unavailable")
+                return ToolResult(
+                    tool_call_id="",
+                    content=(
+                        f"{exc} — use capability_list (kind='tool', tag 'learned') to "
+                        "discover installed learned tools."
+                    ),
+                    is_error=True,
+                )
+
+            granted = await self._permission.check(tool.required_permission)
+            if not granted:
+                span.set_attribute("ravn.learned_tool.outcome", "permission_denied")
+                return ToolResult(
+                    tool_call_id="",
+                    content=(
+                        f"Permission {tool.required_permission!r} denied for learned tool {name!r}."
+                    ),
+                    is_error=True,
+                )
+
+            try:
+                result = await tool.execute(payload)
+            except Exception as exc:
+                logger.warning("learned_tool_run: %r raised: %s", name, exc)
+                result = ToolResult(
+                    tool_call_id="",
+                    content=f"Learned tool {name!r} error: {exc}",
+                    is_error=True,
+                )
+            outcome = "error" if result.is_error else "success"
+            span.set_attribute("ravn.learned_tool.outcome", outcome)
+            if self._skill_manager is not None:
+                try:
+                    lifecycle = await self._skill_manager.record_usage(
+                        name,
+                        success=not result.is_error,
+                    )
+                    usage_attributes = {
+                        **attributes,
+                        "ravn.learned_tool.outcome": outcome,
+                        "ravn.skill.lifecycle.run_count": lifecycle.run_count,
+                        "ravn.skill.lifecycle.failure_count": lifecycle.failure_count,
+                        "ravn.skill.lifecycle.consecutive_failures": (
+                            lifecycle.consecutive_failures
+                        ),
+                    }
+                    telemetry.event(
+                        "ravn.learned_tool.lifecycle.usage_recorded",
+                        attributes=usage_attributes,
+                    )
+                    telemetry.count(
+                        "ravn.learned_tool.lifecycle.runs",
+                        attributes={
+                            "ravn.learned_tool.name": name,
+                            "ravn.learned_tool.outcome": outcome,
+                        },
+                    )
+                except LookupError:
+                    telemetry.event(
+                        "ravn.learned_tool.lifecycle.unmanaged",
+                        attributes=attributes,
+                    )
+                    logger.warning(
+                        "learned_tool_run: %r has no managed lifecycle record",
+                        name,
+                    )
+            return result

--- a/src/ravn/adapters/tools/learned_tool_run.py
+++ b/src/ravn/adapters/tools/learned_tool_run.py
@@ -22,6 +22,7 @@ import logging
 from ravn.domain.models import ToolResult
 from ravn.ports.permission import PermissionPort
 from ravn.ports.tool import ToolPort
+from ravn.skills.management import SkillManagementRegistry
 from ravn.valkyrie_evolution.learned_tools import LearnedToolError, LearnedToolResolver
 
 logger = logging.getLogger(__name__)
@@ -37,9 +38,11 @@ class LearnedToolRunTool(ToolPort):
         *,
         resolver: LearnedToolResolver,
         permission: PermissionPort,
+        skill_manager: SkillManagementRegistry | None = None,
     ) -> None:
         self._resolver = resolver
         self._permission = permission
+        self._skill_manager = skill_manager
 
     @property
     def name(self) -> str:
@@ -98,6 +101,13 @@ class LearnedToolRunTool(ToolPort):
                 is_error=True,
             )
 
+        if self._skill_manager is not None and self._skill_manager.status(name) == "archived":
+            return ToolResult(
+                tool_call_id="",
+                content=f"Learned tool {name!r} is archived and cannot be run.",
+                is_error=True,
+            )
+
         try:
             tool = self._resolver.load(name)
         except LearnedToolError as exc:
@@ -121,11 +131,20 @@ class LearnedToolRunTool(ToolPort):
             )
 
         try:
-            return await tool.execute(payload)
+            result = await tool.execute(payload)
         except Exception as exc:
             logger.warning("learned_tool_run: %r raised: %s", name, exc)
-            return ToolResult(
+            result = ToolResult(
                 tool_call_id="",
                 content=f"Learned tool {name!r} error: {exc}",
                 is_error=True,
             )
+        if self._skill_manager is not None:
+            try:
+                await self._skill_manager.record_usage(name, success=not result.is_error)
+            except LookupError:
+                logger.warning(
+                    "learned_tool_run: %r has no managed lifecycle record",
+                    name,
+                )
+        return result

--- a/src/ravn/adapters/tools/skill_tools.py
+++ b/src/ravn/adapters/tools/skill_tools.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 from uuid import uuid4
 
+from niuu.observability import get_observability
 from ravn.context.autonomy import (
     AutonomyMode,
     AutonomyPolicy,
@@ -337,6 +338,24 @@ class SkillManageTool(ToolPort):
 
     async def execute(self, payload: dict) -> ToolResult:
         action = (payload.get("action") or "").strip()
+        name = (payload.get("name") or "").strip()
+        telemetry = get_observability()
+        attributes = {
+            "ravn.skill.lifecycle.action": action or "unknown",
+            "ravn.skill.name": name,
+        }
+        with telemetry.span("ravn.skill.lifecycle", attributes=attributes) as span:
+            result = await self._execute_action(action, payload)
+            outcome = "error" if result.is_error else "success"
+            span.set_attribute("ravn.skill.lifecycle.outcome", outcome)
+            telemetry.event(
+                "ravn.skill.lifecycle.finished",
+                attributes={**attributes, "ravn.skill.lifecycle.outcome": outcome},
+                content=result.content,
+            )
+            return result
+
+    async def _execute_action(self, action: str, payload: dict) -> ToolResult:
         try:
             if action in {
                 "create",

--- a/src/ravn/adapters/tools/skill_tools.py
+++ b/src/ravn/adapters/tools/skill_tools.py
@@ -55,8 +55,14 @@ class SkillListTool(ToolPort):
     with ``skill_run``.
     """
 
-    def __init__(self, skill_port: SkillPort) -> None:
+    def __init__(
+        self,
+        skill_port: SkillPort,
+        *,
+        manager: SkillManagementRegistry | None = None,
+    ) -> None:
         self._skill_port = skill_port
+        self._manager = manager
 
     @property
     def name(self) -> str:
@@ -94,7 +100,10 @@ class SkillListTool(ToolPort):
         query: str | None = input.get("query") or None
 
         try:
-            skills = await self._skill_port.list_skills(query=query)
+            if self._manager is None:
+                skills = await self._skill_port.list_skills(query=query)
+            else:
+                skills = await self._manager.list_runnable_skills(query=query)
         except Exception as exc:
             logger.warning("skill_list: list_skills failed: %s", exc)
             return ToolResult(
@@ -143,8 +152,14 @@ class SkillRunTool(ToolPort):
     are appended to the skill instructions.
     """
 
-    def __init__(self, skill_port: SkillPort) -> None:
+    def __init__(
+        self,
+        skill_port: SkillPort,
+        *,
+        manager: SkillManagementRegistry | None = None,
+    ) -> None:
         self._skill_port = skill_port
+        self._manager = manager
 
     @property
     def name(self) -> str:
@@ -197,7 +212,11 @@ class SkillRunTool(ToolPort):
             )
 
         try:
-            skill = await self._skill_port.get_skill(skill_name)
+            skill = (
+                await self._manager.get_runnable_skill(skill_name)
+                if self._manager is not None
+                else await self._skill_port.get_skill(skill_name)
+            )
         except Exception as exc:
             logger.warning("skill_run: get_skill(%r) failed: %s", skill_name, exc)
             return ToolResult(

--- a/src/ravn/cli/daemon_runtime.py
+++ b/src/ravn/cli/daemon_runtime.py
@@ -118,6 +118,12 @@ async def _run_daemon(
         await environment_signal_publisher.start()
         environment_signal_publisher_started = True
 
+    resident_learning_runtime = _build_resident_learning_runtime(
+        settings,
+        publisher=environment_signal_publisher,
+        workspace=workspace,
+    )
+
     def _agent_factory(
         channel: ChannelPort,
         task_id: str | None = None,
@@ -212,6 +218,9 @@ async def _run_daemon(
             ),
             permission=permission,
             a2a_activity_emitter=_emit_a2a_activity,
+            skill_manager=(
+                resident_learning_runtime.skills if resident_learning_runtime is not None else None
+            ),
         )
         if profile_cfg.include_mcp:
             tools.extend(_filter_tools(mcp_tools, settings, resolved_persona))
@@ -292,6 +301,11 @@ async def _run_daemon(
             publisher=environment_signal_publisher or sleipnir_catalog_publisher or daemon_bus,
             drive_loop=drive_loop,
             a2a_activity_emitter=_emit_a2a_activity,
+            installed_artifact_recorder=(
+                resident_learning_runtime.register_installed_artifact
+                if resident_learning_runtime is not None
+                else None
+            ),
         )
 
     tasks: list[asyncio.Task] = []
@@ -350,7 +364,6 @@ async def _run_daemon(
     drive_loop: Any = None
     _cascade_participant: Any = None
     environment_signal_runtime: Any | None = None
-    resident_learning_runtime: Any | None = None
     resident_wakefulness: Any | None = None
     odin_court: Any | None = None
     feedback_recorder: Any | None = None
@@ -470,11 +483,6 @@ async def _run_daemon(
         trigger_names = [t.name for t in drive_loop._triggers]
         tasks.append(asyncio.create_task(drive_loop.run(), name="drive_loop"))
 
-    resident_learning_runtime = _build_resident_learning_runtime(
-        settings,
-        publisher=environment_signal_publisher,
-        workspace=_resolve_workspace(settings),
-    )
     if resident_learning_runtime is not None:
         await resident_learning_runtime.start()
         tasks.append(asyncio.create_task(asyncio.Event().wait(), name="resident_learning"))

--- a/src/ravn/cli/runtime_builders.py
+++ b/src/ravn/cli/runtime_builders.py
@@ -60,6 +60,7 @@ def _attach_agent_build_tool(
     publisher: Any | None = None,
     drive_loop: Any | None = None,
     a2a_activity_emitter: Any | None = None,
+    installed_artifact_recorder: Any | None = None,
 ) -> Any:
     """Attach build_tool when the active persona explicitly allows it."""
     if not enabled:
@@ -143,6 +144,7 @@ def _attach_agent_build_tool(
             investigation_context=_investigation_context,
             max_repair_attempts=settings.resident_evolution.build_repair_attempts,
             flock_confidence=settings.resident_evolution.self_registered_tool_confidence,
+            installed_artifact_recorder=installed_artifact_recorder,
         )
     except TypeError:
         logger.debug("build_tool not attached: executor does not support dynamic tools")

--- a/src/ravn/cli/tool_builders.py
+++ b/src/ravn/cli/tool_builders.py
@@ -38,6 +38,7 @@ def _build_tools(
     session_join_manager: Any | None = None,
     permission: Any | None = None,
     a2a_activity_emitter: Callable[[dict[str, object]], Awaitable[None]] | None = None,
+    skill_manager: Any | None = None,
 ) -> list[Any]:
     """Build the tool list from the built-in registry, filtered by profile.
 
@@ -95,13 +96,31 @@ def _build_tools(
         resolver = _build_learned_tool_resolver(settings, workspace)
         if resolver is not None:
             runtime_ctx["learned_tool_resolver"] = resolver
-            runtime_ctx["learned_tools_provider"] = resolver.list_artifacts
 
-    # Pre-build shared skill port so both skill_list and skill_run reuse one instance
-    if "skill" in include_groups and settings.skill.enabled:
+    # One lifecycle registry backs skill discovery, management, and learned-tool
+    # execution. Resident daemons inject their long-lived registry; other
+    # runtimes get one local instance for this tool set.
+    if skill_manager is not None or (
+        settings.skill.enabled and ("skill" in include_groups or dispatch_learned_tools)
+    ):
         from ravn.adapters.tools.builtin_registry import _build_skill_port  # noqa: PLC0415
+        from ravn.skills.management import SkillManagementRegistry  # noqa: PLC0415
 
-        runtime_ctx["skill_port"] = _build_skill_port(settings, workspace)
+        skill_port = (
+            skill_manager.skill_port
+            if skill_manager is not None
+            else _build_skill_port(settings, workspace)
+        )
+        skill_manager = skill_manager or SkillManagementRegistry(
+            skill_port,
+            metadata_path=_resident_ravn_state_dir(workspace, settings) / "skill_management.json",
+        )
+        runtime_ctx["skill_port"] = skill_port
+        runtime_ctx["skill_manager"] = skill_manager
+
+    resolver = runtime_ctx.get("learned_tool_resolver")
+    if resolver is not None:
+        runtime_ctx["learned_tools_provider"] = resolver.list_artifacts
 
     if "workflow" in include_groups:
         workflow_sources = _build_workflow_capability_sources(settings)
@@ -195,7 +214,14 @@ def _build_tools(
             logger.warning("Failed to load custom tool %r: %s", ct.adapter, exc)
 
     if not dispatch_learned_tools:
-        tools.extend(_load_resident_learned_tools(settings, workspace, tools))
+        tools.extend(
+            _load_resident_learned_tools(
+                settings,
+                workspace,
+                tools,
+                skill_manager=skill_manager,
+            )
+        )
 
     # -- Apply enabled/disabled filters --
     tools = _filter_tools(tools, settings, persona_config)
@@ -244,6 +270,8 @@ def _load_resident_learned_tools(
     settings: Settings,
     workspace: Path,
     existing_tools: list[Any],
+    *,
+    skill_manager: Any | None = None,
 ) -> list[Any]:
     """Legacy bulk mode: load every learned tool as a native callable.
 
@@ -258,6 +286,8 @@ def _load_resident_learned_tools(
     loaded: list[Any] = []
     for artifact in resolver.list_artifacts():
         name = artifact.manifest.name
+        if skill_manager is not None and skill_manager.status(name) == "archived":
+            continue
         if name in seen:
             continue
         try:

--- a/src/ravn/skills/management.py
+++ b/src/ravn/skills/management.py
@@ -58,6 +58,16 @@ class SkillManagementRegistry:
         self._metadata: dict[str, SkillLifecycle] = {}
         self._load()
 
+    @property
+    def skill_port(self) -> SkillPort:
+        """The backing skill store shared by lifecycle-aware tool adapters."""
+        return self._skill_port
+
+    def status(self, name: str) -> str | None:
+        """Return managed lifecycle status, or ``None`` for an unmanaged skill."""
+        meta = self._metadata.get(self._key(name))
+        return meta.status if meta is not None else None
+
     async def create(
         self,
         *,
@@ -219,6 +229,18 @@ class SkillManagementRegistry:
             rows.append({"skill": asdict(skill), "metadata": asdict(meta)})
         rows.sort(key=lambda row: (not row["metadata"]["pinned"], row["skill"]["name"].lower()))
         return rows
+
+    async def list_runnable_skills(self, query: str | None = None) -> list[Skill]:
+        """List skills that are available for discovery and execution."""
+        skills = await self._skill_port.list_skills(query)
+        runnable = [skill for skill in skills if not self._is_archived(skill.name)]
+        return sorted(
+            runnable,
+            key=lambda skill: (
+                not self._metadata_for(skill).pinned,
+                skill.name.lower(),
+            ),
+        )
 
     async def get_runnable_skill(self, name: str) -> Skill | None:
         skill = await self._skill_port.get_skill(name)

--- a/src/ravn/valkyrie_evolution/resident_learning.py
+++ b/src/ravn/valkyrie_evolution/resident_learning.py
@@ -406,6 +406,8 @@ class ResidentLearningRuntime:
                 )
                 continue
             manifest = artifact.manifest
+            if self._skills.status(manifest.name) == "archived":
+                continue
             records.append(
                 {
                     "skill_name": manifest.name,
@@ -584,6 +586,18 @@ class ResidentLearningRuntime:
                 }
             ],
         }
+
+    async def register_installed_artifact(self, artifact: ResidentLearningArtifact) -> None:
+        """Put an already-installed local tool under the resident lifecycle.
+
+        ``build_tool`` has already verified, reviewed, persisted, and registered
+        the implementation before calling this hook. This method records the
+        same managed-skill projection used by peer adoption, without installing
+        the code a second time.
+        """
+        _, build = review_inputs(artifact, self.identity)
+        await self._record_installed_skill(artifact, build)
+        await self._refresh_skill_inventory()
 
     async def execute_selected_capability(
         self,
@@ -1632,6 +1646,27 @@ class ResidentLearningRuntime:
                 build=build,
             )
 
+        await self._record_installed_skill(artifact, build, skill_name=skill_name)
+        if (
+            build.artifact_type != "agent_tool"
+            and build.has_tool_implementation
+            and self._tools_dir is not None
+        ):
+            write_tool(
+                tools_dir=self._tools_dir,
+                skill_name=skill_name,
+                tool_code=build.tool_code,
+            )
+        return skill_name
+
+    async def _record_installed_skill(
+        self,
+        artifact: ResidentLearningArtifact,
+        build: BuildResult,
+        *,
+        skill_name: str | None = None,
+    ) -> None:
+        skill_name = skill_name or build.skill_name
         scope = _normalise_scope(artifact.scope)
         try:
             await self._skills.create(
@@ -1661,17 +1696,6 @@ class ResidentLearningRuntime:
                 environment_id=self.identity.environment_id,
                 domain=self.identity.domain or artifact.domain,
             )
-        if (
-            build.artifact_type != "agent_tool"
-            and build.has_tool_implementation
-            and self._tools_dir is not None
-        ):
-            write_tool(
-                tools_dir=self._tools_dir,
-                skill_name=skill_name,
-                tool_code=build.tool_code,
-            )
-        return skill_name
 
     async def _archive_learning_skill(self, artifact: ResidentLearningArtifact) -> str:
         rows = await self._skills.list_skills(include_archived=True)

--- a/tests/test_ravn/test_build_tool_verify.py
+++ b/tests/test_ravn/test_build_tool_verify.py
@@ -86,6 +86,25 @@ async def test_verify_passes_then_tool_installs_real_venv(tmp_path) -> None:
     assert verification["attempts"] == 0
 
 
+async def test_successful_install_records_resident_lifecycle_artifact(tmp_path) -> None:
+    recorded = []
+
+    async def record(artifact) -> None:
+        recorded.append(artifact)
+
+    tool, _ = _tool(tmp_path, installed_artifact_recorder=record)
+    result = await tool.execute(
+        {
+            "manifest": _manifest("managed_echo"),
+            "tool_code": _ECHO_TOOL,
+            "test_code": "",
+        }
+    )
+
+    assert not result.is_error
+    assert [artifact.title for artifact in recorded] == ["managed_echo"]
+
+
 async def test_verify_skipped_for_empty_test_code_still_installs(tmp_path) -> None:
     tool, registered = _tool(tmp_path)
     result = await tool.execute(

--- a/tests/test_ravn/test_capability_list_tool.py
+++ b/tests/test_ravn/test_capability_list_tool.py
@@ -248,6 +248,29 @@ async def test_capability_list_includes_learned_tools_without_loading_them() -> 
 
 
 @pytest.mark.asyncio
+async def test_capability_list_hides_archived_learned_tools() -> None:
+    class ArchivedSkillManager:
+        def status(self, name: str) -> str | None:
+            return "archived" if name == "obsolete_probe" else None
+
+    tool = CapabilityListTool(
+        tools_provider=lambda: [FakeTool()],
+        learned_tools_provider=lambda: [
+            _learned_artifact("obsolete_probe"),
+            _learned_artifact("current_probe"),
+        ],
+        skill_manager=ArchivedSkillManager(),  # type: ignore[arg-type]
+    )
+
+    result = await tool.execute({"kind": "tool"})
+
+    payload = json.loads(result.content)
+    names = [item["name"] for item in payload["capabilities"]]
+    assert "obsolete_probe" not in names
+    assert "current_probe" in names
+
+
+@pytest.mark.asyncio
 async def test_capability_list_dedupes_learned_tools_against_native_names() -> None:
     # A learned tool already registered natively (legacy bulk mode, or freshly
     # built in-session) must not appear twice in the catalog.

--- a/tests/test_ravn/test_learned_tool_run.py
+++ b/tests/test_ravn/test_learned_tool_run.py
@@ -7,7 +7,9 @@ from pathlib import Path
 import pytest
 
 from ravn.adapters.permission.allow_deny import AllowAllPermission, DenyAllPermission
+from ravn.adapters.skill.file_registry import FileSkillRegistry
 from ravn.adapters.tools.learned_tool_run import LearnedToolRunTool
+from ravn.skills.management import SkillManagementRegistry
 from ravn.valkyrie_evolution.learned_tools import (
     ContainedLearnedToolRunner,
     LearnedToolError,
@@ -105,11 +107,39 @@ class TestLearnedToolResolver:
 
 
 class TestLearnedToolRunTool:
-    def _dispatch(self, tmp_path: Path, permission=None) -> LearnedToolRunTool:
+    def _dispatch(
+        self,
+        tmp_path: Path,
+        permission=None,
+        skill_manager: SkillManagementRegistry | None = None,
+    ) -> LearnedToolRunTool:
         return LearnedToolRunTool(
             resolver=LearnedToolResolver(state_dir=tmp_path),
             permission=permission or AllowAllPermission(),
+            skill_manager=skill_manager,
         )
+
+    async def _manager(
+        self,
+        tmp_path: Path,
+        name: str,
+    ) -> SkillManagementRegistry:
+        skills_dir = tmp_path / "skills"
+        manager = SkillManagementRegistry(
+            FileSkillRegistry(
+                skill_dirs=[str(skills_dir)],
+                write_dir=skills_dir,
+                include_builtin=False,
+                cwd=tmp_path,
+            ),
+            metadata_path=tmp_path / "skill_management.json",
+        )
+        await manager.create(
+            name=name,
+            content=f"capability: tool.{name}",
+            description=f"Managed learned tool {name}",
+        )
+        return manager
 
     async def test_executes_installed_tool_by_name(self, tmp_path: Path) -> None:
         _install_tool(tmp_path, "metric_window")
@@ -181,3 +211,29 @@ class TestLearnedToolRunTool:
         result = await dispatch.execute({"name": "broken_tool", "input": {}})
 
         assert result.is_error
+
+    async def test_records_real_execution_outcome_in_shared_lifecycle(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        _install_tool(tmp_path, "metric_window")
+        manager = await self._manager(tmp_path, "metric_window")
+        dispatch = self._dispatch(tmp_path, skill_manager=manager)
+
+        result = await dispatch.execute({"name": "metric_window", "input": {}})
+
+        assert not result.is_error
+        shown = await manager.show("metric_window")
+        assert shown["metadata"]["run_count"] == 1
+        assert shown["metadata"]["success_count"] == 1
+
+    async def test_archived_learned_tool_cannot_run(self, tmp_path: Path) -> None:
+        _install_tool(tmp_path, "obsolete_probe")
+        manager = await self._manager(tmp_path, "obsolete_probe")
+        await manager.archive("obsolete_probe")
+        dispatch = self._dispatch(tmp_path, skill_manager=manager)
+
+        result = await dispatch.execute({"name": "obsolete_probe", "input": {}})
+
+        assert result.is_error
+        assert "archived" in result.content

--- a/tests/test_ravn/test_observability.py
+++ b/tests/test_ravn/test_observability.py
@@ -101,6 +101,132 @@ def test_span_context_and_metrics_are_real_when_sdk_is_installed() -> None:
     telemetry.shutdown()
 
 
+@pytest.mark.asyncio
+async def test_learned_tool_lifecycle_has_explicit_trace_spans(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    from contextlib import contextmanager
+
+    import ravn.adapters.tools.build_tool as build_tool_module
+    import ravn.adapters.tools.learned_tool_run as learned_tool_module
+    import ravn.adapters.tools.skill_tools as skill_tools_module
+    from ravn.adapters.permission.allow_deny import AllowAllPermission
+    from ravn.adapters.skill.file_registry import FileSkillRegistry
+    from ravn.adapters.tools.build_tool import BuildTool
+    from ravn.adapters.tools.learned_tool_run import LearnedToolRunTool
+    from ravn.adapters.tools.skill_tools import SkillManageTool
+    from ravn.skills.management import SkillManagementRegistry
+
+    class Span:
+        def set_attribute(self, _name, _value) -> None:
+            return None
+
+    class RecordingTelemetry:
+        def __init__(self) -> None:
+            self.spans = []
+            self.events = []
+            self._active = []
+
+        @contextmanager
+        def span(self, name, **_kwargs):
+            self.spans.append(name)
+            self._active.append(name)
+            try:
+                yield Span()
+            finally:
+                self._active.pop()
+
+        def event(self, name, **_kwargs) -> None:
+            self.events.append((self._active[-1] if self._active else "", name))
+
+        def set_attributes(self, _attributes) -> None:
+            return None
+
+        def mark_error(self, *_args, **_kwargs) -> None:
+            return None
+
+        def count(self, *_args, **_kwargs) -> None:
+            return None
+
+        def gauge(self, *_args, **_kwargs) -> None:
+            return None
+
+    telemetry = RecordingTelemetry()
+    monkeypatch.setattr(build_tool_module, "get_observability", lambda: telemetry)
+    monkeypatch.setattr(learned_tool_module, "get_observability", lambda: telemetry)
+    monkeypatch.setattr(skill_tools_module, "get_observability", lambda: telemetry)
+
+    skills_dir = tmp_path / "skills"
+    manager = SkillManagementRegistry(
+        FileSkillRegistry(
+            skill_dirs=[str(skills_dir)],
+            write_dir=skills_dir,
+            include_builtin=False,
+            cwd=tmp_path,
+        ),
+        metadata_path=tmp_path / "skill_management.json",
+    )
+    await manager.create(name="status_probe", content="capability: tool.status_probe")
+
+    class LearnedTool:
+        required_permission = "tool:run"
+
+        async def execute(self, payload):
+            return ToolResult(tool_call_id="", content="ok")
+
+    class Resolver:
+        def load(self, name):
+            return LearnedTool()
+
+    await LearnedToolRunTool(
+        resolver=Resolver(),  # type: ignore[arg-type]
+        permission=AllowAllPermission(),
+        skill_manager=manager,
+    ).execute({"name": "status_probe", "input": {}})
+    await SkillManageTool(manager.skill_port, manager=manager).execute(
+        {"action": "archive", "name": "status_probe"}
+    )
+
+    async def record_installed(_artifact) -> None:
+        return None
+
+    built = BuildTool(
+        tools_dir=tmp_path / "tools",
+        artifacts_dir=tmp_path / "artifacts",
+        register_tool=lambda *_args, **_kwargs: None,
+        autonomy_mode="autonomous",
+        installed_artifact_recorder=record_installed,
+    )
+    await built.execute(
+        {
+            "manifest": {
+                "name": "new_probe",
+                "description": "Inspect status",
+                "input_schema": {"type": "object"},
+                "required_permission": "tool:run",
+            },
+            "tool_code": "def run(payload):\n    return {'ok': True}\n",
+            "test_code": "",
+        }
+    )
+
+    assert {
+        "ravn.learned_tool.lifecycle.run",
+        "ravn.skill.lifecycle",
+        "ravn.learned_tool.lifecycle.register",
+    }.issubset(telemetry.spans)
+    assert (
+        "ravn.learned_tool.lifecycle.run",
+        "ravn.learned_tool.lifecycle.usage_recorded",
+    ) in telemetry.events
+    assert ("ravn.skill.lifecycle", "ravn.skill.lifecycle.finished") in telemetry.events
+    assert (
+        "ravn.learned_tool.lifecycle.register",
+        "ravn.learned_tool.lifecycle.registered",
+    ) in telemetry.events
+
+
 def test_linked_span_starts_a_bounded_trace_with_causal_link() -> None:
     pytest.importorskip("opentelemetry.sdk")
     from opentelemetry.sdk.metrics import MeterProvider

--- a/tests/test_ravn/test_resident_learning_runtime.py
+++ b/tests/test_ravn/test_resident_learning_runtime.py
@@ -203,6 +203,49 @@ def test_nats_transport_kwargs_include_flock_extra_subscription(monkeypatch) -> 
 
 
 @pytest.mark.asyncio
+async def test_local_build_is_registered_in_existing_skill_lifecycle(tmp_path) -> None:
+    bus = InProcessBus()
+    manager = _manager(tmp_path, "resident")
+    runtime = ResidentLearningRuntime(
+        identity=ResidentLearningIdentity(
+            environment_id="workshop",
+            environment_type="workshop",
+            valkyrie_id="valkyrie:workshop",
+            domain="workshop",
+            flock_ids=["workshop-flock"],
+            autonomy_mode="yolo",
+        ),
+        skills=manager,
+        publisher=bus,
+        subscriber=bus,
+        tools_dir=tmp_path / "resident" / "tools",
+    )
+    artifact = ResidentLearningArtifact(
+        learning_id="learned-tool:status_probe",
+        title="status_probe",
+        summary="Inspect live status",
+        content="",
+        artifact_type="agent_tool",
+        scope="environment",
+        confidence=0.9,
+        source_environment_id="workshop",
+        source_valkyrie_id="valkyrie:workshop",
+        learned_tool_manifest={
+            "name": "status_probe",
+            "description": "Inspect live status",
+            "input_schema": {"type": "object"},
+            "required_permission": "tool:run",
+        },
+    )
+
+    await runtime.register_installed_artifact(artifact)
+
+    shown = await manager.show("status_probe")
+    assert shown["metadata"]["status"] == "active"
+    assert shown["metadata"]["source"] == "flock-learning:learned-tool:status_probe"
+
+
+@pytest.mark.asyncio
 async def test_resident_installs_learning_and_exposes_it_as_a_signal_hint(tmp_path) -> None:
     bus = InProcessBus()
     events: list[SleipnirEvent] = []

--- a/tests/test_ravn/test_skill_management.py
+++ b/tests/test_ravn/test_skill_management.py
@@ -121,6 +121,21 @@ async def test_lifecycle_archive_restore_pin_promote_and_usage(tmp_path: Path) -
     assert telemetry.action_safety_class == "diagnostic"
 
 
+async def test_skill_tools_honor_shared_archive_state(tmp_path: Path) -> None:
+    skill_port = await _adapter(tmp_path)
+    manager = SkillManagementRegistry(skill_port, metadata_path=tmp_path / "meta.json")
+    await manager.create(name="obsolete probe", content="Inspect with `probe`.")
+    await manager.archive("obsolete probe")
+
+    listed = await SkillListTool(skill_port, manager=manager).execute({})
+    loaded = await SkillRunTool(skill_port, manager=manager).execute(
+        {"skill_name": "obsolete probe"}
+    )
+
+    assert "obsolete probe" not in listed.content
+    assert loaded.is_error
+
+
 async def test_successful_environment_episodes_feed_skill_extraction(tmp_path: Path) -> None:
     skill_port = await _adapter(tmp_path, threshold=2)
     manager = SkillManagementRegistry(skill_port, metadata_path=tmp_path / "meta.json")


### PR DESCRIPTION
## What changed

- share the resident's existing skill lifecycle registry across build, discovery, management, and learned-tool execution
- register successful `build_tool` installs in that lifecycle without installing code twice
- record real learned-tool success/failure usage evidence
- hide archived tools from capability discovery, skill discovery, inventory, bulk loading, and execution
- add explicit OTEL spans/events for learned-tool registration and runs plus skill lifecycle actions

## Root cause

The lifecycle implementation already existed, but direct learned-tool dispatch and `build_tool` registration bypassed it, while tool adapters constructed separate registry instances. As a result, the resident lacked durable evidence needed to judge that a tool should be archived or superseded.

## Behavior

No environment or signal-specific rules were added. The LLM still decides whether evidence warrants archive, restore, update, or replacement using the existing generic tools and supersedes chain.

## Validation

- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- focused composition/lifecycle tests: 216 passed
- full Python suite before the telemetry-only follow-up: 17,581 passed, 33 skipped, 129 deselected, 1 expected xfail
- telemetry follow-up tests: 45 passed, 2 optional-SDK skips
