### PR TITLE
fix(ravn): prioritize directed user messages

### DIFF
--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -2060,7 +2060,7 @@ class DriveLoop:
             triggered_by="skuld:directed_message",
             output_mode=OutputMode.SURFACE,
             persona=persona,
-            priority=1,  # high priority — user is waiting
+            priority=0,  # user input precedes autonomous continuation work
             human_initiated=True,
             resident_inbox_refs=[inbox_ref] if inbox_ref else [],
         )

--- a/tests/test_ravn/test_drive_loop_outcome_contract.py
+++ b/tests/test_ravn/test_drive_loop_outcome_contract.py
@@ -1462,6 +1462,7 @@ summary: post-mortem source captured
 
         enqueued = dl.enqueue.await_args.args[0]
         assert enqueued.human_initiated is True
+        assert enqueued.priority == 0
         assert enqueued.persona == "council-chair"
         assert enqueued.root_correlation_id == "root-1"
         assert enqueued.workflow_parent_event_id == "parent-1"


### PR DESCRIPTION
## Summary
- give directed human messages priority 0
- ensure queued operator steering runs before autonomous scheduled wakes
- retain live steering when the active runtime supports it

## Validation
- `uv run pytest tests/test_ravn/test_drive_loop_outcome_contract.py -q` (53 passed)
- focused Ruff check and format check