### PR TITLE
feat(ravn): preserve configured model reasoning

### DIFF
--- a/src/ravn/adapters/llm/anthropic.py
+++ b/src/ravn/adapters/llm/anthropic.py
@@ -36,6 +36,13 @@ _RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503})
 _DEFAULT_BASE_URL = "https://api.anthropic.com"
 
 
+def _without_reasoning(messages: list[dict]) -> list[dict]:
+    """Remove prior internal reasoning from Anthropic input messages."""
+    return [
+        {key: value for key, value in message.items() if key != "reasoning"} for message in messages
+    ]
+
+
 class AnthropicAdapter(LLMPort):
     """Calls the Anthropic Messages API with streaming and tool support.
 
@@ -118,7 +125,7 @@ class AnthropicAdapter(LLMPort):
         body: dict = {
             "model": model or self._default_model,
             "max_tokens": effective_max_tokens,
-            "messages": messages,
+            "messages": _without_reasoning(messages),
             "stream": stream,
         }
         system_blocks = self._build_system(system)
@@ -346,12 +353,12 @@ class AnthropicAdapter(LLMPort):
         data = response.json()
         content_text = ""
         tool_calls: list[ToolCall] = []
-        thinking_chars = 0
+        thinking_parts: list[str] = []
 
         for block in data.get("content", []):
             match block.get("type"):
                 case "thinking":
-                    thinking_chars += len(block.get("thinking", ""))
+                    thinking_parts.append(block.get("thinking", ""))
                 case "text":
                     content_text += block.get("text", "")
                 case "tool_use":
@@ -364,6 +371,7 @@ class AnthropicAdapter(LLMPort):
                     )
 
         usage_data = data.get("usage", {})
+        reasoning = "".join(thinking_parts)
         stop_reason_raw = data.get("stop_reason", "end_turn")
         try:
             stop_reason = StopReason(stop_reason_raw)
@@ -379,6 +387,7 @@ class AnthropicAdapter(LLMPort):
                 output_tokens=usage_data.get("output_tokens", 0),
                 cache_read_tokens=usage_data.get("cache_read_input_tokens", 0),
                 cache_write_tokens=usage_data.get("cache_creation_input_tokens", 0),
-                thinking_tokens=thinking_chars // 4,
+                thinking_tokens=len(reasoning) // 4,
             ),
+            reasoning=reasoning,
         )

--- a/src/ravn/adapters/llm/openai.py
+++ b/src/ravn/adapters/llm/openai.py
@@ -6,6 +6,7 @@ server that implements the OpenAI Chat Completions API.
 Features:
 - Streaming via SSE (``data: {...}`` events)
 - Tool calling in OpenAI function-calling format
+- Reasoning output from both ``reasoning`` and legacy ``reasoning_content`` fields
 - Token usage normalisation: ``prompt_tokens`` → ``input_tokens``,
   ``completion_tokens`` → ``output_tokens``
 - Token estimation fallback when the API response does not include usage data
@@ -42,6 +43,7 @@ families and substitutes the role automatically so callers do not need to know.
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 import logging
 import re
@@ -135,7 +137,13 @@ def _system_to_string(system: SystemPrompt) -> str:
     return "\n\n".join(block.get("text", "") for block in system if block.get("text"))
 
 
-def _normalise_usage(raw: dict, *, input_text: str = "", output_text: str = "") -> TokenUsage:
+def _normalise_usage(
+    raw: dict,
+    *,
+    input_text: str = "",
+    output_text: str = "",
+    reasoning_text: str = "",
+) -> TokenUsage:
     """Normalise an OpenAI usage dict to TokenUsage.
 
     When the API response does not include usage data (e.g. local Ollama
@@ -149,18 +157,25 @@ def _normalise_usage(raw: dict, *, input_text: str = "", output_text: str = "") 
 
     input_tokens = raw.get("prompt_tokens", 0)
     output_tokens = raw.get("completion_tokens", 0)
+    completion_details = raw.get("completion_tokens_details") or {}
+    thinking_tokens = (
+        completion_details.get("reasoning_tokens", 0) if isinstance(completion_details, dict) else 0
+    )
 
     # Estimation fallback: when the API sends no usage numbers, estimate from text length.
     if input_tokens == 0 and input_text:
         input_tokens = max(1, TokenEstimator.rough(input_text))
     if output_tokens == 0 and output_text:
         output_tokens = max(1, TokenEstimator.rough(output_text))
+    if thinking_tokens == 0 and reasoning_text:
+        thinking_tokens = max(1, TokenEstimator.rough(reasoning_text))
 
     return TokenUsage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cache_read_tokens=cache_read,
         cache_write_tokens=0,  # OpenAI does not expose cache writes
+        thinking_tokens=thinking_tokens,
     )
 
 
@@ -177,9 +192,14 @@ def _convert_anthropic_messages(messages: list[dict]) -> list[dict]:
     for msg in messages:
         content = msg.get("content")
 
-        # Plain string content — pass through unchanged.
+        # Plain string content — map Ravn's generic reasoning field to the
+        # OpenAI-compatible field expected by reasoning chat templates.
         if not isinstance(content, list):
-            converted.append(msg)
+            out = dict(msg)
+            reasoning = out.pop("reasoning", "")
+            if msg.get("role") == "assistant" and reasoning:
+                out["reasoning_content"] = reasoning
+            converted.append(out)
             continue
 
         if msg.get("role") == "assistant":
@@ -204,6 +224,8 @@ def _convert_anthropic_messages(messages: list[dict]) -> list[dict]:
                     text_parts.append(block)
 
             out: dict = {"role": "assistant", "content": "\n".join(text_parts) or None}
+            if msg.get("reasoning"):
+                out["reasoning_content"] = msg["reasoning"]
             if tool_calls_out:
                 out["tool_calls"] = tool_calls_out
             converted.append(out)
@@ -245,6 +267,10 @@ class OpenAICompatibleAdapter(LLMPort):
     Constructor kwargs are forwarded from config via the dynamic adapter pattern.
     """
 
+    @property
+    def supports_thinking(self) -> bool:
+        return True
+
     def __init__(
         self,
         *,
@@ -256,6 +282,8 @@ class OpenAICompatibleAdapter(LLMPort):
         retry_base_delay: float = 1.0,
         timeout: float = 120.0,
         system_prefix: str = "",
+        request_options: dict | None = None,
+        thinking_request_options: dict | None = None,
     ) -> None:
         self._api_key = api_key
         self._base_url = base_url.rstrip("/")
@@ -265,6 +293,8 @@ class OpenAICompatibleAdapter(LLMPort):
         self._retry_base_delay = retry_base_delay
         self._timeout = timeout
         self._system_prefix = system_prefix
+        self._request_options = copy.deepcopy(request_options or {})
+        self._thinking_request_options = copy.deepcopy(thinking_request_options or {})
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -310,14 +340,20 @@ class OpenAICompatibleAdapter(LLMPort):
         model: str,
         max_tokens: int,
         stream: bool,
+        thinking: dict | None = None,
     ) -> dict:
         effective_model = model or self._default_model
-        body: dict = {
-            "model": effective_model,
-            _max_tokens_param(effective_model): max_tokens or self._default_max_tokens,
-            "messages": self._build_messages(messages, system, effective_model),
-            "stream": stream,
-        }
+        body = copy.deepcopy(self._request_options)
+        if thinking is not None:
+            body.update(copy.deepcopy(self._thinking_request_options))
+        body.update(
+            {
+                "model": effective_model,
+                _max_tokens_param(effective_model): max_tokens or self._default_max_tokens,
+                "messages": self._build_messages(messages, system, effective_model),
+                "stream": stream,
+            }
+        )
         if stream:
             # Request usage data in the final stream chunk.
             body["stream_options"] = {"include_usage": True}
@@ -399,7 +435,7 @@ class OpenAICompatibleAdapter(LLMPort):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
-        thinking: dict | None = None,  # noqa: ARG002 — Anthropic-only, ignored here
+        thinking: dict | None = None,
     ) -> AsyncIterator[StreamEvent]:
         payload = self._build_request(
             messages,
@@ -408,6 +444,7 @@ class OpenAICompatibleAdapter(LLMPort):
             model=model,
             max_tokens=max_tokens,
             stream=True,
+            thinking=thinking,
         )
 
         async with httpx.AsyncClient(headers=self._headers(), timeout=self._timeout) as client:
@@ -427,6 +464,7 @@ class OpenAICompatibleAdapter(LLMPort):
 
             # Accumulate output text for estimation fallback when usage is absent.
             accumulated_text: list[str] = []
+            accumulated_reasoning: list[str] = []
             usage_emitted = False
 
             async for line in response.aiter_lines():
@@ -447,7 +485,10 @@ class OpenAICompatibleAdapter(LLMPort):
                     usage_emitted = True
                     yield StreamEvent(
                         type=StreamEventType.MESSAGE_DONE,
-                        usage=_normalise_usage(usage_raw),
+                        usage=_normalise_usage(
+                            usage_raw,
+                            reasoning_text="".join(accumulated_reasoning),
+                        ),
                     )
                     continue
 
@@ -458,6 +499,11 @@ class OpenAICompatibleAdapter(LLMPort):
                 choice = choices[0]
                 delta = choice.get("delta") or {}
                 finish_reason = choice.get("finish_reason")
+
+                reasoning = delta.get("reasoning") or delta.get("reasoning_content")
+                if reasoning:
+                    accumulated_reasoning.append(reasoning)
+                    yield StreamEvent(type=StreamEventType.THINKING, text=reasoning)
 
                 # Text content delta.
                 content = delta.get("content")
@@ -507,7 +553,12 @@ class OpenAICompatibleAdapter(LLMPort):
                 output_text = "".join(accumulated_text)
                 yield StreamEvent(
                     type=StreamEventType.MESSAGE_DONE,
-                    usage=_normalise_usage({}, input_text=input_text, output_text=output_text),
+                    usage=_normalise_usage(
+                        {},
+                        input_text=input_text,
+                        output_text=output_text,
+                        reasoning_text="".join(accumulated_reasoning),
+                    ),
                 )
 
     async def generate(
@@ -518,7 +569,7 @@ class OpenAICompatibleAdapter(LLMPort):
         system: SystemPrompt,
         model: str,
         max_tokens: int,
-        thinking: dict | None = None,  # noqa: ARG002 — Anthropic-only, ignored here
+        thinking: dict | None = None,
     ) -> LLMResponse:
         payload = self._build_request(
             messages,
@@ -527,6 +578,7 @@ class OpenAICompatibleAdapter(LLMPort):
             model=model,
             max_tokens=max_tokens,
             stream=False,
+            thinking=thinking,
         )
 
         async with httpx.AsyncClient(headers=self._headers(), timeout=self._timeout) as client:
@@ -544,6 +596,7 @@ class OpenAICompatibleAdapter(LLMPort):
         finish_reason = choices[0].get("finish_reason", "stop") if choices else "stop"
 
         content_text = _strip_reasoning_tags(message.get("content") or "")
+        reasoning_text = message.get("reasoning") or message.get("reasoning_content") or ""
         tool_calls: list[ToolCall] = []
 
         # First, check for API-returned tool calls
@@ -574,6 +627,7 @@ class OpenAICompatibleAdapter(LLMPort):
             data.get("usage") or {},
             input_text=input_text,
             output_text=content_text,
+            reasoning_text=reasoning_text,
         )
 
         return LLMResponse(
@@ -581,4 +635,5 @@ class OpenAICompatibleAdapter(LLMPort):
             tool_calls=tool_calls,
             stop_reason=stop_reason,
             usage=usage,
+            reasoning=reasoning_text,
         )

--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -277,7 +277,7 @@ class RavnAgent:
 
     def _build_api_messages(self) -> list[dict]:
         """Convert session messages to the API format."""
-        return [{"role": m.role, "content": m.content} for m in self._session.messages]
+        return [message.to_api_dict() for message in self._session.messages]
 
     async def _emit_session_started(self) -> None:
         """Publish ravn.session.started to Sleipnir (no-op when publisher absent)."""
@@ -489,7 +489,6 @@ class RavnAgent:
             self._enforce_prompt_budget(prompt_sections)
 
             thinking_param = self._resolve_thinking(
-                user_input=user_input,
                 iteration=iteration,
                 explicit=explicit_thinking,
                 last_had_tool_error=last_had_tool_error,
@@ -518,7 +517,13 @@ class RavnAgent:
                         )
                     )
                 final_response = llm_response.content
-                self._session.add_message(Message(role="assistant", content=llm_response.content))
+                self._session.add_message(
+                    Message(
+                        role="assistant",
+                        content=llm_response.content,
+                        reasoning=llm_response.reasoning,
+                    )
+                )
                 break
 
             # Track partial response for checkpointing during tool-call iterations.
@@ -527,7 +532,13 @@ class RavnAgent:
 
             # Append the assistant message (with tool calls) to history.
             assistant_content = _build_assistant_content(llm_response)
-            self._session.messages.append(Message(role="assistant", content=assistant_content))
+            self._session.messages.append(
+                Message(
+                    role="assistant",
+                    content=assistant_content,
+                    reasoning=llm_response.reasoning,
+                )
+            )
 
             # Execute all tool calls sequentially and collect results.
             tool_results_content = []
@@ -896,9 +907,7 @@ class RavnAgent:
 
         from ravn.domain.checkpoint import Checkpoint
 
-        messages: list[dict] = [
-            {"role": m.role, "content": m.content} for m in self._session.messages
-        ]
+        messages = [message.to_api_dict() for message in self._session.messages]
         todos: list[dict] = [
             {"id": t.id, "content": t.content, "status": str(t.status), "priority": t.priority}
             for t in self._session.todos
@@ -973,9 +982,7 @@ class RavnAgent:
             return
 
         # Serialise messages to plain dicts for storage.
-        messages: list[dict] = [
-            {"role": m.role, "content": m.content} for m in self._session.messages
-        ]
+        messages = [message.to_api_dict() for message in self._session.messages]
         todos: list[dict] = [
             {"id": t.id, "content": t.content, "status": str(t.status), "priority": t.priority}
             for t in self._session.todos
@@ -1098,7 +1105,6 @@ class RavnAgent:
     def _resolve_thinking(
         self,
         *,
-        user_input: str,
         iteration: int,
         explicit: bool,
         last_had_tool_error: bool,
@@ -1107,7 +1113,7 @@ class RavnAgent:
 
         Extended thinking is activated when:
         - Explicitly requested (``think:`` prefix / ``--think`` flag).
-        - Auto-trigger is on AND the input looks like a planning/ambiguous task.
+        - Auto-trigger is on for the persona.
         - Auto-trigger-on-retry is on AND a tool failed on the previous iteration.
         """
         et = self._extended_thinking
@@ -1120,7 +1126,7 @@ class RavnAgent:
         if et.auto_trigger_on_retry and iteration > 0 and last_had_tool_error:
             return {"type": "enabled", "budget_tokens": et.budget_tokens}
 
-        if et.auto_trigger and _looks_like_planning_task(user_input):
+        if et.auto_trigger:
             return {"type": "enabled", "budget_tokens": et.budget_tokens}
 
         return None
@@ -1196,6 +1202,7 @@ class RavnAgent:
                 },
                 content={
                     "content": response.content,
+                    "reasoning": response.reasoning,
                     "tool_calls": [
                         {"id": call.id, "name": call.name, "input": call.input}
                         for call in response.tool_calls
@@ -1230,6 +1237,7 @@ class RavnAgent:
     ) -> LLMResponse:
         """Call the LLM with streaming and accumulate into an LLMResponse."""
         accumulated_text = ""
+        accumulated_reasoning = ""
         tool_calls: list[ToolCall] = []
         final_usage = TokenUsage(input_tokens=0, output_tokens=0)
         stop_reason = StopReason.END_TURN
@@ -1237,7 +1245,7 @@ class RavnAgent:
             system_prompt if system_prompt is not None else self._system_prompt
         )
         api_messages = (
-            [{"role": m.role, "content": m.content} for m in messages]
+            [message.to_api_dict() for message in messages]
             if messages is not None
             else self._build_api_messages()
         )
@@ -1264,6 +1272,7 @@ class RavnAgent:
                         )
                 case StreamEventType.THINKING:
                     if event.text:
+                        accumulated_reasoning += event.text
                         await self._channel.emit(
                             RavnEvent.thinking(
                                 self._source_id,
@@ -1286,6 +1295,7 @@ class RavnAgent:
             tool_calls=tool_calls,
             stop_reason=stop_reason,
             usage=final_usage,
+            reasoning=accumulated_reasoning,
         )
 
     async def _execute_tool(self, tool_call: ToolCall) -> ToolResult:
@@ -1698,21 +1708,6 @@ _THINK_PREFIXES = ("think:", "think: ")
 # Captures any surrounding whitespace so collapsing leaves a single space.
 _THINK_FLAG_RE = re.compile(r"(?<!\S)--think(?!\S)")
 
-# Single-word planning keywords matched with \b to avoid substring false-positives
-# (e.g. "unplanned" must not match "plan").
-_PLANNING_WORD_RE = re.compile(
-    r"\b(?:plan|design|architect|architecture|strategy|roadmap|approach)\b",
-    re.IGNORECASE,
-)
-# Multi-word phrases can remain as plain substring checks.
-_PLANNING_PHRASES = (
-    "how should",
-    "what approach",
-    "what's the best",
-    "best way to",
-    "how do i",
-)
-
 
 def _parse_think_flag(user_input: str) -> tuple[bool, str]:
     """Return (explicit_thinking, cleaned_input).
@@ -1733,19 +1728,6 @@ def _parse_think_flag(user_input: str) -> tuple[bool, str]:
         cleaned = re.sub(r" {2,}", " ", cleaned)
         return True, cleaned
     return False, stripped
-
-
-def _looks_like_planning_task(user_input: str) -> bool:
-    """Return True if the input looks like a planning or ambiguous task.
-
-    Single-word keywords are matched with word boundaries to prevent
-    substring false-positives (e.g. ``unplanned`` must not match ``plan``).
-    Multi-word phrases are matched as plain substrings.
-    """
-    if _PLANNING_WORD_RE.search(user_input):
-        return True
-    lower = user_input.lower()
-    return any(phrase in lower for phrase in _PLANNING_PHRASES)
 
 
 def _build_assistant_content(response: LLMResponse) -> list[dict]:

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -68,7 +68,11 @@ approvals_app = typer.Typer(
 )
 app.add_typer(approvals_app, name="approvals")
 
-from ravn.cli.runtime_config import _configure_logging, _log_effective_config  # noqa: E402
+from ravn.cli.runtime_config import (  # noqa: E402
+    _configure_logging,
+    _log_effective_config,
+    _resolve_extended_thinking,
+)
 from ravn.cli.warden_commands import (  # noqa: E402, F401
     _parse_deployment_kwargs,
     warden_app,
@@ -542,10 +546,10 @@ def _build_agent(
     pre_hooks, post_hooks = _build_hooks(settings)
     checkpoint_port = _build_checkpoint(settings)
 
-    extended_thinking = (
-        settings.llm.extended_thinking
-        if settings.llm.extended_thinking.enabled and not cli_transport_executor
-        else None
+    extended_thinking = _resolve_extended_thinking(
+        settings,
+        persona_config,
+        cli_transport_executor=cli_transport_executor,
     )
 
     cp_cfg = settings.checkpoint
@@ -786,7 +790,13 @@ async def _load_checkpoint_session(
     # Reconstruct session from checkpoint messages.
     session = Session()
     for raw_msg in checkpoint.messages:
-        session.messages.append(Message(role=raw_msg["role"], content=raw_msg["content"]))
+        session.messages.append(
+            Message(
+                role=raw_msg["role"],
+                content=raw_msg["content"],
+                reasoning=raw_msg.get("reasoning", ""),
+            )
+        )
 
     # Restore todo list.
     for raw_todo in checkpoint.todos:
@@ -1313,10 +1323,10 @@ async def _run_gateway(
     prompt_builder = _build_prompt_builder(settings)
     pre_hooks, post_hooks = _build_hooks(settings)
 
-    extended_thinking = (
-        settings.llm.extended_thinking
-        if settings.llm.extended_thinking.enabled and not cli_transport_executor
-        else None
+    extended_thinking = _resolve_extended_thinking(
+        settings,
+        persona_config,
+        cli_transport_executor=cli_transport_executor,
     )
 
     # Start MCP servers (shared across sessions)

--- a/src/ravn/cli/daemon_runtime.py
+++ b/src/ravn/cli/daemon_runtime.py
@@ -58,12 +58,6 @@ async def _run_daemon(
     compressor = None if cli_transport_executor else _build_compressor(settings, llm)
     pre_hooks, post_hooks = _build_hooks(settings)
 
-    extended_thinking = (
-        settings.llm.extended_thinking
-        if settings.llm.extended_thinking.enabled and not cli_transport_executor
-        else None
-    )
-
     mcp_manager: Any | None = None
     mcp_tools: list[Any] = []
 
@@ -241,6 +235,11 @@ async def _run_daemon(
         tools = _apply_trust_filter(tools, settings, triggered_by)
 
         executor = _build_executor(resolved_persona)
+        resolved_extended_thinking = _resolve_extended_thinking(
+            settings,
+            resolved_persona,
+            cli_transport_executor=_uses_cli_transport_executor(resolved_persona),
+        )
         agent = executor.build(
             llm=llm,
             tools=tools,
@@ -268,7 +267,7 @@ async def _run_daemon(
             task_summary_max_chars=settings.memory.task_summary_max_chars,
             input_token_cost_per_million=settings.memory.input_token_cost_per_million,
             output_token_cost_per_million=settings.memory.output_token_cost_per_million,
-            extended_thinking=extended_thinking,
+            extended_thinking=resolved_extended_thinking,
             # NIU-598: session lifecycle events for optional reflection storage
             sleipnir_publisher=daemon_bus,
             persona=resolved_persona.name if resolved_persona else "",

--- a/src/ravn/cli/runtime_config.py
+++ b/src/ravn/cli/runtime_config.py
@@ -4,10 +4,30 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import Any
 
-from ravn.config import Settings
+from ravn.config import ExtendedThinkingConfig, Settings
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_extended_thinking(
+    settings: Settings,
+    persona_config: Any | None,
+    *,
+    cli_transport_executor: bool,
+) -> ExtendedThinkingConfig | None:
+    """Resolve reasoning policy for one concrete agent."""
+    if cli_transport_executor:
+        return None
+
+    configured = settings.llm.extended_thinking
+    enabled = configured.enabled or bool(
+        persona_config is not None and persona_config.llm.thinking_enabled
+    )
+    if not enabled:
+        return None
+    return configured.model_copy(update={"enabled": True})
 
 
 def _configure_logging(settings: Settings) -> None:

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -89,8 +89,8 @@ class ExtendedThinkingConfig(BaseModel):
     """Extended thinking (extended reasoning budget) configuration.
 
     Extended thinking allocates a deliberate reasoning budget to hard problems
-    before the model produces its response.  Anthropic-only — FallbackAdapter
-    skips this when routing to a non-Anthropic provider.
+    before the model produces its response. Each LLM adapter maps the generic
+    reasoning request to its provider protocol.
     """
 
     enabled: bool = Field(
@@ -103,7 +103,7 @@ class ExtendedThinkingConfig(BaseModel):
     )
     auto_trigger: bool = Field(
         default=True,
-        description="Automatically activate thinking on planning/ambiguous inputs.",
+        description="Activate reasoning on every model call.",
     )
     auto_trigger_on_retry: bool = Field(
         default=True,

--- a/src/ravn/domain/checkpoint.py
+++ b/src/ravn/domain/checkpoint.py
@@ -100,7 +100,13 @@ def restore_session_from_checkpoint(session: Session, checkpoint: Checkpoint) ->
 
     session.messages.clear()
     for raw in checkpoint.messages:
-        session.messages.append(Message(role=raw["role"], content=raw["content"]))
+        session.messages.append(
+            Message(
+                role=raw["role"],
+                content=raw["content"],
+                reasoning=raw.get("reasoning", ""),
+            )
+        )
 
     session.todos.clear()
     for raw in checkpoint.todos:

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -68,7 +68,7 @@ class StreamEventType(StrEnum):
     TEXT_DELTA = "text_delta"
     TOOL_CALL = "tool_call"
     MESSAGE_DONE = "message_done"
-    THINKING = "thinking"  # Extended thinking block content (Anthropic-only)
+    THINKING = "thinking"  # Provider reasoning content
 
 
 # ---------------------------------------------------------------------------
@@ -175,9 +175,8 @@ class TokenUsage:
     """Token usage for a single LLM call or cumulative across a session.
 
     ``thinking_tokens`` tracks the subset of ``output_tokens`` consumed by
-    extended-thinking blocks (Anthropic-only).  They are already included in
-    ``output_tokens``; this field provides a separate breakdown for cost
-    accounting (Bifrost).
+    model reasoning. They are already included in ``output_tokens``; this field
+    provides a separate breakdown for telemetry and cost accounting (Bifrost).
     """
 
     input_tokens: int
@@ -224,6 +223,14 @@ class Message:
 
     role: str  # "user" or "assistant"
     content: str | list[dict]
+    reasoning: str = ""
+
+    def to_api_dict(self) -> dict[str, Any]:
+        """Return the transport-neutral message representation."""
+        message: dict[str, Any] = {"role": self.role, "content": self.content}
+        if self.reasoning:
+            message["reasoning"] = self.reasoning
+        return message
 
 
 @dataclass(frozen=True)
@@ -234,6 +241,7 @@ class LLMResponse:
     tool_calls: list[ToolCall]
     stop_reason: StopReason
     usage: TokenUsage
+    reasoning: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/ravn/ports/llm.py
+++ b/src/ravn/ports/llm.py
@@ -21,7 +21,7 @@ class LLMPort(ABC):
     def supports_thinking(self) -> bool:
         """Return True if this adapter supports extended thinking.
 
-        Defaults to False.  AnthropicAdapter overrides to True.
+        Defaults to False.  Reasoning-capable adapters override to True.
         FallbackLLMAdapter uses this to decide whether to forward the
         ``thinking`` parameter to a given provider.
         """
@@ -46,9 +46,10 @@ class LLMPort(ABC):
         ``system`` may be a plain string or a list of Anthropic-format text blocks
         with optional ``cache_control`` entries for prompt caching.
 
-        ``thinking`` enables extended thinking when set to
-        ``{"type": "enabled", "budget_tokens": N}``.  Ignored by adapters that
-        do not support extended thinking (``supports_thinking == False``).
+        ``thinking`` enables deliberate reasoning when set. Adapters translate
+        this transport-neutral request into their provider's wire format.
+        Ignored by adapters that do not support reasoning
+        (``supports_thinking == False``).
         """
         raise NotImplementedError
 
@@ -65,8 +66,7 @@ class LLMPort(ABC):
     ) -> LLMResponse:
         """Generate a complete (non-streaming) response from the LLM.
 
-        ``thinking`` enables extended thinking when set to
-        ``{"type": "enabled", "budget_tokens": N}``.  Ignored by adapters that
-        do not support extended thinking (``supports_thinking == False``).
+        ``thinking`` enables deliberate reasoning when set. Adapters translate
+        this transport-neutral request into their provider's wire format.
         """
         raise NotImplementedError

--- a/tests/ravn/unit/test_extended_thinking.py
+++ b/tests/ravn/unit/test_extended_thinking.py
@@ -10,8 +10,8 @@ Covers:
 - FallbackLLMAdapter: passes thinking to supports_thinking providers, strips
   it for non-supporting providers
 - LLMPort.supports_thinking property
-- Agent: _parse_think_flag, _looks_like_planning_task, _resolve_thinking,
-  THINKING events emitted in _call_llm_streaming, explicit/auto triggers
+- Agent: _parse_think_flag, configured reasoning activation,
+  THINKING events emitted in _call_llm_streaming
 """
 
 from __future__ import annotations
@@ -25,11 +25,7 @@ import respx
 
 from ravn.adapters.llm.anthropic import AnthropicAdapter
 from ravn.adapters.llm.fallback import FallbackLLMAdapter
-from ravn.agent import (
-    RavnAgent,
-    _looks_like_planning_task,
-    _parse_think_flag,
-)
+from ravn.agent import RavnAgent, _parse_think_flag
 from ravn.config import ExtendedThinkingConfig
 from ravn.domain.events import RavnEvent, RavnEventType
 from ravn.domain.models import (
@@ -169,32 +165,6 @@ def test_parse_think_flag(user_input, expected_flag, expected_text):
 
 
 # ---------------------------------------------------------------------------
-# _looks_like_planning_task helper
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "user_input, expected",
-    [
-        ("design a database schema", True),
-        ("plan the migration", True),
-        ("what approach should i use", True),
-        ("best way to implement this", True),
-        ("how should I structure this", True),
-        ("just fix the bug", False),
-        ("run the tests", False),
-        ("", False),
-        # Word-boundary false-positive regression cases
-        ("this bug was unplanned, just fix it", False),
-        ("no replanning needed", False),
-        ("I need to re-architect the service", True),  # still matches "architect"
-    ],
-)
-def test_looks_like_planning_task(user_input, expected):
-    assert _looks_like_planning_task(user_input) == expected
-
-
-# ---------------------------------------------------------------------------
 # AnthropicAdapter — _headers with thinking enabled
 # ---------------------------------------------------------------------------
 
@@ -245,6 +215,21 @@ def test_anthropic_adapter_build_request_with_thinking():
         thinking=thinking,
     )
     assert req["thinking"] == thinking
+
+
+def test_anthropic_adapter_does_not_send_prior_reasoning_as_message_field():
+    adapter = AnthropicAdapter(api_key="sk-test")
+    req = adapter._build_request(
+        [{"role": "assistant", "content": "answer", "reasoning": "internal"}],
+        tools=[],
+        system="",
+        model="claude-sonnet-4-6",
+        max_tokens=1024,
+        stream=False,
+        thinking=None,
+    )
+
+    assert req["messages"] == [{"role": "assistant", "content": "answer"}]
 
 
 # ---------------------------------------------------------------------------
@@ -380,6 +365,7 @@ async def test_anthropic_adapter_generate_with_thinking_blocks():
 
     assert result.content == "Here is my answer."
     thinking_text = "Let me reason about this carefully." * 10
+    assert result.reasoning == thinking_text
     assert result.usage.thinking_tokens == len(thinking_text) // 4
     assert result.usage.input_tokens == 50
     assert result.usage.output_tokens == 120
@@ -689,17 +675,16 @@ async def test_agent_no_thinking_without_config():
 
 
 @pytest.mark.asyncio
-async def test_agent_auto_trigger_on_planning_input():
+async def test_agent_auto_trigger_applies_to_ordinary_input():
     agent, ch, llm = make_thinking_agent(auto_trigger=True)
-    await agent.run_turn("plan the new architecture for this service")
+    await agent.run_turn("read the file foo.py")
     assert llm.thinking_params[0] == {"type": "enabled", "budget_tokens": 4000}
 
 
 @pytest.mark.asyncio
 async def test_agent_no_auto_trigger_when_disabled():
     agent, ch, llm = make_thinking_agent(auto_trigger=False)
-    await agent.run_turn("plan the new architecture for this service")
-    # auto_trigger off → should be None even for planning input
+    await agent.run_turn("read the file foo.py")
     assert llm.thinking_params[0] is None
 
 
@@ -755,6 +740,7 @@ async def test_agent_thinking_events_emitted_to_channel():
     ]
     assert len(thinking_events) == 1
     assert thinking_events[0].payload["text"] == "reasoning step"
+    assert agent._session.messages[-1].reasoning == "reasoning step"
 
 
 @pytest.mark.asyncio

--- a/tests/ravn/unit/test_runtime_config.py
+++ b/tests/ravn/unit/test_runtime_config.py
@@ -1,0 +1,60 @@
+"""Tests for shared CLI runtime configuration resolution."""
+
+from ravn.adapters.personas.loader import PersonaConfig, PersonaLLMConfig
+from ravn.cli.runtime_config import _resolve_extended_thinking
+from ravn.config import Settings
+
+
+def test_persona_can_enable_reasoning() -> None:
+    settings = Settings()
+    persona = PersonaConfig(
+        name="resident",
+        llm=PersonaLLMConfig(thinking_enabled=True),
+    )
+
+    resolved = _resolve_extended_thinking(
+        settings,
+        persona,
+        cli_transport_executor=False,
+    )
+
+    assert resolved is not None
+    assert resolved.enabled is True
+    assert resolved.budget_tokens == settings.llm.extended_thinking.budget_tokens
+
+
+def test_global_reasoning_remains_enabled_for_persona_without_override() -> None:
+    settings = Settings()
+    settings.llm.extended_thinking.enabled = True
+
+    resolved = _resolve_extended_thinking(
+        settings,
+        PersonaConfig(name="resident"),
+        cli_transport_executor=False,
+    )
+
+    assert resolved is not None
+    assert resolved.enabled is True
+
+
+def test_reasoning_is_absent_when_not_enabled() -> None:
+    resolved = _resolve_extended_thinking(
+        Settings(),
+        PersonaConfig(name="resident"),
+        cli_transport_executor=False,
+    )
+
+    assert resolved is None
+
+
+def test_cli_transport_owns_its_reasoning_contract() -> None:
+    settings = Settings()
+    settings.llm.extended_thinking.enabled = True
+
+    resolved = _resolve_extended_thinking(
+        settings,
+        PersonaConfig(name="resident"),
+        cli_transport_executor=True,
+    )
+
+    assert resolved is None

--- a/tests/test_ravn/test_models.py
+++ b/tests/test_ravn/test_models.py
@@ -80,6 +80,24 @@ class TestMessage:
         m = Message(role="assistant", content=blocks)
         assert m.content == blocks
 
+    def test_api_dict_includes_reasoning_when_present(self) -> None:
+        m = Message(
+            role="assistant",
+            content="Answer",
+            reasoning="Evidence first",
+        )
+        assert m.to_api_dict() == {
+            "role": "assistant",
+            "content": "Answer",
+            "reasoning": "Evidence first",
+        }
+
+    def test_api_dict_omits_empty_reasoning(self) -> None:
+        assert Message(role="user", content="Hello").to_api_dict() == {
+            "role": "user",
+            "content": "Hello",
+        }
+
     def test_frozen(self) -> None:
         m = Message(role="user", content="Hello")
         with pytest.raises(Exception):

--- a/tests/test_ravn/test_openai_llm.py
+++ b/tests/test_ravn/test_openai_llm.py
@@ -64,6 +64,20 @@ def _text_chunk(content: str, finish_reason: str | None = None) -> str:
     )
 
 
+def _reasoning_chunk(content: str, *, legacy: bool = False) -> str:
+    field = "reasoning_content" if legacy else "reasoning"
+    return json.dumps(
+        {
+            "choices": [
+                {
+                    "delta": {field: content},
+                    "finish_reason": None,
+                }
+            ]
+        }
+    )
+
+
 def _tool_chunk(
     idx: int = 0,
     *,
@@ -94,10 +108,13 @@ def _non_stream_response(
     tool_calls: list | None = None,
     finish_reason: str = "stop",
     usage: dict | None = None,
+    reasoning: str = "",
 ) -> dict:
     message: dict = {"role": "assistant", "content": content}
     if tool_calls:
         message["tool_calls"] = tool_calls
+    if reasoning:
+        message["reasoning"] = reasoning
     return {
         "choices": [{"message": message, "finish_reason": finish_reason}],
         "usage": usage or {"prompt_tokens": 10, "completion_tokens": 5},
@@ -154,6 +171,23 @@ class TestNormaliseUsage:
             }
         )
         assert usage.cache_read_tokens == 40
+
+    def test_reasoning_tokens_from_completion_details(self) -> None:
+        usage = _normalise_usage(
+            {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "completion_tokens_details": {"reasoning_tokens": 32},
+            }
+        )
+        assert usage.thinking_tokens == 32
+
+    def test_reasoning_tokens_estimated_when_provider_omits_details(self) -> None:
+        usage = _normalise_usage(
+            {"prompt_tokens": 10, "completion_tokens": 5},
+            reasoning_text="reasoning that the provider did not itemise",
+        )
+        assert usage.thinking_tokens > 0
 
     def test_empty_dict_returns_zeros(self) -> None:
         usage = _normalise_usage({})
@@ -238,6 +272,9 @@ class TestOpenAIAdapterInit:
         assert adapter._default_model == "gpt-4o"
         assert adapter._max_retries >= 0
 
+    def test_supports_thinking(self) -> None:
+        assert OpenAICompatibleAdapter().supports_thinking is True
+
     def test_custom_base_url_trailing_slash_stripped(self) -> None:
         adapter = OpenAICompatibleAdapter(base_url="http://proxy/")
         assert not adapter._base_url.endswith("/")
@@ -251,6 +288,66 @@ class TestOpenAIAdapterInit:
         adapter = OpenAICompatibleAdapter(api_key="")
         headers = adapter._headers()
         assert "authorization" not in headers
+
+    def test_reasoning_request_options_are_config_driven(self) -> None:
+        adapter = OpenAICompatibleAdapter(
+            request_options={"temperature": 1.0, "model": "must-not-override"},
+            thinking_request_options={
+                "chat_template_kwargs": {
+                    "enable_thinking": True,
+                    "preserve_thinking": True,
+                }
+            },
+        )
+
+        ordinary = adapter._build_request(
+            _MESSAGES,
+            tools=[],
+            system="",
+            model="configured-model",
+            max_tokens=100,
+            stream=False,
+        )
+        reasoned = adapter._build_request(
+            _MESSAGES,
+            tools=[],
+            system="",
+            model="configured-model",
+            max_tokens=100,
+            stream=False,
+            thinking={"type": "enabled", "budget_tokens": 8000},
+        )
+
+        assert ordinary["temperature"] == 1.0
+        assert "chat_template_kwargs" not in ordinary
+        assert reasoned["chat_template_kwargs"]["preserve_thinking"] is True
+        assert reasoned["model"] == "configured-model"
+
+    def test_assistant_reasoning_is_preserved_in_tool_history(self) -> None:
+        adapter = OpenAICompatibleAdapter()
+        request = adapter._build_request(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "call-1",
+                            "name": "inspect",
+                            "input": {},
+                        }
+                    ],
+                    "reasoning": "I should inspect first.",
+                }
+            ],
+            tools=[],
+            system="",
+            model="configured-model",
+            max_tokens=100,
+            stream=False,
+        )
+
+        assert request["messages"][0]["reasoning_content"] == "I should inspect first."
 
 
 # ---------------------------------------------------------------------------
@@ -283,6 +380,28 @@ class TestOpenAIAdapterGenerate:
         result = await adapter.generate(_MESSAGES, **_KWARGS)
         assert result.usage.input_tokens == 20
         assert result.usage.output_tokens == 10
+
+    @respx.mock
+    async def test_generate_preserves_reasoning(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json=_non_stream_response(
+                    content="Answer.",
+                    reasoning="I should inspect the evidence.",
+                ),
+            )
+        )
+
+        result = await adapter.generate(
+            _MESSAGES,
+            **_KWARGS,
+            thinking={"type": "enabled", "budget_tokens": 8000},
+        )
+
+        assert result.reasoning == "I should inspect the evidence."
+        assert result.usage.thinking_tokens > 0
 
     @respx.mock
     async def test_generate_tool_call_extracted(self) -> None:
@@ -430,6 +549,33 @@ class TestOpenAIAdapterStream:
         assert done_events[0].usage is not None
         assert done_events[0].usage.input_tokens == 10
         assert done_events[0].usage.output_tokens == 5
+
+    @respx.mock
+    async def test_stream_emits_current_and_legacy_reasoning_fields(self) -> None:
+        adapter = OpenAICompatibleAdapter(api_key="k", base_url=_BASE_URL)
+        sse = _make_sse_lines(
+            _reasoning_chunk("Inspect "),
+            _reasoning_chunk("evidence.", legacy=True),
+            _text_chunk("Answer."),
+            usage={"prompt_tokens": 10, "completion_tokens": 9},
+        )
+        respx.post(f"{_BASE_URL}/v1/chat/completions").mock(
+            return_value=httpx.Response(200, content=sse)
+        )
+
+        events = []
+        async for event in adapter.stream(
+            _MESSAGES,
+            **_KWARGS,
+            thinking={"type": "enabled", "budget_tokens": 8000},
+        ):
+            events.append(event)
+
+        thinking_events = [event for event in events if event.type == StreamEventType.THINKING]
+        assert "".join(event.text or "" for event in thinking_events) == "Inspect evidence."
+        done = next(event for event in events if event.type == StreamEventType.MESSAGE_DONE)
+        assert done.usage is not None
+        assert done.usage.thinking_tokens > 0
 
     @respx.mock
     async def test_stream_tool_call_extracted(self) -> None:


### PR DESCRIPTION
## Summary
- replace prompt-keyword reasoning routing with persona/config activation
- preserve provider reasoning through Ravn tool turns and checkpoints
- add configurable OpenAI-compatible request options and Qwen reasoning streaming

## Validation
- `uv run --frozen ruff check src/ tests/`
- `uv run --frozen ruff format --check src/ tests/`
- `uv run --frozen pytest -q` (17,615 passed, 33 skipped, 1 xfailed)