### PR TITLE
fix(a2a): fail workflows and deliver durable callbacks

### DIFF
--- a/charts/ting/templates/migrations-configmap.yaml
+++ b/charts/ting/templates/migrations-configmap.yaml
@@ -1440,4 +1440,30 @@ data:
     -- cluster.
     ALTER TABLE workflow_campaigns ADD COLUMN IF NOT EXISTS connection_id TEXT;
 
+  000032_a2a_push_notifications.down.sql: |
+    DROP TABLE IF EXISTS a2a_push_notification_configs;
+
+  000032_a2a_push_notifications.up.sql: |
+    CREATE TABLE IF NOT EXISTS a2a_push_notification_configs (
+        task_id TEXT NOT NULL,
+        config_id TEXT NOT NULL,
+        owner_id TEXT NOT NULL,
+        config_data BYTEA NOT NULL,
+        pending_event JSONB,
+        delivery_version TEXT,
+        next_attempt_at TIMESTAMPTZ,
+        attempt_count INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        delivered_at TIMESTAMPTZ,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (task_id, config_id, owner_id),
+        CONSTRAINT a2a_push_notification_task_fk
+            FOREIGN KEY (task_id) REFERENCES workflow_campaigns(slug) ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_a2a_push_notification_due
+        ON a2a_push_notification_configs (next_attempt_at)
+        WHERE pending_event IS NOT NULL;
+
 {{- end }}

--- a/migrations/ting/000032_a2a_push_notifications.down.sql
+++ b/migrations/ting/000032_a2a_push_notifications.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS a2a_push_notification_configs;

--- a/migrations/ting/000032_a2a_push_notifications.up.sql
+++ b/migrations/ting/000032_a2a_push_notifications.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS a2a_push_notification_configs (
+    task_id TEXT NOT NULL,
+    config_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    config_data BYTEA NOT NULL,
+    pending_event JSONB,
+    delivery_version TEXT,
+    next_attempt_at TIMESTAMPTZ,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    delivered_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (task_id, config_id, owner_id),
+    CONSTRAINT a2a_push_notification_task_fk
+        FOREIGN KEY (task_id) REFERENCES workflow_campaigns(slug) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_a2a_push_notification_due
+    ON a2a_push_notification_configs (next_attempt_at)
+    WHERE pending_event IS NOT NULL;

--- a/src/ravn/adapters/channels/gateway_http.py
+++ b/src/ravn/adapters/channels/gateway_http.py
@@ -24,7 +24,7 @@ from datetime import UTC, datetime
 from importlib.resources import files
 from typing import Any
 
-from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel
@@ -178,6 +178,49 @@ class HttpGateway:
             )
 
         if self._resident_runtime is not None:
+            if self._config.a2a_push_enabled:
+
+                @app.post("/a2a/push")
+                async def a2a_push(
+                    request: Request,
+                    x_a2a_notification_token: str | None = Header(default=None),
+                ) -> dict[str, Any]:
+                    """Persist an authenticated A2A task update and wake the resident."""
+                    expected = self._config.a2a_push_notification_token.get_secret_value().strip()
+                    if not expected:
+                        raise HTTPException(
+                            status_code=503,
+                            detail="A2A push receiver is disabled because its token is missing",
+                        )
+                    if not x_a2a_notification_token or not secrets.compare_digest(
+                        x_a2a_notification_token,
+                        expected,
+                    ):
+                        raise HTTPException(
+                            status_code=401, detail="Invalid A2A notification token"
+                        )
+                    raw = await request.body()
+                    if len(raw) > self._config.a2a_push_max_body_bytes:
+                        raise HTTPException(
+                            status_code=413, detail="A2A callback body is too large"
+                        )
+                    try:
+                        payload = json.loads(raw)
+                    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                        raise HTTPException(
+                            status_code=400, detail="Invalid JSON callback"
+                        ) from exc
+                    if not isinstance(payload, dict):
+                        raise HTTPException(
+                            status_code=422, detail="A2A callback must be an object"
+                        )
+                    try:
+                        return await self._resident_runtime.submit_a2a_push(payload)
+                    except ValueError as exc:
+                        raise HTTPException(status_code=422, detail=str(exc)) from exc
+                    except RuntimeError as exc:
+                        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
             if self._config.resident_hud_enabled:
 
                 @app.get("/resident/hud", response_class=HTMLResponse)

--- a/src/ravn/adapters/tools/a2a_task.py
+++ b/src/ravn/adapters/tools/a2a_task.py
@@ -36,6 +36,9 @@ class A2ATaskTool(ToolPort):
         result_max_chars: int = _DEFAULT_RESULT_MAX_CHARS,
         message_max_chars: int = _DEFAULT_MESSAGE_MAX_CHARS,
         activity_emitter: Callable[[dict[str, object]], Awaitable[None]] | None = None,
+        default_connection_id: str = "",
+        push_callback_url: str = "",
+        push_notification_token: str = "",
     ) -> None:
         self._directory = agent_directory
         self._client = client
@@ -45,6 +48,9 @@ class A2ATaskTool(ToolPort):
         self._result_max_chars = max(1_000, result_max_chars)
         self._message_max_chars = max(1_000, message_max_chars)
         self._activity_emitter = activity_emitter
+        self._default_connection_id = default_connection_id.strip()
+        self._push_callback_url = push_callback_url.strip()
+        self._push_notification_token = push_notification_token.strip()
 
     @property
     def name(self) -> str:
@@ -56,7 +62,9 @@ class A2ATaskTool(ToolPort):
             "Interact with a peer skill discovered through capability_list. "
             "Operations: start a task, get its current state/artifacts, reply when "
             "it requests input, or cancel it. Preserve agent_id and task_id from "
-            "the response for later turns. The peer and skill are your choice."
+            "the response for later turns. A start response with push_registered=true "
+            "will wake the resident on state changes, so do not repeatedly poll it. "
+            "The peer and skill are your choice."
         )
 
     @property
@@ -187,6 +195,19 @@ class A2ATaskTool(ToolPort):
             (task.get("id") if isinstance(task, dict) else "") or input.get("task_id") or ""
         )
         state = str(status.get("state") or "")
+        push_registered: bool | None = None
+        if operation == "start" and task_id and self._push_callback_url:
+            push_registered = False
+            if bool(agent.capabilities.get("pushNotifications")):
+                try:
+                    await self._register_push(endpoint, task_id)
+                    push_registered = True
+                except _A2ATaskError as exc:
+                    logger.warning(
+                        "A2A push registration failed for task %s; polling remains available: %s",
+                        task_id,
+                        exc,
+                    )
         result_attributes = {
             "a2a.agent.id": agent.id,
             "a2a.operation": operation,
@@ -217,6 +238,7 @@ class A2ATaskTool(ToolPort):
                     500,
                 ),
                 "source_tool": self.name,
+                **({"push_registered": push_registered} if push_registered is not None else {}),
             }
         )
         return ToolResult(
@@ -227,7 +249,20 @@ class A2ATaskTool(ToolPort):
                 result=result,
                 requested_task_id=str(input.get("task_id") or "").strip(),
                 max_chars=self._result_max_chars,
+                push_registered=push_registered,
             ),
+        )
+
+    async def _register_push(self, endpoint: str, task_id: str) -> None:
+        await self._rpc(
+            endpoint,
+            "CreateTaskPushNotificationConfig",
+            {
+                "taskId": task_id,
+                "id": f"ravn-{uuid4()}",
+                "url": self._push_callback_url,
+                "token": self._push_notification_token,
+            },
         )
 
     async def _emit_activity(self, activity: dict[str, object]) -> None:
@@ -259,6 +294,8 @@ class A2ATaskTool(ToolPort):
             metadata = dict(supplied_metadata) if isinstance(supplied_metadata, dict) else {}
             self._validate_metadata(metadata)
             metadata["skillId"] = skill_id
+            if self._default_connection_id:
+                metadata.setdefault("connectionId", self._default_connection_id)
             trace_context = get_observability().inject()
             if trace_context:
                 metadata["traceContext"] = trace_context
@@ -410,6 +447,7 @@ def _render_response_payload(
     result: dict[str, Any],
     requested_task_id: str,
     max_chars: int,
+    push_registered: bool | None = None,
 ) -> str:
     embedded = result.get("task")
     task = embedded if isinstance(embedded, dict) else result
@@ -445,6 +483,8 @@ def _render_response_payload(
             "directory": [item.model_dump(by_alias=True) for item in agent.provenance[:8]],
         },
     }
+    if push_registered is not None:
+        payload["push_registered"] = push_registered
     message = status.get("message") or status.get("update")
     if message:
         payload["status_message"] = _truncate(str(message), 2_000)

--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -402,6 +402,11 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
             "message_max_chars": s.gateway.platform.a2a_message_max_chars,
             "result_max_chars": s.gateway.platform.a2a_result_max_chars,
             "activity_emitter": ctx.get("a2a_activity_emitter"),
+            "default_connection_id": s.gateway.platform.a2a_default_connection_id,
+            "push_callback_url": s.gateway.platform.a2a_push_callback_url,
+            "push_notification_token": (
+                s.gateway.platform.a2a_push_notification_token.get_secret_value().strip()
+            ),
         },
     ),
     "ting_plan": BuiltinToolDef(

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import AliasChoices, BaseModel, Field, model_validator
+from pydantic import AliasChoices, BaseModel, Field, SecretStr, model_validator
 from pydantic_settings import (
     BaseSettings,
     EnvSettingsSource,
@@ -995,6 +995,19 @@ class HttpChannelConfig(BaseModel):
             "operator-question and answer endpoints. Missing tokens disable those endpoints."
         ),
     )
+    a2a_push_enabled: bool = Field(
+        default=False,
+        description="Accept authenticated A2A task callbacks and wake the resident.",
+    )
+    a2a_push_notification_token: SecretStr = Field(
+        default=SecretStr(""),
+        description="A2A callback verification token; set through a secret config override.",
+    )
+    a2a_push_max_body_bytes: int = Field(
+        default=1_048_576,
+        ge=1024,
+        description="Maximum accepted A2A callback body size.",
+    )
     resident_hud_enabled: bool = Field(
         default=False,
         description="Expose the resident's read-only HUD and live data endpoints.",
@@ -1146,6 +1159,18 @@ class PlatformToolsConfig(BaseModel):
             "Use this for platform workflow facades or other stable peers that are not "
             "projected by an Observatory Agent Directory."
         ),
+    )
+    a2a_default_connection_id: str = Field(
+        default="",
+        description="Default Volundr target injected into newly started A2A workflows.",
+    )
+    a2a_push_callback_url: str = Field(
+        default="",
+        description=("Public HTTPS callback registered for A2A tasks that advertise push support."),
+    )
+    a2a_push_notification_token: SecretStr = Field(
+        default=SecretStr(""),
+        description="Token sent to the configured A2A callback; inject through secret config.",
     )
     a2a_message_max_chars: int = Field(
         default=12_000,

--- a/src/ravn/personas/ivaldi.yaml
+++ b/src/ravn/personas/ivaldi.yaml
@@ -27,6 +27,10 @@ system_prompt_template: |
 
   Use `capability_list` to inspect native, learned, workflow, and peer
   capabilities. Use `a2a_task` to collaborate with a discovered A2A peer.
+  When an A2A start result says `push_registered: true`, record its task ID and
+  sleep with `next_action_timing: external_event`; the authenticated callback
+  will wake you with the new task state. Do not poll that task repeatedly. If
+  push registration is false or absent, schedule one bounded recheck instead.
   `build_tool` is complete only after its build, tests, review, provenance, and
   adoption succeed. When its capability description says a build backend is
   configured, commission the build instead of authoring the implementation

--- a/src/ravn/resident_runtime.py
+++ b/src/ravn/resident_runtime.py
@@ -28,7 +28,12 @@ from ravn.domain.resident_continuation import (
 from ravn.domain.resident_state import ResidentStatePort
 from ravn.ports.trigger import TriggerPort
 from ravn.resident_continuation import _scheduled_wake_at
-from ravn.resident_inbox import ResidentInboxBackend, ResidentInboxStatus
+from ravn.resident_inbox import (
+    ResidentInboxBackend,
+    ResidentInboxClassification,
+    ResidentInboxSignal,
+    ResidentInboxStatus,
+)
 from ravn.resident_text import compact_line
 
 EnqueueResidentTask = Callable[[AgentTask], Awaitable[bool | None]]
@@ -210,6 +215,56 @@ class ResidentRuntime:
             attributes={"ravn.resident.id": self._resident_id},
         )
         return ref
+
+    async def submit_a2a_push(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Persist an A2A task update and immediately wake the resident when idle."""
+        if self._inbox is None:
+            raise RuntimeError("Resident inbox is not configured")
+        event = next(
+            (
+                payload.get(key)
+                for key in ("task", "statusUpdate", "artifactUpdate")
+                if isinstance(payload.get(key), dict)
+            ),
+            None,
+        )
+        if not isinstance(event, dict):
+            raise ValueError("A2A callback must contain task, statusUpdate, or artifactUpdate")
+        task_id = str(event.get("id") or event.get("taskId") or "").strip()
+        if not task_id:
+            raise ValueError("A2A callback does not identify a task")
+        status = event.get("status")
+        status = status if isinstance(status, dict) else {}
+        state = str(status.get("state") or event.get("state") or "TASK_STATE_UNSPECIFIED")
+        now = datetime.now(UTC)
+        normalized = json.loads(json.dumps(payload, sort_keys=True, default=str))
+        digest = hashlib.sha256(json.dumps(normalized, sort_keys=True).encode()).hexdigest()[:16]
+        signal = ResidentInboxSignal(
+            id=f"a2a-{task_id}-{digest}",
+            source="a2a:push",
+            kind="a2a.task_update",
+            summary=f"A2A task {task_id} changed to {state}.",
+            payload=normalized,
+            classification=ResidentInboxClassification.STATUS_UPDATE.value,
+            confidence=1.0,
+            status=ResidentInboxStatus.NEW.value,
+            observed_at=now.isoformat(),
+        )
+        inbox_ref = await self._inbox.write_signal(signal)
+        task = await self.next_home_task(
+            limit=1,
+            persona=None,
+            output_mode=OutputMode.SURFACE,
+        )
+        queued = bool(task and await self._enqueue_task(task))
+        if task is not None and not queued:
+            self.release_failed_task(task)
+        return {
+            "task_id": task_id,
+            "state": state,
+            "inbox_ref": inbox_ref,
+            "queued": queued,
+        }
 
     async def handle_completed_turn(
         self,

--- a/src/skuld/activity_reporting.py
+++ b/src/skuld/activity_reporting.py
@@ -67,7 +67,7 @@ class ActivityReportingMixin:
         """Report activity state change to Volundr.
 
         States: provisioning, active, idle, tool_executing, awaiting_input,
-        stopped. Debounces rapid transitions — only reports when the state
+        stopped, error. Debounces rapid transitions — only reports when the state
         actually changes, unless extra_metadata is attached (used by the
         heartbeat and by attention reports so they always land). The POST body
         ALWAYS carries ``state`` and ``state_since`` so a transition (including

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -263,6 +263,27 @@ def _normalize_browser_message_content(content: object) -> str:
     return "\n\n".join(lines).strip()
 
 
+def _peer_error_message(frame: dict[str, Any]) -> str:
+    """Extract a bounded, human-readable error from a room peer frame."""
+    data = frame.get("data")
+    if isinstance(data, str):
+        message = data
+    elif isinstance(data, dict):
+        raw_error = data.get("error")
+        if isinstance(raw_error, dict):
+            message = str(raw_error.get("message") or raw_error.get("error") or "")
+        else:
+            message = str(
+                raw_error
+                or data.get("message")
+                or data.get("content")
+                or "Peer workflow agent failed"
+            )
+    else:
+        message = str(frame.get("error") or "Peer workflow agent failed")
+    return message.strip()[:2000] or "Peer workflow agent failed"
+
+
 @dataclass
 class PeerWatchState:
     """Tracks one active flock peer task for Skuld's silence watchdog."""
@@ -382,6 +403,7 @@ class Broker(
             run_id=self._settings.session.run_id,
         )
         self._flock_completion_reported = False
+        self._flock_failure_reported = False
         self._session_start_reported = False
         self._event_sequence = 0
         # Durable full-fidelity event log (session_event_log). Every CLI frame is
@@ -1401,6 +1423,8 @@ class Broker(
                 return
             await self._report_peer_help_needed_activity(peer_id, frame)
             await self._emit_peer_help_needed_sleipnir_event(peer_id, frame)
+        elif event_type == "error":
+            await self._maybe_report_flock_failure(peer_id, frame)
 
         now = time.monotonic()
         watch = self._peer_watches.get(peer_id)
@@ -2255,7 +2279,11 @@ class Broker(
         Use that existing path for ravn_flock completion instead of relying on an
         out-of-process Sleipnir transport during co-hosted development runs.
         """
-        if self._flock_completion_reported or not self._is_room_only_workflow_session():
+        if (
+            self._flock_completion_reported
+            or self._flock_failure_reported
+            or not self._is_room_only_workflow_session()
+        ):
             return
         if self._room_bridge is None:
             return
@@ -2296,6 +2324,50 @@ class Broker(
 
         self._flock_completion_reported = True
         await self._report_activity_state("idle", extra_metadata=extra_metadata)
+
+    async def _maybe_report_flock_failure(
+        self,
+        peer_id: str,
+        frame: dict[str, Any],
+    ) -> None:
+        """Report a terminal peer error for unattended flock workflows.
+
+        A peer ``error`` frame is terminal for that agent turn. Previously it
+        was visible in chat and tracing only, leaving the workflow campaign in
+        ``running`` forever. Report an explicit terminal activity state so
+        Volundr, Ting, and A2A clients agree that the workflow failed.
+        """
+        if (
+            self._flock_failure_reported
+            or self._flock_completion_reported
+            or not self._is_room_only_workflow_session()
+        ):
+            return
+
+        participant = self._room_bridge.participants.get(peer_id) if self._room_bridge else None
+        persona = (participant.persona if participant is not None else "").strip()
+        error = _peer_error_message(frame)
+        extra_metadata = {
+            "failure_source": "ravn_flock",
+            "failure_peer_id": peer_id,
+            "failure_persona": persona,
+            "error": error,
+        }
+
+        # Set the terminal guard before awaiting the report so a concurrent
+        # completion event cannot overwrite the failure with ``idle``.
+        self._flock_failure_reported = True
+        await self._report_activity_state("error", extra_metadata=extra_metadata)
+        await self._finish_trace_span(
+            self._trace_workflow_span_id,
+            status="failed",
+            attributes={
+                "reason": "peer_error",
+                "peer_id": peer_id,
+                "persona": persona,
+            },
+        )
+        self._trace_workflow_span_id = None
 
     async def _peer_watchdog_loop(self) -> None:
         """Warn in chat when a flock peer accepted work but goes quiet."""

--- a/src/ting/adapters/a2a_push_dispatcher.py
+++ b/src/ting/adapters/a2a_push_dispatcher.py
@@ -1,0 +1,204 @@
+"""Durable A2A task push delivery."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import suppress
+from urllib.parse import urlsplit
+
+import httpx
+from a2a.types import TaskPushNotificationConfig
+from google.protobuf.json_format import MessageToDict
+
+from ting.domain.models import WorkflowCampaign
+from ting.ports.a2a_push import A2APushConfigRepositoryPort, A2APushDelivery
+
+logger = logging.getLogger(__name__)
+
+
+def callback_origin(url: str) -> str:
+    """Return a normalized HTTPS origin, rejecting unsafe callback URLs."""
+    parsed = urlsplit(str(url or "").strip())
+    if parsed.scheme.lower() != "https" or not parsed.hostname:
+        raise ValueError("A2A push callback URL must use HTTPS")
+    if parsed.username or parsed.password or parsed.fragment:
+        raise ValueError("A2A push callback URL must not contain userinfo or a fragment")
+    host = parsed.hostname.lower()
+    port = parsed.port
+    return f"https://{host}{f':{port}' if port and port != 443 else ''}"
+
+
+class A2APushDispatcher:
+    """Queue the latest task state and retry callbacks from a durable outbox."""
+
+    def __init__(
+        self,
+        *,
+        repo: A2APushConfigRepositoryPort,
+        allowed_callback_origins: list[str],
+        timeout_seconds: float,
+        poll_seconds: float,
+        retry_initial_seconds: float,
+        retry_max_seconds: float,
+        claim_limit: int,
+        lease_seconds: float,
+        max_url_chars: int,
+        max_credential_chars: int,
+        max_configs_page_size: int,
+    ) -> None:
+        self._repo = repo
+        self._allowed_origins = frozenset(
+            callback_origin(origin) for origin in allowed_callback_origins
+        )
+        self._client = httpx.AsyncClient(timeout=timeout_seconds)
+        self._poll_seconds = poll_seconds
+        self._retry_initial_seconds = retry_initial_seconds
+        self._retry_max_seconds = retry_max_seconds
+        self._claim_limit = claim_limit
+        self._lease_seconds = lease_seconds
+        self._max_url_chars = max_url_chars
+        self._max_credential_chars = max_credential_chars
+        self._max_configs_page_size = max_configs_page_size
+        self._task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._allowed_origins)
+
+    @property
+    def max_configs_page_size(self) -> int:
+        return self._max_configs_page_size
+
+    def validate_config(self, config: TaskPushNotificationConfig) -> None:
+        if len(config.url) > self._max_url_chars:
+            raise ValueError(f"A2A push callback URL exceeds {self._max_url_chars} characters")
+        if (
+            len(config.token) > self._max_credential_chars
+            or len(config.authentication.credentials) > self._max_credential_chars
+        ):
+            raise ValueError(
+                f"A2A push callback credential exceeds {self._max_credential_chars} characters"
+            )
+        origin = callback_origin(config.url)
+        if origin not in self._allowed_origins:
+            raise ValueError(f"A2A push callback origin is not allowed: {origin}")
+        scheme = config.authentication.scheme.strip().lower()
+        if scheme and scheme != "bearer":
+            raise ValueError("A2A push callback authentication supports bearer only")
+
+    async def save_config(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config: TaskPushNotificationConfig,
+    ) -> TaskPushNotificationConfig:
+        return await self._repo.save_config(task_id=task_id, owner_id=owner_id, config=config)
+
+    async def get_config(self, *, task_id: str, owner_id: str, config_id: str):
+        return await self._repo.get_for_owner(
+            task_id=task_id,
+            owner_id=owner_id,
+            config_id=config_id,
+        )
+
+    async def list_configs(self, *, task_id: str, owner_id: str):
+        return await self._repo.list_for_owner(task_id=task_id, owner_id=owner_id)
+
+    async def delete_config(self, *, task_id: str, owner_id: str, config_id: str) -> bool:
+        return await self._repo.delete_for_owner(
+            task_id=task_id,
+            owner_id=owner_id,
+            config_id=config_id,
+        )
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._run(), name="a2a-push-dispatcher")
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._task is not None:
+            self._task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        await self._client.aclose()
+
+    async def queue_campaign(self, campaign: WorkflowCampaign) -> int:
+        # Local import avoids making the domain projector depend on the API module.
+        from a2a.utils.proto_utils import to_stream_response  # noqa: PLC0415
+
+        from ting.api.a2a import campaign_to_task  # noqa: PLC0415
+
+        payload = MessageToDict(to_stream_response(campaign_to_task(campaign)))
+        return await self._repo.queue_event(campaign.slug, payload)
+
+    async def _run(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    deliveries = await self._repo.claim_due(
+                        limit=self._claim_limit,
+                        lease_seconds=self._lease_seconds,
+                    )
+                    if deliveries:
+                        await asyncio.gather(*(self._deliver(item) for item in deliveries))
+                except Exception:
+                    logger.exception("A2A push outbox pass failed")
+                try:
+                    await asyncio.wait_for(self._stop_event.wait(), timeout=self._poll_seconds)
+                except TimeoutError:
+                    continue
+        except asyncio.CancelledError:
+            raise
+
+    async def _deliver(self, delivery: A2APushDelivery) -> None:
+        config = delivery.config
+        try:
+            self.validate_config(config)
+            headers: dict[str, str] = {"A2A-Version": "1.0"}
+            if config.token:
+                headers["X-A2A-Notification-Token"] = config.token
+            if config.authentication.scheme.lower() == "bearer":
+                headers["Authorization"] = f"Bearer {config.authentication.credentials}"
+            response = await self._client.post(config.url, json=delivery.payload, headers=headers)
+            response.raise_for_status()
+        except Exception as exc:
+            attempts = delivery.attempt_count + 1
+            delay = self._retry_initial_seconds
+            for _attempt in range(max(0, attempts - 1)):
+                if delay >= self._retry_max_seconds:
+                    break
+                delay = min(self._retry_max_seconds, delay * 2)
+            await self._repo.retry_later(
+                delivery,
+                delay_seconds=delay,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            logger.warning(
+                "A2A push delivery failed task=%s config=%s origin=%s attempt=%d",
+                delivery.task_id,
+                delivery.config_id,
+                _safe_origin(config.url),
+                attempts,
+            )
+            return
+        await self._repo.mark_delivered(delivery)
+        logger.info(
+            "A2A push delivered task=%s config=%s origin=%s",
+            delivery.task_id,
+            delivery.config_id,
+            _safe_origin(config.url),
+        )
+
+
+def _safe_origin(url: str) -> str:
+    try:
+        return callback_origin(url)
+    except ValueError:
+        return "invalid"

--- a/src/ting/adapters/postgres_a2a_push.py
+++ b/src/ting/adapters/postgres_a2a_push.py
@@ -1,0 +1,245 @@
+"""Encrypted, durable A2A push configurations and delivery outbox."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+import asyncpg
+from a2a.types import TaskPushNotificationConfig
+from cryptography.fernet import Fernet, InvalidToken
+from google.protobuf.json_format import MessageToJson, Parse
+
+from ting.ports.a2a_push import A2APushDelivery
+
+
+class PostgresA2APushConfigRepository:
+    """Persist encrypted callback credentials and retryable task events."""
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        encryption_key: str,
+        *,
+        max_error_chars: int,
+    ) -> None:
+        self._pool = pool
+        self._max_error_chars = max_error_chars
+        try:
+            self._fernet = Fernet(encryption_key.encode("utf-8"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("A2A push encryption key must be a valid Fernet key") from exc
+
+    async def save_config(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config: TaskPushNotificationConfig,
+    ) -> TaskPushNotificationConfig:
+        saved = TaskPushNotificationConfig()
+        saved.CopyFrom(config)
+        saved.task_id = task_id
+        if not saved.id:
+            saved.id = str(uuid4())
+        encrypted = self._encrypt(saved)
+        await self._pool.execute(
+            """
+            INSERT INTO a2a_push_notification_configs (
+                task_id, config_id, owner_id, config_data
+            ) VALUES ($1, $2, $3, $4)
+            ON CONFLICT (task_id, config_id, owner_id) DO UPDATE SET
+                config_data = EXCLUDED.config_data,
+                updated_at = NOW()
+            """,
+            task_id,
+            saved.id,
+            owner_id,
+            encrypted,
+        )
+        return saved
+
+    async def list_for_owner(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+    ) -> list[TaskPushNotificationConfig]:
+        rows = await self._pool.fetch(
+            """
+            SELECT config_data
+            FROM a2a_push_notification_configs
+            WHERE task_id = $1 AND owner_id = $2
+            ORDER BY created_at, config_id
+            """,
+            task_id,
+            owner_id,
+        )
+        return [self._decrypt(row["config_data"]) for row in rows]
+
+    async def get_for_owner(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config_id: str,
+    ) -> TaskPushNotificationConfig | None:
+        raw = await self._pool.fetchval(
+            """
+            SELECT config_data
+            FROM a2a_push_notification_configs
+            WHERE task_id = $1 AND owner_id = $2 AND config_id = $3
+            """,
+            task_id,
+            owner_id,
+            config_id,
+        )
+        return self._decrypt(raw) if raw is not None else None
+
+    async def delete_for_owner(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config_id: str,
+    ) -> bool:
+        result = await self._pool.execute(
+            """
+            DELETE FROM a2a_push_notification_configs
+            WHERE task_id = $1 AND owner_id = $2 AND config_id = $3
+            """,
+            task_id,
+            owner_id,
+            config_id,
+        )
+        return result == "DELETE 1"
+
+    async def queue_event(self, task_id: str, payload: dict[str, Any]) -> int:
+        """Replace any older pending snapshot with the latest task state."""
+        version = str(uuid4())
+        result = await self._pool.execute(
+            """
+            UPDATE a2a_push_notification_configs
+            SET pending_event = $2::jsonb,
+                delivery_version = $3,
+                next_attempt_at = NOW(),
+                attempt_count = 0,
+                last_error = NULL,
+                delivered_at = NULL,
+                updated_at = NOW()
+            WHERE task_id = $1
+            """,
+            task_id,
+            json.dumps(payload),
+            version,
+        )
+        return int(result.rsplit(" ", 1)[-1])
+
+    async def claim_due(
+        self,
+        *,
+        limit: int,
+        lease_seconds: float,
+    ) -> list[A2APushDelivery]:
+        """Lease due rows so multiple Ting replicas do not double-send them."""
+        lease_until = datetime.now(UTC) + timedelta(seconds=max(1.0, lease_seconds))
+        async with self._pool.acquire() as conn, conn.transaction():
+            rows = await conn.fetch(
+                """
+                SELECT task_id, config_id, owner_id, config_data, pending_event,
+                       delivery_version, attempt_count
+                FROM a2a_push_notification_configs
+                WHERE pending_event IS NOT NULL
+                  AND next_attempt_at <= NOW()
+                ORDER BY next_attempt_at, updated_at
+                FOR UPDATE SKIP LOCKED
+                LIMIT $1
+                """,
+                max(1, limit),
+            )
+            for row in rows:
+                await conn.execute(
+                    """
+                    UPDATE a2a_push_notification_configs
+                    SET next_attempt_at = $4
+                    WHERE task_id = $1 AND config_id = $2 AND owner_id = $3
+                    """,
+                    row["task_id"],
+                    row["config_id"],
+                    row["owner_id"],
+                    lease_until,
+                )
+
+        deliveries: list[A2APushDelivery] = []
+        for row in rows:
+            payload = row["pending_event"]
+            if isinstance(payload, str):
+                payload = json.loads(payload)
+            deliveries.append(
+                A2APushDelivery(
+                    task_id=row["task_id"],
+                    config_id=row["config_id"],
+                    owner_id=row["owner_id"],
+                    config=self._decrypt(row["config_data"]),
+                    payload=dict(payload or {}),
+                    delivery_version=str(row["delivery_version"] or ""),
+                    attempt_count=int(row["attempt_count"] or 0),
+                )
+            )
+        return deliveries
+
+    async def mark_delivered(self, delivery: A2APushDelivery) -> None:
+        await self._pool.execute(
+            """
+            UPDATE a2a_push_notification_configs
+            SET pending_event = NULL,
+                next_attempt_at = NULL,
+                last_error = NULL,
+                delivered_at = NOW(),
+                updated_at = NOW()
+            WHERE task_id = $1 AND config_id = $2 AND owner_id = $3
+              AND delivery_version = $4
+            """,
+            delivery.task_id,
+            delivery.config_id,
+            delivery.owner_id,
+            delivery.delivery_version,
+        )
+
+    async def retry_later(
+        self,
+        delivery: A2APushDelivery,
+        *,
+        delay_seconds: float,
+        error: str,
+    ) -> None:
+        next_attempt = datetime.now(UTC) + timedelta(seconds=max(1.0, delay_seconds))
+        await self._pool.execute(
+            """
+            UPDATE a2a_push_notification_configs
+            SET next_attempt_at = $5,
+                attempt_count = attempt_count + 1,
+                last_error = $6,
+                updated_at = NOW()
+            WHERE task_id = $1 AND config_id = $2 AND owner_id = $3
+              AND delivery_version = $4
+            """,
+            delivery.task_id,
+            delivery.config_id,
+            delivery.owner_id,
+            delivery.delivery_version,
+            next_attempt,
+            error[: self._max_error_chars],
+        )
+
+    def _encrypt(self, config: TaskPushNotificationConfig) -> bytes:
+        return self._fernet.encrypt(MessageToJson(config).encode("utf-8"))
+
+    def _decrypt(self, encrypted: bytes) -> TaskPushNotificationConfig:
+        try:
+            payload = self._fernet.decrypt(bytes(encrypted)).decode("utf-8")
+        except InvalidToken as exc:
+            raise ValueError("A2A push configuration could not be decrypted") from exc
+        return Parse(payload, TaskPushNotificationConfig())

--- a/src/ting/adapters/volundr_http.py
+++ b/src/ting/adapters/volundr_http.py
@@ -174,6 +174,8 @@ class VolundrHTTPAdapter(VolundrPort):
                 branch=source.get("branch", ""),
                 base_branch=source.get("base_branch", ""),
                 workload_type=data.get("workload_type", "default"),
+                activity_state=data.get("activity_state"),
+                activity_metadata=data.get("activity_metadata") or {},
             )
 
     async def get_session(
@@ -204,6 +206,8 @@ class VolundrHTTPAdapter(VolundrPort):
                 branch=source.get("branch", ""),
                 base_branch=source.get("base_branch", ""),
                 workload_type=data.get("workload_type", "default"),
+                activity_state=data.get("activity_state"),
+                activity_metadata=data.get("activity_metadata") or {},
             )
 
     async def list_sessions(
@@ -231,6 +235,8 @@ class VolundrHTTPAdapter(VolundrPort):
                     chat_endpoint=_public_chat_endpoint(s.get("chat_endpoint"), self._base_url),
                     cluster_name=self._name,
                     workload_type=s.get("workload_type", "default"),
+                    activity_state=s.get("activity_state"),
+                    activity_metadata=s.get("activity_metadata") or {},
                 )
                 for s in resp.json()
             ]

--- a/src/ting/api/a2a.py
+++ b/src/ting/api/a2a.py
@@ -69,6 +69,7 @@ from ting.api.workflows import (
 )
 from ting.domain.models import WorkflowCampaign, WorkflowCampaignStatus
 from ting.domain.workflow_snapshot import workflow_artifact_paths_from_snapshot
+from ting.ports.a2a_push import A2APushDispatcherPort
 from ting.ports.volundr import VolundrFactory
 from ting.ports.workflow_campaign_repository import WorkflowCampaignRepository
 from ting.ports.workflow_repository import WorkflowRepository
@@ -124,6 +125,11 @@ def campaign_to_task(campaign: WorkflowCampaign) -> Task:
                 if campaign.metadata.get("branch")
                 else {}
             ),
+            **(
+                {"error": str(campaign.metadata["failure_error"])}
+                if campaign.metadata.get("failure_error")
+                else {}
+            ),
         }
     )
     return task
@@ -132,11 +138,9 @@ def campaign_to_task(campaign: WorkflowCampaign) -> Task:
 class WorkflowTaskHandler(RequestHandler):
     """Per-request A2A handler bound to the caller's identity.
 
-    Streaming, push notifications, and task listing are deliberately
-    unsupported: the agent card advertises ``streaming=false`` /
-    ``pushNotifications=false``, and polling ``GetTask`` is the supported
-    follow mechanism. The extended agent card IS supported — it adds the
-    caller's user-scope workflows to the public catalog.
+    Streaming remains deliberately unsupported. Task listing and durable push
+    notifications are supported; the agent card only advertises push when its
+    encrypted callback outbox is configured.
     """
 
     def __init__(
@@ -301,6 +305,7 @@ class WorkflowTaskHandler(RequestHandler):
                 )
             raise
         await _emit_campaign_event(self._request, "workflow.campaign.created", saved)
+        await self._queue_push(saved)
         return campaign_to_task(saved)
 
     async def on_get_task(
@@ -351,9 +356,10 @@ class WorkflowTaskHandler(RequestHandler):
         )
         saved = await self._campaign_repo.save_campaign(updated)
         await _emit_campaign_event(self._request, "workflow.campaign.updated", saved)
+        await self._queue_push(saved)
         return campaign_to_task(saved)
 
-    # -- Unsupported protocol surface ----------------------------------- #
+    # -- Additional protocol surface ------------------------------------ #
 
     async def on_list_tasks(
         self,
@@ -428,28 +434,87 @@ class WorkflowTaskHandler(RequestHandler):
         params: TaskPushNotificationConfig,
         context: ServerCallContext,
     ) -> TaskPushNotificationConfig:
-        raise UnsupportedOperationError("push notifications are not supported")
+        task_id = str(params.task_id or "").strip()
+        if not task_id:
+            raise InvalidParamsError("taskId is required")
+        campaign = await self._owned_campaign(task_id)
+        dispatcher = self._push_dispatcher()
+        self._validate_push_config(dispatcher, params)
+        saved = await dispatcher.save_config(
+            task_id=task_id,
+            owner_id=self._principal.user_id,
+            config=params,
+        )
+        await dispatcher.queue_campaign(campaign)
+        return saved
 
     async def on_get_task_push_notification_config(
         self,
         params: GetTaskPushNotificationConfigRequest,
         context: ServerCallContext,
     ) -> TaskPushNotificationConfig:
-        raise UnsupportedOperationError("push notifications are not supported")
+        task_id = str(params.task_id or "").strip()
+        config_id = str(params.id or "").strip()
+        if not task_id or not config_id:
+            raise InvalidParamsError("taskId and id are required")
+        await self._owned_campaign(task_id)
+        config = await self._push_dispatcher().get_config(
+            task_id=task_id,
+            owner_id=self._principal.user_id,
+            config_id=config_id,
+        )
+        if config is None:
+            raise InvalidParamsError("push notification config was not found")
+        return config
 
     async def on_list_task_push_notification_configs(
         self,
         params: ListTaskPushNotificationConfigsRequest,
         context: ServerCallContext,
     ) -> ListTaskPushNotificationConfigsResponse:
-        raise UnsupportedOperationError("push notifications are not supported")
+        task_id = str(params.task_id or "").strip()
+        if not task_id:
+            raise InvalidParamsError("taskId is required")
+        await self._owned_campaign(task_id)
+        dispatcher = self._push_dispatcher()
+        configs = await dispatcher.list_configs(
+            task_id=task_id,
+            owner_id=self._principal.user_id,
+        )
+        try:
+            offset = int(params.page_token or 0)
+        except ValueError as exc:
+            raise InvalidParamsError("pageToken must be a non-negative integer") from exc
+        if offset < 0:
+            raise InvalidParamsError("pageToken must be a non-negative integer")
+        page_size = min(
+            int(params.page_size) if params.page_size > 0 else dispatcher.max_configs_page_size,
+            dispatcher.max_configs_page_size,
+        )
+        selected = configs[offset : offset + page_size]
+        next_offset = offset + len(selected)
+        return ListTaskPushNotificationConfigsResponse(
+            configs=selected,
+            next_page_token=str(next_offset) if next_offset < len(configs) else "",
+        )
 
     async def on_delete_task_push_notification_config(
         self,
         params: DeleteTaskPushNotificationConfigRequest,
         context: ServerCallContext,
     ) -> None:
-        raise UnsupportedOperationError("push notifications are not supported")
+        task_id = str(params.task_id or "").strip()
+        config_id = str(params.id or "").strip()
+        if not task_id or not config_id:
+            raise InvalidParamsError("taskId and id are required")
+        await self._owned_campaign(task_id)
+        deleted = await self._push_dispatcher().delete_config(
+            task_id=task_id,
+            owner_id=self._principal.user_id,
+            config_id=config_id,
+        )
+        if not deleted:
+            raise InvalidParamsError("push notification config was not found")
 
     async def on_get_extended_agent_card(
         self,
@@ -558,6 +623,7 @@ class WorkflowTaskHandler(RequestHandler):
         )
         saved = await self._campaign_repo.save_campaign(updated)
         await _emit_campaign_event(self._request, "workflow.campaign.updated", saved)
+        await self._queue_push(saved)
         return campaign_to_task(saved)
 
     async def _answer_question(
@@ -614,7 +680,29 @@ class WorkflowTaskHandler(RequestHandler):
         )
         saved = await self._campaign_repo.save_campaign(updated)
         await _emit_campaign_event(self._request, "workflow.campaign.updated", saved)
+        await self._queue_push(saved)
         return campaign_to_task(saved)
+
+    def _push_dispatcher(self) -> A2APushDispatcherPort:
+        dispatcher = getattr(self._request.app.state, "a2a_push_dispatcher", None)
+        if dispatcher is None or not dispatcher.enabled:
+            raise UnsupportedOperationError("push notifications are not configured")
+        return dispatcher
+
+    async def _queue_push(self, campaign: WorkflowCampaign) -> None:
+        dispatcher = getattr(self._request.app.state, "a2a_push_dispatcher", None)
+        if dispatcher is not None and dispatcher.enabled:
+            await dispatcher.queue_campaign(campaign)
+
+    @staticmethod
+    def _validate_push_config(
+        dispatcher: A2APushDispatcherPort,
+        config: TaskPushNotificationConfig,
+    ) -> None:
+        try:
+            dispatcher.validate_config(config)
+        except ValueError as exc:
+            raise InvalidParamsError(str(exc)) from exc
 
     async def _attach_pending_questions(self, task: Task, campaign: WorkflowCampaign) -> None:
         """Attach pending peer questions to an INPUT_REQUIRED task.

--- a/src/ting/api/a2a_card.py
+++ b/src/ting/api/a2a_card.py
@@ -50,7 +50,7 @@ def build_agent_card(
         version=package_version(),
         capabilities=AgentCapabilities(
             streaming=False,
-            push_notifications=False,
+            push_notifications=config.push_notifications_enabled,
             extended_agent_card=True,
         ),
         default_input_modes=["text/plain"],

--- a/src/ting/config.py
+++ b/src/ting/config.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, Field, SecretStr, field_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -1080,6 +1080,72 @@ class A2AConfig(BaseModel):
         ge=0,
         description="Cache-Control max-age for the served agent card.",
     )
+    push_encryption_key: SecretStr = Field(
+        default=SecretStr(""),
+        description="Fernet key used to encrypt callback credentials at rest.",
+    )
+    push_callback_allowed_origins: list[str] = Field(
+        default_factory=list,
+        description="Exact HTTPS origins allowed to receive A2A task callbacks.",
+    )
+    push_timeout_seconds: float = Field(
+        default=10.0,
+        ge=1.0,
+        description="HTTP timeout for one A2A callback attempt.",
+    )
+    push_poll_seconds: float = Field(
+        default=1.0,
+        ge=0.1,
+        description="Seconds between durable callback outbox passes.",
+    )
+    push_retry_initial_seconds: float = Field(
+        default=2.0,
+        ge=0.1,
+        description="Initial callback retry delay.",
+    )
+    push_retry_max_seconds: float = Field(
+        default=300.0,
+        ge=1.0,
+        description="Maximum callback retry delay.",
+    )
+    push_claim_limit: int = Field(
+        default=20,
+        ge=1,
+        description="Maximum callback deliveries leased in one outbox pass.",
+    )
+    push_lease_seconds: float = Field(
+        default=30.0,
+        ge=1.0,
+        description="Lease duration for one claimed callback delivery.",
+    )
+    push_max_url_chars: int = Field(
+        default=2048,
+        ge=256,
+        description="Maximum callback URL length.",
+    )
+    push_max_credential_chars: int = Field(
+        default=8192,
+        ge=256,
+        description="Maximum callback token or bearer credential length.",
+    )
+    push_max_configs_page_size: int = Field(
+        default=100,
+        ge=1,
+        description="Maximum A2A callback configurations returned per page.",
+    )
+    push_max_error_chars: int = Field(
+        default=2000,
+        ge=128,
+        description="Maximum persisted callback delivery error length.",
+    )
+
+    @property
+    def push_notifications_enabled(self) -> bool:
+        return bool(
+            self.push_encryption_key.get_secret_value().strip()
+            and self.push_callback_allowed_origins
+        )
+
     inline_artifact_max_chars: int = Field(
         default=65536,
         ge=0,

--- a/src/ting/domain/services/activity_subscriber.py
+++ b/src/ting/domain/services/activity_subscriber.py
@@ -293,6 +293,10 @@ class SessionActivitySubscriber:
             await self._on_session_failed(event, volundr, owner_id)
             return
 
+        if event.state == "error":
+            await self._on_session_failed(event, volundr, owner_id)
+            return
+
         if await self._maybe_handle_help_needed(event, owner_id):
             return
 
@@ -784,7 +788,10 @@ class SessionActivitySubscriber:
             )
             return
 
-        await self._handle_failure(run, tracker, owner_id, reason=f"Session {event.session_status}")
+        reason = str(event.metadata.get("error") or event.metadata.get("message") or "").strip()
+        if not reason:
+            reason = f"Session {event.session_status or event.state or 'failed'}"
+        await self._handle_failure(run, tracker, owner_id, reason=reason)
 
     async def _try_handle_reviewer_failure(self, session_id: str, reason: str) -> None:
         """If the failed session is a tracked reviewer, hand off to review_engine."""

--- a/src/ting/domain/services/workflow_campaign_projector.py
+++ b/src/ting/domain/services/workflow_campaign_projector.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from datetime import UTC, datetime
 
 from ting.domain.models import WorkflowCampaign, WorkflowCampaignStatus
+from ting.ports.a2a_push import A2APushDispatcherPort
 from ting.ports.event_bus import EventBusPort, TingEvent
 from ting.ports.volundr import VolundrFactory
 from ting.ports.workflow_campaign_repository import WorkflowCampaignRepository
@@ -24,11 +25,13 @@ class WorkflowCampaignProjector:
         repo: WorkflowCampaignRepository,
         volundr_factory: VolundrFactory,
         event_bus: EventBusPort,
+        push_dispatcher: A2APushDispatcherPort | None = None,
         interval_seconds: float = 15.0,
     ) -> None:
         self._repo = repo
         self._volundr_factory = volundr_factory
         self._event_bus = event_bus
+        self._push_dispatcher = push_dispatcher
         self._interval_seconds = interval_seconds
         self._task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
@@ -83,7 +86,12 @@ class WorkflowCampaignProjector:
         session = await adapter.get_session(campaign.session_id)
         if session is None:
             return
-        next_status = _status_from_session(session.status, fallback=campaign.status)
+        activity_state = str(getattr(session, "activity_state", "") or "").strip().lower()
+        next_status = (
+            WorkflowCampaignStatus.FAILED
+            if activity_state == "error"
+            else _status_from_session(session.status, fallback=campaign.status)
+        )
         if next_status == WorkflowCampaignStatus.RUNNING:
             # Volundr's lifecycle status never says "waiting" — blocked-ness is
             # a session-internal condition (a peer's pending help question or a
@@ -140,11 +148,21 @@ class WorkflowCampaignProjector:
             return
 
         now = datetime.now(UTC)
+        metadata = dict(campaign.metadata)
+        if next_status == WorkflowCampaignStatus.FAILED:
+            activity_metadata = getattr(session, "activity_metadata", {}) or {}
+            failure_error = str(
+                activity_metadata.get("error") or activity_metadata.get("message") or ""
+            ).strip()
+            if failure_error:
+                metadata["failure_error"] = failure_error
+
         updated = WorkflowCampaign(
             **{
                 **campaign.__dict__,
                 "session_name": session.name,
                 "status": next_status,
+                "metadata": metadata,
                 "updated_at": now,
                 "last_activity_at": now,
                 "completed_at": now
@@ -170,9 +188,16 @@ class WorkflowCampaignProjector:
                     "session_id": saved.session_id,
                     "workflow_id": str(saved.workflow_id),
                     "active_stage_id": saved.active_stage_id,
+                    **(
+                        {"error": str(saved.metadata["failure_error"])}
+                        if saved.metadata.get("failure_error")
+                        else {}
+                    ),
                 },
             )
         )
+        if self._push_dispatcher is not None:
+            await self._push_dispatcher.queue_campaign(saved)
 
 
 _PENDING_BLOCKER_STATUSES = frozenset({"", "pending", "open", "waiting", "help_needed", "blocked"})

--- a/src/ting/main.py
+++ b/src/ting/main.py
@@ -21,12 +21,14 @@ from niuu.service_runtime import create_workload_identity_service
 from niuu.utils import import_class, resolve_secret_kwargs
 from ravn.adapters.personas.loader import FilesystemPersonaAdapter
 from ravn.ports.persona import PersonaPort
+from ting.adapters.a2a_push_dispatcher import A2APushDispatcher
 from ting.adapters.github_git import GitHubGitAdapter
 from ting.adapters.guild_instances import GuildInstanceRegistryClient
 from ting.adapters.inbound.rest_integrations import create_telegram_setup_router
 from ting.adapters.inbound.rest_pats import create_pats_router
 from ting.adapters.inbound.rest_telegram_webhook import create_telegram_webhook_router
 from ting.adapters.notification_channel_factory import NotificationChannelFactory
+from ting.adapters.postgres_a2a_push import PostgresA2APushConfigRepository
 from ting.adapters.postgres_dispatcher import PostgresDispatcherRepository
 from ting.adapters.postgres_notification_subscriptions import (
     PostgresNotificationSubscriptionRepository,
@@ -565,6 +567,30 @@ def create_app(
             workflow_campaign_repo = PostgresWorkflowCampaignRepository(pool)
             app.state.workflow_campaign_repo = workflow_campaign_repo
 
+            a2a_push_dispatcher = None
+            if settings.a2a.push_notifications_enabled:
+                a2a_push_repo = PostgresA2APushConfigRepository(
+                    pool,
+                    settings.a2a.push_encryption_key.get_secret_value(),
+                    max_error_chars=settings.a2a.push_max_error_chars,
+                )
+                a2a_push_dispatcher = A2APushDispatcher(
+                    repo=a2a_push_repo,
+                    allowed_callback_origins=settings.a2a.push_callback_allowed_origins,
+                    timeout_seconds=settings.a2a.push_timeout_seconds,
+                    poll_seconds=settings.a2a.push_poll_seconds,
+                    retry_initial_seconds=settings.a2a.push_retry_initial_seconds,
+                    retry_max_seconds=settings.a2a.push_retry_max_seconds,
+                    claim_limit=settings.a2a.push_claim_limit,
+                    lease_seconds=settings.a2a.push_lease_seconds,
+                    max_url_chars=settings.a2a.push_max_url_chars,
+                    max_credential_chars=settings.a2a.push_max_credential_chars,
+                    max_configs_page_size=settings.a2a.push_max_configs_page_size,
+                )
+                await a2a_push_dispatcher.start()
+                logger.info("A2A push dispatcher started")
+            app.state.a2a_push_dispatcher = a2a_push_dispatcher
+
             async def _resolve_workflow_campaign_repo() -> WorkflowCampaignRepository:
                 return workflow_campaign_repo
 
@@ -698,6 +724,7 @@ def create_app(
                 repo=workflow_campaign_repo,
                 volundr_factory=app.state.volundr_factory,
                 event_bus=event_bus,
+                push_dispatcher=a2a_push_dispatcher,
             )
             app.state.workflow_campaign_projector = workflow_campaign_projector
             await workflow_campaign_projector.start()
@@ -964,6 +991,8 @@ def create_app(
             if ting_sleipnir_bridge is not None:
                 await ting_sleipnir_bridge.stop()
             await workflow_campaign_projector.stop()
+            if a2a_push_dispatcher is not None:
+                await a2a_push_dispatcher.stop()
             await review_engine.stop()
             if ravn_dispatcher is not None:
                 await ravn_dispatcher.close()

--- a/src/ting/ports/a2a_push.py
+++ b/src/ting/ports/a2a_push.py
@@ -1,0 +1,120 @@
+"""Port for durable A2A task push registration and delivery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from a2a.types import TaskPushNotificationConfig
+
+from ting.domain.models import WorkflowCampaign
+
+
+@dataclass(frozen=True)
+class A2APushDelivery:
+    """One leased callback delivery from the durable outbox."""
+
+    task_id: str
+    config_id: str
+    owner_id: str
+    config: TaskPushNotificationConfig
+    payload: dict[str, Any]
+    delivery_version: str
+    attempt_count: int
+
+
+class A2APushConfigRepositoryPort(Protocol):
+    async def save_config(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config: TaskPushNotificationConfig,
+    ) -> TaskPushNotificationConfig: ...
+
+    async def get_for_owner(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config_id: str,
+    ) -> TaskPushNotificationConfig | None: ...
+
+    async def list_for_owner(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+    ) -> list[TaskPushNotificationConfig]: ...
+
+    async def delete_for_owner(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config_id: str,
+    ) -> bool: ...
+
+    async def queue_event(self, task_id: str, payload: dict[str, Any]) -> int: ...
+
+    async def claim_due(
+        self,
+        *,
+        limit: int,
+        lease_seconds: float,
+    ) -> list[A2APushDelivery]: ...
+
+    async def mark_delivered(self, delivery: A2APushDelivery) -> None: ...
+
+    async def retry_later(
+        self,
+        delivery: A2APushDelivery,
+        *,
+        delay_seconds: float,
+        error: str,
+    ) -> None: ...
+
+
+class A2APushDispatcherPort(Protocol):
+    """Ownership-safe callback registry plus durable task-state outbox."""
+
+    @property
+    def enabled(self) -> bool: ...
+
+    @property
+    def max_configs_page_size(self) -> int: ...
+
+    def validate_config(self, config: TaskPushNotificationConfig) -> None: ...
+
+    async def save_config(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config: TaskPushNotificationConfig,
+    ) -> TaskPushNotificationConfig: ...
+
+    async def get_config(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config_id: str,
+    ) -> TaskPushNotificationConfig | None: ...
+
+    async def list_configs(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+    ) -> list[TaskPushNotificationConfig]: ...
+
+    async def delete_config(
+        self,
+        *,
+        task_id: str,
+        owner_id: str,
+        config_id: str,
+    ) -> bool: ...
+
+    async def queue_campaign(self, campaign: WorkflowCampaign) -> int: ...

--- a/src/ting/ports/volundr.py
+++ b/src/ting/ports/volundr.py
@@ -71,13 +71,16 @@ class VolundrSession:
     branch: str = ""
     base_branch: str = ""
     workload_type: str = "default"
+    activity_state: str | None = None
+    activity_metadata: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
 class ActivityEvent:
     """An activity or session lifecycle event received from Volundr SSE.
 
-    For activity events: state is "active"/"idle"/"tool_executing", session_status is empty.
+    For activity events: state is "active"/"idle"/"tool_executing"/"error",
+    session_status is empty.
     For session lifecycle events: session_status is "stopped"/"failed"/etc., state is empty.
     """
 

--- a/src/volundr/adapters/inbound/rest.py
+++ b/src/volundr/adapters/inbound/rest.py
@@ -806,7 +806,7 @@ class SessionResponse(BaseModel):
         default=None,
         description=(
             "Current activity state "
-            "(provisioning/active/idle/tool_executing/awaiting_input/stopped)"
+            "(provisioning/active/idle/tool_executing/awaiting_input/stopped/error)"
         ),
     )
     activity_state_since: str | None = Field(

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -90,6 +90,9 @@ class SessionActivityState(StrEnum):
       message but is NOT blocked on anything.
     - ``stopped`` — the transport died (e.g. its tmux session vanished); the
       session is no longer running and the last live state is final.
+    - ``error`` — an unattended workflow reached a terminal agent/transport
+      error. The workload may remain up long enough to report diagnostics, but
+      downstream workflow state must treat this as failed.
     - ``awaiting_input`` — the session is BLOCKED on a human: an
       ``AskUserQuestion``, a confirmation, or a tool-permission prompt. This is
       the "needs attention" state — the agent cannot make progress until the
@@ -104,6 +107,7 @@ class SessionActivityState(StrEnum):
     TOOL_EXECUTING = "tool_executing"
     AWAITING_INPUT = "awaiting_input"
     STOPPED = "stopped"
+    ERROR = "error"
 
     @property
     def is_busy(self) -> bool:

--- a/src/volundr/domain/services/session.py
+++ b/src/volundr/domain/services/session.py
@@ -384,6 +384,9 @@ class SessionService:
         # session that just transitioned.
         session.activity_state_since = state_since or datetime.now(UTC)
         session.activity_metadata = metadata
+        if state is SessionActivityState.ERROR:
+            message = str(metadata.get("error") or metadata.get("message") or "").strip()
+            session.error = message or "Workflow agent failed"
         # Treat each activity report as a liveness heartbeat so the reconciler can
         # tell a live-but-idle session from one whose broker has died.
         session.last_active = datetime.now(UTC)

--- a/tests/test_ravn/test_a2a_task_tool.py
+++ b/tests/test_ravn/test_a2a_task_tool.py
@@ -226,6 +226,97 @@ async def test_a2a_task_propagates_active_trace_in_message_metadata(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_a2a_task_injects_configured_default_connection() -> None:
+    client = _Client([{"task": {"id": "task-1", "status": {"state": "TASK_STATE_SUBMITTED"}}}])
+    tool = A2ATaskTool(
+        agent_directory=_Directory(_agent()),
+        client=client,
+        default_connection_id="Noatun",
+    )
+
+    result = await tool.execute(
+        {
+            "operation": "start",
+            "agent_id": _agent().id,
+            "skill_id": "review",
+            "prompt": "Review the change.",
+        }
+    )
+
+    assert not result.is_error
+    assert client.posts[0][1]["params"]["message"]["metadata"]["connectionId"] == "Noatun"
+
+
+@pytest.mark.asyncio
+async def test_a2a_task_registers_push_and_reports_delivery_mode() -> None:
+    agent = _agent().model_copy(deep=True)
+    agent.capabilities = {"pushNotifications": True}
+    client = _Client(
+        [
+            {"task": {"id": "task-push", "status": {"state": "TASK_STATE_SUBMITTED"}}},
+            {
+                "taskId": "task-push",
+                "id": "callback-1",
+                "url": "https://resident.example/a2a/push",
+            },
+        ]
+    )
+    tool = A2ATaskTool(
+        agent_directory=_Directory(agent),
+        client=client,
+        push_callback_url="https://resident.example/a2a/push",
+        push_notification_token="notification-secret",
+    )
+
+    result = await tool.execute(
+        {
+            "operation": "start",
+            "agent_id": agent.id,
+            "skill_id": "review",
+            "prompt": "Review the change.",
+        }
+    )
+
+    assert not result.is_error
+    assert json.loads(result.content)["push_registered"] is True
+    assert [body["method"] for _, body, _ in client.posts] == [
+        "SendMessage",
+        "CreateTaskPushNotificationConfig",
+    ]
+    registration = client.posts[1][1]["params"]
+    assert registration["taskId"] == "task-push"
+    assert registration["url"] == "https://resident.example/a2a/push"
+    assert registration["token"] == "notification-secret"
+
+
+@pytest.mark.asyncio
+async def test_a2a_task_keeps_polling_available_when_push_registration_fails() -> None:
+    agent = _agent().model_copy(deep=True)
+    agent.capabilities = {"pushNotifications": True}
+    client = _Client(
+        [{"task": {"id": "task-fallback", "status": {"state": "TASK_STATE_SUBMITTED"}}}]
+    )
+    tool = A2ATaskTool(
+        agent_directory=_Directory(agent),
+        client=client,
+        push_callback_url="https://resident.example/a2a/push",
+        push_notification_token="notification-secret",
+    )
+
+    result = await tool.execute(
+        {
+            "operation": "start",
+            "agent_id": agent.id,
+            "skill_id": "review",
+            "prompt": "Review the change.",
+        }
+    )
+
+    assert not result.is_error
+    assert json.loads(result.content)["push_registered"] is False
+
+
+@pytest.mark.asyncio
 async def test_a2a_task_rejects_unknown_agent_and_unpublished_skill() -> None:
     unknown = A2ATaskTool(agent_directory=_Directory(), client=_Client([]))
     missing_agent = await unknown.execute(

--- a/tests/test_ravn/test_gateway_http.py
+++ b/tests/test_ravn/test_gateway_http.py
@@ -87,6 +87,51 @@ def test_status_endpoint_no_sessions():
     assert resp.json()["session_count"] == 0
 
 
+def test_a2a_push_requires_token_and_wakes_resident():
+    runtime = MagicMock()
+    runtime.submit_a2a_push = AsyncMock(
+        return_value={
+            "task_id": "task-1",
+            "state": "TASK_STATE_COMPLETED",
+            "inbox_ref": "resident/inbox/task-1",
+            "queued": True,
+        }
+    )
+    gateway = HttpGateway(
+        _make_http_config(a2a_push_enabled=True),
+        _make_gateway_mock(),
+        resident_runtime=runtime,
+    )
+    client = TestClient(gateway.app)
+    payload = {
+        "task": {
+            "id": "task-1",
+            "status": {"state": "TASK_STATE_COMPLETED"},
+        }
+    }
+
+    assert client.post("/a2a/push", json=payload).status_code == 503
+    configured_gateway = HttpGateway(
+        _make_http_config(
+            a2a_push_enabled=True,
+            a2a_push_notification_token="push-secret",
+        ),
+        _make_gateway_mock(),
+        resident_runtime=runtime,
+    )
+    client = TestClient(configured_gateway.app)
+    assert client.post("/a2a/push", json=payload).status_code == 401
+    response = client.post(
+        "/a2a/push",
+        json=payload,
+        headers={"X-A2A-Notification-Token": "push-secret"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["queued"] is True
+    runtime.submit_a2a_push.assert_awaited_once_with(payload)
+
+
 # ---------------------------------------------------------------------------
 # POST /chat
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_resident_runtime.py
+++ b/tests/test_ravn/test_resident_runtime.py
@@ -18,7 +18,7 @@ from ravn.domain.resident_continuation import (
 )
 from ravn.drive_loop import DriveLoop
 from ravn.resident_continuation import _scheduled_wake_at
-from ravn.resident_inbox import MimirResidentInbox, ResidentInboxStatus
+from ravn.resident_inbox import LocalResidentInbox, MimirResidentInbox, ResidentInboxStatus
 from ravn.resident_runtime import ResidentHomeTrigger, ResidentRuntime, _metadata
 
 
@@ -85,6 +85,39 @@ def test_working_state_rejects_oversized_entries() -> None:
     assert validate_resident_working_state(state) == [
         "working_state.observations[0] exceeds 500 characters"
     ]
+
+
+@pytest.mark.asyncio
+async def test_a2a_push_is_persisted_and_immediately_wakes_resident(tmp_path) -> None:
+    state = LocalResidentState(tmp_path / "state")
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+    queued: list[AgentTask] = []
+
+    async def enqueue(task: AgentTask) -> bool:
+        queued.append(task)
+        return True
+
+    runtime = ResidentRuntime(state=state, inbox=inbox, resident_id="ivaldi")
+    runtime.bind_enqueue(enqueue)
+    result = await runtime.submit_a2a_push(
+        {
+            "task": {
+                "id": "workflow-123",
+                "status": {"state": "TASK_STATE_FAILED"},
+                "metadata": {"error": "worker authentication failed"},
+            }
+        }
+    )
+
+    assert result["task_id"] == "workflow-123"
+    assert result["state"] == "TASK_STATE_FAILED"
+    assert result["queued"] is True
+    assert len(queued) == 1
+    assert queued[0].triggered_by == "resident:home"
+    assert "workflow-123" in queued[0].initiative_context
+    rows = await inbox.list_signals(status=ResidentInboxStatus.NEW.value, limit=10)
+    assert len(rows) == 1
+    assert rows[0][1].classification == "status_update"
 
 
 @pytest.mark.asyncio

--- a/tests/test_services/test_activity.py
+++ b/tests/test_services/test_activity.py
@@ -80,6 +80,23 @@ class TestUpdateActivity:
         assert updated.activity_metadata == metadata
 
     @pytest.mark.asyncio
+    async def test_terminal_error_activity_persists_failure_reason(self, service):
+        session = await service.create_session(
+            name="Test",
+            model="codex",
+            source=GitSource(repo="https://github.com/test/repo", branch="main"),
+        )
+
+        updated = await service.update_activity(
+            session.id,
+            SessionActivityState.ERROR,
+            {"error": "refresh token was already used"},
+        )
+
+        assert updated.activity_state == SessionActivityState.ERROR
+        assert updated.error == "refresh token was already used"
+
+    @pytest.mark.asyncio
     async def test_update_activity_clears_stale_liveness_error(self, service, repository):
         """A heartbeat is proof of life — a lingering liveness verdict is
         demonstrably false and must clear (the clients render `error` as a
@@ -512,6 +529,7 @@ class TestSessionActivityState:
         assert SessionActivityState.TOOL_EXECUTING == "tool_executing"
         assert SessionActivityState.AWAITING_INPUT == "awaiting_input"
         assert SessionActivityState.STOPPED == "stopped"
+        assert SessionActivityState.ERROR == "error"
 
     def test_from_string(self) -> None:
         assert SessionActivityState("provisioning") == SessionActivityState.PROVISIONING
@@ -520,6 +538,7 @@ class TestSessionActivityState:
         assert SessionActivityState("tool_executing") == SessionActivityState.TOOL_EXECUTING
         assert SessionActivityState("awaiting_input") == SessionActivityState.AWAITING_INPUT
         assert SessionActivityState("stopped") == SessionActivityState.STOPPED
+        assert SessionActivityState("error") == SessionActivityState.ERROR
 
     def test_invalid_raises(self) -> None:
         with pytest.raises(ValueError):

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -1417,6 +1417,36 @@ class TestBroker:
         assert "flock-coder" not in test_broker._peer_watches
 
     @pytest.mark.asyncio
+    async def test_peer_error_fails_room_only_workflow_once(self, test_broker):
+        participant = MagicMock(persona="specification-framer")
+        test_broker._room_bridge = MagicMock()
+        test_broker._room_bridge.participants = {"flock-framer": participant}
+        test_broker._report_activity_state = AsyncMock()
+        test_broker._finish_trace_span = AsyncMock()
+        test_broker._is_room_only_workflow_session = MagicMock(return_value=True)
+
+        frame = {
+            "data": {
+                "error": (
+                    "Your access token could not be refreshed because your refresh token "
+                    "was already used."
+                )
+            }
+        }
+        await test_broker._observe_room_peer_event("flock-framer", "error", frame)
+        await test_broker._observe_room_peer_event("flock-framer", "error", frame)
+
+        test_broker._report_activity_state.assert_awaited_once_with(
+            "error",
+            extra_metadata={
+                "failure_source": "ravn_flock",
+                "failure_peer_id": "flock-framer",
+                "failure_persona": "specification-framer",
+                "error": frame["data"]["error"],
+            },
+        )
+
+    @pytest.mark.asyncio
     async def test_peer_git_checkpoint_signals_increment_artifacts(self, test_broker):
         test_broker._room_bridge = MagicMock()
 

--- a/tests/test_ting/test_a2a_card.py
+++ b/tests/test_ting/test_a2a_card.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from a2a.client.card_resolver import parse_agent_card
+from cryptography.fernet import Fernet
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -127,6 +128,17 @@ class TestAgentCard:
         assert response.status_code == 200
         card = parse_agent_card(response.json())
         assert list(card.skills) == []
+
+    def test_card_advertises_push_only_when_outbox_is_fully_configured(self) -> None:
+        config = A2AConfig(
+            push_encryption_key=Fernet.generate_key().decode(),
+            push_callback_allowed_origins=["https://resident.example"],
+        )
+        client = _client(InMemoryWorkflowRepository(), config=config)
+
+        card = parse_agent_card(client.get(CARD_PATH).json())
+
+        assert card.capabilities.push_notifications is True
 
     def test_workflow_without_declared_tags_gets_protocol_tag(self) -> None:
         workflow = _workflow()

--- a/tests/test_ting/test_a2a_push_dispatcher.py
+++ b/tests/test_ting/test_a2a_push_dispatcher.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import respx
+from a2a.types import TaskPushNotificationConfig
+from cryptography.fernet import Fernet
+
+from ting.adapters.a2a_push_dispatcher import A2APushDispatcher, callback_origin
+from ting.adapters.postgres_a2a_push import PostgresA2APushConfigRepository
+from ting.ports.a2a_push import A2APushDelivery
+
+
+def _config() -> TaskPushNotificationConfig:
+    return TaskPushNotificationConfig(
+        task_id="task-1",
+        id="callback-1",
+        url="https://resident.example/a2a/push",
+        token="notification-secret",
+    )
+
+
+def _delivery() -> A2APushDelivery:
+    return A2APushDelivery(
+        task_id="task-1",
+        config_id="callback-1",
+        owner_id="user-1",
+        config=_config(),
+        payload={"task": {"id": "task-1", "status": {"state": "TASK_STATE_FAILED"}}},
+        delivery_version="version-1",
+        attempt_count=0,
+    )
+
+
+def _dispatcher(repo: MagicMock) -> A2APushDispatcher:
+    return A2APushDispatcher(
+        repo=repo,
+        allowed_callback_origins=["https://resident.example"],
+        timeout_seconds=10.0,
+        poll_seconds=1.0,
+        retry_initial_seconds=2.0,
+        retry_max_seconds=300.0,
+        claim_limit=20,
+        lease_seconds=30.0,
+        max_url_chars=2048,
+        max_credential_chars=8192,
+        max_configs_page_size=100,
+    )
+
+
+def test_callback_origin_requires_allowlisted_https_shape() -> None:
+    assert callback_origin("https://Resident.Example:443/a2a/push") == "https://resident.example"
+    with pytest.raises(ValueError, match="HTTPS"):
+        callback_origin("http://resident.example/a2a/push")
+    with pytest.raises(ValueError, match="userinfo"):
+        callback_origin("https://user:password@resident.example/a2a/push")
+    with pytest.raises(ValueError, match="fragment"):
+        callback_origin("https://resident.example/a2a/push#secret")
+
+
+@pytest.mark.asyncio
+async def test_push_delivery_uses_standard_token_header_and_marks_delivered() -> None:
+    repo = MagicMock()
+    repo.mark_delivered = AsyncMock()
+    repo.retry_later = AsyncMock()
+    dispatcher = _dispatcher(repo)
+    with respx.mock:
+        route = respx.post("https://resident.example/a2a/push").mock(
+            return_value=httpx.Response(204)
+        )
+        await dispatcher._deliver(_delivery())
+
+    assert route.called
+    assert route.calls[0].request.headers["X-A2A-Notification-Token"] == ("notification-secret")
+    repo.mark_delivered.assert_awaited_once()
+    repo.retry_later.assert_not_awaited()
+    await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_push_delivery_retries_without_dropping_failed_event() -> None:
+    repo = MagicMock()
+    repo.mark_delivered = AsyncMock()
+    repo.retry_later = AsyncMock()
+    dispatcher = _dispatcher(repo)
+    with respx.mock:
+        respx.post("https://resident.example/a2a/push").mock(return_value=httpx.Response(503))
+        await dispatcher._deliver(_delivery())
+
+    repo.retry_later.assert_awaited_once()
+    repo.mark_delivered.assert_not_awaited()
+    await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_repository_encrypts_callback_credentials_before_storage() -> None:
+    pool = MagicMock()
+    pool.execute = AsyncMock(return_value="INSERT 0 1")
+    repo = PostgresA2APushConfigRepository(
+        pool,
+        Fernet.generate_key().decode(),
+        max_error_chars=2000,
+    )
+
+    saved = await repo.save_config(
+        task_id="task-1",
+        owner_id="user-1",
+        config=_config(),
+    )
+
+    encrypted = pool.execute.await_args.args[-1]
+    assert isinstance(encrypted, bytes)
+    assert b"notification-secret" not in encrypted
+    assert repo._decrypt(encrypted) == saved

--- a/tests/test_ting/test_a2a_tasks.py
+++ b/tests/test_ting/test_a2a_tasks.py
@@ -252,6 +252,71 @@ class RecordingVolundrFactory:
         return list(self._adapters)
 
 
+class InMemoryPushRepository:
+    def __init__(self) -> None:
+        self.configs: dict[tuple[str, str, str], Any] = {}
+
+    async def save_config(self, *, task_id: str, owner_id: str, config):
+        saved = type(config)()
+        saved.CopyFrom(config)
+        saved.task_id = task_id
+        saved.id = saved.id or "push-1"
+        self.configs[(task_id, owner_id, saved.id)] = saved
+        return saved
+
+    async def get_for_owner(self, *, task_id: str, owner_id: str, config_id: str):
+        return self.configs.get((task_id, owner_id, config_id))
+
+    async def list_for_owner(self, *, task_id: str, owner_id: str):
+        return [
+            config
+            for (stored_task, stored_owner, _), config in self.configs.items()
+            if stored_task == task_id and stored_owner == owner_id
+        ]
+
+    async def delete_for_owner(self, *, task_id: str, owner_id: str, config_id: str):
+        return self.configs.pop((task_id, owner_id, config_id), None) is not None
+
+
+class RecordingPushDispatcher:
+    enabled = True
+    max_configs_page_size = 100
+
+    def __init__(self) -> None:
+        self.repo = InMemoryPushRepository()
+        self.queued: list[str] = []
+
+    def validate_config(self, config) -> None:
+        if not config.url.startswith("https://resident.example/"):
+            raise ValueError("callback origin is not allowed")
+        if config.authentication.scheme and config.authentication.scheme.casefold() != "bearer":
+            raise ValueError("unsupported authentication scheme")
+
+    async def save_config(self, *, task_id: str, owner_id: str, config):
+        return await self.repo.save_config(task_id=task_id, owner_id=owner_id, config=config)
+
+    async def get_config(self, *, task_id: str, owner_id: str, config_id: str):
+        return await self.repo.get_for_owner(
+            task_id=task_id,
+            owner_id=owner_id,
+            config_id=config_id,
+        )
+
+    async def list_configs(self, *, task_id: str, owner_id: str):
+        return await self.repo.list_for_owner(task_id=task_id, owner_id=owner_id)
+
+    async def delete_config(self, *, task_id: str, owner_id: str, config_id: str):
+        return await self.repo.delete_for_owner(
+            task_id=task_id,
+            owner_id=owner_id,
+            config_id=config_id,
+        )
+
+    async def queue_campaign(self, campaign: WorkflowCampaign) -> int:
+        self.queued.append(campaign.slug)
+        return 1
+
+
 def _make_workflow(*, name: str = "tool-builder") -> WorkflowDefinition:
     now = datetime.now(UTC)
     return WorkflowDefinition(
@@ -336,6 +401,7 @@ def _make_client(
     campaign_repo: WorkflowCampaignRepository | None = None,
     volundr: RecordingVolundrPort | None = None,
     settings: Settings | None = None,
+    push_dispatcher: Any | None = None,
 ) -> tuple[TestClient, InMemoryCampaignRepository, RecordingVolundrPort]:
     workflow_repo = workflow_repo or InMemoryWorkflowRepository()
     campaigns = campaign_repo or InMemoryCampaignRepository()
@@ -344,6 +410,7 @@ def _make_client(
     app.include_router(create_a2a_router())
     app.include_router(create_research_router())
     app.state.settings = settings or Settings(auth=AuthConfig(allow_anonymous_dev=False))
+    app.state.a2a_push_dispatcher = push_dispatcher
     app.dependency_overrides[resolve_workflow_repo] = lambda: workflow_repo
     app.dependency_overrides[resolve_workflow_campaign_repo] = lambda: campaigns
     app.dependency_overrides[resolve_volundr_factory] = lambda: RecordingVolundrFactory([port])
@@ -677,6 +744,25 @@ class TestGetTask:
         assert result["id"] == campaign.slug
         assert result["status"]["state"] == expected_state
 
+    def test_failed_task_exposes_worker_error(self) -> None:
+        campaign = _make_campaign(status=WorkflowCampaignStatus.FAILED)
+        campaign = WorkflowCampaign(
+            **{
+                **campaign.__dict__,
+                "metadata": {
+                    **campaign.metadata,
+                    "failure_error": "refresh token was already used",
+                },
+            }
+        )
+        client, _, _ = _make_client(campaign_repo=InMemoryCampaignRepository([campaign]))
+
+        response = _rpc(client, "GetTask", {"id": campaign.slug})
+
+        result = response.json()["result"]
+        assert result["status"]["state"] == "TASK_STATE_FAILED"
+        assert result["metadata"]["error"] == "refresh token was already used"
+
     def test_unknown_task_is_not_found(self) -> None:
         client, _, _ = _make_client()
 
@@ -828,6 +914,93 @@ class TestProtocolSurface:
         )
 
         assert response.status_code == 401
+
+
+class TestPushNotifications:
+    def test_create_get_list_and_delete_owned_callback(self) -> None:
+        campaign = _make_campaign()
+        dispatcher = RecordingPushDispatcher()
+        client, _, _ = _make_client(
+            campaign_repo=InMemoryCampaignRepository([campaign]),
+            push_dispatcher=dispatcher,
+        )
+
+        created = _rpc(
+            client,
+            "CreateTaskPushNotificationConfig",
+            {
+                "taskId": campaign.slug,
+                "id": "ivaldi-callback",
+                "url": "https://resident.example/a2a/push",
+                "token": "notification-secret",
+            },
+        ).json()["result"]
+
+        assert created["taskId"] == campaign.slug
+        assert created["id"] == "ivaldi-callback"
+        assert dispatcher.queued == [campaign.slug]
+        fetched = _rpc(
+            client,
+            "GetTaskPushNotificationConfig",
+            {"taskId": campaign.slug, "id": "ivaldi-callback"},
+        ).json()["result"]
+        assert fetched["url"] == "https://resident.example/a2a/push"
+        listed = _rpc(
+            client,
+            "ListTaskPushNotificationConfigs",
+            {"taskId": campaign.slug},
+        ).json()["result"]
+        assert [config["id"] for config in listed["configs"]] == ["ivaldi-callback"]
+        deleted = _rpc(
+            client,
+            "DeleteTaskPushNotificationConfig",
+            {"taskId": campaign.slug, "id": "ivaldi-callback"},
+        )
+        assert deleted.status_code == 200
+        assert dispatcher.repo.configs == {}
+
+    def test_rejects_unowned_or_unallowlisted_callback(self) -> None:
+        campaign = _make_campaign()
+        dispatcher = RecordingPushDispatcher()
+        client, _, _ = _make_client(
+            campaign_repo=InMemoryCampaignRepository([campaign]),
+            push_dispatcher=dispatcher,
+        )
+
+        unowned = _rpc(
+            client,
+            "CreateTaskPushNotificationConfig",
+            {
+                "taskId": campaign.slug,
+                "url": "https://resident.example/a2a/push",
+            },
+            headers=_headers(user_id="user-2"),
+        ).json()["error"]
+        assert unowned["code"] == -32001
+        unsafe = _rpc(
+            client,
+            "CreateTaskPushNotificationConfig",
+            {
+                "taskId": campaign.slug,
+                "url": "https://attacker.example/a2a/push",
+            },
+        ).json()["error"]
+        assert unsafe["code"] == -32602
+        assert dispatcher.repo.configs == {}
+
+    def test_push_methods_are_unsupported_when_outbox_is_disabled(self) -> None:
+        campaign = _make_campaign()
+        client, _, _ = _make_client(
+            campaign_repo=InMemoryCampaignRepository([campaign]),
+        )
+
+        error = _rpc(
+            client,
+            "CreateTaskPushNotificationConfig",
+            {"taskId": campaign.slug, "url": "https://resident.example/a2a/push"},
+        ).json()["error"]
+
+        assert error["code"] == -32004
 
 
 class TestExtendedAgentCard:

--- a/tests/test_ting/test_activity_subscriber.py
+++ b/tests/test_ting/test_activity_subscriber.py
@@ -429,6 +429,24 @@ class TestSubscriberLifecycle:
 
 class TestActivityEventHandling:
     @pytest.mark.asyncio
+    async def test_terminal_activity_error_fails_run_with_worker_reason(self) -> None:
+        sub, volundr, tracker, _ = _make_subscriber()
+        event = ActivityEvent(
+            session_id=SESSION_ID,
+            state="error",
+            metadata={"error": "refresh token was already used"},
+            owner_id=OWNER_ID,
+        )
+
+        await sub._on_activity_event(event, volundr, OWNER_ID)
+
+        tracker.update_run_progress.assert_awaited_once_with(
+            TRACKER_ISSUE_ID,
+            status=RunStatus.FAILED,
+            reason="refresh token was already used",
+        )
+
+    @pytest.mark.asyncio
     async def test_idle_event_triggers_completion(self) -> None:
         """Idle event with sufficient turns completes the session."""
         sub, volundr, tracker, event_bus = _make_subscriber()

--- a/tests/test_ting/test_workflow_campaign_projector.py
+++ b/tests/test_ting/test_workflow_campaign_projector.py
@@ -49,14 +49,23 @@ class _Adapter:
         help_requests: list | None = None,
         gates: list | None = None,
         blocker_error: Exception | None = None,
+        activity_state: str | None = None,
+        activity_metadata: dict | None = None,
     ) -> None:
         self._session_status = session_status
         self._help_requests = help_requests or []
         self._gates = gates or []
         self._blocker_error = blocker_error
+        self._activity_state = activity_state
+        self._activity_metadata = activity_metadata or {}
 
     async def get_session(self, session_id, *, auth_token=None, principal=None):
-        return SimpleNamespace(status=self._session_status, name="tool-build-test")
+        return SimpleNamespace(
+            status=self._session_status,
+            name="tool-build-test",
+            activity_state=self._activity_state,
+            activity_metadata=self._activity_metadata,
+        )
 
     async def get_help_requests(self, session_id, *, auth_token=None, principal=None):
         if self._blocker_error is not None:
@@ -170,6 +179,26 @@ async def test_stopped_session_completes_without_blocker_checks() -> None:
 
     saved = repo.save_campaign.await_args.args[0]
     assert saved.status == WorkflowCampaignStatus.COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_terminal_activity_error_fails_running_campaign() -> None:
+    adapter = _Adapter(
+        session_status="running",
+        activity_state="error",
+        activity_metadata={"error": "refresh token was already used"},
+        blocker_error=RuntimeError("must not be called"),
+    )
+    projector, repo, event_bus = _projector(adapter)
+
+    await projector._refresh_campaign(_campaign())
+
+    saved = repo.save_campaign.await_args.args[0]
+    assert saved.status == WorkflowCampaignStatus.FAILED
+    assert saved.metadata["failure_error"] == "refresh token was already used"
+    emitted = event_bus.emit.await_args.args[0]
+    assert emitted.event == "workflow.campaign.failed"
+    assert emitted.data["error"] == "refresh token was already used"
 
 
 class TestConnectionAffinity:

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -807,6 +807,7 @@ function toSessionState(session: VolundrSession): Session['state'] {
     case 'running':
       if (session.needsAttention || session.activityState === 'awaiting_input')
         return 'awaiting_input';
+      if (session.activityState === 'error') return 'failed';
       return session.activityState === 'idle' ? 'idle' : 'running';
     case 'stopping':
       return 'terminating';
@@ -1098,6 +1099,7 @@ function toPodStatus(session: VolundrSession): Cluster['pods'][number]['status']
     case 'provisioning':
       return 'pending';
     case 'running':
+      if (session.activityState === 'error') return 'failed';
       return session.activityState === 'idle' ? 'idle' : 'running';
     case 'failed':
     case 'error':

--- a/web-next/packages/plugin-volundr/src/models/volundr.model.ts
+++ b/web-next/packages/plugin-volundr/src/models/volundr.model.ts
@@ -176,7 +176,7 @@ export interface VolundrSession {
   taskType?: string;
   archivedAt?: Date;
   trackerIssue?: TrackerIssue;
-  activityState?: 'active' | 'idle' | 'tool_executing' | 'awaiting_input' | null;
+  activityState?: 'active' | 'idle' | 'tool_executing' | 'awaiting_input' | 'error' | null;
   /** True when the session is blocked waiting on the user (awaiting_input). */
   needsAttention?: boolean;
   ownerId?: string;


### PR DESCRIPTION
## Summary
- propagate terminal flock peer errors through Volundr, Ting campaigns, A2A tasks, and the web status projection
- add ownership-scoped encrypted A2A push registrations backed by a durable PostgreSQL outbox with retry
- register callbacks from Ravn, persist callback events in the resident inbox, and wake the resident without polling
- add a configurable default A2A connection so automation can use Noatun OpenShell credential brokering

## Verification
- 523 focused Python/chart tests passed against the frozen dependency lock
- ruff passed for affected packages
- Helm lint passed for the Ting chart
- @niuulabs/plugin-volundr and @niuulabs/niuu TypeScript checks passed