### PR TITLE
fix(ravn): prevent recurring task queue starvation

### DIFF
--- a/src/ravn/adapters/tools/bash.py
+++ b/src/ravn/adapters/tools/bash.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import signal
 from pathlib import Path
 
 from ravn.adapters.permission.bash_validator import BashValidationPipeline
@@ -134,11 +136,18 @@ class BashTool(ToolPort):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 cwd=str(self._workspace_root),
+                start_new_session=True,
             )
             try:
                 stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=self._timeout)
             except TimeoutError:
-                proc.kill()
+                # The shell may have spawned descendants which inherited its
+                # stdout pipe. Killing only the shell leaves communicate()
+                # waiting forever for those descendants to close the pipe.
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
                 await proc.communicate()
                 output = self._build_output(b"", warnings)
                 return ToolResult(

--- a/src/ravn/adapters/triggers/cron.py
+++ b/src/ravn/adapters/triggers/cron.py
@@ -29,7 +29,7 @@ import time
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import asdict, dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import IO
 
@@ -66,6 +66,13 @@ _DELIVERY_TO_OUTPUT_MODE: dict[str, OutputMode] = {
     "sleipnir": OutputMode.AMBIENT,
     "platform": OutputMode.SURFACE,
 }
+
+
+def _task_deadline(canonical: str, now: datetime) -> datetime | None:
+    """Expire interval work when its next occurrence becomes due."""
+    if canonical.startswith("every:"):
+        return now + timedelta(seconds=int(canonical[6:]))
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +467,7 @@ class CronTrigger(TriggerPort):
                             output_mode=job.output_mode,
                             persona=job.persona,
                             priority=job.priority,
+                            deadline=_task_deadline(job.canonical, now),
                         )
                         logger.info("cron: firing job %r (task_id=%s)", job.name, task_id)
                         await enqueue(task)
@@ -496,6 +504,7 @@ class CronTrigger(TriggerPort):
                                 output_mode=output_mode,
                                 persona=record.persona or None,
                                 priority=record.priority,
+                                deadline=_task_deadline(canonical, now),
                                 output_path=output_path,
                             )
                             logger.info(

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -1308,6 +1308,22 @@ class DriveLoop:
             await self._emit_sleipnir_task_dropped(task, reason="duplicate_task")
             return False, "duplicate_task"
 
+        recurring_key = self._recurring_key(task)
+        if recurring_key is not None and any(
+            self._recurring_key(existing) == recurring_key
+            for existing in (
+                *self._inflight_tasks.values(),
+                *(queued for _priority, _counter, queued in self._queue._queue),
+            )
+        ):
+            logger.info(
+                "drive_loop: recurring task %s (%r) already queued or active — discarding tick",
+                recurring_key,
+                task.title,
+            )
+            await self._emit_sleipnir_task_dropped(task, reason="recurring_task_pending")
+            return False, "recurring_task_pending"
+
         if task.deadline is not None and datetime.now(UTC) > task.deadline:
             logger.info(
                 "drive_loop: task %s (%r) deadline exceeded before enqueue — discarding",
@@ -1340,6 +1356,11 @@ class DriveLoop:
             len(self._active_tasks),
         )
         return True, "accepted"
+
+    @staticmethod
+    def _recurring_key(task: AgentTask) -> str | None:
+        """Return the stable identity shared by occurrences of a cron job."""
+        return task.triggered_by if task.triggered_by.startswith("cron:") else None
 
     def _record_queue_state(self) -> None:
         telemetry = get_observability()
@@ -4019,7 +4040,7 @@ class DriveLoop:
             }
             fan_in_data = raw.get("fan_in_pending", {})
 
-        restored = 0
+        restored_tasks: list[tuple[AgentTask, bool]] = []
         for rec in records:
             try:
                 deadline = datetime.fromisoformat(rec["deadline"]) if rec.get("deadline") else None
@@ -4065,17 +4086,43 @@ class DriveLoop:
                         task.task_id,
                     )
                     continue
-                counter = self._next_counter()
-                self._queue.put_nowait((task.priority, counter, task))
-                track = getattr(self._resident_runtime, "track_task", None)
-                if track is not None:
-                    track(task)
-                if task.task_id in inflight_task_ids:
-                    self._restored_inflight_task_ids.add(task.task_id)
-                restored += 1
+                restored_tasks.append((task, task.task_id in inflight_task_ids))
             except Exception as exc:
                 logger.warning("drive_loop: failed to restore journal entry: %s", exc)
 
+        # A restart turns formerly active tasks back into pending work. For a
+        # recurring job only its newest occurrence is useful; older ticks
+        # describe an environment state that has already been superseded.
+        recurring: dict[str, tuple[AgentTask, bool]] = {}
+        unique: list[tuple[AgentTask, bool]] = []
+        for candidate in restored_tasks:
+            task, _was_inflight = candidate
+            key = self._recurring_key(task)
+            if key is None:
+                unique.append(candidate)
+                continue
+            current = recurring.get(key)
+            if current is None or task.created_at > current[0].created_at:
+                recurring[key] = candidate
+
+        selected = [*unique, *recurring.values()]
+        dropped = len(restored_tasks) - len(selected)
+        if dropped:
+            logger.info(
+                "drive_loop: discarded %d superseded recurring task(s) from journal",
+                dropped,
+            )
+
+        for task, was_inflight in selected:
+            counter = self._next_counter()
+            self._queue.put_nowait((task.priority, counter, task))
+            track = getattr(self._resident_runtime, "track_task", None)
+            if track is not None:
+                track(task)
+            if was_inflight:
+                self._restored_inflight_task_ids.add(task.task_id)
+
+        restored = len(selected)
         if restored:
             logger.info("drive_loop: restored %d task(s) from journal", restored)
 
@@ -4086,3 +4133,5 @@ class DriveLoop:
                 "drive_loop: restored %d fan-in slot(s) from journal",
                 self._fan_in.pending_count,
             )
+        if dropped:
+            self._persist_queue()

--- a/tests/ravn/unit/test_drive_loop.py
+++ b/tests/ravn/unit/test_drive_loop.py
@@ -30,12 +30,13 @@ def _make_task(
     priority: int = 10,
     output_mode: OutputMode = OutputMode.SILENT,
     deadline: datetime | None = None,
+    triggered_by: str | None = None,
 ) -> AgentTask:
     return AgentTask(
         task_id=f"task_{uuid4().hex}_0001",
         title="test task",
         initiative_context="do something useful",
-        triggered_by="cron:test",
+        triggered_by=triggered_by or f"event:test:{uuid4().hex}",
         output_mode=output_mode,
         priority=priority,
         deadline=deadline,
@@ -220,6 +221,28 @@ async def test_drive_loop_enqueue_rejects_duplicate_task_id(tmp_path: Path) -> N
     assert await loop.enqueue(task) is False
 
     assert loop.queued_task_ids() == ["task-duplicate"]
+
+
+@pytest.mark.asyncio
+async def test_drive_loop_keeps_one_pending_occurrence_per_cron_job(tmp_path: Path) -> None:
+    loop, _ = _make_drive_loop(tmp_path)
+    first = _make_task(triggered_by="cron:monitor")
+    second = _make_task(triggered_by="cron:monitor")
+
+    assert await loop.enqueue(first) is True
+    assert await loop.enqueue(second) is False
+
+    assert loop.queued_task_ids() == [first.task_id]
+
+
+@pytest.mark.asyncio
+async def test_drive_loop_allows_different_cron_jobs(tmp_path: Path) -> None:
+    loop, _ = _make_drive_loop(tmp_path)
+
+    assert await loop.enqueue(_make_task(triggered_by="cron:monitor-a")) is True
+    assert await loop.enqueue(_make_task(triggered_by="cron:monitor-b")) is True
+
+    assert loop._queue.qsize() == 2
 
 
 @pytest.mark.asyncio
@@ -422,6 +445,39 @@ async def test_drive_loop_journal_skips_expired_tasks(tmp_path: Path) -> None:
     assert loop._queue.empty()
 
 
+def test_drive_loop_journal_keeps_newest_recurring_occurrence(tmp_path: Path) -> None:
+    journal = tmp_path / "queue.json"
+    old = _make_task(triggered_by="cron:monitor")
+    old.task_id = "task-old"
+    old.created_at = datetime.now(UTC) - timedelta(minutes=10)
+    new = _make_task(triggered_by="cron:monitor")
+    new.task_id = "task-new"
+    new.created_at = datetime.now(UTC)
+    journal.write_text(
+        json.dumps(
+            {
+                "queue": [
+                    DriveLoop._task_journal_record(old),
+                    DriveLoop._task_journal_record(new),
+                ],
+                "inflight": [],
+            }
+        )
+    )
+    loop = DriveLoop(
+        agent_factory=MagicMock(),
+        config=_make_initiative_config(queue_journal_path=str(journal)),
+        settings=Settings(),
+    )
+
+    loop._load_journal()
+
+    assert loop.queued_task_ids() == ["task-new"]
+    assert [record["task_id"] for record in json.loads(journal.read_text())["queue"]] == [
+        "task-new"
+    ]
+
+
 # ---------------------------------------------------------------------------
 # DriveLoop — surface escalation
 # ---------------------------------------------------------------------------
@@ -550,6 +606,8 @@ async def test_cron_trigger_fires_on_schedule(tmp_path: Path) -> None:
 
     assert len(enqueued) >= 1
     assert enqueued[0].triggered_by == "cron:test_job"
+    assert enqueued[0].deadline is not None
+    assert enqueued[0].deadline > enqueued[0].created_at
 
 
 @pytest.mark.asyncio
@@ -1483,7 +1541,7 @@ async def test_finalise_thread_skipped_for_non_thread_task(tmp_path: Path) -> No
     mock_agent.run_turn = AsyncMock(return_value=None)
     factory.return_value = mock_agent
 
-    task = _make_task()  # triggered_by="cron:test"
+    task = _make_task()
     await loop._run_task(task)
 
     mock_mimir.update_thread_state.assert_not_awaited()

--- a/tests/test_ravn/test_bash_tool.py
+++ b/tests/test_ravn/test_bash_tool.py
@@ -6,6 +6,7 @@ sandbox. They do NOT require Docker or any external services.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
@@ -126,6 +127,24 @@ class TestTimeout:
     async def test_command_times_out(self, tmp_path: Path) -> None:
         tool = make_tool(tmp_path, timeout_seconds=0.2)
         result = await tool.execute({"command": "sleep 10"})
+        assert result.is_error
+        assert "timed out" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_timeout_kills_descendants_holding_output_pipe(self, tmp_path: Path) -> None:
+        tool = make_tool(tmp_path, timeout_seconds=0.2)
+        started = time.monotonic()
+
+        result = await tool.execute(
+            {
+                "command": (
+                    'python3 -c "import subprocess, time; '
+                    "subprocess.Popen(['sleep', '10']); time.sleep(10)\""
+                )
+            }
+        )
+
+        assert time.monotonic() - started < 2
         assert result.is_error
         assert "timed out" in result.content.lower()
 


### PR DESCRIPTION
## What changed

- coalesce recurring cron occurrences while one is queued or running
- expire interval-triggered work when the next occurrence becomes due
- compact superseded recurring occurrences during journal recovery
- kill the complete subprocess group when bash execution times out

## Root cause

A runtime-created five-minute monitor produced a new task ID on every tick. With one executor, occurrences accumulated until the durable queue reached its 50-task cap. Separately, BashTool killed only the parent shell on timeout; descendants retaining stdout could leave communicate() blocked indefinitely and stop the executor entirely.

## Behavior

This changes scheduling mechanics only. Ravn still judges whether a recurring job should be retained or deleted. Different recurring jobs and non-recurring tasks remain independent.

## Validation

- make lint
- make test-ravn (7,044 passed, 8 skipped; 85.87% coverage)
- focused regression suite (120 passed, 1 skipped)