### PR TITLE
fix(ravn): stop replaying completed resident wakes

### DIFF
--- a/src/ravn/resident_runtime.py
+++ b/src/ravn/resident_runtime.py
@@ -377,6 +377,22 @@ class ResidentRuntime:
             budget_ref = await self._state.write_budget(snapshot)
             budget_span.set_attribute("ravn.resident.budget_ref", budget_ref)
 
+        # The wake is a delivery marker, not evidence. Once the resumed turn and
+        # its budget are durable, that wake has been handled even when the model
+        # misses the outcome schema. Executor crashes never reach this point, so
+        # their wake remains pending for recovery.
+        if task.resident_wake_ref:
+            wake = await self._state.read(task.resident_wake_ref)
+            if wake is not None and wake.path == task.resident_wake_ref:
+                with telemetry.span(
+                    "ravn.port.resident_state.consume_scheduled_wake",
+                    attributes={
+                        "ravn.resident.case_id": case_id,
+                        "ravn.resident.wake_ref": task.resident_wake_ref,
+                    },
+                ):
+                    await self._state.consume_scheduled_wake(wake)
+
         if not outcome_valid:
             self._inflight_cases.discard(case_id)
             self._inflight_refs.difference_update(task.resident_inbox_refs)
@@ -405,17 +421,6 @@ class ResidentRuntime:
             answer = await self._state.read_operator_answer(case_id)
             if answer is not None and answer.path == task.resident_answer_ref:
                 await self._state.consume_operator_answer(answer)
-        if task.resident_wake_ref:
-            wake = await self._state.read(task.resident_wake_ref)
-            if wake is not None and wake.path == task.resident_wake_ref:
-                with telemetry.span(
-                    "ravn.port.resident_state.consume_scheduled_wake",
-                    attributes={
-                        "ravn.resident.case_id": case_id,
-                        "ravn.resident.wake_ref": task.resident_wake_ref,
-                    },
-                ):
-                    await self._state.consume_scheduled_wake(wake)
 
         self._inflight_cases.discard(case_id)
         self._inflight_refs.difference_update(task.resident_inbox_refs)

--- a/tests/test_ravn/test_resident_runtime.py
+++ b/tests/test_ravn/test_resident_runtime.py
@@ -1004,6 +1004,39 @@ async def test_a_failed_resumed_turn_leaves_the_wake_pending_for_retry(tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_a_completed_resumed_turn_consumes_wake_when_outcome_is_invalid(tmp_path) -> None:
+    state = LocalResidentState(tmp_path)
+    runtime = ResidentRuntime(state=state)
+    queued: list[AgentTask] = []
+
+    async def enqueue(task: AgentTask) -> bool:
+        queued.append(task)
+        return True
+
+    runtime.bind_enqueue(enqueue)
+    await state.write_scheduled_wake(
+        ResidentScheduledWakeRecord(
+            case_id="case-invalid-outcome",
+            root_correlation_id="root-invalid-outcome",
+            wake_at=datetime.now(UTC) - timedelta(minutes=1),
+            reason="recheck after sleeping",
+        )
+    )
+
+    assert await runtime.resume_due_wakes() == 1
+    disposition = await runtime.handle_completed_turn(
+        task=queued[0],
+        prompt="completed recheck",
+        result=_result({"continuation": "stop"}, outcome_valid=False),
+        response_text="schema-invalid response",
+    )
+
+    assert disposition.reason == "resident outcome contract was invalid"
+    assert await state.list_scheduled_wakes() == []
+    assert await runtime.resume_due_wakes() == 0
+
+
+@pytest.mark.asyncio
 async def test_scheduled_resume_preserves_and_enforces_the_turn_budget(tmp_path) -> None:
     state = LocalResidentState(tmp_path)
     runtime = ResidentRuntime(state=state, max_turns=3)


### PR DESCRIPTION
## Summary
- consume a scheduled wake after its resumed turn and budget have been durably recorded
- preserve wake retry when execution crashes before completion
- prevent invalid structured outcomes from immediately replaying the same already-delivered wake forever

## Validation
- `make lint`
- `make test-ravn` (7,053 passed, 8 skipped; 85.87% coverage)
- focused resident runtime tests (42 passed)