### PR TITLE
Fix A2A coding execution contracts and Codex credential auth

### DIFF
--- a/src/niuu/adapters/cli/runtime.py
+++ b/src/niuu/adapters/cli/runtime.py
@@ -118,7 +118,13 @@ class CliTurnRunner:
             nonlocal current_text_block
             event_type = data.get("type", "")
 
-            if event_type == "assistant":
+            if event_type == "error":
+                error = data.get("error") or data.get("message") or "CLI runtime failed"
+                if isinstance(error, dict):
+                    error = error.get("message") or str(error)
+                if not result_future.done():
+                    result_future.set_exception(RuntimeError(str(error)))
+            elif event_type == "assistant":
                 flush_current_text_block()
                 self._capture_assistant_text(data, collected_text)
             elif event_type == "content_block_start":

--- a/src/niuu/adapters/openbao_credential_store.py
+++ b/src/niuu/adapters/openbao_credential_store.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
+from typing import Any
 from uuid import uuid4
 
 import httpx
@@ -32,6 +33,7 @@ class OpenBaoCredentialStore(CredentialStorePort):
     Supported auth modes:
     - ``token``: use a pre-provisioned token
     - ``approle``: authenticate via ``auth/approle/login``
+    - ``jwt``: authenticate a workload JWT via ``auth/<jwt_mount_path>/login``
 
     Constructor kwargs:
         url: Base OpenBao URL.
@@ -42,6 +44,9 @@ class OpenBaoCredentialStore(CredentialStorePort):
         approle_mount_path: AppRole mount path.
         role_id: AppRole role ID for ``approle`` auth.
         secret_id: AppRole secret ID for ``approle`` auth.
+        jwt_mount_path: JWT auth backend path.
+        jwt_role: JWT auth role.
+        jwt_token_file: File containing the workload JWT.
     """
 
     def __init__(
@@ -54,6 +59,9 @@ class OpenBaoCredentialStore(CredentialStorePort):
         approle_mount_path: str = "auth/approle",
         role_id: str = "",
         secret_id: str = "",
+        jwt_mount_path: str = "auth/jwt",
+        jwt_role: str = "",
+        jwt_token_file: str = "/var/run/secrets/kubernetes.io/serviceaccount/token",
     ) -> None:
         self._url = url.rstrip("/")
         self._namespace = namespace.strip("/")
@@ -63,6 +71,9 @@ class OpenBaoCredentialStore(CredentialStorePort):
         self._approle_mount_path = approle_mount_path.strip("/")
         self._role_id = role_id
         self._secret_id = secret_id
+        self._jwt_mount_path = jwt_mount_path.strip("/")
+        self._jwt_role = jwt_role
+        self._jwt_token_file = jwt_token_file
         self._client: httpx.AsyncClient | None = None
         self._client_token: str | None = token or None
 
@@ -88,22 +99,34 @@ class OpenBaoCredentialStore(CredentialStorePort):
         if self._auth_method == "token":
             return ""
 
-        if self._auth_method != "approle":
-            raise RuntimeError("OpenBao credential store requires a token or approle credentials")
-        if not self._role_id or not self._secret_id:
-            raise RuntimeError("AppRole auth requires role_id and secret_id")
-
         client = await self._get_client()
-        response = await client.post(
-            f"/v1/{self._approle_mount_path}/login",
-            json={
-                "role_id": self._role_id,
-                "secret_id": self._secret_id,
-            },
-        )
+        if self._auth_method == "approle":
+            if not self._role_id or not self._secret_id:
+                raise RuntimeError("AppRole auth requires role_id and secret_id")
+            path = f"/v1/{self._approle_mount_path}/login"
+            payload = {"role_id": self._role_id, "secret_id": self._secret_id}
+            label = "AppRole"
+        elif self._auth_method == "jwt":
+            if not self._jwt_role:
+                raise RuntimeError("JWT auth requires jwt_role")
+            try:
+                jwt = Path(self._jwt_token_file).read_text().strip()
+            except OSError as exc:
+                raise RuntimeError(f"JWT auth could not read token file: {exc}") from exc
+            if not jwt:
+                raise RuntimeError("JWT auth token file is empty")
+            path = f"/v1/{self._jwt_mount_path}/login"
+            payload = {"role": self._jwt_role, "jwt": jwt}
+            label = "JWT"
+        else:
+            raise RuntimeError(
+                "OpenBao credential store requires token, approle, or jwt authentication"
+            )
+
+        response = await client.post(path, json=payload)
         if response.status_code >= 400:
             raise RuntimeError(
-                f"OpenBao AppRole auth failed ({response.status_code}): {response.text}"
+                f"OpenBao {label} auth failed ({response.status_code}): {response.text}"
             )
 
         self._client_token = response.json()["auth"]["client_token"]
@@ -117,6 +140,17 @@ class OpenBaoCredentialStore(CredentialStorePort):
         if self._namespace:
             headers["X-Vault-Namespace"] = self._namespace
         return headers
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue one authenticated request, re-authenticating once when a lease expires."""
+        client = await self._get_client()
+        request = getattr(client, method)
+        response = await request(path, headers=await self._headers(), **kwargs)
+        if response.status_code not in {401, 403} or self._auth_method == "token":
+            return response
+
+        self._client_token = None
+        return await request(path, headers=await self._headers(), **kwargs)
 
     async def close(self) -> None:
         if self._client:
@@ -133,10 +167,9 @@ class OpenBaoCredentialStore(CredentialStorePort):
         return str(PurePosixPath(self._mount_path, "metadata", f"{owner_type}s", owner_id))
 
     async def _read_raw(self, owner_type: str, owner_id: str, name: str) -> dict[str, str] | None:
-        client = await self._get_client()
-        response = await client.get(
+        response = await self._request(
+            "get",
             f"/v1/{self._data_path(owner_type, owner_id, name)}",
-            headers=await self._headers(),
         )
         if response.status_code == 404:
             return None
@@ -156,7 +189,6 @@ class OpenBaoCredentialStore(CredentialStorePort):
         data: dict[str, str],
         metadata: dict | None = None,
     ) -> StoredCredential:
-        client = await self._get_client()
         now = datetime.now(UTC)
 
         existing = await self.get(owner_type, owner_id, name)
@@ -178,9 +210,9 @@ class OpenBaoCredentialStore(CredentialStorePort):
             }
         )
 
-        response = await client.post(
+        response = await self._request(
+            "post",
             f"/v1/{self._data_path(owner_type, owner_id, name)}",
-            headers=await self._headers(),
             json={"data": payload},
         )
         if response.status_code >= 400:
@@ -236,10 +268,9 @@ class OpenBaoCredentialStore(CredentialStorePort):
         return {k: v for k, v in raw.items() if k != _META_KEY}
 
     async def delete(self, owner_type: str, owner_id: str, name: str) -> None:
-        client = await self._get_client()
-        response = await client.delete(
+        response = await self._request(
+            "delete",
             f"/v1/{self._data_path(owner_type, owner_id, name)}",
-            headers=await self._headers(),
         )
         if response.status_code >= 400 and response.status_code != 404:
             logger.error("OpenBao delete failed: %s %s", response.status_code, response.text)
@@ -250,10 +281,9 @@ class OpenBaoCredentialStore(CredentialStorePort):
         owner_id: str,
         secret_type: SecretType | None = None,
     ) -> list[StoredCredential]:
-        client = await self._get_client()
-        response = await client.get(
+        response = await self._request(
+            "get",
             f"/v1/{self._list_path(owner_type, owner_id)}",
-            headers=await self._headers(),
             params={"list": "true"},
         )
         if response.status_code == 404:

--- a/src/ravn/adapters/tools/platform_tools.py
+++ b/src/ravn/adapters/tools/platform_tools.py
@@ -29,6 +29,7 @@ _DEFAULT_WORKLOAD_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/to
 _DEFAULT_WORKLOAD_AUDIENCES = ["volundr-api", "forge", "ting", "mimir", "guild"]
 _FORGE_SESSIONS_PATH = "/api/v1/forge/sessions"
 _FORGE_REPOS_PATH = "/api/v1/forge/repos"
+_NIUU_REPOS_PATH = "/api/v1/niuu/repos"
 _TRACKER_ISSUES_PATH = "/api/v1/tracker/issues"
 _TING_WORKFLOWS_PATH = "/api/v1/ting/workflows"
 
@@ -334,6 +335,7 @@ class VolundrGitTool(_PlatformAuthMixin, ToolPort):
     """Perform git operations via the Volundr API.
 
     Actions:
+    - ``list_repos``    — list repositories visible to the current identity.
     - ``list_branches`` — list branches for a repo (requires ``repo_url``).
     - ``create_pr``     — open a pull request (requires ``session_id``, ``title``).
     - ``list_prs``      — list pull requests (requires ``repo_url``).
@@ -367,7 +369,7 @@ class VolundrGitTool(_PlatformAuthMixin, ToolPort):
     @property
     def description(self) -> str:
         return (
-            "Git operations via Volundr: list_branches (repo_url), "
+            "Git operations via Volundr: list_repos, list_branches (repo_url), "
             "create_pr (session_id + title), list_prs (repo_url), "
             "get_pr (pr_number + repo_url), merge_pr (pr_number + repo_url), "
             "ci_status (pr_number + repo_url + branch)."
@@ -381,6 +383,7 @@ class VolundrGitTool(_PlatformAuthMixin, ToolPort):
                 "action": {
                     "type": "string",
                     "enum": [
+                        "list_repos",
                         "list_branches",
                         "create_pr",
                         "list_prs",
@@ -438,6 +441,8 @@ class VolundrGitTool(_PlatformAuthMixin, ToolPort):
         action = input.get("action", "")
         async with await self._client() as client:
             match action:
+                case "list_repos":
+                    return await self._list_repos(client)
                 case "list_branches":
                     return await self._list_branches(client, input)
                 case "create_pr":
@@ -453,6 +458,14 @@ class VolundrGitTool(_PlatformAuthMixin, ToolPort):
                 case _:
                     return _err(f"Unknown action: {action!r}")
         raise AssertionError("Unreachable execute fallthrough")
+
+    async def _list_repos(self, client: httpx.AsyncClient) -> ToolResult:
+        try:
+            resp = await client.get(_NIUU_REPOS_PATH)
+            resp.raise_for_status()
+            return _ok(resp.json())
+        except Exception as exc:
+            return _err(f"Failed to list repositories: {exc}")
 
     async def _list_branches(self, client: httpx.AsyncClient, input: dict) -> ToolResult:
         repo_url = input.get("repo_url", "")

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -243,6 +243,7 @@ class CodexWebSocketTransport(CLITransport):
         self._thread_id: str | None = None
         self._current_turn_id: str | None = None
         self._last_result: dict | None = None
+        self._turn_error: str | None = None
         self._last_usage: dict | None = None
         self._alive = False
         self._block_index: int = 0
@@ -715,6 +716,16 @@ class CodexWebSocketTransport(CLITransport):
                 return
 
             self._active_user_prompt = None
+            if self._turn_error:
+                self._last_result = {
+                    "type": "result",
+                    "stop_reason": "error",
+                    "result": self._turn_error,
+                    "is_error": True,
+                    "modelUsage": self._last_usage or {},
+                }
+                await self._emit(self._last_result)
+                return
             # Merge saved usage into result event.
             usage = self._last_usage or {}
             self._last_result = {
@@ -813,6 +824,7 @@ class CodexWebSocketTransport(CLITransport):
                 if recovered:
                     return
             logger.warning("Codex error notification: %s", message)
+            self._turn_error = message
             await self._emit({"type": "error", "error": message})
             return
 
@@ -1606,6 +1618,7 @@ class CodexWebSocketTransport(CLITransport):
             raise RuntimeError("No active thread — call start() first")
 
         self._last_result = None
+        self._turn_error = None
         self._last_usage = None
         self._block_index = 0
         self._active_user_prompt = content

--- a/src/ting/api/a2a_card.py
+++ b/src/ting/api/a2a_card.py
@@ -84,8 +84,19 @@ def _workflow_skill(workflow: WorkflowDefinition) -> AgentSkill:
     return AgentSkill(
         id=str(workflow.id),
         name=workflow.name,
-        description=workflow.description,
+        description=(
+            f"{workflow.description}\n\n"
+            "Launch context may be supplied in A2A message metadata: repo is a "
+            "repository URL, branch selects its starting branch, and connectionId "
+            "selects an execution connection."
+        ),
         tags=tags or ["workflow"],
+        examples=[
+            (
+                "Select a repository from the platform repository catalog, then start "
+                "this skill with metadata containing repo and, when needed, branch."
+            )
+        ],
     )
 
 

--- a/tests/test_niuu/test_cli_runtime.py
+++ b/tests/test_niuu/test_cli_runtime.py
@@ -84,6 +84,24 @@ async def test_cli_turn_runner_falls_back_to_assistant_content() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cli_turn_runner_raises_when_transport_reports_error() -> None:
+    transport = StubTransport(
+        {
+            "first": [
+                {"type": "error", "error": "authentication expired"},
+                {"type": "result", "result": ""},
+            ]
+        }
+    )
+    runner = CliTurnRunner(transport)
+
+    with pytest.raises(RuntimeError, match="authentication expired"):
+        await runner.run_prompt("first", "req-1")
+
+    assert runner.pending_responses == {}
+
+
+@pytest.mark.asyncio
 async def test_cli_turn_runner_falls_back_to_streamed_delta_text() -> None:
     transport = StubTransport(
         {

--- a/tests/test_niuu/test_openbao_credential_store.py
+++ b/tests/test_niuu/test_openbao_credential_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -84,9 +85,9 @@ class TestAppRoleAuth:
 
     @pytest.mark.asyncio()
     async def test_invalid_auth_method_raises(self):
-        store = OpenBaoCredentialStore(auth_method="jwt")
+        store = OpenBaoCredentialStore(auth_method="invalid")
 
-        with pytest.raises(RuntimeError, match="requires a token or approle"):
+        with pytest.raises(RuntimeError, match="token, approle, or jwt"):
             await store._ensure_authenticated()
 
     @pytest.mark.asyncio()
@@ -95,6 +96,59 @@ class TestAppRoleAuth:
 
         with pytest.raises(RuntimeError, match="requires role_id and secret_id"):
             await store._ensure_authenticated()
+
+    @pytest.mark.asyncio()
+    async def test_jwt_login_reads_workload_token_and_caches_client_token(self, tmp_path: Path):
+        token_file = tmp_path / "token"
+        token_file.write_text("workload-jwt")
+        store = OpenBaoCredentialStore(
+            auth_method="jwt",
+            jwt_mount_path="auth/jwt-valhalla",
+            jwt_role="volundr-app",
+            jwt_token_file=str(token_file),
+        )
+        mock_client = AsyncMock()
+        mock_client.post.return_value = _mock_response(
+            json_data={"auth": {"client_token": "bao-token"}}
+        )
+        store._client = mock_client
+
+        token = await store._ensure_authenticated()
+
+        assert token == "bao-token"
+        mock_client.post.assert_called_once_with(
+            "/v1/auth/jwt-valhalla/login",
+            json={"role": "volundr-app", "jwt": "workload-jwt"},
+        )
+
+    @pytest.mark.asyncio()
+    async def test_jwt_request_reauthenticates_once_after_expired_lease(self, tmp_path: Path):
+        token_file = tmp_path / "token"
+        token_file.write_text("workload-jwt")
+        store = OpenBaoCredentialStore(
+            auth_method="jwt",
+            jwt_role="volundr-app",
+            jwt_token_file=str(token_file),
+        )
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = [
+            _mock_response(status_code=403, text="expired"),
+            _mock_response(status_code=404),
+        ]
+        mock_client.post.return_value = _mock_response(
+            json_data={"auth": {"client_token": "renewed-token"}}
+        )
+        store._client = mock_client
+        store._client_token = "expired-token"
+
+        assert await store.get("user", "alice", "github") is None
+
+        assert mock_client.get.call_count == 2
+        first_headers = mock_client.get.call_args_list[0].kwargs["headers"]
+        assert first_headers["X-Vault-Token"] == "expired-token"
+        assert (
+            mock_client.get.call_args_list[1].kwargs["headers"]["X-Vault-Token"] == "renewed-token"
+        )
 
     @pytest.mark.asyncio()
     async def test_approle_login_failure_raises(self):

--- a/tests/test_ravn/test_platform_tools.py
+++ b/tests/test_ravn/test_platform_tools.py
@@ -188,6 +188,30 @@ class TestVolundrGitTool:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_list_repos(self):
+        respx.get(f"{BASE_URL}/api/v1/niuu/repos").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "github": [
+                        {
+                            "name": "laevateinn",
+                            "url": "https://github.com/niuulabs/laevateinn",
+                            "clone_url": "https://github.com/niuulabs/laevateinn.git",
+                            "default_branch": "dev",
+                        }
+                    ]
+                },
+            )
+        )
+
+        result = await self.tool.execute({"action": "list_repos"})
+
+        assert not result.is_error
+        assert json.loads(result.content)["github"][0]["name"] == "laevateinn"
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_list_branches(self):
         respx.get(f"{FORGE_GIT_URL}/branches").mock(
             return_value=httpx.Response(200, json=[{"name": "main"}])

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -918,6 +918,32 @@ class TestEventNormalization:
         assert event["error"] == "rate limit exceeded"
 
     @pytest.mark.asyncio
+    async def test_error_notification_cannot_be_overwritten_by_successful_completion(
+        self, tmp_path
+    ):
+        t = _make_transport(tmp_path)
+        emit = _collect_emits(t)
+
+        await t._handle_server_message(
+            {
+                "method": "error",
+                "params": {"error": {"message": "authentication expired"}},
+            }
+        )
+        await t._handle_server_message(
+            {
+                "method": "turn/completed",
+                "params": {"turn": {"id": "turn-1", "status": "failed"}},
+            }
+        )
+
+        result = _events_of_type(emit, "result")[0]
+        assert result["stop_reason"] == "error"
+        assert result["is_error"] is True
+        assert result["result"] == "authentication expired"
+        assert t.last_result == result
+
+    @pytest.mark.asyncio
     async def test_thread_closed_sets_not_alive(self, tmp_path):
         t = _make_transport(tmp_path)
         t._alive = True

--- a/tests/test_ting/test_a2a_card.py
+++ b/tests/test_ting/test_a2a_card.py
@@ -105,6 +105,9 @@ class TestAgentCard:
         assert [skill.id for skill in card.skills] == [str(system.id)]
         assert card.skills[0].name == "tool-builder"
         assert list(card.skills[0].tags) == ["tool-builder", "build"]
+        assert "metadata" in card.skills[0].description
+        assert "repo" in card.skills[0].description
+        assert list(card.skills[0].examples)
         assert card.capabilities.streaming is False
         assert card.capabilities.push_notifications is False
         assert card.capabilities.extended_agent_card is True


### PR DESCRIPTION
## What changed

- propagate CLI transport errors as failed turns so Codex authentication failures cannot become `code.completed` or `review.passed`
- retain Codex error state when a later `turn/completed` notification arrives
- expose the existing authenticated repository catalog through `volundr_git.list_repos`
- advertise Ting workflow launch metadata (`repo`, `branch`, `connectionId`) in the A2A Agent Card
- add workload-JWT authentication and lease reauthentication to the existing OpenBao credential-store adapter

## Why

Ivaldi genuinely launched a Code & Review A2A task, but it had no discoverable repository contract and three Codex runtimes raced an expired shared OAuth refresh token. The transport then incorrectly projected those failures as successful workflow outcomes.

This change makes the execution truthful, gives Ravn a generic repository-discovery path, and enables the existing OpenShell credential proxy to use renewable workload identity rather than a static OpenBao application token.

## Validation

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- 256 focused tests covering CLI runtime errors, Codex WebSocket completion, OpenBao JWT auth, repository discovery, platform tools, and Ting A2A cards
