### PR TITLE
feat(ravn): steward learned capability lifecycle

### DIFF
--- a/src/ravn/adapters/tools/capability_catalog.py
+++ b/src/ravn/adapters/tools/capability_catalog.py
@@ -61,7 +61,8 @@ class CapabilityListTool(ToolPort):
             "resident learned tools, resident skills, configured remote workflows, "
             "and peer Agent Card skills. Use this before building new tools so existing "
             "capabilities are not duplicated. Entries tagged 'learned' are not native "
-            "tools — execute them by name with learned_tool_run."
+            "tools — execute them by name with learned_tool_run. Learned entries include "
+            "lifecycle, usage, failure, and supersession evidence for portfolio review."
         )
 
     @property
@@ -237,6 +238,8 @@ class CapabilityListTool(ToolPort):
                                 "verification": verification_outcome,
                                 "has_tests": bool(artifact.test_code),
                                 "requirements_count": len(artifact.requirements),
+                                "supersedes": artifact.supersedes,
+                                "lifecycle": self._learned_tool_lifecycle(manifest.name),
                             },
                         )
                     )
@@ -341,6 +344,27 @@ class CapabilityListTool(ToolPort):
             )
 
         return capabilities, errors
+
+    def _learned_tool_lifecycle(self, name: str) -> dict[str, Any]:
+        if self._skill_manager is None:
+            return {"status": "unmanaged"}
+        metadata = self._skill_manager.lifecycle_metadata(name)
+        if metadata is None:
+            return {"status": "unmanaged"}
+        return {
+            key: metadata[key]
+            for key in (
+                "status",
+                "scope",
+                "version",
+                "pinned",
+                "run_count",
+                "success_count",
+                "failure_count",
+                "consecutive_failures",
+                "last_used_at",
+            )
+        }
 
 
 def _parse_kind(value: Any) -> CapabilityKind | None:

--- a/src/ravn/adapters/tools/skill_tools.py
+++ b/src/ravn/adapters/tools/skill_tools.py
@@ -268,7 +268,9 @@ class SkillManageTool(ToolPort):
         return (
             "Write-capable skill management for resident Valkyries. Supports "
             "create, update, archive, restore, pin, unpin, promote, show, list, "
-            "validate, and telemetry actions with Environment/Flock scope metadata."
+            "validate, and telemetry actions with Environment/Flock scope metadata. "
+            "Use lifecycle and usage evidence to maintain the capability portfolio; "
+            "after verifying a replacement, archive an obsolete or inferior capability."
         )
 
     @property

--- a/src/ravn/skills/management.py
+++ b/src/ravn/skills/management.py
@@ -68,6 +68,11 @@ class SkillManagementRegistry:
         meta = self._metadata.get(self._key(name))
         return meta.status if meta is not None else None
 
+    def lifecycle_metadata(self, name: str) -> dict[str, object] | None:
+        """Return a read-only lifecycle snapshot for capability discovery."""
+        meta = self._metadata.get(self._key(name))
+        return asdict(meta) if meta is not None else None
+
     async def create(
         self,
         *,

--- a/src/ravn/valkyrie_evolution/resident_learning.py
+++ b/src/ravn/valkyrie_evolution/resident_learning.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
+from niuu.observability import get_observability
 from ravn.adapters.reflection.flock_learning import (
     FlockLearningCandidate,
     FlockLearningRecord,
@@ -291,6 +292,7 @@ class ResidentLearningRuntime:
     async def start(self) -> None:
         if self._subscription is not None:
             return
+        await self._enroll_persisted_learned_tools()
         self._subscription = await self._subscriber.subscribe(
             _SUBSCRIBED_EVENT_TYPES,
             self._handle_learning_event,
@@ -441,6 +443,59 @@ class ResidentLearningRuntime:
                 }
             )
         return records
+
+    async def _enroll_persisted_learned_tools(self) -> int:
+        """Bring durable learned-tool envelopes under the existing lifecycle."""
+        enrolled = 0
+        telemetry = get_observability()
+        for record in self._iter_learned_tool_inventory():
+            name = record["skill_name"]
+            if self._skills.status(name) is not None:
+                continue
+            attributes = {
+                "ravn.learned_tool.name": name,
+                "ravn.learned_tool.artifact_id": record["learning_id"],
+                "ravn.skill.lifecycle.action": "enroll",
+            }
+            with telemetry.span(
+                "ravn.learned_tool.lifecycle.enroll",
+                attributes=attributes,
+            ) as span:
+                try:
+                    await self._record_inventory_skill(record)
+                except Exception as exc:  # noqa: BLE001 — continue enrolling valid artifacts
+                    telemetry.mark_error(span, type(exc).__name__, str(exc))
+                    logger.exception(
+                        "resident_learning: could not enroll persisted learned tool %s",
+                        name,
+                    )
+                    continue
+                enrolled += 1
+                telemetry.event(
+                    "ravn.learned_tool.lifecycle.enrolled",
+                    attributes={**attributes, "ravn.skill.lifecycle.status": "active"},
+                )
+        return enrolled
+
+    async def _record_inventory_skill(self, record: dict[str, Any]) -> None:
+        artifact = ResidentLearningArtifact(
+            learning_id=record["learning_id"],
+            title=record["skill_name"],
+            summary=record["summary_text"],
+            content=record["skill_content"],
+            artifact_type="agent_tool",
+            scope=record["learning_scope"],
+            confidence=0.0,
+            source_environment_id=record["source_environment_id"],
+            source_valkyrie_id=record["source_valkyrie_id"],
+            domain=self.identity.domain,
+            tool_code=record["tool_code"],
+            learned_tool_manifest=record["learned_tool_manifest"],
+            test_code=record["test_code"],
+            requirements=record["requirements"],
+        )
+        _, build = review_inputs(artifact, self.identity)
+        await self._record_installed_skill(artifact, build)
 
     async def _iter_managed_skill_inventory(self) -> list[dict[str, Any]]:
         """Full records for installed managed skills (markdown + optional tool)."""
@@ -1732,22 +1787,8 @@ class ResidentLearningRuntime:
         for record in self._iter_learned_tool_inventory():
             if not any(marker in record["skill_content"] for marker in markers):
                 continue
-            try:
-                skill = await self._skills.create(
-                    name=record["skill_name"],
-                    content=record["skill_content"],
-                    description=record["summary_text"],
-                    scope=_normalise_scope(record["learning_scope"]),
-                    environment_id=self.identity.environment_id,
-                    domain=self.identity.domain,
-                    source=record["learning_source"],
-                    source_environment_id=record["source_environment_id"],
-                    source_valkyrie_id=record["source_valkyrie_id"],
-                    action_safety_class=_safety_class_from_content(record["skill_content"]),
-                )
-            except ValueError:
-                continue
-            return skill
+            await self._record_inventory_skill(record)
+            return await self._skills.get_runnable_skill(record["skill_name"])
         return None
 
     async def _publish_odin_decision(

--- a/tests/test_ravn/test_capability_list_tool.py
+++ b/tests/test_ravn/test_capability_list_tool.py
@@ -206,7 +206,12 @@ async def test_capability_list_rejects_unknown_kind() -> None:
     assert "Unsupported capability kind" in result.content
 
 
-def _learned_artifact(name: str, description: str = "Read a metric window."):
+def _learned_artifact(
+    name: str,
+    description: str = "Read a metric window.",
+    *,
+    supersedes: str = "",
+):
     from ravn.valkyrie_evolution.models import LearnedToolArtifact, LearnedToolManifest
 
     return LearnedToolArtifact(
@@ -219,6 +224,7 @@ def _learned_artifact(name: str, description: str = "Read a metric window."):
             declared_reach=[],
         ),
         tool_code="def run(input):\n    return {'ok': True}\n",
+        supersedes=supersedes,
     )
 
 
@@ -244,6 +250,55 @@ async def test_capability_list_includes_learned_tools_without_loading_them() -> 
         "verification": "unknown",
         "has_tests": False,
         "requirements_count": 0,
+        "supersedes": "",
+        "lifecycle": {"status": "unmanaged"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_capability_list_exposes_learned_tool_lifecycle_evidence() -> None:
+    class ManagedSkillManager:
+        def status(self, name: str) -> str | None:
+            return "active"
+
+        def lifecycle_metadata(self, name: str) -> dict[str, object] | None:
+            return {
+                "status": "active",
+                "scope": "environment",
+                "version": 2,
+                "pinned": False,
+                "run_count": 4,
+                "success_count": 3,
+                "failure_count": 1,
+                "consecutive_failures": 0,
+                "last_used_at": "2026-07-27T08:00:00+00:00",
+            }
+
+    tool = CapabilityListTool(
+        tools_provider=lambda: [],
+        learned_tools_provider=lambda: [
+            _learned_artifact(
+                "current_probe",
+                supersedes="learned-tool:old_probe:abc123",
+            )
+        ],
+        skill_manager=ManagedSkillManager(),  # type: ignore[arg-type]
+    )
+
+    result = await tool.execute({"kind": "tool"})
+
+    metadata = json.loads(result.content)["capabilities"][0]["metadata"]
+    assert metadata["supersedes"] == "learned-tool:old_probe:abc123"
+    assert metadata["lifecycle"] == {
+        "status": "active",
+        "scope": "environment",
+        "version": 2,
+        "pinned": False,
+        "run_count": 4,
+        "success_count": 3,
+        "failure_count": 1,
+        "consecutive_failures": 0,
+        "last_used_at": "2026-07-27T08:00:00+00:00",
     }
 
 
@@ -252,6 +307,9 @@ async def test_capability_list_hides_archived_learned_tools() -> None:
     class ArchivedSkillManager:
         def status(self, name: str) -> str | None:
             return "archived" if name == "obsolete_probe" else None
+
+        def lifecycle_metadata(self, name: str) -> dict[str, object] | None:
+            return None
 
     tool = CapabilityListTool(
         tools_provider=lambda: [FakeTool()],

--- a/tests/test_ravn/test_resident_learning_runtime.py
+++ b/tests/test_ravn/test_resident_learning_runtime.py
@@ -19,7 +19,15 @@ from ravn.cli.commands import (
 from ravn.config import Settings
 from ravn.odin.review import ReviewItem, ReviewKind, review_decided_event
 from ravn.skills.management import SkillManagementRegistry
-from ravn.valkyrie_evolution.models import OperationalSignal
+from ravn.valkyrie_evolution.learned_tools import (
+    learned_tool_storage,
+    write_learned_tool_artifact,
+)
+from ravn.valkyrie_evolution.models import (
+    LearnedToolArtifact,
+    LearnedToolManifest,
+    OperationalSignal,
+)
 from ravn.valkyrie_evolution.resident_learning import (
     EVOLUTION_SKILL_INVENTORY_EVENT,
     ResidentLearningArtifact,
@@ -243,6 +251,59 @@ async def test_local_build_is_registered_in_existing_skill_lifecycle(tmp_path) -
     shown = await manager.show("status_probe")
     assert shown["metadata"]["status"] == "active"
     assert shown["metadata"]["source"] == "flock-learning:learned-tool:status_probe"
+
+
+@pytest.mark.asyncio
+async def test_start_enrolls_persisted_learned_tools_in_existing_lifecycle(tmp_path) -> None:
+    bus = InProcessBus()
+    manager = _manager(tmp_path, "resident")
+    tools_dir = tmp_path / "resident" / "tools"
+    _, artifacts_dir = learned_tool_storage(tools_dir.parent)
+    write_learned_tool_artifact(
+        artifacts_dir=artifacts_dir,
+        artifact=LearnedToolArtifact(
+            artifact_id="learned-tool:fleet_status:abc123",
+            manifest=LearnedToolManifest(
+                name="fleet_status",
+                description="Inspect the current fleet status.",
+                input_schema={"type": "object"},
+                required_permission="tool:run",
+            ),
+            tool_code="def run(input):\n    return {'ok': True}\n",
+            provenance={
+                "scope": "environment",
+                "source_environment_id": "workshop",
+                "source_valkyrie_id": "valkyrie:workshop",
+            },
+        ),
+    )
+    runtime = ResidentLearningRuntime(
+        identity=ResidentLearningIdentity(
+            environment_id="workshop",
+            environment_type="workshop",
+            valkyrie_id="valkyrie:workshop",
+            domain="workshop",
+            flock_ids=["workshop-flock"],
+            autonomy_mode="yolo",
+        ),
+        skills=manager,
+        publisher=bus,
+        subscriber=bus,
+        tools_dir=tools_dir,
+    )
+
+    await runtime.start()
+
+    shown = await manager.show("fleet_status")
+    assert shown["metadata"]["status"] == "active"
+    assert shown["metadata"]["scope"] == "environment"
+    assert shown["metadata"]["source"] == ("flock-learning:learned-tool:fleet_status:abc123")
+    assert await runtime._enroll_persisted_learned_tools() == 0
+
+    await manager.archive("fleet_status")
+    assert await runtime._enroll_persisted_learned_tools() == 0
+    assert manager.status("fleet_status") == "archived"
+    await runtime.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/test_ravn/test_skill_management.py
+++ b/tests/test_ravn/test_skill_management.py
@@ -121,6 +121,19 @@ async def test_lifecycle_archive_restore_pin_promote_and_usage(tmp_path: Path) -
     assert telemetry.action_safety_class == "diagnostic"
 
 
+async def test_lifecycle_metadata_returns_detached_discovery_snapshot(tmp_path: Path) -> None:
+    skill_port = await _adapter(tmp_path)
+    manager = SkillManagementRegistry(skill_port, metadata_path=tmp_path / "meta.json")
+    await manager.create(name="printer probe", content="Inspect with `printerctl`.")
+
+    snapshot = manager.lifecycle_metadata("printer probe")
+
+    assert snapshot is not None
+    assert snapshot["status"] == "active"
+    snapshot["status"] = "archived"
+    assert manager.status("printer probe") == "active"
+
+
 async def test_skill_tools_honor_shared_archive_state(tmp_path: Path) -> None:
     skill_port = await _adapter(tmp_path)
     manager = SkillManagementRegistry(skill_port, metadata_path=tmp_path / "meta.json")


### PR DESCRIPTION
## Summary
- enroll persisted learned-tool artifacts into the existing resident skill lifecycle at startup
- expose lifecycle, usage, failure, and supersession evidence through capability discovery
- clarify skill management as the existing portfolio retirement action while leaving retirement judgment to the model
- trace durable-tool enrollment without adding an automatic retirement rule

## Validation
- `make lint`
- `make test-ravn` (7040 passed, 8 skipped; 85.85% coverage)