### PR TITLE
fix(ravn): preserve durable HUD state during active turns

### DIFF
--- a/src/ravn/resident_timeline.py
+++ b/src/ravn/resident_timeline.py
@@ -67,6 +67,9 @@ class ResidentTimelineTurn:
     evidence_refs: tuple[str, ...] = ()
     inbox_refs: tuple[str, ...] = ()
     working_state: dict[str, list[str]] = field(default_factory=dict)
+    working_state_turn_index: int = 0
+    working_state_updated_at: str = ""
+    working_state_authored: bool = False
     changes: dict[str, ResidentStateChange] = field(default_factory=dict)
 
     def as_dict(self) -> dict[str, Any]:
@@ -90,6 +93,9 @@ class ResidentTimelineTurn:
             "evidence_refs": list(self.evidence_refs),
             "inbox_refs": list(self.inbox_refs),
             "working_state": {key: list(value) for key, value in self.working_state.items()},
+            "working_state_turn_index": self.working_state_turn_index,
+            "working_state_updated_at": self.working_state_updated_at,
+            "working_state_authored": self.working_state_authored,
             "changes": {key: value.as_dict() for key, value in self.changes.items()},
         }
 
@@ -153,16 +159,27 @@ def _with_changes(turns: list[ResidentTimelineTurn]) -> list[ResidentTimelineTur
     """Attach per-field added/retained/removed against the previous turn."""
     projected: list[ResidentTimelineTurn] = []
     previous: dict[str, list[str]] = {}
+    previous_turn_index = 0
+    previous_updated_at = ""
     for turn in turns:
+        authored = bool(turn.working_state)
+        if authored:
+            current_state = {key: list(value) for key, value in turn.working_state.items()}
+            state_turn_index = turn.turn_index
+            state_updated_at = turn.updated_at
+        else:
+            current_state = {key: list(value) for key, value in previous.items()}
+            state_turn_index = previous_turn_index
+            state_updated_at = previous_updated_at
         changes: dict[str, ResidentStateChange] = {}
         for name in RESIDENT_WORKING_STATE_FIELDS:
-            if not turn.working_state:
+            if not authored:
                 # A turn that authored no snapshot revised nothing. Diffing it
                 # against the baseline would render as the resident dropping its
                 # entire model, which is the opposite of what happened.
                 changes[name] = ResidentStateChange()
                 continue
-            current_entries = turn.working_state.get(name, [])
+            current_entries = current_state.get(name, [])
             prior_entries = previous.get(name, [])
             prior_set = set(prior_entries)
             current_set = set(current_entries)
@@ -191,14 +208,19 @@ def _with_changes(turns: list[ResidentTimelineTurn]) -> list[ResidentTimelineTur
                 judgment=turn.judgment,
                 evidence_refs=turn.evidence_refs,
                 inbox_refs=turn.inbox_refs,
-                working_state=turn.working_state,
+                working_state=current_state,
+                working_state_turn_index=state_turn_index,
+                working_state_updated_at=state_updated_at,
+                working_state_authored=authored,
                 changes=changes,
             )
         )
         # Only a turn that authored a snapshot moves the baseline; a turn with an
         # invalid outcome must not read as the resident dropping everything.
-        if turn.working_state:
-            previous = turn.working_state
+        if authored:
+            previous = current_state
+            previous_turn_index = turn.turn_index
+            previous_updated_at = turn.updated_at
     return projected
 
 

--- a/src/ravn/static/resident-hud.html
+++ b/src/ravn/static/resident-hud.html
@@ -170,6 +170,18 @@
   .wake .meta{display:flex; gap:20px; font-size:10px; color:var(--dim2); letter-spacing:.1em; white-space:nowrap}
   .wake .meta b{color:var(--tx); font-weight:500}
 
+  /* ── durable state and active overlay ───────────────── */
+  .state-layers{display:flex;align-items:center;justify-content:space-between;gap:14px;
+    border:1px solid var(--line);background:var(--panel);padding:7px 11px}
+  .state-layer{display:flex;align-items:baseline;gap:8px;min-width:0}
+  .state-layer .kind{font-size:8.5px;letter-spacing:.2em;text-transform:uppercase;
+    color:var(--obs);white-space:nowrap}
+  .state-layer b{font-size:10px;color:var(--tx);font-weight:500}
+  .state-layer .detail{font-size:9px;color:var(--dim);white-space:nowrap}
+  .state-layer.live{border-left:1px solid var(--line2);padding-left:14px}
+  .state-layer.live .kind{color:var(--hyp)}
+  .state-layer.live[hidden]{display:none}
+
   /* ── callouts ───────────────────────────────────────── */
   .flags{display:flex; gap:8px; min-height:26px; flex-wrap:wrap}
   .flag{font-size:10px; letter-spacing:.18em; text-transform:uppercase; padding:4px 11px;
@@ -262,6 +274,8 @@
     .live-card{height:320px}
     .cols{grid-template-columns:1fr 1fr}
     .charter{display:none}
+    .state-layers{align-items:flex-start;flex-direction:column}
+    .state-layer.live{border-left:0;border-top:1px solid var(--line2);padding:7px 0 0;width:100%}
   }
 </style>
 </head>
@@ -373,6 +387,18 @@
   </div>
 
   <div class="flags" id="flags"></div>
+
+  <div class="state-layers">
+    <div class="state-layer">
+      <span class="kind">Durable model</span>
+      <b id="durable-state">No persisted state yet</b>
+    </div>
+    <div class="state-layer live" id="live-state-layer" hidden>
+      <span class="kind">Live overlay</span>
+      <b id="live-state">—</b>
+      <span class="detail">provisional until the turn persists a judgment</span>
+    </div>
+  </div>
 
   <div class="cols" id="cols"></div>
 
@@ -939,6 +965,16 @@ function renderRuntime(d){
     :"—";
   document.getElementById("live-tools").textContent=progress.tool_calls||0;
   document.getElementById("live-warnings").textContent=progress.warnings||0;
+  const liveStateLayer=document.getElementById("live-state-layer");
+  liveStateLayer.hidden=!activeTask;
+  document.getElementById("live-state").textContent=activeTask
+    ? [
+        progress.iteration_budget
+          ? `iteration ${progress.iteration||0} / ${progress.iteration_budget}`
+          : `iteration ${progress.iteration||0}`,
+        `${progress.tool_calls||0} tool call${progress.tool_calls===1?"":"s"}`,
+      ].join(" · ")
+    :"—";
   renderA2A(runtime);
   renderActivity(
     events,
@@ -965,6 +1001,7 @@ function renderEmpty(){
   document.getElementById("wtok").textContent="0";
   document.getElementById("wnext").textContent="—";
   document.getElementById("flags").innerHTML="";
+  document.getElementById("durable-state").textContent="No persisted state yet";
   document.getElementById("stamp").textContent="0 / 0";
 }
 
@@ -981,6 +1018,11 @@ function render(n){
   document.getElementById("wnext").textContent=(t.continuation||"—").toUpperCase();
   document.getElementById("flags").innerHTML=judgmentFacts(t)
     .map(fact=>`<span class="flag fact">${esc(fact)}</span>`).join("");
+  const stateTime=t.working_state_updated_at?new Date(t.working_state_updated_at):null;
+  document.getElementById("durable-state").textContent=t.working_state_turn_index
+    ? `turn ${t.working_state_turn_index}${stateTime&&!isNaN(stateTime)
+        ?" · "+stateTime.toISOString().slice(0,16).replace("T"," ")+"Z":""}`
+    :"No persisted state yet";
 
   FIELDS.forEach(k=>{
     const cur=t.working_state?.[k]||[], c=ch[k]||{};

--- a/tests/test_ravn/test_gateway_http.py
+++ b/tests/test_ravn/test_gateway_http.py
@@ -573,6 +573,10 @@ def test_resident_hud_serves_live_durable_and_inflight_state_without_operator_to
     assert "RESIDENT · HUD" in page.text
     assert "What happened" in page.text
     assert "Current progress" in page.text
+    assert "Durable model" in page.text
+    assert "Live overlay" in page.text
+    assert 'id="durable-state"' in page.text
+    assert 'id="live-state-layer"' in page.text
     assert 'id="live-context"' in page.text
     assert '"objectives", "observations"' in page.text
     assert 'id="progress-status"' in page.text

--- a/tests/test_ravn/test_resident_timeline.py
+++ b/tests/test_ravn/test_resident_timeline.py
@@ -152,10 +152,15 @@ async def test_a_turn_without_a_snapshot_does_not_read_as_wiping_the_model(tmp_p
 
     timeline = await build_resident_timeline(state)
 
-    assert timeline.turns[1].working_state == {}
+    assert timeline.turns[1].working_state["observations"] == ["printer A is idle"]
+    assert timeline.turns[1].working_state_authored is False
+    assert timeline.turns[1].working_state_turn_index == 1
+    assert timeline.turns[1].working_state_updated_at == timeline.turns[0].updated_at
     assert timeline.turns[1].changes["observations"].removed == ()
     # The baseline held, so the unchanged entry is retained rather than "new".
     assert timeline.turns[2].changes["observations"].retained == ("printer A is idle",)
+    assert timeline.turns[2].working_state_authored is True
+    assert timeline.turns[2].working_state_turn_index == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- carry the most recently authored resident working state through turns that emit no new snapshot
- expose the exact source turn and timestamp for the durable state in the HUD payload
- label the resident columns as the durable model and show active iteration/tool-call facts as a separate provisional live overlay
- add regression coverage for no-snapshot turns and the new HUD surface

## Why

The HUD selected the latest completed turn unconditionally. When that turn had no `working_state`, the displayed resident model became empty even though the previous durable state remained valid. That made active work appear to erase the resident's state.

## Impact

The last real resident model remains visible while work is in progress. Live activity is explicitly marked provisional until a judgment is persisted, so operators can distinguish stable state from an in-flight turn.

## Validation

- `make lint`
- `uv run pytest tests/ravn tests/test_ravn -v --tb=short --override-ini=addopts= --cov=src/ravn --cov-report=term-missing --cov-fail-under=85` — 7,060 passed, 1 skipped, 85.97% coverage
- focused HUD/timeline tests — 29 passed
- embedded HUD JavaScript syntax check
