### PR TITLE
feat(observatory): redesign the topology canvas — LOD, agent meshes, A2A cards, layer filters

### DIFF
--- a/web-next/apps/niuu/src/services.test.ts
+++ b/web-next/apps/niuu/src/services.test.ts
@@ -56,6 +56,7 @@ const ravnMocks = vi.hoisted(() => ({
 }));
 
 const observatoryMocks = vi.hoisted(() => ({
+  createMockAgentDirectory: vi.fn(() => ({ kind: 'mock-observatory-agents' })),
   createMockRegistryRepository: vi.fn(() => ({})),
   createMockTopologyStream: vi.fn(() => ({})),
   createMockEventStream: vi.fn(() => ({})),
@@ -429,6 +430,20 @@ describe('resolveForgeServiceBase', () => {
 describe('buildServices live base selection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('serves the observatory agent directory from the mock in demo mode', () => {
+    const services = buildServices({ demoMode: true, services: {} } as any);
+
+    expect(observatoryMocks.createMockAgentDirectory).toHaveBeenCalled();
+    expect(services['observatory.agents']).toEqual({ kind: 'mock-observatory-agents' });
+  });
+
+  it('leaves the agent directory unavailable outside demo mode', () => {
+    const services = buildServices({ demoMode: false, services: {} } as any);
+
+    expect(observatoryMocks.createMockAgentDirectory).not.toHaveBeenCalled();
+    expect(isUnavailableService(services['observatory.agents'])).toBe(true);
   });
 
   it('builds separate forge runtime and volundr catalog adapters', () => {

--- a/web-next/apps/niuu/src/services.test.ts
+++ b/web-next/apps/niuu/src/services.test.ts
@@ -61,6 +61,7 @@ const observatoryMocks = vi.hoisted(() => ({
   createMockTopologyStream: vi.fn(() => ({})),
   createMockEventStream: vi.fn(() => ({})),
   buildObservatoryRegistryHttpAdapter: vi.fn(() => ({})),
+  buildObservatoryTopologyAggregateAdapter: vi.fn(() => ({})),
   buildObservatoryTopologySseStream: vi.fn(() => ({})),
   buildObservatoryEventsSseStream: vi.fn(() => ({})),
   buildObservatoryAgentDirectoryHttpAdapter: vi.fn((client) => ({
@@ -1724,9 +1725,11 @@ describe('buildServices', () => {
     expect(observatoryMocks.buildObservatoryRegistryHttpAdapter).toHaveBeenCalledWith({
       basePath: 'http://localhost:8080/api/v1/observatory',
     });
-    expect(observatoryMocks.buildObservatoryTopologySseStream).toHaveBeenCalledWith(
-      'http://localhost:8080/api/v1/observatory/topology',
-    );
+    // Topology reads the merged Guild aggregate, not one cluster's feed, so it
+    // is built from an ApiClient rather than a stream URL.
+    expect(observatoryMocks.buildObservatoryTopologyAggregateAdapter).toHaveBeenCalledWith({
+      basePath: 'http://localhost:8080/api/v1/observatory/topology',
+    });
     expect(observatoryMocks.buildObservatoryEventsSseStream).toHaveBeenCalledWith(
       'http://localhost:8080/api/v1/observatory/events',
     );
@@ -1763,9 +1766,11 @@ describe('buildServices', () => {
     expect(observatoryMocks.buildObservatoryRegistryHttpAdapter).toHaveBeenCalledWith({
       basePath: 'http://localhost:8080/api/v1/observatory',
     });
-    expect(observatoryMocks.buildObservatoryTopologySseStream).toHaveBeenCalledWith(
-      'http://localhost:8080/api/v1/observatory/topology',
-    );
+    // Topology reads the merged Guild aggregate, not one cluster's feed, so it
+    // is built from an ApiClient rather than a stream URL.
+    expect(observatoryMocks.buildObservatoryTopologyAggregateAdapter).toHaveBeenCalledWith({
+      basePath: 'http://localhost:8080/api/v1/observatory/topology',
+    });
     expect(observatoryMocks.buildObservatoryEventsSseStream).toHaveBeenCalledWith(
       'http://localhost:8080/api/v1/observatory/events',
     );

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -45,7 +45,7 @@ import {
   createMockTopologyStream,
   createMockEventStream,
   buildObservatoryRegistryHttpAdapter,
-  buildObservatoryTopologySseStream,
+  buildObservatoryTopologyAggregateAdapter,
   buildObservatoryEventsSseStream,
   buildObservatoryAgentDirectoryHttpAdapter,
 } from '@niuulabs/plugin-observatory';
@@ -454,7 +454,10 @@ function resolveObservatoryServiceBase(
     return explicitBase;
   }
 
-  if (serviceKey === 'observatory.agents') {
+  // Both of these are estate-wide: the Guild merges every cluster plus every
+  // source that pushes instead of being polled. A single cluster's endpoint
+  // would render a fraction of the graph and give no sign the rest exists.
+  if (serviceKey === 'observatory.agents' || serviceKey === 'observatory.topology') {
     const aggregateBase = resolveNiuuRegistryBase(config);
     if (aggregateBase) return `${aggregateBase}/observatory`;
   }
@@ -1432,7 +1435,7 @@ export function buildServices(config: NiuuConfig): ServicesMap {
     ? buildObservatoryRegistryHttpAdapter(createApiClient(observatoryRegistryBase))
     : demoService(config, 'observatory.registry', createMockRegistryRepository);
   const observatoryTopology = observatoryTopologyBase
-    ? buildObservatoryTopologySseStream(observatoryTopologyBase)
+    ? buildObservatoryTopologyAggregateAdapter(createApiClient(observatoryTopologyBase))
     : demoService(config, 'observatory.topology', createMockTopologyStream);
   const observatoryEvents = observatoryEventsBase
     ? buildObservatoryEventsSseStream(observatoryEventsBase)

--- a/web-next/apps/niuu/src/services.ts
+++ b/web-next/apps/niuu/src/services.ts
@@ -40,6 +40,7 @@ import {
 } from '@niuulabs/plugin-ting';
 import { createMimirMockAdapter, buildMimirHttpAdapter } from '@niuulabs/plugin-mimir';
 import {
+  createMockAgentDirectory,
   createMockRegistryRepository,
   createMockTopologyStream,
   createMockEventStream,
@@ -47,7 +48,6 @@ import {
   buildObservatoryTopologySseStream,
   buildObservatoryEventsSseStream,
   buildObservatoryAgentDirectoryHttpAdapter,
-  type IAgentDirectory,
 } from '@niuulabs/plugin-observatory';
 import {
   createMockVolundrService,
@@ -1439,7 +1439,7 @@ export function buildServices(config: NiuuConfig): ServicesMap {
     : demoService(config, 'observatory.events', createMockEventStream);
   const observatoryAgents = observatoryAgentsBase
     ? buildObservatoryAgentDirectoryHttpAdapter(createApiClient(observatoryAgentsBase))
-    : unavailableService<IAgentDirectory>('observatory.agents');
+    : demoService(config, 'observatory.agents', createMockAgentDirectory);
   // ── Valkyrie ──
   const valkyrieBase = resolveValkyrieServiceBase(config, 'valkyrie');
   const valkyrieReviewsBase = resolveValkyrieServiceBase(config, 'valkyrie.reviews');

--- a/web-next/e2e/observatory.spec.ts
+++ b/web-next/e2e/observatory.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { CANVAS } from '../packages/plugin-observatory/src/ui/TopologyCanvas/config';
 
 async function openTopologyDrawer(page: Page, testId: string, name: RegExp) {
   const nodeButton = page.getByTestId(testId);
@@ -83,15 +84,18 @@ test('zoom cannot exceed 300%', async ({ page }) => {
   expect(pct).toBeLessThanOrEqual(300);
 });
 
-test('zoom cannot fall below 30%', async ({ page }) => {
+test('zoom clamps at the configured floor', async ({ page }) => {
   await page.goto('/observatory');
   await page.waitForSelector('[data-testid="zoom-display"]');
 
   const zoomOut = page.getByRole('button', { name: /zoom out/i });
   for (let i = 0; i < 30; i++) await zoomOut.click();
 
+  // Asserted against the config rather than a literal, so the floor can be
+  // tuned for a larger topology without silently breaking this expectation.
   const pct = parseInt((await page.getByTestId('zoom-display').textContent()) ?? '0', 10);
-  expect(pct).toBeGreaterThanOrEqual(30);
+  expect(pct).toBeGreaterThanOrEqual(Math.round(CANVAS.ZOOM_MIN * 100));
+  expect(pct).toBeLessThan(Math.round(CANVAS.ZOOM_MAX * 100));
 });
 
 test('camera reset restores default zoom', async ({ page }) => {
@@ -190,14 +194,14 @@ test('arrow keys pan the canvas when focused', async ({ page }) => {
 
 // ── Minimap interaction ───────────────────────────────────────────────────────
 
-test('minimap SVG overlay is visible with topology content', async ({ page }) => {
+test('minimap overlay is visible with topology content', async ({ page }) => {
   await page.goto('/observatory');
   const minimapPanel = page.getByTestId('minimap-panel');
   await minimapPanel.waitFor();
 
-  // New minimap is a static SVG overview, not a click-to-pan canvas
+  // The minimap is a canvas the render loop paints, not an SVG document.
   await expect(minimapPanel).toBeVisible();
-  await expect(minimapPanel.locator('svg')).toBeVisible();
+  await expect(minimapPanel.locator('canvas')).toBeVisible();
 });
 
 // ── Registry page ─────────────────────────────────────────────────────────────
@@ -394,4 +398,79 @@ test('EventLog overlay is visible and shows events', async ({ page }) => {
 test('Minimap overlay is visible on observatory page', async ({ page }) => {
   await page.goto('/observatory');
   await expect(page.getByRole('img', { name: /topology minimap/i })).toBeVisible({ timeout: 3000 });
+});
+
+// ── Connection layers ─────────────────────────────────────────────────────────
+
+test('layer filters toggle and can be restored', async ({ page }) => {
+  await page.goto('/observatory');
+
+  const memory = page.getByTestId('layer-toggle-memory');
+  await expect(memory).toBeVisible({ timeout: 5000 });
+  await expect(memory).toHaveAttribute('aria-pressed', 'true');
+
+  await memory.click();
+  await expect(memory).toHaveAttribute('aria-pressed', 'false');
+
+  // Other layers are unaffected by hiding one.
+  await expect(page.getByTestId('layer-toggle-mesh')).toHaveAttribute('aria-pressed', 'true');
+
+  const showAll = page.getByTestId('layer-toggle-all');
+  await expect(showAll).toBeEnabled();
+  await showAll.click();
+  await expect(memory).toHaveAttribute('aria-pressed', 'true');
+  await expect(showAll).toBeDisabled();
+});
+
+test('every connection layer offers a toggle with a count', async ({ page }) => {
+  await page.goto('/observatory');
+  for (const layer of ['mesh', 'memory', 'inference', 'platform', 'observability', 'signals']) {
+    await expect(page.getByTestId(`layer-toggle-${layer}`)).toBeVisible({ timeout: 5000 });
+  }
+});
+
+// ── Rail sections ─────────────────────────────────────────────────────────────
+
+test('rail sections collapse and expand independently', async ({ page }) => {
+  await page.goto('/observatory');
+
+  const realms = page.getByTestId('subnav-section-realms');
+  await expect(realms).toBeVisible({ timeout: 5000 });
+  await expect(realms).toHaveAttribute('open', '');
+
+  await page.getByTestId('subnav-toggle-realms').click();
+  await expect(realms).not.toHaveAttribute('open', '');
+  await expect(page.getByTestId('subnav-section-clusters')).toHaveAttribute('open', '');
+
+  await page.getByTestId('subnav-toggle-realms').click();
+  await expect(realms).toHaveAttribute('open', '');
+});
+
+// ── A2A card ──────────────────────────────────────────────────────────────────
+
+test('selecting a resident shows the A2A card it publishes', async ({ page }) => {
+  await page.goto('/observatory');
+  await openTopologyDrawer(page, 'node-btn-ravn-huginn', /huginn/i);
+
+  const card = page.getByTestId('agent-card');
+  await expect(card).toBeVisible({ timeout: 5000 });
+  await expect(page.getByTestId('agent-card-kind')).toHaveText(/resident/i);
+  await expect(page.getByTestId('agent-card-url')).toContainText('agent-card.json');
+  await expect(page.getByTestId('agent-card-skills')).toBeVisible();
+});
+
+test('selecting a workflow session shows its card kind', async ({ page }) => {
+  await page.goto('/observatory');
+  await openTopologyDrawer(page, 'node-btn-run-research', /research-session/i);
+
+  await expect(page.getByTestId('agent-card-kind')).toHaveText(/workflow-session/i, {
+    timeout: 5000,
+  });
+});
+
+test('a node that publishes no card shows no A2A panel', async ({ page }) => {
+  await page.goto('/observatory');
+  await openTopologyDrawer(page, 'node-btn-host-saehrimnir', /sæhrímnir/i);
+
+  await expect(page.getByTestId('agent-card')).toHaveCount(0);
 });

--- a/web-next/packages/plugin-observatory/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/http.test.ts
@@ -300,7 +300,6 @@ describe('buildObservatoryEventsSseStream', () => {
   });
 });
 
-
 describe('buildObservatoryTopologyAggregateAdapter', () => {
   /**
    * The aggregate spans every cluster plus every source that pushes rather
@@ -340,9 +339,7 @@ describe('buildObservatoryTopologyAggregateAdapter', () => {
 
     const unsub = adapter.subscribe((t) => received.push(t));
     await vi.waitFor(() =>
-      expect(
-        (client.get as ReturnType<typeof vi.fn>).mock.calls.length,
-      ).toBeGreaterThanOrEqual(2),
+      expect((client.get as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(2),
     );
     unsub();
 
@@ -388,9 +385,7 @@ describe('buildObservatoryTopologyAggregateAdapter', () => {
 
     const unsub = adapter.subscribe(() => {});
     await vi.waitFor(() =>
-      expect(
-        (client.get as ReturnType<typeof vi.fn>).mock.calls.length,
-      ).toBeGreaterThanOrEqual(2),
+      expect((client.get as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(2),
     );
     unsub();
 

--- a/web-next/packages/plugin-observatory/src/adapters/http.test.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/http.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApiClient } from '@niuulabs/query';
 import {
   buildObservatoryRegistryHttpAdapter,
+  buildObservatoryTopologyAggregateAdapter,
   buildObservatoryTopologySseStream,
   buildObservatoryEventsSseStream,
   buildObservatoryAgentDirectoryHttpAdapter,
@@ -296,5 +297,151 @@ describe('buildObservatoryEventsSseStream', () => {
         body: 'Valhalla is reachable',
       },
     ]);
+  });
+});
+
+
+describe('buildObservatoryTopologyAggregateAdapter', () => {
+  /**
+   * The aggregate spans every cluster plus every source that pushes rather
+   * than being polled, so it — not one cluster's feed — is the estate view.
+   */
+  function clientReturning(...snapshots: Topology[]): { client: ApiClient; calls: () => number } {
+    let index = 0;
+    const client = {
+      get: vi.fn(async () => {
+        const snapshot = snapshots[Math.min(index, snapshots.length - 1)];
+        index += 1;
+        return snapshot as unknown;
+      }),
+    } as unknown as ApiClient;
+    return { client, calls: () => (client.get as ReturnType<typeof vi.fn>).mock.calls.length };
+  }
+
+  it('publishes the merged snapshot to a new subscriber', async () => {
+    const { client } = clientReturning(topologyA);
+    const adapter = buildObservatoryTopologyAggregateAdapter(client, { intervalMs: 10_000 });
+    const received: Topology[] = [];
+
+    const unsub = adapter.subscribe((t) => received.push(t));
+    await vi.waitFor(() => expect(received).toHaveLength(1));
+    unsub();
+
+    expect(received[0]).toEqual(topologyA);
+    expect(adapter.getSnapshot()).toEqual(topologyA);
+    expect(client.get).toHaveBeenCalledWith('/snapshot');
+  });
+
+  it('drops an unchanged poll instead of re-rendering the canvas', async () => {
+    const withRevision: Topology = { ...topologyA, revision: 'rev-1' };
+    const { client } = clientReturning(withRevision, withRevision);
+    const adapter = buildObservatoryTopologyAggregateAdapter(client, { intervalMs: 5 });
+    const received: Topology[] = [];
+
+    const unsub = adapter.subscribe((t) => received.push(t));
+    await vi.waitFor(() =>
+      expect(
+        (client.get as ReturnType<typeof vi.fn>).mock.calls.length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+    unsub();
+
+    expect(received).toHaveLength(1);
+  });
+
+  it('publishes again when the revision changes', async () => {
+    const { client } = clientReturning(
+      { ...topologyA, revision: 'rev-1' },
+      { ...topologyB, revision: 'rev-2' },
+    );
+    const adapter = buildObservatoryTopologyAggregateAdapter(client, { intervalMs: 5 });
+    const received: Topology[] = [];
+
+    const unsub = adapter.subscribe((t) => received.push(t));
+    await vi.waitFor(() => expect(received).toHaveLength(2));
+    unsub();
+
+    expect(received[1]?.nodes[0]?.id).toBe('n2');
+  });
+
+  it('publishes every poll when the producer sends no revision', async () => {
+    // Otherwise a producer that omits it would leave the view frozen.
+    const { client } = clientReturning(topologyA, topologyA);
+    const adapter = buildObservatoryTopologyAggregateAdapter(client, { intervalMs: 5 });
+    const received: Topology[] = [];
+
+    const unsub = adapter.subscribe((t) => received.push(t));
+    await vi.waitFor(() => expect(received.length).toBeGreaterThanOrEqual(2));
+    unsub();
+  });
+
+  it('keeps the last good graph when a poll fails', async () => {
+    let call = 0;
+    const client = {
+      get: vi.fn(async () => {
+        call += 1;
+        if (call === 1) return { ...topologyA, revision: 'rev-1' } as unknown;
+        throw new Error('gateway down');
+      }),
+    } as unknown as ApiClient;
+    const adapter = buildObservatoryTopologyAggregateAdapter(client, { intervalMs: 5 });
+
+    const unsub = adapter.subscribe(() => {});
+    await vi.waitFor(() =>
+      expect(
+        (client.get as ReturnType<typeof vi.fn>).mock.calls.length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+    unsub();
+
+    expect(adapter.getSnapshot()?.nodes[0]?.id).toBe('n1');
+  });
+
+  it('stops polling once the last subscriber leaves', async () => {
+    const { client } = clientReturning(topologyA);
+    const adapter = buildObservatoryTopologyAggregateAdapter(client, { intervalMs: 5 });
+
+    const unsub = adapter.subscribe(() => {});
+    await vi.waitFor(() => expect(client.get).toHaveBeenCalled());
+    unsub();
+    const afterUnsub = (client.get as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect((client.get as ReturnType<typeof vi.fn>).mock.calls.length).toBe(afterUnsub);
+  });
+
+  it('replays the cached snapshot immediately to a second subscriber', async () => {
+    const { client } = clientReturning({ ...topologyA, revision: 'rev-1' });
+    const adapter = buildObservatoryTopologyAggregateAdapter(client, { intervalMs: 10_000 });
+
+    const first = adapter.subscribe(() => {});
+    await vi.waitFor(() => expect(adapter.getSnapshot()).not.toBeNull());
+    const received: Topology[] = [];
+    const second = adapter.subscribe((t) => received.push(t));
+
+    expect(received).toHaveLength(1);
+    first();
+    second();
+  });
+
+  it('carries source health so a partial estate is visible', async () => {
+    const partial: Topology = {
+      ...topologyA,
+      partial: true,
+      sources: [
+        { sourceId: 'ymir', status: 'healthy', transport: 'pull' },
+        { sourceId: 'spark-1', status: 'stale', transport: 'push', lastSeen: '12:00:00Z' },
+      ],
+    };
+    const { client } = clientReturning(partial);
+    const adapter = buildObservatoryTopologyAggregateAdapter(client, { intervalMs: 10_000 });
+
+    const unsub = adapter.subscribe(() => {});
+    await vi.waitFor(() => expect(adapter.getSnapshot()).not.toBeNull());
+    unsub();
+
+    expect(adapter.getSnapshot()?.partial).toBe(true);
+    expect(adapter.getSnapshot()?.sources?.[1]?.status).toBe('stale');
   });
 });

--- a/web-next/packages/plugin-observatory/src/adapters/http.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/http.ts
@@ -142,6 +142,68 @@ async function loadTopologySnapshot(streamUrl: string): Promise<Topology | null>
   return (await response.json()) as Topology;
 }
 
+/** How often the aggregate is re-polled while anything is subscribed. */
+const AGGREGATE_POLL_MS = 15_000;
+
+/**
+ * Poll the Guild's merged topology and present it as a live stream.
+ *
+ * The aggregate spans every cluster plus every source that pushes rather than
+ * being polled, so it — not one cluster's SSE feed — is what the estate view
+ * should render. There is no server-side stream for it, so this polls; the
+ * snapshot carries a `revision` that only changes when the graph does, so an
+ * unchanged poll is dropped instead of re-rendering the canvas.
+ *
+ * Polling only runs while something is subscribed.
+ */
+export function buildObservatoryTopologyAggregateAdapter(
+  client: ApiClient,
+  { intervalMs = AGGREGATE_POLL_MS }: { intervalMs?: number } = {},
+): ILiveTopologyStream {
+  let current: Topology | null = null;
+  let revision: string | null = null;
+  const listeners = new Set<TopologyListener>();
+  let timer: ReturnType<typeof setInterval> | null = null;
+  let inFlight = false;
+
+  async function poll(): Promise<void> {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      const snapshot = await client.get<Topology>('/snapshot');
+      const next = snapshot.revision ?? null;
+      // No revision means the producer cannot tell us whether it changed, so
+      // publish rather than risk a view that silently stops updating.
+      if (next !== null && next === revision) return;
+      revision = next;
+      current = snapshot;
+      for (const listener of listeners) listener(snapshot);
+    } catch {
+      // A failed poll leaves the last good graph on screen; the snapshot's own
+      // `sources` and `partial` are what report per-source trouble.
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  return {
+    getSnapshot: () => current,
+    subscribe(listener) {
+      listeners.add(listener);
+      if (current) listener(current);
+      void poll();
+      timer ??= setInterval(() => void poll(), intervalMs);
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0 && timer) {
+          clearInterval(timer);
+          timer = null;
+        }
+      };
+    },
+  };
+}
+
 /**
  * Wrap an SSE topology stream so it satisfies the ILiveTopologyStream contract:
  * - `getSnapshot()` returns the most recent snapshot ever received.

--- a/web-next/packages/plugin-observatory/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/mock.test.ts
@@ -221,18 +221,20 @@ describe('createMockEventStream', () => {
 describe('createMockAgentDirectory', () => {
   it('projects every agent-bearing topology node and nothing else', async () => {
     const page = await createMockAgentDirectory().listAgents();
-    expect(page.items.map((a) => a.sourceAgentId).sort()).toEqual([
-      'ravn-huginn',
-      'ravn-muninn',
-      'run-0',
-    ]);
+    const topology = createMockTopologyStream().getSnapshot();
+    const expected = (topology?.nodes ?? [])
+      .filter((n) => ['ravn_long', 'valkyrie', 'run'].includes(n.typeId))
+      .map((n) => n.id)
+      .sort();
+    expect(expected.length).toBeGreaterThan(0);
+    expect(page.items.map((a) => a.sourceAgentId).sort()).toEqual(expected);
   });
 
   it('maps node types onto directory kinds', async () => {
     const page = await createMockAgentDirectory().listAgents();
     const kinds = Object.fromEntries(page.items.map((a) => [a.sourceAgentId, a.kind]));
     expect(kinds['ravn-huginn']).toBe('resident');
-    expect(kinds['run-0']).toBe('workflow-session');
+    expect(kinds['run-research']).toBe('workflow-session');
   });
 
   it('links each entry back to the topology node it projects', async () => {
@@ -253,7 +255,8 @@ describe('createMockAgentDirectory', () => {
 
   it('filters by kind', async () => {
     const page = await createMockAgentDirectory().listAgents({ kinds: ['workflow-session'] });
-    expect(page.items.map((a) => a.sourceAgentId)).toEqual(['run-0']);
+    expect(page.items.map((a) => a.sourceAgentId).sort()).toEqual(['run-coding', 'run-research']);
+    expect(page.items.every((a) => a.kind === 'workflow-session')).toBe(true);
   });
 
   it('filters by skill', async () => {
@@ -261,18 +264,25 @@ describe('createMockAgentDirectory', () => {
     expect(page.items.map((a) => a.sourceAgentId)).toEqual(['ravn-muninn']);
   });
 
+  it('filters by a skill shared by nobody', async () => {
+    const page = await createMockAgentDirectory().listAgents({ skills: ['not_a_skill'] });
+    expect(page.items).toEqual([]);
+  });
+
   it('filters by tag, cluster and instance', async () => {
     const directory = createMockAgentDirectory();
-    expect((await directory.listAgents({ tags: ['resident'] })).items).toHaveLength(2);
+    const residents = await directory.listAgents({ tags: ['resident'] });
+    expect(residents.items.length).toBeGreaterThan(0);
+    expect(residents.items.every((a) => a.kind === 'resident')).toBe(true);
     expect((await directory.listAgents({ clusterIds: ['nope'] })).items).toHaveLength(0);
     expect(
-      (await directory.listAgents({ instanceIds: ['observatory-valaskjalf'] })).items.length,
+      (await directory.listAgents({ instanceIds: ['observatory-asgard'] })).items.length,
     ).toBeGreaterThan(0);
   });
 
   it('filters by observed status', async () => {
     const page = await createMockAgentDirectory().listAgents({ statuses: ['observing'] });
-    expect(page.items.map((a) => a.sourceAgentId)).toEqual(['run-0']);
+    expect(page.items.map((a) => a.sourceAgentId).sort()).toEqual(['run-coding', 'run-research']);
   });
 
   it('ands the filters together', async () => {
@@ -281,11 +291,21 @@ describe('createMockAgentDirectory', () => {
       skills: ['recall_context'],
     });
     expect(page.items.map((a) => a.sourceAgentId)).toEqual(['ravn-muninn']);
+    expect(
+      (
+        await createMockAgentDirectory().listAgents({
+          kinds: ['workflow-session'],
+          skills: ['recall_context'],
+        })
+      ).items,
+    ).toEqual([]);
   });
 
   it('treats an empty filter array as unfiltered', async () => {
-    const page = await createMockAgentDirectory().listAgents({ kinds: [], skills: [] });
-    expect(page.items).toHaveLength(3);
+    const directory = createMockAgentDirectory();
+    const all = await directory.listAgents();
+    const empty = await directory.listAgents({ kinds: [], skills: [] });
+    expect(empty.items).toHaveLength(all.items.length);
   });
 
   it('carries a usable A2A card surface on every entry', async () => {

--- a/web-next/packages/plugin-observatory/src/adapters/mock.test.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/mock.test.ts
@@ -3,6 +3,7 @@ import {
   createMockRegistryRepository,
   createMockTopologyStream,
   createMockEventStream,
+  createMockAgentDirectory,
 } from './mock';
 
 describe('createMockRegistryRepository', () => {
@@ -212,5 +213,105 @@ describe('createMockEventStream', () => {
     expect(types.has('RAVN')).toBe(true);
     expect(types.has('BIFROST')).toBe(true);
     expect(types.has('MIMIR')).toBe(true);
+  });
+});
+
+// ── Agent directory ───────────────────────────────────────────────────────────
+
+describe('createMockAgentDirectory', () => {
+  it('projects every agent-bearing topology node and nothing else', async () => {
+    const page = await createMockAgentDirectory().listAgents();
+    expect(page.items.map((a) => a.sourceAgentId).sort()).toEqual([
+      'ravn-huginn',
+      'ravn-muninn',
+      'run-0',
+    ]);
+  });
+
+  it('maps node types onto directory kinds', async () => {
+    const page = await createMockAgentDirectory().listAgents();
+    const kinds = Object.fromEntries(page.items.map((a) => [a.sourceAgentId, a.kind]));
+    expect(kinds['ravn-huginn']).toBe('resident');
+    expect(kinds['run-0']).toBe('workflow-session');
+  });
+
+  it('links each entry back to the topology node it projects', async () => {
+    const directory = createMockAgentDirectory();
+    const page = await directory.listAgents();
+    const topology = createMockTopologyStream().getSnapshot();
+    for (const entry of page.items) {
+      expect(topology?.nodes.some((n) => n.id === entry.topologyNodeId)).toBe(true);
+    }
+  });
+
+  it('reports a healthy source and a complete page', async () => {
+    const page = await createMockAgentDirectory().listAgents();
+    expect(page.partial).toBe(false);
+    expect(page.warnings).toEqual([]);
+    expect(page.sources[0]?.status).toBe('healthy');
+  });
+
+  it('filters by kind', async () => {
+    const page = await createMockAgentDirectory().listAgents({ kinds: ['workflow-session'] });
+    expect(page.items.map((a) => a.sourceAgentId)).toEqual(['run-0']);
+  });
+
+  it('filters by skill', async () => {
+    const page = await createMockAgentDirectory().listAgents({ skills: ['recall_context'] });
+    expect(page.items.map((a) => a.sourceAgentId)).toEqual(['ravn-muninn']);
+  });
+
+  it('filters by tag, cluster and instance', async () => {
+    const directory = createMockAgentDirectory();
+    expect((await directory.listAgents({ tags: ['resident'] })).items).toHaveLength(2);
+    expect((await directory.listAgents({ clusterIds: ['nope'] })).items).toHaveLength(0);
+    expect(
+      (await directory.listAgents({ instanceIds: ['observatory-valaskjalf'] })).items.length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('filters by observed status', async () => {
+    const page = await createMockAgentDirectory().listAgents({ statuses: ['observing'] });
+    expect(page.items.map((a) => a.sourceAgentId)).toEqual(['run-0']);
+  });
+
+  it('ands the filters together', async () => {
+    const page = await createMockAgentDirectory().listAgents({
+      kinds: ['resident'],
+      skills: ['recall_context'],
+    });
+    expect(page.items.map((a) => a.sourceAgentId)).toEqual(['ravn-muninn']);
+  });
+
+  it('treats an empty filter array as unfiltered', async () => {
+    const page = await createMockAgentDirectory().listAgents({ kinds: [], skills: [] });
+    expect(page.items).toHaveLength(3);
+  });
+
+  it('carries a usable A2A card surface on every entry', async () => {
+    const entry = await createMockAgentDirectory().getAgent('ravn-huginn');
+    expect(entry.cardUrl).toMatch(/\.well-known\/agent-card\.json$/);
+    expect(entry.supportedInterfaces[0]?.protocolVersion).toBe('0.3.0');
+    expect(entry.capabilities).toMatchObject({ streaming: true });
+    expect(entry.skillIds.length).toBeGreaterThan(0);
+  });
+
+  it('resolves an agent by directory id as well as source id', async () => {
+    const directory = createMockAgentDirectory();
+    expect((await directory.getAgent('agent-ravn-huginn')).name).toBe('huginn');
+    expect((await directory.getAgent('ravn-huginn')).name).toBe('huginn');
+  });
+
+  it('throws for an unknown agent rather than returning empty', async () => {
+    await expect(createMockAgentDirectory().getAgent('nope')).rejects.toThrow(
+      'Unknown agent: nope',
+    );
+  });
+
+  it('hands out copies so callers cannot mutate the seed', async () => {
+    const directory = createMockAgentDirectory();
+    const first = await directory.getAgent('ravn-huginn');
+    first.name = 'mutated';
+    expect((await directory.getAgent('ravn-huginn')).name).toBe('huginn');
   });
 });

--- a/web-next/packages/plugin-observatory/src/adapters/mock.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/mock.ts
@@ -1,11 +1,22 @@
 import type {
+  IAgentDirectory,
   IRegistryRepository,
   ILiveTopologyStream,
   IEventStream,
   TopologyListener,
   ObservatoryEventListener,
 } from '../ports';
-import type { Registry, Topology, TopologyNode, TopologyEdge, ObservatoryEvent } from '../domain';
+import type {
+  AgentDirectoryEntry,
+  AgentDirectoryFilters,
+  AgentDirectoryPage,
+  AgentKind,
+  Registry,
+  Topology,
+  TopologyNode,
+  TopologyEdge,
+  ObservatoryEvent,
+} from '../domain';
 
 // ── Seed registry (mirrors the earlier prototype DEFAULT_REGISTRY seed data) ──
 
@@ -472,6 +483,7 @@ const SEED_NODES: TopologyNode[] = [
     zone: 'asgard',
     cluster: 'valaskjalf',
     purpose: 'refactor bifrost rule engine',
+    flockId: 'forge-mesh',
     state: 'working',
     activity: 'delegating',
   },
@@ -483,6 +495,7 @@ const SEED_NODES: TopologyNode[] = [
     status: 'healthy',
     zone: 'asgard',
     hostId: 'host-mjolnir',
+    flockId: 'forge-mesh',
     persona: 'thought',
     specialty: 'architecture & design',
     tokens: 42800,
@@ -496,6 +509,7 @@ const SEED_NODES: TopologyNode[] = [
     status: 'idle',
     zone: 'asgard',
     hostId: 'host-mjolnir',
+    flockId: 'forge-mesh',
     persona: 'memory',
     specialty: 'history & context',
     tokens: 18200,
@@ -604,6 +618,143 @@ export function createMockEventStream(): IEventStream {
       return () => {
         // mock: events already emitted synchronously; no interval to clear
       };
+    },
+  };
+}
+
+// ── Agent directory (A2A) ─────────────────────────────────────────────────────
+
+/** Which directory kind a topology node projects as. */
+function agentKindFor(node: TopologyNode): AgentKind | null {
+  if (node.typeId === 'ravn_long') return 'resident';
+  if (node.typeId === 'valkyrie') return 'steward';
+  if (node.typeId === 'run') return 'workflow-session';
+  return null;
+}
+
+const SKILLS_BY_NODE: Record<string, string[]> = {
+  'ravn-huginn': ['design_review', 'architecture_sketch', 'tradeoff_analysis'],
+  'ravn-muninn': ['recall_context', 'session_distil', 'fact_detect'],
+  'run-0': ['refactor_plan', 'apply_patch', 'verify_build'],
+};
+
+/**
+ * Project the agent-bearing seed nodes into directory entries.
+ *
+ * The card fields mirror the shape a real A2A agent card carries so the UI can
+ * be built against the same contract the HTTP adapter returns.
+ */
+function seedAgents(): AgentDirectoryEntry[] {
+  return SEED_NODES.flatMap((node) => {
+    const kind = agentKindFor(node);
+    if (!kind) return [];
+
+    const clusterId = node.cluster ?? node.zone ?? 'valaskjalf';
+    const host = `${node.label}.${clusterId}.asgard.niuu.world`;
+    const skillIds = SKILLS_BY_NODE[node.id] ?? [];
+
+    return [
+      {
+        id: `agent-${node.id}`,
+        canonicalId: `niuu:agent:${node.id}`,
+        sourceAgentId: node.id,
+        sourceInstanceId: `observatory-${clusterId}`,
+        clusterId,
+        environmentId: null,
+        topologyNodeId: node.id,
+        name: node.label,
+        description:
+          node.purpose ?? node.specialty ?? `${kind} projected from topology node ${node.id}`,
+        kind,
+        cardUrl: `https://${host}/.well-known/agent-card.json`,
+        cardVersion: '0.0.1',
+        cardHash: `sha256:${node.id}`,
+        signatureVerified: kind === 'workflow-session' ? null : true,
+        signatureKeyIds: kind === 'workflow-session' ? [] : ['niuu-a2a-signing'],
+        signatureKeyFingerprints: kind === 'workflow-session' ? [] : ['SHA256:mock-fingerprint'],
+        skillIds,
+        tags: [kind, clusterId],
+        defaultInputModes: ['text/plain', 'application/json'],
+        defaultOutputModes: ['text/plain', 'application/json'],
+        supportedInterfaces: [
+          {
+            url: `https://${host}/a2a`,
+            protocolBinding: 'JSONRPC',
+            protocolVersion: '0.3.0',
+            tenant: 'niuu.world',
+          },
+        ],
+        capabilities: {
+          streaming: true,
+          pushNotifications: kind !== 'workflow-session',
+          stateTransitionHistory: true,
+        },
+        securitySchemes: { oauth2: { type: 'oauth2', flows: { clientCredentials: {} } } },
+        securityRequirements: [{ oauth2: [] }],
+        observedStatus: node.status,
+        activity: node.activity ?? 'idle',
+        lastSeen: SEED_TOPOLOGY.timestamp,
+        ownerId: null,
+        tenantId: 'niuu.world',
+        visibility: 'realm',
+        provenance: [
+          {
+            sourceAgentId: node.id,
+            sourceInstanceId: `observatory-${clusterId}`,
+            clusterId,
+            environmentId: null,
+            topologyNodeId: node.id,
+          },
+        ],
+      },
+    ];
+  });
+}
+
+const SEED_AGENTS: AgentDirectoryEntry[] = seedAgents();
+
+/** Every filter is AND-ed; each is satisfied when the entry matches any value. */
+function matchesFilters(entry: AgentDirectoryEntry, filters: AgentDirectoryFilters): boolean {
+  const anyOf = (values: readonly string[] | undefined, has: (value: string) => boolean) =>
+    !values || values.length === 0 || values.some(has);
+
+  return (
+    anyOf(filters.skills, (skill) => entry.skillIds.includes(skill)) &&
+    anyOf(filters.tags, (tag) => entry.tags.includes(tag)) &&
+    anyOf(filters.kinds, (kind) => entry.kind === kind) &&
+    anyOf(filters.statuses, (status) => entry.observedStatus === status) &&
+    anyOf(filters.clusterIds, (clusterId) => entry.clusterId === clusterId) &&
+    anyOf(filters.instanceIds, (instanceId) => entry.sourceInstanceId === instanceId) &&
+    anyOf(filters.environmentIds, (envId) => entry.environmentId === envId)
+  );
+}
+
+export function createMockAgentDirectory(): IAgentDirectory {
+  return {
+    async listAgents(filters: AgentDirectoryFilters = {}): Promise<AgentDirectoryPage> {
+      const items = SEED_AGENTS.filter((entry) => matchesFilters(entry, filters));
+      return structuredClone({
+        items,
+        warnings: [],
+        sources: [
+          {
+            instanceId: 'observatory-valaskjalf',
+            clusterId: 'valaskjalf',
+            status: 'healthy' as const,
+            revision: SEED_TOPOLOGY.timestamp,
+            message: '',
+          },
+        ],
+        partial: false,
+        revision: SEED_TOPOLOGY.timestamp,
+      });
+    },
+
+    async getAgent(agentId: string): Promise<AgentDirectoryEntry> {
+      const entry = SEED_AGENTS.find((a) => a.id === agentId || a.sourceAgentId === agentId);
+      // Fail loudly: a missing agent is a wiring bug, not an empty result.
+      if (!entry) throw new Error(`Unknown agent: ${agentId}`);
+      return structuredClone(entry);
     },
   };
 }

--- a/web-next/packages/plugin-observatory/src/adapters/mock.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/mock.ts
@@ -6,6 +6,7 @@ import type {
   TopologyListener,
   ObservatoryEventListener,
 } from '../ports';
+import { SEED_NODES, SEED_TOPOLOGY } from './seedTopology';
 import type {
   AgentDirectoryEntry,
   AgentDirectoryFilters,
@@ -14,7 +15,6 @@ import type {
   Registry,
   Topology,
   TopologyNode,
-  TopologyEdge,
   ObservatoryEvent,
 } from '../domain';
 
@@ -379,165 +379,6 @@ const SEED_REGISTRY: Registry = {
 
 // ── Seed topology ─────────────────────────────────────────────────────────────
 
-const SEED_NODES: TopologyNode[] = [
-  {
-    id: 'realm-asgard',
-    typeId: 'realm',
-    label: 'asgard',
-    parentId: null,
-    status: 'healthy',
-    zone: 'asgard',
-    vlan: 90,
-    dns: 'asgard.niuu.world',
-    purpose: 'AI / compute / dev',
-    activity: 'idle',
-  },
-  {
-    id: 'cluster-valaskjalf',
-    typeId: 'cluster',
-    label: 'valaskjálf',
-    parentId: 'realm-asgard',
-    status: 'healthy',
-    zone: 'asgard',
-    purpose: 'DGX Spark cluster',
-    activity: 'idle',
-  },
-  {
-    id: 'cluster-valhalla',
-    typeId: 'cluster',
-    label: 'valhalla',
-    parentId: 'realm-asgard',
-    status: 'healthy',
-    zone: 'asgard',
-    purpose: 'AI/ML workloads',
-    activity: 'idle',
-  },
-  {
-    id: 'host-mjolnir',
-    typeId: 'host',
-    label: 'mjölnir',
-    parentId: 'realm-asgard',
-    status: 'healthy',
-    zone: 'asgard',
-    hw: 'DGX Spark',
-    os: 'Ubuntu 24',
-    cores: 144,
-    ram: '1 TiB',
-    gpu: 'GH200',
-    activity: 'idle',
-  },
-  {
-    id: 'ting-0',
-    typeId: 'ting',
-    label: 'ting-0',
-    parentId: 'cluster-valaskjalf',
-    status: 'healthy',
-    zone: 'asgard',
-    cluster: 'valaskjalf',
-    mode: 'active',
-    activeSagas: 3,
-    pendingRuns: 2,
-    activity: 'thinking',
-  },
-  {
-    id: 'bifrost-0',
-    typeId: 'bifrost',
-    label: 'bifröst-0',
-    parentId: 'cluster-valaskjalf',
-    status: 'healthy',
-    zone: 'asgard',
-    cluster: 'valaskjalf',
-    providers: ['Anthropic', 'OpenAI', 'Google', 'Local'],
-    reqPerMin: 42,
-    cacheHitRate: 0.68,
-    activity: 'idle',
-  },
-  {
-    id: 'volundr-0',
-    typeId: 'volundr',
-    label: 'völundr-0',
-    parentId: 'cluster-valhalla',
-    status: 'healthy',
-    zone: 'asgard',
-    cluster: 'valhalla',
-    activeSessions: 5,
-    maxSessions: 20,
-    activity: 'tooling',
-  },
-  {
-    id: 'mimir-0',
-    typeId: 'mimir',
-    label: 'mímir-0',
-    parentId: 'cluster-valaskjalf',
-    status: 'healthy',
-    zone: 'asgard',
-    cluster: 'valaskjalf',
-    activity: 'reading',
-  },
-  {
-    id: 'run-0',
-    typeId: 'run',
-    label: 'run-omega',
-    parentId: 'cluster-valaskjalf',
-    status: 'observing',
-    zone: 'asgard',
-    cluster: 'valaskjalf',
-    purpose: 'refactor bifrost rule engine',
-    flockId: 'forge-mesh',
-    state: 'working',
-    activity: 'delegating',
-  },
-  {
-    id: 'ravn-huginn',
-    typeId: 'ravn_long',
-    label: 'huginn',
-    parentId: 'host-mjolnir',
-    status: 'healthy',
-    zone: 'asgard',
-    hostId: 'host-mjolnir',
-    flockId: 'forge-mesh',
-    persona: 'thought',
-    specialty: 'architecture & design',
-    tokens: 42800,
-    activity: 'thinking',
-  },
-  {
-    id: 'ravn-muninn',
-    typeId: 'ravn_long',
-    label: 'muninn',
-    parentId: 'host-mjolnir',
-    status: 'idle',
-    zone: 'asgard',
-    hostId: 'host-mjolnir',
-    flockId: 'forge-mesh',
-    persona: 'memory',
-    specialty: 'history & context',
-    tokens: 18200,
-    activity: 'idle',
-  },
-];
-
-const SEED_EDGES: TopologyEdge[] = [
-  // solid: direct coordinator link
-  { id: 'e-ting-volundr', sourceId: 'ting-0', targetId: 'volundr-0', kind: 'solid' },
-  // dashed-anim: active run dispatch
-  { id: 'e-ting-run', sourceId: 'ting-0', targetId: 'run-0', kind: 'dashed-anim' },
-  // dashed-long: raven async memory access
-  { id: 'e-huginn-mimir', sourceId: 'ravn-huginn', targetId: 'mimir-0', kind: 'dashed-long' },
-  // soft: bifrost references mimir for cache
-  { id: 'e-bifrost-mimir', sourceId: 'bifrost-0', targetId: 'mimir-0', kind: 'soft' },
-  // run: inter-raven coordination within the run
-  { id: 'e-run-huginn', sourceId: 'run-0', targetId: 'ravn-huginn', kind: 'run' },
-];
-
-const SEED_TOPOLOGY: Topology = {
-  nodes: SEED_NODES,
-  edges: SEED_EDGES,
-  timestamp: '2026-04-19T00:00:00Z',
-};
-
-// ── Seed events (web2 format: time, type, subject, body) ─────────────────────
-
 const SEED_EVENTS: ObservatoryEvent[] = [
   {
     id: 'ev-1',
@@ -633,9 +474,18 @@ function agentKindFor(node: TopologyNode): AgentKind | null {
 }
 
 const SKILLS_BY_NODE: Record<string, string[]> = {
-  'ravn-huginn': ['design_review', 'architecture_sketch', 'tradeoff_analysis'],
-  'ravn-muninn': ['recall_context', 'session_distil', 'fact_detect'],
-  'run-0': ['refactor_plan', 'apply_patch', 'verify_build'],
+  'ravn-huginn': ['gpu_pressure_probe', 'replica_warm', 'canary_triage'],
+  'ravn-muninn': ['helm_release_diff', 'cert_expiry_sweep', 'recall_context'],
+  'ravn-kvasir': ['page_compact', 'fact_promote', 'dedupe_entities'],
+  'ravn-njord': ['rollout_drain', 'pg_failover_probe', 'schema_diff'],
+  'ravn-forseti': ['trace_correlate', 'ingester_lag_watch', 'series_budget'],
+  'ravn-angrboda': ['transcode_queue', 'library_scan_window'],
+  'ravn-freyja': ['vm_rebalance', 'migration_window', 'host_pressure'],
+  'ravn-ivaldi': ['spindle_load_watch', 'nats_gap_detect', 'shift_handover'],
+  'ravn-eldhrimnir': ['direct_infer', 'model_warm', 'thermal_guard'],
+  'ravn-vidar': ['host_signature', 'evict_predict'],
+  'run-research': ['literature_sweep', 'source_triage', 'compose_brief'],
+  'run-coding': ['refactor_plan', 'apply_patch', 'verify_build'],
 };
 
 /**

--- a/web-next/packages/plugin-observatory/src/adapters/seedTopology.test.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/seedTopology.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { SEED_NODES, SEED_EDGES, SEED_TOPOLOGY } from './seedTopology';
+import { createMockRegistryRepository } from './mock';
+import { deriveAgentMeshes } from '../domain/agentMesh';
+import type { EntityType } from '../domain';
+
+const byId = new Map(SEED_NODES.map((n) => [n.id, n]));
+
+describe('seed topology structure', () => {
+  it('gives every node a unique id', () => {
+    expect(new Set(SEED_NODES.map((n) => n.id)).size).toBe(SEED_NODES.length);
+  });
+
+  it('gives every edge a unique id', () => {
+    expect(new Set(SEED_EDGES.map((e) => e.id)).size).toBe(SEED_EDGES.length);
+  });
+
+  it('resolves every parent reference', () => {
+    for (const node of SEED_NODES) {
+      if (node.parentId === null) continue;
+      expect(byId.has(node.parentId), `${node.id} -> ${node.parentId}`).toBe(true);
+    }
+  });
+
+  it('resolves both endpoints of every edge', () => {
+    for (const e of SEED_EDGES) {
+      expect(byId.has(e.sourceId), `${e.id} source ${e.sourceId}`).toBe(true);
+      expect(byId.has(e.targetId), `${e.id} target ${e.targetId}`).toBe(true);
+    }
+  });
+
+  it('roots only realms', () => {
+    const roots = SEED_NODES.filter((n) => n.parentId === null);
+    expect(roots.every((n) => n.typeId === 'realm')).toBe(true);
+    expect(roots).toHaveLength(5);
+  });
+
+  it('contains no parent cycles', () => {
+    for (const node of SEED_NODES) {
+      const seen = new Set<string>([node.id]);
+      let current = node.parentId;
+      while (current) {
+        expect(seen.has(current), `cycle through ${node.id}`).toBe(false);
+        seen.add(current);
+        current = byId.get(current)?.parentId ?? null;
+      }
+    }
+  });
+
+  it('obeys the registry parentTypes for every node', async () => {
+    const registry = await createMockRegistryRepository().getRegistry();
+    const types = new Map<string, EntityType>(registry.types.map((t) => [t.id, t]));
+
+    for (const node of SEED_NODES) {
+      const type = types.get(node.typeId);
+      expect(type, `unknown typeId ${node.typeId} on ${node.id}`).toBeDefined();
+      if (!type || node.parentId === null) continue;
+      const parent = byId.get(node.parentId);
+      expect(
+        type.parentTypes.includes(parent?.typeId ?? ''),
+        `${node.id} (${node.typeId}) under ${parent?.typeId}`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe('seed topology content', () => {
+  const count = (typeId: string) => SEED_NODES.filter((n) => n.typeId === typeId).length;
+
+  it('spans five realms and eight clusters', () => {
+    expect(count('realm')).toBe(5);
+    expect(count('cluster')).toBe(8);
+  });
+
+  it('places a resident in every cluster', () => {
+    const clusters = SEED_NODES.filter((n) => n.typeId === 'cluster').map((n) => n.id);
+    const residentParents = new Set(
+      SEED_NODES.filter((n) => n.typeId === 'ravn_long').map((n) => n.parentId),
+    );
+    for (const cluster of clusters) {
+      expect(residentParents.has(cluster), `no resident in ${cluster}`).toBe(true);
+    }
+  });
+
+  it('runs two residents directly on bare metal, outside kubernetes', () => {
+    const onHosts = SEED_NODES.filter(
+      (n) => n.typeId === 'ravn_long' && byId.get(n.parentId ?? '')?.typeId === 'host',
+    );
+    expect(onHosts.map((n) => n.label).sort()).toEqual(['eldhrímnir', 'víðarr']);
+  });
+
+  it('carries several distinct knowledge Mimir instances', () => {
+    const mimirs = SEED_NODES.filter((n) => n.typeId === 'mimir');
+    expect(mimirs.length).toBeGreaterThanOrEqual(3);
+    // Each lives in a different cluster — they are separate stores, not replicas.
+    expect(new Set(mimirs.map((n) => n.parentId)).size).toBe(mimirs.length);
+  });
+
+  it('models the metrics store as a service, never as a knowledge Mimir', () => {
+    const metrics = SEED_NODES.find((n) => n.id === 'svc-mimir-metrics');
+    expect(metrics?.typeId).toBe('service');
+    expect(metrics?.purpose).toMatch(/not a knowledge base/i);
+  });
+
+  it('marks the unreachable cluster and its Mimir as unverified rather than healthy', () => {
+    expect(byId.get('cluster-valhalla')?.status).toBe('unknown');
+    expect(byId.get('mimir-valhalla')?.status).toBe('unknown');
+    const declared = SEED_EDGES.filter((e) => e.confidence === 'declared');
+    expect(declared.length).toBeGreaterThan(0);
+  });
+
+  it('exposes three DGX Sparks with GPUs', () => {
+    const sparks = SEED_NODES.filter((n) => n.typeId === 'host' && n.hw === 'DGX Spark');
+    expect(sparks).toHaveLength(3);
+    expect(sparks.every((n) => n.gpu === 'GB10')).toBe(true);
+  });
+
+  it('runs two workflow sessions, each with its own run agents', () => {
+    const runs = SEED_NODES.filter((n) => n.typeId === 'run');
+    expect(runs).toHaveLength(2);
+    for (const run of runs) {
+      const agents = SEED_NODES.filter((n) => n.typeId === 'ravn_run' && n.parentId === run.id);
+      expect(agents.length).toBeGreaterThanOrEqual(4);
+    }
+  });
+
+  it('forms agent meshes that span clusters', () => {
+    const meshes = deriveAgentMeshes(SEED_TOPOLOGY);
+    expect(meshes.length).toBeGreaterThanOrEqual(3);
+
+    const spanning = meshes.find((m) => m.id === 'ops-mesh');
+    expect(spanning).toBeDefined();
+    const clusters = new Set(
+      spanning?.memberIds.map((id) => byId.get(id)?.parentId).filter(Boolean),
+    );
+    expect(clusters.size).toBeGreaterThan(1);
+  });
+});

--- a/web-next/packages/plugin-observatory/src/adapters/seedTopology.ts
+++ b/web-next/packages/plugin-observatory/src/adapters/seedTopology.ts
@@ -1,0 +1,912 @@
+/**
+ * Seed topology for demo mode.
+ *
+ * Shaped after the real platform: five DNS realms, eight clusters, the DGX
+ * Spark fleet, one resident per cluster plus two on bare metal, two live
+ * workflow sessions, and the several distinct Mímir instances. Counts are the
+ * ones the clusters actually report.
+ *
+ * Containment follows the registry's `parentTypes`: hosts and devices hang off
+ * a realm, services and runs off a cluster, run agents off their run, models
+ * off a Bifröst.
+ */
+
+import type { Topology, TopologyEdge, TopologyNode } from '../domain';
+
+const TIMESTAMP = '2026-08-01T12:00:00Z';
+
+// ── Realms ────────────────────────────────────────────────────────────────────
+
+const REALMS: TopologyNode[] = [
+  {
+    id: 'realm-asgard',
+    typeId: 'realm',
+    label: 'asgard',
+    parentId: null,
+    status: 'healthy',
+    zone: 'asgard',
+    vlan: 90,
+    dns: 'asgard.niuu.world',
+    purpose: 'platform, GPU and hypervisor',
+  },
+  {
+    id: 'realm-yggdrasil',
+    typeId: 'realm',
+    label: 'yggdrasil',
+    parentId: null,
+    status: 'healthy',
+    zone: 'yggdrasil',
+    vlan: 10,
+    dns: 'yggdrasil.niuu.world',
+    purpose: 'platform and identity',
+  },
+  {
+    id: 'realm-alfheim',
+    typeId: 'realm',
+    label: 'alfheim',
+    parentId: null,
+    status: 'healthy',
+    zone: 'alfheim',
+    vlan: 20,
+    dns: 'alfheim.niuu.world',
+    purpose: 'observability and object store',
+  },
+  {
+    id: 'realm-svartalfheim',
+    typeId: 'realm',
+    label: 'svartalfheim',
+    parentId: null,
+    status: 'healthy',
+    zone: 'svartalfheim',
+    vlan: 30,
+    dns: 'svartalfheim.niuu.world',
+    purpose: 'workshop and OT',
+  },
+  {
+    id: 'realm-midgard',
+    typeId: 'realm',
+    label: 'midgard',
+    parentId: null,
+    status: 'healthy',
+    zone: 'midgard',
+    vlan: 40,
+    dns: 'midgard.niuu.world',
+    purpose: 'general workloads',
+  },
+];
+
+// ── Clusters ──────────────────────────────────────────────────────────────────
+
+interface ClusterSeed {
+  id: string;
+  label: string;
+  realm: string;
+  zone: string;
+  purpose: string;
+  nodes: number;
+  status: TopologyNode['status'];
+}
+
+const CLUSTER_SEEDS: ClusterSeed[] = [
+  {
+    id: 'cluster-valaskjalf',
+    label: 'valaskjálf',
+    realm: 'realm-asgard',
+    zone: 'asgard',
+    purpose: 'GPU · inference · sandboxes — 9 nodes, 4 GPU, 225 pods',
+    nodes: 9,
+    status: 'healthy',
+  },
+  {
+    id: 'cluster-valhalla',
+    label: 'valhalla',
+    realm: 'realm-asgard',
+    zone: 'asgard',
+    purpose: 'platform — cluster API unreachable, declared from chart values',
+    nodes: 6,
+    status: 'unknown',
+  },
+  {
+    id: 'cluster-vanaheim',
+    label: 'vanaheim',
+    realm: 'realm-asgard',
+    zone: 'asgard',
+    purpose: 'harvester hypervisor — 9 hosts, 695 pods',
+    nodes: 9,
+    status: 'healthy',
+  },
+  {
+    id: 'cluster-noatun',
+    label: 'nóatún',
+    realm: 'realm-asgard',
+    zone: 'asgard',
+    purpose: 'second niuu deployment — 6 nodes, 163 pods',
+    nodes: 6,
+    status: 'healthy',
+  },
+  {
+    id: 'cluster-ymir',
+    label: 'ymir',
+    realm: 'realm-yggdrasil',
+    zone: 'yggdrasil',
+    purpose: 'platform · identity · mímir — 8 nodes, 227 pods',
+    nodes: 8,
+    status: 'healthy',
+  },
+  {
+    id: 'cluster-glitnir',
+    label: 'glitnir',
+    realm: 'realm-alfheim',
+    zone: 'alfheim',
+    purpose: 'observability · object store — 8 nodes, 216 pods',
+    nodes: 8,
+    status: 'healthy',
+  },
+  {
+    id: 'cluster-eitri',
+    label: 'eitri',
+    realm: 'realm-svartalfheim',
+    zone: 'svartalfheim',
+    purpose: 'workshop · OT · printers — 12 nodes, 218 pods',
+    nodes: 12,
+    status: 'healthy',
+  },
+  {
+    id: 'cluster-jarnvidr',
+    label: 'járnviðr',
+    realm: 'realm-midgard',
+    zone: 'midgard',
+    purpose: 'media · general workloads — 7 nodes, 1 GPU, 190 pods',
+    nodes: 7,
+    status: 'healthy',
+  },
+];
+
+const CLUSTERS: TopologyNode[] = CLUSTER_SEEDS.map((c) => ({
+  id: c.id,
+  typeId: 'cluster',
+  label: c.label,
+  parentId: c.realm,
+  status: c.status,
+  zone: c.zone,
+  purpose: c.purpose,
+  activity: 'idle',
+}));
+
+// ── Hosts ─────────────────────────────────────────────────────────────────────
+
+function host(
+  id: string,
+  label: string,
+  realm: string,
+  zone: string,
+  hw: string,
+  cores: number,
+  ram: string,
+  gpu: string | null,
+): TopologyNode {
+  return {
+    id,
+    typeId: 'host',
+    label,
+    parentId: realm,
+    status: 'healthy',
+    zone,
+    hw,
+    os: 'talos',
+    cores,
+    ram,
+    gpu,
+  };
+}
+
+const HOSTS: TopologyNode[] = [
+  host('host-saehrimnir', 'sæhrímnir', 'realm-asgard', 'asgard', 'DGX Spark', 20, '122 GB', 'GB10'),
+  host(
+    'host-tanngnjost',
+    'tanngnjóst',
+    'realm-asgard',
+    'asgard',
+    'DGX Spark',
+    20,
+    '120 GB',
+    'GB10',
+  ),
+  host(
+    'host-tanngrisnir',
+    'tanngrisnir',
+    'realm-asgard',
+    'asgard',
+    'DGX Spark',
+    20,
+    '122 GB',
+    'GB10',
+  ),
+  host('host-baldr', 'baldr', 'realm-asgard', 'asgard', 'bare metal', 112, '441 GB', null),
+  host('host-frigg', 'frigg', 'realm-asgard', 'asgard', 'bare metal', 112, '504 GB', null),
+  host('host-alviss', 'alviss', 'realm-svartalfheim', 'svartalfheim', 'arm64', 4, '8 GB', null),
+  host('host-brokk', 'brokk', 'realm-svartalfheim', 'svartalfheim', 'arm64', 4, '8 GB', null),
+];
+
+// ── Services ──────────────────────────────────────────────────────────────────
+
+function service(
+  id: string,
+  label: string,
+  parentId: string,
+  zone: string,
+  svcType: string,
+  purpose: string,
+  status: TopologyNode['status'] = 'healthy',
+): TopologyNode {
+  return { id, typeId: 'service', label, parentId, status, zone, svcType, purpose };
+}
+
+const SERVICES: TopologyNode[] = [
+  // valaskjálf — GPU serving and sandboxes
+  service(
+    'svc-inference-gateway',
+    'inference-gateway',
+    'cluster-valaskjalf',
+    'asgard',
+    'serving',
+    'llm-d gateway · ns vllm · 1/1',
+  ),
+  service(
+    'svc-vllm-router',
+    'vllm-router',
+    'cluster-valaskjalf',
+    'asgard',
+    'serving',
+    'vLLM deployment router · 1/1',
+  ),
+  service(
+    'svc-openshell',
+    'openshell',
+    'cluster-valaskjalf',
+    'asgard',
+    'sandbox',
+    'sandbox runtime · sts 1/1',
+  ),
+  service(
+    'svc-openclaw',
+    'openclaw',
+    'cluster-valaskjalf',
+    'asgard',
+    'runtime',
+    'agent runtime · sts 0/0 · scaled to zero',
+    'idle',
+  ),
+  service('svc-nats-valaskjalf', 'nats', 'cluster-valaskjalf', 'asgard', 'mesh', 'nats · 1/1'),
+
+  // ymir — platform and identity
+  service('svc-guild', 'guild', 'cluster-ymir', 'yggdrasil', 'niuu', 'niuu-guild · 1/1'),
+  service(
+    'svc-keycloak',
+    'keycloak',
+    'cluster-ymir',
+    'yggdrasil',
+    'identity',
+    'keycloak.niuu.world',
+  ),
+  service('svc-openbao', 'openbao', 'cluster-ymir', 'yggdrasil', 'secrets', 'openbao.niuu.world'),
+  service(
+    'svc-warden-ymir',
+    'warden-agent',
+    'cluster-ymir',
+    'yggdrasil',
+    'niuu',
+    'mimir-shared-warden-agent · 1/1',
+  ),
+  service('svc-nats-ymir', 'nats', 'cluster-ymir', 'yggdrasil', 'mesh', 'nats-yggdrasil · 3/3'),
+
+  // nóatún — second deployment
+  service(
+    'svc-envoy-noatun',
+    'envoy-gateway',
+    'cluster-noatun',
+    'asgard',
+    'gateway',
+    'envoy-volundr-gateway · 1/1',
+  ),
+  service('svc-nats-noatun', 'nats', 'cluster-noatun', 'asgard', 'mesh', 'nats-noatun · 1/1'),
+
+  // glitnir — observability. Grafana Mimir is a metrics TSDB, deliberately not
+  // modelled as a `mimir` node: it shares the name but stores no agent memory.
+  service(
+    'svc-mimir-metrics',
+    'mimir · metrics',
+    'cluster-glitnir',
+    'alfheim',
+    'observability',
+    'Grafana Mimir TSDB — 12 workloads, 3 ingesters. Not a knowledge base.',
+  ),
+  service('svc-grafana', 'grafana', 'cluster-glitnir', 'alfheim', 'observability', 'dashboards'),
+  service('svc-loki', 'loki', 'cluster-glitnir', 'alfheim', 'observability', 'logs'),
+  service('svc-tempo', 'tempo', 'cluster-glitnir', 'alfheim', 'observability', 'traces'),
+  service('svc-minio', 'minio', 'cluster-glitnir', 'alfheim', 'storage', 'object store'),
+  service('svc-nats-glitnir', 'nats', 'cluster-glitnir', 'alfheim', 'mesh', 'nats-glitnir · 1/1'),
+
+  // eitri — workshop
+  service(
+    'svc-spoolman',
+    'spoolman',
+    'cluster-eitri',
+    'svartalfheim',
+    'workshop',
+    'filament tracking',
+  ),
+  service(
+    'svc-orca',
+    'orca-slicer',
+    'cluster-eitri',
+    'svartalfheim',
+    'workshop',
+    'orca-slicer-api',
+  ),
+  service('svc-nats-eitri', 'nats', 'cluster-eitri', 'svartalfheim', 'mesh', 'nats-eitri · 1/1'),
+
+  // vanaheim — hypervisor
+  service(
+    'svc-harvester',
+    'harvester',
+    'cluster-vanaheim',
+    'asgard',
+    'hypervisor',
+    'hosts the guest clusters',
+  ),
+  service(
+    'svc-rancher',
+    'rancher',
+    'cluster-vanaheim',
+    'asgard',
+    'management',
+    'rancher.niuu.world',
+  ),
+
+  // járnviðr — media
+  service('svc-plex', 'plex', 'cluster-jarnvidr', 'midgard', 'media', 'plex'),
+  service(
+    'svc-arr',
+    '*arr stack',
+    'cluster-jarnvidr',
+    'midgard',
+    'media',
+    'radarr · sonarr · sabnzbd',
+  ),
+  service(
+    'svc-nats-jarnvidr',
+    'nats',
+    'cluster-jarnvidr',
+    'midgard',
+    'mesh',
+    'nats-jarnvidr · 1/1',
+  ),
+];
+
+// ── Platform coordinators ─────────────────────────────────────────────────────
+
+const COORDINATORS: TopologyNode[] = [
+  {
+    id: 'volundr-ymir',
+    typeId: 'volundr',
+    label: 'völundr',
+    parentId: 'cluster-ymir',
+    status: 'healthy',
+    zone: 'yggdrasil',
+    activeSessions: 4,
+    maxSessions: 24,
+  },
+  {
+    id: 'ting-ymir',
+    typeId: 'ting',
+    label: 'ting',
+    parentId: 'cluster-ymir',
+    status: 'healthy',
+    zone: 'yggdrasil',
+    mode: 'active',
+    activeSagas: 2,
+    pendingRuns: 1,
+  },
+  {
+    id: 'bifrost-ymir',
+    typeId: 'bifrost',
+    label: 'bifröst',
+    parentId: 'cluster-ymir',
+    status: 'healthy',
+    zone: 'yggdrasil',
+    providers: ['anthropic', 'openai', 'xai', 'valaskjalf'],
+    reqPerMin: 184,
+    cacheHitRate: 0.62,
+  },
+  {
+    id: 'volundr-noatun',
+    typeId: 'volundr',
+    label: 'völundr',
+    parentId: 'cluster-noatun',
+    status: 'healthy',
+    zone: 'asgard',
+    activeSessions: 1,
+    maxSessions: 12,
+  },
+  {
+    id: 'bifrost-noatun',
+    typeId: 'bifrost',
+    label: 'bifröst',
+    parentId: 'cluster-noatun',
+    status: 'healthy',
+    zone: 'asgard',
+    providers: ['valaskjalf'],
+    reqPerMin: 46,
+    cacheHitRate: 0.55,
+  },
+];
+
+// ── Mímir — the knowledge instances ───────────────────────────────────────────
+
+const MIMIRS: TopologyNode[] = [
+  {
+    id: 'mimir-ymir',
+    typeId: 'mimir',
+    label: 'mímir-shared',
+    parentId: 'cluster-ymir',
+    status: 'healthy',
+    zone: 'yggdrasil',
+    purpose: 'primary shared knowledge base — mimir.yggdrasil.niuu.world',
+    pages: 203,
+    writes: 12,
+    mountCount: 2,
+    mounts: ['local', 'shared'],
+    activity: 'writing',
+  },
+  {
+    id: 'mimir-noatun',
+    typeId: 'mimir',
+    label: 'mímir-shared',
+    parentId: 'cluster-noatun',
+    status: 'healthy',
+    zone: 'asgard',
+    purpose: 'second deployment — separate database, not a replica of ymir',
+    pages: 64,
+    writes: 3,
+    mountCount: 1,
+    mounts: ['shared'],
+    activity: 'reading',
+  },
+  {
+    id: 'mimir-valhalla',
+    typeId: 'mimir',
+    label: 'mímir-shared',
+    parentId: 'cluster-valhalla',
+    status: 'unknown',
+    zone: 'asgard',
+    purpose: 'declared by chart values; cluster API returns 403 so unconfirmed',
+    mountCount: 1,
+    mounts: ['shared'],
+    activity: 'idle',
+  },
+];
+
+// ── Models ────────────────────────────────────────────────────────────────────
+
+function model(
+  id: string,
+  label: string,
+  parentId: string,
+  zone: string,
+  provider: string,
+  location: string,
+  status: TopologyNode['status'],
+): TopologyNode {
+  return { id, typeId: 'model', label, parentId, status, zone, provider, location };
+}
+
+const MODELS: TopologyNode[] = [
+  model(
+    'model-nemotron',
+    'nemotron-3-super',
+    'bifrost-ymir',
+    'yggdrasil',
+    'valaskjalf',
+    'self-hosted · valaskjálf vLLM · 2/2',
+    'healthy',
+  ),
+  model(
+    'model-qwen36',
+    'qwen3.6-coder',
+    'bifrost-ymir',
+    'yggdrasil',
+    'valaskjalf',
+    'self-hosted · llm-d · 0 replicas',
+    'idle',
+  ),
+  model(
+    'model-claude',
+    'claude-fable-5',
+    'bifrost-ymir',
+    'yggdrasil',
+    'anthropic',
+    'metered · leaves the realm',
+    'healthy',
+  ),
+  model(
+    'model-gpt',
+    'gpt-5.6-sol',
+    'bifrost-ymir',
+    'yggdrasil',
+    'openai',
+    'metered · leaves the realm',
+    'healthy',
+  ),
+  model(
+    'model-grok',
+    'grok-build',
+    'bifrost-ymir',
+    'yggdrasil',
+    'xai',
+    'metered · leaves the realm',
+    'idle',
+  ),
+];
+
+// ── Residents ─────────────────────────────────────────────────────────────────
+
+function resident(
+  id: string,
+  label: string,
+  parentId: string,
+  zone: string,
+  specialty: string,
+  flockId: string,
+  status: TopologyNode['status'],
+  activity: TopologyNode['activity'],
+  tokens: number,
+): TopologyNode {
+  return {
+    id,
+    typeId: 'ravn_long',
+    label,
+    parentId,
+    status,
+    zone,
+    specialty,
+    flockId,
+    persona: 'steward',
+    tokens,
+    activity,
+  };
+}
+
+const RESIDENTS: TopologyNode[] = [
+  resident(
+    'ravn-huginn',
+    'huginn',
+    'cluster-valaskjalf',
+    'asgard',
+    'inference steward',
+    'forge-mesh',
+    'healthy',
+    'thinking',
+    42800,
+  ),
+  resident(
+    'ravn-muninn',
+    'muninn',
+    'cluster-valhalla',
+    'asgard',
+    'platform steward',
+    'ops-mesh',
+    'healthy',
+    'tooling',
+    18200,
+  ),
+  resident(
+    'ravn-kvasir',
+    'kvasir',
+    'cluster-ymir',
+    'yggdrasil',
+    'memory steward',
+    'ops-mesh',
+    'healthy',
+    'writing',
+    31500,
+  ),
+  resident(
+    'ravn-njord',
+    'njörð',
+    'cluster-noatun',
+    'asgard',
+    'deployment steward',
+    'workshop-mesh',
+    'healthy',
+    'tooling',
+    12400,
+  ),
+  resident(
+    'ravn-forseti',
+    'forseti',
+    'cluster-glitnir',
+    'alfheim',
+    'observability steward',
+    'ops-mesh',
+    'healthy',
+    'reading',
+    22600,
+  ),
+  resident(
+    'ravn-angrboda',
+    'angrboða',
+    'cluster-jarnvidr',
+    'midgard',
+    'media steward',
+    'workshop-mesh',
+    'idle',
+    'idle',
+    4100,
+  ),
+  resident(
+    'ravn-freyja',
+    'freyja',
+    'cluster-vanaheim',
+    'asgard',
+    'fleet steward',
+    'ops-mesh',
+    'healthy',
+    'thinking',
+    15900,
+  ),
+  resident(
+    'ravn-ivaldi',
+    'ivaldi',
+    'cluster-eitri',
+    'svartalfheim',
+    'workshop steward',
+    'workshop-mesh',
+    'healthy',
+    'tooling',
+    27300,
+  ),
+  // Two residents run straight on bare metal, outside Kubernetes entirely.
+  resident(
+    'ravn-eldhrimnir',
+    'eldhrímnir',
+    'host-saehrimnir',
+    'asgard',
+    'on-host inference · systemd',
+    'forge-mesh',
+    'healthy',
+    'thinking',
+    51200,
+  ),
+  resident(
+    'ravn-vidar',
+    'víðarr',
+    'host-baldr',
+    'asgard',
+    'host signatures · systemd',
+    'ops-mesh',
+    'healthy',
+    'reading',
+    9800,
+  ),
+];
+
+// ── Workflow sessions ─────────────────────────────────────────────────────────
+
+function runAgent(
+  id: string,
+  label: string,
+  runId: string,
+  zone: string,
+  role: string,
+  confidence: number,
+  activity: TopologyNode['activity'],
+): TopologyNode {
+  return {
+    id,
+    typeId: 'ravn_run',
+    label,
+    parentId: runId,
+    status: 'healthy',
+    zone,
+    role,
+    confidence,
+    flockId: runId,
+    activity,
+  };
+}
+
+const SESSIONS: TopologyNode[] = [
+  {
+    id: 'run-research',
+    typeId: 'run',
+    label: 'research-session',
+    parentId: 'cluster-valhalla',
+    status: 'observing',
+    zone: 'asgard',
+    purpose: 'prior art for the bifröst rate limiter',
+    state: 'working',
+    flockId: 'run-research',
+    activity: 'delegating',
+  },
+  runAgent('run-research-planner', 'planner', 'run-research', 'asgard', 'coord', 0.86, 'thinking'),
+  runAgent('run-research-search', 'searcher', 'run-research', 'asgard', 'scholar', 0.74, 'tooling'),
+  runAgent('run-research-read', 'reader', 'run-research', 'asgard', 'scholar', 0.79, 'reading'),
+  runAgent('run-research-write', 'writer', 'run-research', 'asgard', 'reviewer', 0.68, 'waiting'),
+  {
+    id: 'run-coding',
+    typeId: 'run',
+    label: 'coding-session',
+    parentId: 'cluster-noatun',
+    status: 'observing',
+    zone: 'asgard',
+    purpose: 'refactor the bifröst rule engine',
+    state: 'working',
+    flockId: 'run-coding',
+    activity: 'delegating',
+  },
+  runAgent('run-coding-architect', 'architect', 'run-coding', 'asgard', 'coord', 0.91, 'thinking'),
+  runAgent('run-coding-impl', 'implementer', 'run-coding', 'asgard', 'scholar', 0.82, 'writing'),
+  runAgent('run-coding-review', 'reviewer', 'run-coding', 'asgard', 'reviewer', 0.7, 'waiting'),
+  runAgent('run-coding-test', 'tester', 'run-coding', 'asgard', 'scholar', 0.77, 'tooling'),
+];
+
+// ── Workshop devices ──────────────────────────────────────────────────────────
+
+const DEVICES: TopologyNode[] = [
+  {
+    id: 'device-bambuddy',
+    typeId: 'printer',
+    label: 'bambuddy',
+    parentId: 'realm-svartalfheim',
+    status: 'healthy',
+    zone: 'svartalfheim',
+    model: 'Bambu X1C fleet',
+  },
+  {
+    id: 'device-ovfarm',
+    typeId: 'vaettir',
+    label: 'ovfarm',
+    parentId: 'realm-svartalfheim',
+    status: 'healthy',
+    zone: 'svartalfheim',
+    sensors: 'equipment · ot-operators',
+  },
+  {
+    id: 'device-laevateinn',
+    typeId: 'beacon',
+    label: 'lævateinn',
+    parentId: 'realm-svartalfheim',
+    status: 'healthy',
+    zone: 'svartalfheim',
+    purpose: 'shop-floor signal source — 01-04 + console, 5/5',
+  },
+];
+
+export const SEED_NODES: TopologyNode[] = [
+  ...REALMS,
+  ...CLUSTERS,
+  ...HOSTS,
+  ...COORDINATORS,
+  ...MIMIRS,
+  ...MODELS,
+  ...SERVICES,
+  ...RESIDENTS,
+  ...SESSIONS,
+  ...DEVICES,
+];
+
+// ── Edges ─────────────────────────────────────────────────────────────────────
+
+function edge(
+  id: string,
+  sourceId: string,
+  targetId: string,
+  kind: TopologyEdge['kind'],
+  relationType: TopologyEdge['relationType'],
+  confidence: TopologyEdge['confidence'] = 'observed',
+): TopologyEdge {
+  return { id, sourceId, targetId, kind, relationType, confidence };
+}
+
+const MEMORY_EDGES: TopologyEdge[] = [
+  ...[
+    'ravn-huginn',
+    'ravn-kvasir',
+    'ravn-forseti',
+    'ravn-freyja',
+    'ravn-eldhrimnir',
+    'ravn-vidar',
+  ].map((id) => edge(`mem-${id}`, id, 'mimir-ymir', 'dashed-long', 'writes')),
+  edge('mem-njord', 'ravn-njord', 'mimir-noatun', 'dashed-long', 'writes'),
+  edge('mem-angrboda', 'ravn-angrboda', 'mimir-noatun', 'dashed-long', 'reads'),
+  edge('mem-muninn', 'ravn-muninn', 'mimir-valhalla', 'dashed-long', 'writes', 'declared'),
+  edge('mem-ivaldi', 'ravn-ivaldi', 'mimir-ymir', 'dashed-long', 'writes'),
+  edge('mem-shared', 'mimir-noatun', 'mimir-ymir', 'soft', 'reads'),
+  edge('mem-research', 'run-research', 'mimir-valhalla', 'dashed-long', 'writes', 'declared'),
+  edge('mem-coding', 'run-coding', 'mimir-noatun', 'dashed-long', 'writes'),
+];
+
+const MODEL_EDGES: TopologyEdge[] = [
+  edge('mdl-gw', 'bifrost-ymir', 'svc-inference-gateway', 'solid', 'routes_to'),
+  edge('mdl-gw-n', 'bifrost-noatun', 'svc-inference-gateway', 'solid', 'routes_to'),
+  edge('mdl-router', 'svc-inference-gateway', 'svc-vllm-router', 'solid', 'routes_to'),
+  edge('mdl-nemotron-host', 'model-nemotron', 'host-saehrimnir', 'soft', 'uses'),
+  edge('mdl-nemotron-host2', 'model-nemotron', 'host-tanngnjost', 'soft', 'uses'),
+  edge('mdl-qwen-host', 'model-qwen36', 'host-tanngrisnir', 'soft', 'uses', 'declared'),
+  // The bare-metal residents call the Sparks directly, skipping the gateway.
+  edge('mdl-eldhrimnir', 'ravn-eldhrimnir', 'svc-vllm-router', 'solid', 'uses'),
+  ...['ravn-huginn', 'ravn-kvasir', 'ravn-forseti', 'ravn-freyja', 'ravn-muninn'].map((id) =>
+    edge(`mdl-${id}`, id, 'bifrost-ymir', 'solid', 'uses'),
+  ),
+  ...['ravn-njord', 'ravn-angrboda'].map((id) =>
+    edge(`mdl-${id}`, id, 'bifrost-noatun', 'solid', 'uses'),
+  ),
+];
+
+const PLATFORM_EDGES: TopologyEdge[] = [
+  edge('plat-ting-volundr', 'ting-ymir', 'volundr-ymir', 'solid', 'manages'),
+  edge('plat-ting-research', 'ting-ymir', 'run-research', 'dashed-anim', 'manages'),
+  edge('plat-ting-coding', 'ting-ymir', 'run-coding', 'dashed-anim', 'manages'),
+  edge('plat-guild-ting', 'svc-guild', 'ting-ymir', 'soft', 'uses'),
+  edge('plat-keycloak', 'svc-keycloak', 'volundr-ymir', 'soft', 'uses'),
+  edge('plat-openbao', 'svc-openbao', 'volundr-ymir', 'soft', 'uses'),
+  edge('plat-warden', 'svc-warden-ymir', 'mimir-ymir', 'soft', 'observes'),
+  edge('plat-envoy', 'svc-envoy-noatun', 'volundr-noatun', 'solid', 'routes_to'),
+  edge('plat-sandbox', 'run-coding', 'svc-openshell', 'dashed-anim', 'uses'),
+  edge('plat-openclaw', 'svc-openclaw', 'svc-openshell', 'soft', 'uses'),
+  edge('plat-harvester', 'svc-harvester', 'svc-rancher', 'soft', 'manages'),
+  edge('plat-baldr', 'host-baldr', 'svc-harvester', 'soft', 'uses'),
+  edge('plat-frigg', 'host-frigg', 'svc-harvester', 'soft', 'uses'),
+  edge('plat-laevateinn', 'device-laevateinn', 'ravn-ivaldi', 'dashed-anim', 'signals_to'),
+  edge('plat-ovfarm', 'device-laevateinn', 'device-ovfarm', 'soft', 'observes'),
+  edge('plat-bambuddy', 'device-bambuddy', 'svc-spoolman', 'soft', 'uses'),
+  edge('plat-orca', 'device-bambuddy', 'svc-orca', 'soft', 'uses'),
+  edge('plat-plex', 'svc-plex', 'svc-arr', 'soft', 'uses'),
+];
+
+/** Telemetry from every cluster's mesh node lands on glitnir. */
+const OBSERVABILITY_EDGES: TopologyEdge[] = [
+  'svc-nats-valaskjalf',
+  'svc-nats-ymir',
+  'svc-nats-noatun',
+  'svc-nats-eitri',
+  'svc-nats-jarnvidr',
+].map((id) => edge(`obs-${id}`, id, 'svc-tempo', 'soft', 'observes'));
+
+/** NATS peers the clusters with each other — a mesh, not a hub. */
+const MESH_EDGES: TopologyEdge[] = [
+  ['svc-nats-valaskjalf', 'svc-nats-ymir'],
+  ['svc-nats-ymir', 'svc-nats-glitnir'],
+  ['svc-nats-glitnir', 'svc-nats-eitri'],
+  ['svc-nats-eitri', 'svc-nats-noatun'],
+  ['svc-nats-noatun', 'svc-nats-valaskjalf'],
+  ['svc-nats-jarnvidr', 'svc-nats-ymir'],
+].map(([a, b], i) => edge(`mesh-${i}`, a as string, b as string, 'solid', 'member_of'));
+
+/** Residents that share a mesh peer directly. */
+const AGENT_MESH_EDGES: TopologyEdge[] = [
+  ['ravn-huginn', 'ravn-eldhrimnir'],
+  ['ravn-muninn', 'ravn-kvasir'],
+  ['ravn-kvasir', 'ravn-forseti'],
+  ['ravn-forseti', 'ravn-freyja'],
+  ['ravn-freyja', 'ravn-vidar'],
+  ['ravn-ivaldi', 'ravn-angrboda'],
+  ['ravn-angrboda', 'ravn-njord'],
+].map(([a, b], i) => edge(`amesh-${i}`, a as string, b as string, 'run', 'member_of'));
+
+export const SEED_EDGES: TopologyEdge[] = [
+  ...MEMORY_EDGES,
+  ...MODEL_EDGES,
+  ...PLATFORM_EDGES,
+  ...OBSERVABILITY_EDGES,
+  ...MESH_EDGES,
+  ...AGENT_MESH_EDGES,
+];
+
+export const SEED_TOPOLOGY: Topology = {
+  nodes: SEED_NODES,
+  edges: SEED_EDGES,
+  timestamp: TIMESTAMP,
+  layoutHints: { mode: 'hybrid', scope: 'world' },
+};

--- a/web-next/packages/plugin-observatory/src/application/useObservatoryStore.test.ts
+++ b/web-next/packages/plugin-observatory/src/application/useObservatoryStore.test.ts
@@ -22,7 +22,7 @@ describe('useObservatoryStore', () => {
 
     const { result } = renderHook(() => useObservatoryStore());
 
-    expect(result.current[0]).toEqual({ selectedId: null, filter: 'all' });
+    expect(result.current[0]).toEqual({ selectedId: null, filter: 'all', hiddenLayers: new Set() });
 
     act(() => {
       store.setSelected('agent-1');
@@ -31,9 +31,57 @@ describe('useObservatoryStore', () => {
       store.setFilter('agents');
     });
 
-    expect(result.current[0]).toEqual({ selectedId: 'agent-1', filter: 'agents' });
+    expect(result.current[0]).toEqual({
+      selectedId: 'agent-1',
+      filter: 'agents',
+      hiddenLayers: new Set(),
+    });
     expect(notify).toHaveBeenCalledTimes(2);
 
     unsubscribe();
+  });
+});
+
+describe('layer visibility', () => {
+  beforeEach(() => {
+    __resetObservatoryStore();
+  });
+
+  it('starts with every layer shown', () => {
+    expect(getObservatoryStore().read().hiddenLayers.size).toBe(0);
+  });
+
+  it('toggles a layer off and back on', () => {
+    const store = getObservatoryStore();
+    store.toggleLayer('memory');
+    expect(store.read().hiddenLayers.has('memory')).toBe(true);
+    store.toggleLayer('memory');
+    expect(store.read().hiddenLayers.has('memory')).toBe(false);
+  });
+
+  it('notifies subscribers on every layer change', () => {
+    const store = getObservatoryStore();
+    let calls = 0;
+    const unsubscribe = store.subscribe(() => (calls += 1));
+    store.toggleLayer('mesh');
+    store.toggleLayer('inference');
+    unsubscribe();
+    expect(calls).toBe(2);
+  });
+
+  it('replaces the whole hidden set', () => {
+    const store = getObservatoryStore();
+    store.setHiddenLayers(new Set(['mesh', 'memory']));
+    expect(store.read().hiddenLayers.size).toBe(2);
+    store.setHiddenLayers(new Set());
+    expect(store.read().hiddenLayers.size).toBe(0);
+  });
+
+  it('copies the incoming set so later mutation cannot leak in', () => {
+    const store = getObservatoryStore();
+    const incoming = new Set<'mesh'>(['mesh']);
+    store.setHiddenLayers(incoming);
+    incoming.clear();
+    expect(store.read().hiddenLayers.has('mesh')).toBe(true);
   });
 });

--- a/web-next/packages/plugin-observatory/src/application/useObservatoryStore.ts
+++ b/web-next/packages/plugin-observatory/src/application/useObservatoryStore.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from 'react';
+import type { EdgeLayer } from '../domain/edgeLayer';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -7,12 +8,16 @@ export type ObservatoryFilter = 'all' | 'agents' | 'runs' | 'services' | 'device
 interface ObservatoryStoreState {
   selectedId: string | null;
   filter: ObservatoryFilter;
+  /** Layers the operator has switched off. Empty means everything is shown. */
+  hiddenLayers: ReadonlySet<EdgeLayer>;
 }
 
 interface ObservatoryStore {
   read(): ObservatoryStoreState;
   setSelected(id: string | null): void;
   setFilter(filter: ObservatoryFilter): void;
+  toggleLayer(layer: EdgeLayer): void;
+  setHiddenLayers(layers: ReadonlySet<EdgeLayer>): void;
   subscribe(fn: () => void): () => void;
 }
 
@@ -26,7 +31,11 @@ export function getObservatoryStore(): ObservatoryStore {
   if (_store) return _store;
 
   const subscribers = new Set<() => void>();
-  let state: ObservatoryStoreState = { selectedId: null, filter: 'all' };
+  let state: ObservatoryStoreState = {
+    selectedId: null,
+    filter: 'all',
+    hiddenLayers: new Set<EdgeLayer>(),
+  };
 
   _store = {
     read(): ObservatoryStoreState {
@@ -40,6 +49,17 @@ export function getObservatoryStore(): ObservatoryStore {
     setFilter(filter: ObservatoryFilter): void {
       if (state.filter === filter) return;
       state = { ...state, filter };
+      subscribers.forEach((fn) => fn());
+    },
+    toggleLayer(layer: EdgeLayer): void {
+      const next = new Set(state.hiddenLayers);
+      if (next.has(layer)) next.delete(layer);
+      else next.add(layer);
+      state = { ...state, hiddenLayers: next };
+      subscribers.forEach((fn) => fn());
+    },
+    setHiddenLayers(layers: ReadonlySet<EdgeLayer>): void {
+      state = { ...state, hiddenLayers: new Set(layers) };
       subscribers.forEach((fn) => fn());
     },
     subscribe(fn: () => void): () => void {

--- a/web-next/packages/plugin-observatory/src/domain/agentMesh.test.ts
+++ b/web-next/packages/plugin-observatory/src/domain/agentMesh.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { deriveAgentMeshes, findMeshForNode, isMeshMember } from './agentMesh';
+import type { Topology, TopologyNode } from './index';
+
+function node(id: string, typeId: string, flockId?: string): TopologyNode {
+  return { id, typeId, label: id, parentId: null, status: 'healthy', flockId };
+}
+
+function topology(nodes: TopologyNode[]): Topology {
+  return { nodes, edges: [], timestamp: '2026-08-01T00:00:00Z' };
+}
+
+describe('isMeshMember', () => {
+  it('accepts agent types carrying a flock id', () => {
+    expect(isMeshMember(node('a', 'ravn_long', 'forge'))).toBe(true);
+    expect(isMeshMember(node('b', 'valkyrie', 'forge'))).toBe(true);
+    expect(isMeshMember(node('c', 'ravn_run', 'run-1'))).toBe(true);
+    expect(isMeshMember(node('d', 'run', 'run-1'))).toBe(true);
+  });
+
+  it('rejects an agent with no flock id', () => {
+    expect(isMeshMember(node('a', 'ravn_long'))).toBe(false);
+    expect(isMeshMember(node('a', 'ravn_long', ''))).toBe(false);
+  });
+
+  it('rejects infrastructure even when it carries a flock id', () => {
+    expect(isMeshMember(node('h', 'host', 'forge'))).toBe(false);
+    expect(isMeshMember(node('m', 'mimir', 'forge'))).toBe(false);
+  });
+});
+
+describe('deriveAgentMeshes', () => {
+  it('groups agents that share a flock id', () => {
+    const meshes = deriveAgentMeshes(
+      topology([
+        node('huginn', 'ravn_long', 'forge'),
+        node('muninn', 'ravn_long', 'forge'),
+        node('kvasir', 'ravn_long', 'ops'),
+        node('forseti', 'ravn_long', 'ops'),
+      ]),
+    );
+    expect(meshes).toEqual([
+      { id: 'forge', memberIds: ['huginn', 'muninn'] },
+      { id: 'ops', memberIds: ['kvasir', 'forseti'] },
+    ]);
+  });
+
+  it('drops a lone agent — one member is not a collaboration', () => {
+    const meshes = deriveAgentMeshes(
+      topology([
+        node('solo', 'ravn_long', 'alone'),
+        node('a', 'ravn_long', 'pair'),
+        node('b', 'ravn_long', 'pair'),
+      ]),
+    );
+    expect(meshes.map((m) => m.id)).toEqual(['pair']);
+  });
+
+  it('ignores nodes that cannot be members', () => {
+    const meshes = deriveAgentMeshes(
+      topology([
+        node('a', 'ravn_long', 'forge'),
+        node('b', 'ravn_long', 'forge'),
+        node('h', 'host', 'forge'),
+        node('s', 'service'),
+      ]),
+    );
+    expect(meshes).toEqual([{ id: 'forge', memberIds: ['a', 'b'] }]);
+  });
+
+  it('preserves topology order so the hull does not shuffle between frames', () => {
+    const first = deriveAgentMeshes(
+      topology([
+        node('z', 'ravn_long', 'm'),
+        node('a', 'ravn_long', 'm'),
+        node('k', 'ravn_long', 'm'),
+      ]),
+    );
+    expect(first[0]?.memberIds).toEqual(['z', 'a', 'k']);
+  });
+
+  it('returns nothing for an absent or empty topology', () => {
+    expect(deriveAgentMeshes(null)).toEqual([]);
+    expect(deriveAgentMeshes(topology([]))).toEqual([]);
+  });
+});
+
+describe('findMeshForNode', () => {
+  const meshes = [
+    { id: 'forge', memberIds: ['a', 'b'] },
+    { id: 'ops', memberIds: ['c', 'd'] },
+  ];
+
+  it('finds the mesh containing a node', () => {
+    expect(findMeshForNode(meshes, 'c')?.id).toBe('ops');
+  });
+
+  it('returns null for a non-member or no selection', () => {
+    expect(findMeshForNode(meshes, 'zzz')).toBeNull();
+    expect(findMeshForNode(meshes, null)).toBeNull();
+  });
+});

--- a/web-next/packages/plugin-observatory/src/domain/agentMesh.ts
+++ b/web-next/packages/plugin-observatory/src/domain/agentMesh.ts
@@ -1,0 +1,63 @@
+/**
+ * Agent meshes — the groups of long-lived agents that collaborate directly.
+ *
+ * Membership is already carried on the topology as `flockId`; nothing derived
+ * it into a first-class group before. A mesh is not a container: its members
+ * are scattered across clusters and realms, which is precisely the point —
+ * a finding by one member becomes evidence for the others.
+ */
+
+import type { Topology, TopologyNode } from './index';
+
+/** Node types that participate in an agent mesh. */
+const MESH_MEMBER_TYPES: ReadonlySet<string> = new Set([
+  'ravn_long',
+  'valkyrie',
+  'ravn_run',
+  'run',
+]);
+
+export interface AgentMesh {
+  /** The `flockId` shared by every member. */
+  id: string;
+  /** Member node ids, in stable topology order. */
+  memberIds: string[];
+}
+
+/** True when a node can belong to an agent mesh. */
+export function isMeshMember(node: TopologyNode): boolean {
+  return MESH_MEMBER_TYPES.has(node.typeId) && !!node.flockId;
+}
+
+/**
+ * Group agent nodes by `flockId`.
+ *
+ * A single-member group is dropped: one agent on its own is not a mesh, and
+ * drawing a hull around it would imply a collaboration that does not exist.
+ * Order is stable so the rendered hull does not shuffle between frames.
+ */
+export function deriveAgentMeshes(topology: Topology | null): AgentMesh[] {
+  if (!topology) return [];
+
+  const byFlock = new Map<string, string[]>();
+  for (const node of topology.nodes) {
+    if (!isMeshMember(node)) continue;
+    const flockId = node.flockId as string;
+    const members = byFlock.get(flockId);
+    if (members) members.push(node.id);
+    else byFlock.set(flockId, [node.id]);
+  }
+
+  const meshes: AgentMesh[] = [];
+  for (const [id, memberIds] of byFlock) {
+    if (memberIds.length < 2) continue;
+    meshes.push({ id, memberIds });
+  }
+  return meshes;
+}
+
+/** The mesh a given node belongs to, if any. */
+export function findMeshForNode(meshes: AgentMesh[], nodeId: string | null): AgentMesh | null {
+  if (!nodeId) return null;
+  return meshes.find((mesh) => mesh.memberIds.includes(nodeId)) ?? null;
+}

--- a/web-next/packages/plugin-observatory/src/domain/edgeLayer.test.ts
+++ b/web-next/packages/plugin-observatory/src/domain/edgeLayer.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EDGE_LAYERS,
+  EDGE_LAYER_LABELS,
+  countEdgesByLayer,
+  edgeLayer,
+  visibleEdges,
+} from './edgeLayer';
+import type { EdgeLayer } from './edgeLayer';
+import type { EdgeRelationType, TopologyEdge } from './index';
+
+const ALL_RELATIONS: EdgeRelationType[] = [
+  'contains',
+  'manages',
+  'uses',
+  'reads',
+  'writes',
+  'routes_to',
+  'exposes',
+  'observes',
+  'signals_to',
+  'member_of',
+];
+
+function edge(relationType?: EdgeRelationType): TopologyEdge {
+  return {
+    id: `e-${relationType ?? 'none'}`,
+    sourceId: 'a',
+    targetId: 'b',
+    kind: 'solid',
+    relationType,
+  };
+}
+
+describe('edgeLayer', () => {
+  it('assigns a layer to every relation in the taxonomy', () => {
+    for (const relation of ALL_RELATIONS) {
+      expect(EDGE_LAYERS).toContain(edgeLayer(edge(relation)));
+    }
+  });
+
+  it('groups the relations by the question they answer', () => {
+    expect(edgeLayer(edge('member_of'))).toBe('mesh');
+    expect(edgeLayer(edge('reads'))).toBe('memory');
+    expect(edgeLayer(edge('writes'))).toBe('memory');
+    expect(edgeLayer(edge('routes_to'))).toBe('inference');
+    expect(edgeLayer(edge('observes'))).toBe('observability');
+    expect(edgeLayer(edge('signals_to'))).toBe('signals');
+    expect(edgeLayer(edge('manages'))).toBe('platform');
+  });
+
+  it('treats an undeclared relation as platform wiring rather than hiding it', () => {
+    expect(edgeLayer(edge(undefined))).toBe('platform');
+  });
+
+  it('labels every layer', () => {
+    for (const layer of EDGE_LAYERS) {
+      expect(EDGE_LAYER_LABELS[layer]).toBeTruthy();
+    }
+  });
+});
+
+describe('visibleEdges', () => {
+  const edges = [edge('member_of'), edge('writes'), edge('routes_to'), edge('manages')];
+
+  it('returns everything when nothing is hidden', () => {
+    expect(visibleEdges(edges, new Set())).toHaveLength(edges.length);
+  });
+
+  it('drops only the hidden layers', () => {
+    const hidden = new Set<EdgeLayer>(['memory']);
+    const shown = visibleEdges(edges, hidden);
+    expect(shown.map((e) => e.relationType)).toEqual(['member_of', 'routes_to', 'manages']);
+  });
+
+  it('can hide everything', () => {
+    expect(visibleEdges(edges, new Set(EDGE_LAYERS))).toEqual([]);
+  });
+
+  it('does not mutate the input', () => {
+    const before = edges.length;
+    visibleEdges(edges, new Set<EdgeLayer>(['mesh']));
+    expect(edges).toHaveLength(before);
+  });
+});
+
+describe('countEdgesByLayer', () => {
+  it('counts each layer and reports zero for the empty ones', () => {
+    const counts = countEdgesByLayer([edge('member_of'), edge('reads'), edge('writes')]);
+    expect(counts.mesh).toBe(1);
+    expect(counts.memory).toBe(2);
+    expect(counts.inference).toBe(0);
+    expect(counts.signals).toBe(0);
+  });
+
+  it('returns a zero for every layer given no edges', () => {
+    const counts = countEdgesByLayer([]);
+    for (const layer of EDGE_LAYERS) expect(counts[layer]).toBe(0);
+  });
+});

--- a/web-next/packages/plugin-observatory/src/domain/edgeLayer.ts
+++ b/web-next/packages/plugin-observatory/src/domain/edgeLayer.ts
@@ -1,0 +1,79 @@
+/**
+ * Edge layers — the readable groupings of the relationship taxonomy.
+ *
+ * `EdgeRelationType` has ten values, which is too many to expose as ten
+ * toggles. They collapse into six layers that answer distinct questions:
+ * who collaborates, what remembers, what runs inference, what holds the
+ * platform together, what watches it, and what the physical world reports.
+ *
+ * The mapping is exhaustive over EdgeRelationType, so a relation added to the
+ * domain must be placed in a layer here or the compiler rejects it.
+ */
+
+import type { EdgeRelationType, TopologyEdge } from './index';
+
+export type EdgeLayer = 'mesh' | 'memory' | 'inference' | 'platform' | 'observability' | 'signals';
+
+export const EDGE_LAYERS: readonly EdgeLayer[] = [
+  'mesh',
+  'memory',
+  'inference',
+  'platform',
+  'observability',
+  'signals',
+] as const;
+
+export const EDGE_LAYER_LABELS: Readonly<Record<EdgeLayer, string>> = {
+  mesh: 'Agent mesh',
+  memory: 'Mímir memory',
+  inference: 'Model calls',
+  platform: 'Platform',
+  observability: 'Telemetry',
+  signals: 'Signals',
+};
+
+const RELATION_LAYER: Readonly<Record<EdgeRelationType, EdgeLayer>> = {
+  member_of: 'mesh',
+  reads: 'memory',
+  writes: 'memory',
+  routes_to: 'inference',
+  observes: 'observability',
+  signals_to: 'signals',
+  contains: 'platform',
+  manages: 'platform',
+  uses: 'platform',
+  exposes: 'platform',
+};
+
+/**
+ * The layer an edge belongs to.
+ *
+ * An edge with no declared relation is platform wiring: that is what the
+ * majority of undeclared structural links turn out to be, and hiding them
+ * behind a layer nobody enables would make them silently invisible.
+ */
+export function edgeLayer(edge: Pick<TopologyEdge, 'relationType'>): EdgeLayer {
+  if (!edge.relationType) return 'platform';
+  return RELATION_LAYER[edge.relationType];
+}
+
+/** Edges surviving the current layer filter. */
+export function visibleEdges<T extends Pick<TopologyEdge, 'relationType'>>(
+  edges: readonly T[],
+  hiddenLayers: ReadonlySet<EdgeLayer>,
+): T[] {
+  if (hiddenLayers.size === 0) return [...edges];
+  return edges.filter((edge) => !hiddenLayers.has(edgeLayer(edge)));
+}
+
+/** How many edges sit in each layer, for the filter counts. */
+export function countEdgesByLayer(
+  edges: readonly Pick<TopologyEdge, 'relationType'>[],
+): Record<EdgeLayer, number> {
+  const counts = Object.fromEntries(EDGE_LAYERS.map((layer) => [layer, 0])) as Record<
+    EdgeLayer,
+    number
+  >;
+  for (const edge of edges) counts[edgeLayer(edge)] += 1;
+  return counts;
+}

--- a/web-next/packages/plugin-observatory/src/domain/index.ts
+++ b/web-next/packages/plugin-observatory/src/domain/index.ts
@@ -26,6 +26,14 @@ export type {
 export { findAgentTopologyNode } from './agentDirectory';
 export type { AgentMesh } from './agentMesh';
 export { deriveAgentMeshes, findMeshForNode, isMeshMember } from './agentMesh';
+export type { EdgeLayer } from './edgeLayer';
+export {
+  EDGE_LAYERS,
+  EDGE_LAYER_LABELS,
+  edgeLayer,
+  visibleEdges,
+  countEdgesByLayer,
+} from './edgeLayer';
 
 // Re-export shared primitives so consumers can import from a single package.
 export type { EntityShape, EntityCategory, TypeRegistry } from '@niuulabs/domain';

--- a/web-next/packages/plugin-observatory/src/domain/index.ts
+++ b/web-next/packages/plugin-observatory/src/domain/index.ts
@@ -228,12 +228,56 @@ export interface TopologyEdge {
   evidence?: Record<string, string>;
 }
 
-/** Point-in-time snapshot of the live topology graph. */
+/** How a source's fragment reached the aggregator. */
+export type SourceTransport = 'pull' | 'push' | 'local' | 'static';
+
+/**
+ * Reachability of one contributing source.
+ *
+ * `stale` is distinct from `failed`: the source was reachable and simply has
+ * not reported within its TTL — a different operator situation from one that
+ * cannot be reached at all.
+ */
+export type SourceStatus = 'healthy' | 'degraded' | 'stale' | 'failed';
+
+/** Per-source health reported alongside the merged graph. */
+export interface TopologySourceHealth {
+  sourceId: string;
+  sourceKind?: string;
+  sourceName?: string;
+  transport?: SourceTransport;
+  status: SourceStatus;
+  clusterId?: string;
+  realmId?: string;
+  revision?: string;
+  nodeCount?: number;
+  lastSeen?: string;
+  message?: string;
+}
+
+/** A degradation that did not stop the snapshot being served. */
+export interface TopologyWarning {
+  sourceId?: string;
+  code?: string;
+  message?: string;
+}
+
+/**
+ * Point-in-time snapshot of the live topology graph.
+ *
+ * When the snapshot comes from the Guild aggregate it also reports how
+ * complete it is. That matters: without `sources` and `partial`, an estate
+ * where half the clusters are unreachable looks exactly like a small estate.
+ */
 export interface Topology {
   nodes: TopologyNode[];
   edges: TopologyEdge[];
   timestamp: string;
   layoutHints?: LayoutHints;
+  revision?: string;
+  sources?: TopologySourceHealth[];
+  warnings?: TopologyWarning[];
+  partial?: boolean;
 }
 
 // ── Event log ─────────────────────────────────────────────────────────────────

--- a/web-next/packages/plugin-observatory/src/domain/index.ts
+++ b/web-next/packages/plugin-observatory/src/domain/index.ts
@@ -24,6 +24,8 @@ export type {
   AgentDirectoryFilters,
 } from './agentDirectory';
 export { findAgentTopologyNode } from './agentDirectory';
+export type { AgentMesh } from './agentMesh';
+export { deriveAgentMeshes, findMeshForNode, isMeshMember } from './agentMesh';
 
 // Re-export shared primitives so consumers can import from a single package.
 export type { EntityShape, EntityCategory, TypeRegistry } from '@niuulabs/domain';

--- a/web-next/packages/plugin-observatory/src/index.tsx
+++ b/web-next/packages/plugin-observatory/src/index.tsx
@@ -31,6 +31,7 @@ export const observatoryPlugin = definePlugin({
 });
 
 export {
+  createMockAgentDirectory,
   createMockRegistryRepository,
   createMockTopologyStream,
   createMockEventStream,

--- a/web-next/packages/plugin-observatory/src/index.tsx
+++ b/web-next/packages/plugin-observatory/src/index.tsx
@@ -50,6 +50,7 @@ export type {
 } from './ports';
 export { AgentCardPanel } from './ui/overlays/AgentCardPanel';
 export { LayerFilterBar } from './ui/LayerFilterBar';
+export { CollapsibleSection } from './ui/CollapsibleSection';
 export { useAgent, useAgents } from './application/useAgents';
 export type {
   EntityType,

--- a/web-next/packages/plugin-observatory/src/index.tsx
+++ b/web-next/packages/plugin-observatory/src/index.tsx
@@ -49,6 +49,7 @@ export type {
   IAgentDirectory,
 } from './ports';
 export { AgentCardPanel } from './ui/overlays/AgentCardPanel';
+export { LayerFilterBar } from './ui/LayerFilterBar';
 export { useAgent, useAgents } from './application/useAgents';
 export type {
   EntityType,

--- a/web-next/packages/plugin-observatory/src/index.tsx
+++ b/web-next/packages/plugin-observatory/src/index.tsx
@@ -38,6 +38,7 @@ export {
 } from './adapters/mock';
 export {
   buildObservatoryRegistryHttpAdapter,
+  buildObservatoryTopologyAggregateAdapter,
   buildObservatoryTopologySseStream,
   buildObservatoryEventsSseStream,
   buildObservatoryAgentDirectoryHttpAdapter,

--- a/web-next/packages/plugin-observatory/src/index.tsx
+++ b/web-next/packages/plugin-observatory/src/index.tsx
@@ -48,6 +48,7 @@ export type {
   IEventStream,
   IAgentDirectory,
 } from './ports';
+export { AgentCardPanel } from './ui/overlays/AgentCardPanel';
 export { useAgent, useAgents } from './application/useAgents';
 export type {
   EntityType,

--- a/web-next/packages/plugin-observatory/src/ui/CollapsibleSection.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/CollapsibleSection.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { CollapsibleSection } from './CollapsibleSection';
+
+function renderSection(props: Partial<Parameters<typeof CollapsibleSection>[0]> = {}) {
+  return render(
+    <CollapsibleSection title="Realms" testId="realms" {...props}>
+      <button data-testid="child">asgard</button>
+    </CollapsibleSection>,
+  );
+}
+
+describe('CollapsibleSection', () => {
+  it('renders the title and its children', () => {
+    renderSection();
+    expect(screen.getByText('Realms')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('is open by default', () => {
+    renderSection();
+    expect(screen.getByTestId('subnav-section-realms')).toHaveAttribute('open');
+  });
+
+  it('can start collapsed', () => {
+    renderSection({ defaultOpen: false });
+    expect(screen.getByTestId('subnav-section-realms')).not.toHaveAttribute('open');
+  });
+
+  it('collapses and expands when the header is activated', () => {
+    renderSection();
+    const section = screen.getByTestId('subnav-section-realms') as HTMLDetailsElement;
+    const toggle = screen.getByTestId('subnav-toggle-realms');
+
+    fireEvent.click(toggle);
+    expect(section.open).toBe(false);
+
+    fireEvent.click(toggle);
+    expect(section.open).toBe(true);
+  });
+
+  it('renders meta content beside the title', () => {
+    renderSection({ meta: <span data-testid="meta">5</span> });
+    expect(screen.getByTestId('meta')).toHaveTextContent('5');
+  });
+
+  it('uses a summary so disclosure semantics come from the element', () => {
+    renderSection();
+    expect(screen.getByTestId('subnav-toggle-realms').tagName).toBe('SUMMARY');
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/CollapsibleSection.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/CollapsibleSection.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react';
+
+export interface CollapsibleSectionProps {
+  title: string;
+  /** Right-aligned count or hint shown beside the title. */
+  meta?: ReactNode;
+  /** Suffix for the section's test id. */
+  testId: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * A collapsible rail section.
+ *
+ * Built on <details>/<summary> so keyboard operation, the disclosure role and
+ * screen-reader expanded state come from the element rather than being
+ * re-implemented with aria attributes and key handlers.
+ */
+export function CollapsibleSection({
+  title,
+  meta,
+  testId,
+  defaultOpen = true,
+  children,
+}: CollapsibleSectionProps) {
+  return (
+    <details
+      className="obs-subnav__section"
+      data-testid={`subnav-section-${testId}`}
+      open={defaultOpen}
+    >
+      <summary className="obs-subnav__label" data-testid={`subnav-toggle-${testId}`}>
+        <span className="obs-subnav__chevron" aria-hidden="true" />
+        <span className="obs-subnav__label-text">{title}</span>
+        {meta}
+      </summary>
+      {children}
+    </details>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/LayerFilterBar.css
+++ b/web-next/packages/plugin-observatory/src/ui/LayerFilterBar.css
@@ -1,0 +1,86 @@
+/* ── Connection-layer toggles — a strip above the topology canvas ── */
+.obs-layer-filter {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border-subtle);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.obs-layer-filter::-webkit-scrollbar {
+  display: none;
+}
+
+.obs-layer-filter__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: none;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs, 0.625rem);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color 130ms ease,
+    border-color 130ms ease,
+    opacity 130ms ease;
+}
+
+.obs-layer-filter__chip:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-faint);
+}
+
+.obs-layer-filter__chip:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 1px;
+}
+
+.obs-layer-filter__chip[aria-pressed='true'] {
+  color: var(--color-text-primary);
+  border-color: var(--color-brand);
+}
+
+/* A disabled layer stays legible but clearly out of play. */
+.obs-layer-filter__chip[aria-pressed='false'] {
+  opacity: 0.4;
+}
+
+.obs-layer-filter__chip--action:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
+.obs-layer-filter__count {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-faint);
+}
+
+.obs-layer-filter__swatch {
+  width: 0.875rem;
+  height: 0;
+  border-top: 2px solid currentColor;
+  flex: none;
+}
+
+.obs-layer-filter__swatch--memory {
+  border-top-style: dotted;
+}
+
+.obs-layer-filter__swatch--observability {
+  border-top-style: dashed;
+}
+
+.obs-layer-filter__swatch--signals {
+  border-top-style: dashed;
+}

--- a/web-next/packages/plugin-observatory/src/ui/LayerFilterBar.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/LayerFilterBar.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LayerFilterBar } from './LayerFilterBar';
+import { __resetObservatoryStore, getObservatoryStore } from '../application/useObservatoryStore';
+import { EDGE_LAYERS } from '../domain';
+import type { Topology } from '../domain';
+
+const TOPOLOGY: Topology = {
+  timestamp: '2026-08-01T12:00:00Z',
+  nodes: [],
+  edges: [
+    { id: 'a', sourceId: '1', targetId: '2', kind: 'run', relationType: 'member_of' },
+    { id: 'b', sourceId: '1', targetId: '3', kind: 'dashed-long', relationType: 'writes' },
+    { id: 'c', sourceId: '1', targetId: '4', kind: 'dashed-long', relationType: 'reads' },
+    { id: 'd', sourceId: '1', targetId: '5', kind: 'solid', relationType: 'routes_to' },
+    { id: 'e', sourceId: '1', targetId: '6', kind: 'soft' },
+  ],
+};
+
+beforeEach(() => {
+  __resetObservatoryStore();
+});
+
+describe('LayerFilterBar', () => {
+  it('renders a toggle for every layer', () => {
+    render(<LayerFilterBar topology={TOPOLOGY} />);
+    for (const layer of EDGE_LAYERS) {
+      expect(screen.getByTestId(`layer-toggle-${layer}`)).toBeInTheDocument();
+    }
+  });
+
+  it('counts the edges in each layer from the live topology', () => {
+    render(<LayerFilterBar topology={TOPOLOGY} />);
+    expect(screen.getByTestId('layer-toggle-memory')).toHaveTextContent('2');
+    expect(screen.getByTestId('layer-toggle-mesh')).toHaveTextContent('1');
+    // The relation-less edge falls to platform rather than vanishing.
+    expect(screen.getByTestId('layer-toggle-platform')).toHaveTextContent('1');
+  });
+
+  it('shows a zero for a layer with no edges rather than omitting it', () => {
+    render(<LayerFilterBar topology={TOPOLOGY} />);
+    expect(screen.getByTestId('layer-toggle-signals')).toHaveTextContent('0');
+  });
+
+  it('starts with every layer shown', () => {
+    render(<LayerFilterBar topology={TOPOLOGY} />);
+    for (const layer of EDGE_LAYERS) {
+      expect(screen.getByTestId(`layer-toggle-${layer}`)).toHaveAttribute('aria-pressed', 'true');
+    }
+  });
+
+  it('toggles a layer off and back on', () => {
+    render(<LayerFilterBar topology={TOPOLOGY} />);
+    const chip = screen.getByTestId('layer-toggle-memory');
+
+    fireEvent.click(chip);
+    expect(chip).toHaveAttribute('aria-pressed', 'false');
+    expect(getObservatoryStore().read().hiddenLayers.has('memory')).toBe(true);
+
+    fireEvent.click(chip);
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+    expect(getObservatoryStore().read().hiddenLayers.has('memory')).toBe(false);
+  });
+
+  it('leaves other layers untouched when one is toggled', () => {
+    render(<LayerFilterBar topology={TOPOLOGY} />);
+    fireEvent.click(screen.getByTestId('layer-toggle-memory'));
+    expect(screen.getByTestId('layer-toggle-mesh')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('restores everything with show all', () => {
+    render(<LayerFilterBar topology={TOPOLOGY} />);
+    fireEvent.click(screen.getByTestId('layer-toggle-memory'));
+    fireEvent.click(screen.getByTestId('layer-toggle-mesh'));
+
+    const showAll = screen.getByTestId('layer-toggle-all');
+    expect(showAll).not.toBeDisabled();
+    fireEvent.click(showAll);
+
+    expect(getObservatoryStore().read().hiddenLayers.size).toBe(0);
+    expect(showAll).toBeDisabled();
+  });
+
+  it('disables show all while nothing is hidden', () => {
+    render(<LayerFilterBar topology={TOPOLOGY} />);
+    expect(screen.getByTestId('layer-toggle-all')).toBeDisabled();
+  });
+
+  it('renders zero counts when there is no topology yet', () => {
+    render(<LayerFilterBar topology={null} />);
+    expect(screen.getByTestId('layer-toggle-mesh')).toHaveTextContent('0');
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/LayerFilterBar.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/LayerFilterBar.tsx
@@ -1,0 +1,56 @@
+import { useMemo } from 'react';
+import type { Topology } from '../domain';
+import { EDGE_LAYERS, EDGE_LAYER_LABELS, countEdgesByLayer } from '../domain';
+import { useObservatoryStore } from '../application/useObservatoryStore';
+import './LayerFilterBar.css';
+
+export interface LayerFilterBarProps {
+  topology: Topology | null;
+}
+
+/**
+ * Toggles for the connection layers.
+ *
+ * The topology carries far more relationships than can be read at once, so the
+ * operator needs to be able to put some down. Counts come from the live
+ * topology rather than being hard-coded, and a layer with no edges is still
+ * listed — its absence is information too.
+ */
+export function LayerFilterBar({ topology }: LayerFilterBarProps) {
+  const [{ hiddenLayers }, store] = useObservatoryStore();
+
+  const counts = useMemo(() => countEdgesByLayer(topology?.edges ?? []), [topology]);
+  const allShown = hiddenLayers.size === 0;
+
+  return (
+    <div className="obs-layer-filter" role="group" aria-label="Connection layers">
+      {EDGE_LAYERS.map((layer) => {
+        const shown = !hiddenLayers.has(layer);
+        return (
+          <button
+            key={layer}
+            type="button"
+            className="obs-layer-filter__chip"
+            data-testid={`layer-toggle-${layer}`}
+            aria-pressed={shown}
+            onClick={() => store.toggleLayer(layer)}
+          >
+            <span className={`obs-layer-filter__swatch obs-layer-filter__swatch--${layer}`} />
+            {EDGE_LAYER_LABELS[layer]}
+            <span className="obs-layer-filter__count">{counts[layer]}</span>
+          </button>
+        );
+      })}
+
+      <button
+        type="button"
+        className="obs-layer-filter__chip obs-layer-filter__chip--action"
+        data-testid="layer-toggle-all"
+        onClick={() => store.setHiddenLayers(new Set())}
+        disabled={allShown}
+      >
+        show all
+      </button>
+    </div>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.test.tsx
@@ -7,6 +7,7 @@ import {
   createMockTopologyStream,
   createMockEventStream,
   createMockRegistryRepository,
+  createMockAgentDirectory,
 } from '../adapters/mock';
 import { makeCtxMock } from './TopologyCanvas/test-helpers';
 import { __resetObservatoryStore } from '../application/useObservatoryStore';
@@ -29,6 +30,7 @@ function wrap(ui: React.ReactNode) {
           'observatory.topology': createMockTopologyStream(),
           'observatory.events': createMockEventStream(),
           'observatory.registry': createMockRegistryRepository(),
+          'observatory.agents': createMockAgentDirectory(),
         }}
       >
         {ui}

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -5,6 +5,7 @@ import { useObservatoryStore } from '../application/useObservatoryStore';
 import type { TopologyNode } from '../domain';
 import { TopologyCanvas } from './TopologyCanvas';
 import { EntityDrawer } from './overlays/EntityDrawer';
+import { AgentCardPanel } from './overlays/AgentCardPanel';
 import { EventLog } from './overlays/EventLog';
 import { ConnectionLegend } from './overlays/ConnectionLegend';
 import { humanizeObservatoryText } from './displayLabels';
@@ -76,6 +77,7 @@ export function ObservatoryPage() {
         registry={registry ?? null}
         onClose={handleDrawerClose}
         onNodeSelect={handleNodeSelect}
+        footer={<AgentCardPanel node={selectedNode} />}
       />
     </div>
   );

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -50,13 +50,31 @@ export function ObservatoryPage() {
     >
       <LayerFilterBar topology={topology} />
 
-      <TopologyCanvas
-        topology={topology}
-        onNodeClick={handleNodeClick}
-        selectedId={selectedId}
-        hiddenLayers={hiddenLayers}
-        className="niuu:flex-1 niuu:min-h-0"
-      />
+      {/*
+        Overlays are absolutely positioned, so they anchor to this stage rather
+        than the page — otherwise they cover the filter bar and swallow its
+        clicks.
+      */}
+      <div className="niuu:relative niuu:flex-1 niuu:min-h-0">
+        <TopologyCanvas
+          topology={topology}
+          onNodeClick={handleNodeClick}
+          selectedId={selectedId}
+          hiddenLayers={hiddenLayers}
+          className="niuu:absolute niuu:inset-0"
+        />
+
+        <ConnectionLegend topology={topology} registry={registry ?? null} />
+        <EventLog events={events} />
+        <EntityDrawer
+          node={selectedNode}
+          topology={topology}
+          registry={registry ?? null}
+          onClose={handleDrawerClose}
+          onNodeSelect={handleNodeSelect}
+          footer={<AgentCardPanel node={selectedNode} />}
+        />
+      </div>
 
       {/* Accessible hidden node list — keyboard / screen-reader alternative to canvas hit-testing */}
       <ul data-testid="topology-node-list" aria-label="Topology nodes" className="niuu:sr-only">
@@ -72,17 +90,6 @@ export function ObservatoryPage() {
           </li>
         ))}
       </ul>
-
-      <ConnectionLegend topology={topology} registry={registry ?? null} />
-      <EventLog events={events} />
-      <EntityDrawer
-        node={selectedNode}
-        topology={topology}
-        registry={registry ?? null}
-        onClose={handleDrawerClose}
-        onNodeSelect={handleNodeSelect}
-        footer={<AgentCardPanel node={selectedNode} />}
-      />
     </div>
   );
 }

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -49,6 +49,7 @@ export function ObservatoryPage() {
       <TopologyCanvas
         topology={topology}
         onNodeClick={handleNodeClick}
+        selectedId={selectedId}
         className="niuu:flex-1 niuu:min-h-0"
       />
 

--- a/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatoryPage.tsx
@@ -4,6 +4,7 @@ import { useRegistry } from '../application/useRegistry';
 import { useObservatoryStore } from '../application/useObservatoryStore';
 import type { TopologyNode } from '../domain';
 import { TopologyCanvas } from './TopologyCanvas';
+import { LayerFilterBar } from './LayerFilterBar';
 import { EntityDrawer } from './overlays/EntityDrawer';
 import { AgentCardPanel } from './overlays/AgentCardPanel';
 import { EventLog } from './overlays/EventLog';
@@ -25,7 +26,7 @@ export function ObservatoryPage() {
   const events = useEvents();
   const { data: registry } = useRegistry();
   const [storeState, store] = useObservatoryStore();
-  const { selectedId } = storeState;
+  const { selectedId, hiddenLayers } = storeState;
 
   const selectedNode: TopologyNode | null =
     selectedId && topology ? (topology.nodes.find((n) => n.id === selectedId) ?? null) : null;
@@ -47,10 +48,13 @@ export function ObservatoryPage() {
       data-testid="observatory-page"
       className="niuu:relative niuu:flex niuu:flex-col niuu:h-full niuu:overflow-hidden"
     >
+      <LayerFilterBar topology={topology} />
+
       <TopologyCanvas
         topology={topology}
         onNodeClick={handleNodeClick}
         selectedId={selectedId}
+        hiddenLayers={hiddenLayers}
         className="niuu:flex-1 niuu:min-h-0"
       />
 

--- a/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.css
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.css
@@ -94,3 +94,43 @@
   color: var(--color-text-muted);
   flex-shrink: 0;
 }
+
+/* ── Collapsible sections ──
+   The label is now a <summary>, so the marker is suppressed and replaced with
+   a chevron that reflects the element's own open state. */
+.obs-subnav__label {
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+
+.obs-subnav__label::-webkit-details-marker {
+  display: none;
+}
+
+.obs-subnav__label:hover {
+  color: var(--color-text-secondary);
+}
+
+.obs-subnav__label:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: -2px;
+}
+
+.obs-subnav__label-text {
+  flex: 1;
+}
+
+.obs-subnav__chevron {
+  width: 0.3125rem;
+  height: 0.3125rem;
+  flex: none;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform 160ms ease;
+}
+
+.obs-subnav__section[open] > .obs-subnav__label > .obs-subnav__chevron {
+  transform: rotate(45deg);
+}

--- a/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.test.tsx
@@ -257,3 +257,29 @@ describe('ObservatorySubnav', () => {
     expect(screen.getByTestId('cluster-cluster-selected')).toHaveAttribute('aria-pressed', 'true');
   });
 });
+
+describe('ObservatorySubnav collapsible sections', () => {
+  it('renders every rail section as a disclosure', () => {
+    render(<ObservatorySubnav />);
+    for (const id of ['filter', 'realms', 'clusters']) {
+      expect(screen.getByTestId(`subnav-section-${id}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`subnav-toggle-${id}`).tagName).toBe('SUMMARY');
+    }
+  });
+
+  it('opens every section by default', () => {
+    render(<ObservatorySubnav />);
+    for (const id of ['filter', 'realms', 'clusters']) {
+      expect(screen.getByTestId(`subnav-section-${id}`)).toHaveAttribute('open');
+    }
+  });
+
+  it('collapses a section without disturbing the others', () => {
+    render(<ObservatorySubnav />);
+    fireEvent.click(screen.getByTestId('subnav-toggle-realms'));
+
+    expect((screen.getByTestId('subnav-section-realms') as HTMLDetailsElement).open).toBe(false);
+    expect((screen.getByTestId('subnav-section-filter') as HTMLDetailsElement).open).toBe(true);
+    expect((screen.getByTestId('subnav-section-clusters') as HTMLDetailsElement).open).toBe(true);
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/ObservatorySubnav.tsx
@@ -3,6 +3,7 @@ import { useTopology } from '../application/useTopology';
 import { useObservatoryStore, type ObservatoryFilter } from '../application/useObservatoryStore';
 import type { TopologyNode } from '../domain';
 import './ObservatorySubnav.css';
+import { CollapsibleSection } from './CollapsibleSection';
 
 // ── Filter section config ─────────────────────────────────────────────────────
 
@@ -78,10 +79,11 @@ export function ObservatorySubnav() {
   return (
     <div className="obs-subnav" data-testid="observatory-subnav">
       {/* Section 1: Entity filter */}
-      <div className="obs-subnav__section">
-        <div className="obs-subnav__label">
-          Filter <span className="obs-subnav__label-dot">·</span>
-        </div>
+      <CollapsibleSection
+        title="Filter"
+        testId="filter"
+        meta={<span className="obs-subnav__label-dot">·</span>}
+      >
         {FILTER_ROWS.map((row) => {
           const count = row.count(nodes);
           const active = filter === row.id;
@@ -103,13 +105,14 @@ export function ObservatorySubnav() {
             </button>
           );
         })}
-      </div>
+      </CollapsibleSection>
 
       {/* Section 2: Realms */}
-      <div className="obs-subnav__section">
-        <div className="obs-subnav__label">
-          Realms <span className="obs-subnav__count">{realms.length}</span>
-        </div>
+      <CollapsibleSection
+        title="Realms"
+        testId="realms"
+        meta={<span className="obs-subnav__count">{realms.length}</span>}
+      >
         {realms.map((realm) => (
           <button
             key={realm.id}
@@ -132,13 +135,14 @@ export function ObservatorySubnav() {
             )}
           </button>
         ))}
-      </div>
+      </CollapsibleSection>
 
       {/* Section 3: Clusters + Active runs */}
-      <div className="obs-subnav__section">
-        <div className="obs-subnav__label">
-          Clusters <span className="obs-subnav__count">{clusters.length}</span>
-        </div>
+      <CollapsibleSection
+        title="Clusters"
+        testId="clusters"
+        meta={<span className="obs-subnav__count">{clusters.length}</span>}
+      >
         {clusters.map((cluster) => (
           <button
             key={cluster.id}
@@ -187,7 +191,7 @@ export function ObservatorySubnav() {
             })}
           </>
         )}
-      </div>
+      </CollapsibleSection>
     </div>
   );
 }

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.test.tsx
@@ -499,4 +499,63 @@ describe('TopologyCanvas', () => {
 
     expect(mainCtx.fillRect).not.toHaveBeenCalled();
   });
+
+  // ── Agent mesh ──────────────────────────────────────────────────────────────
+
+  const MESHED_TOPOLOGY: Topology = {
+    ...MOCK_TOPOLOGY,
+    nodes: [
+      ...MOCK_TOPOLOGY.nodes,
+      {
+        id: 'huginn',
+        typeId: 'ravn_long',
+        label: 'huginn',
+        parentId: 'cluster-vk',
+        status: 'healthy',
+        flockId: 'forge-mesh',
+      },
+      {
+        id: 'muninn',
+        typeId: 'ravn_long',
+        label: 'muninn',
+        parentId: 'cluster-vk',
+        status: 'healthy',
+        flockId: 'forge-mesh',
+      },
+      {
+        id: 'kvasir',
+        typeId: 'ravn_long',
+        label: 'kvasir',
+        parentId: 'cluster-vk',
+        status: 'healthy',
+        flockId: 'forge-mesh',
+      },
+    ],
+  };
+
+  function meshLabelDrawn(): boolean {
+    const calls = mainCtx.fillText.mock.calls as [string, ...unknown[]][];
+    return calls.some(([text]) => typeof text === 'string' && text.includes('FORGE-MESH'));
+  }
+
+  it('outlines no agent mesh while nothing is selected or hovered', async () => {
+    await renderCanvas(MESHED_TOPOLOGY);
+    runAnimationFrame();
+
+    expect(meshLabelDrawn()).toBe(false);
+  });
+
+  it('outlines the mesh of the selected member', async () => {
+    await renderCanvas(MESHED_TOPOLOGY, { selectedId: 'muninn' });
+    runAnimationFrame();
+
+    expect(meshLabelDrawn()).toBe(true);
+  });
+
+  it('outlines nothing when the selection is not a mesh member', async () => {
+    await renderCanvas(MESHED_TOPOLOGY, { selectedId: 'ting-0' });
+    runAnimationFrame();
+
+    expect(meshLabelDrawn()).toBe(false);
+  });
 });

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-library/react';
 import { TopologyCanvas } from './TopologyCanvas';
 import type { Topology } from '../../domain';
 import { makeCtxMock } from './test-helpers';
@@ -557,5 +557,52 @@ describe('TopologyCanvas', () => {
     runAnimationFrame();
 
     expect(meshLabelDrawn()).toBe(false);
+  });
+
+  // ── Layer filtering ─────────────────────────────────────────────────────────
+
+  const LAYERED_TOPOLOGY: Topology = {
+    ...MOCK_TOPOLOGY,
+    edges: [
+      {
+        id: 'l1',
+        sourceId: 'ting-0',
+        targetId: 'bifrost-0',
+        kind: 'solid',
+        relationType: 'manages',
+      },
+      {
+        id: 'l2',
+        sourceId: 'bifrost-0',
+        targetId: 'mimir-0',
+        kind: 'dashed-long',
+        relationType: 'writes',
+      },
+    ],
+  };
+
+  it('stops drawing a layer that has been hidden', async () => {
+    await renderCanvas(LAYERED_TOPOLOGY);
+    runAnimationFrame();
+    const withAll = mainCtx.stroke.mock.calls.length;
+    expect(withAll).toBeGreaterThan(0);
+
+    // Unmount first: a second render would leave both canvases drawing.
+    cleanup();
+    mainCtx.stroke.mockClear();
+    await renderCanvas(LAYERED_TOPOLOGY, {
+      hiddenLayers: new Set(['memory', 'platform'] as const),
+    });
+    runAnimationFrame();
+
+    expect(mainCtx.stroke.mock.calls.length).toBeLessThan(withAll);
+  });
+
+  it('keeps the layout identical when a layer is hidden', async () => {
+    const before = computeLayout(LAYERED_TOPOLOGY).get('ting-0');
+    await renderCanvas(LAYERED_TOPOLOGY, { hiddenLayers: new Set(['platform'] as const) });
+    runAnimationFrame();
+
+    expect(computeLayout(LAYERED_TOPOLOGY).get('ting-0')).toEqual(before);
   });
 });

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.test.tsx
@@ -271,7 +271,7 @@ describe('TopologyCanvas', () => {
     expect(pct).toBeLessThanOrEqual(300);
   });
 
-  it('zoom cannot go below ZOOM_MIN (30%)', () => {
+  it('zoom cannot go below ZOOM_MIN', () => {
     render(<TopologyCanvas topology={MOCK_TOPOLOGY} />);
     const zoomDisplay = screen.getByTestId('zoom-display');
     // Click zoom out many times
@@ -279,7 +279,9 @@ describe('TopologyCanvas', () => {
       fireEvent.click(screen.getByRole('button', { name: /zoom out/i }));
     }
     const pct = parseInt(zoomDisplay.textContent ?? '0', 10);
-    expect(pct).toBeGreaterThanOrEqual(30);
+    // Asserted from config: the floor is tuned to the size of the topology, so
+    // a literal here would have to be edited every time that changes.
+    expect(pct).toBeGreaterThanOrEqual(Math.round(CANVAS.ZOOM_MIN * 100));
   });
 
   it('calls onNodeClick when a node is clicked (via canvas click)', () => {

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.tsx
@@ -407,19 +407,19 @@ export function TopologyCanvas({
       ctx.translate(-cam.x, -cam.y);
 
       if (topo) {
-        drawZones(ctx, topo.nodes, pos, now);
+        drawZones(ctx, topo.nodes, pos, now, cam.zoom);
         drawEdges(ctx, topo, pos, now);
 
         // Draw hosts first (background layer), then other nodes
         for (const node of topo.nodes) {
           if (node.typeId !== 'host') continue;
           const p = pos.get(node.id);
-          if (p) drawNode(ctx, node, p, node.id === hoveredId);
+          if (p) drawNode(ctx, node, p, node.id === hoveredId, cam.zoom);
         }
         for (const node of topo.nodes) {
           if (node.typeId === 'host' || node.typeId === 'mimir') continue;
           const p = pos.get(node.id);
-          if (p) drawNode(ctx, node, p, node.id === hoveredId);
+          if (p) drawNode(ctx, node, p, node.id === hoveredId, cam.zoom);
         }
 
         // Mímir last (always on top)

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { zoom, zoomIdentity, type D3ZoomEvent, type ZoomBehavior } from 'd3-zoom';
 import type { Topology } from '../../domain';
+import { deriveAgentMeshes, findMeshForNode } from '../../domain/agentMesh';
 import {
   clampZoom,
   applyKeyPan,
@@ -12,6 +13,7 @@ import {
 } from './canvasMath';
 import { computeLayout, computeLayoutBounds, HOST_HALF_W, HOST_HALF_H } from './layoutEngine';
 import {
+  drawAgentMesh,
   drawStars,
   drawZones,
   drawEdges,
@@ -29,6 +31,8 @@ export interface TopologyCanvasProps {
   topology: Topology | null;
   /** Called when the user clicks a node. */
   onNodeClick?: (nodeId: string) => void;
+  /** Currently selected node — drives which agent mesh is outlined. */
+  selectedId?: string | null;
   /** Show the minimap panel (default true). */
   showMinimap?: boolean;
   /** Extra CSS class applied to the wrapper div. */
@@ -49,6 +53,7 @@ export interface TopologyCanvasProps {
 export function TopologyCanvas({
   topology,
   onNodeClick,
+  selectedId = null,
   showMinimap = true,
   className,
   style,
@@ -69,6 +74,7 @@ export function TopologyCanvas({
 
   // Compute layout whenever topology changes (memoised — pure function)
   const positions = useMemo(() => (topology ? computeLayout(topology) : new Map()), [topology]);
+  const agentMeshes = useMemo(() => deriveAgentMeshes(topology), [topology]);
   const topologySignature = useMemo(() => {
     if (!topology) return 'empty';
     return topology.nodes
@@ -79,11 +85,23 @@ export function TopologyCanvas({
 
   // Stable reference to drawing data so the rAF loop always reads fresh values
   // without being re-subscribed on every state tick.
-  const drawRef = useRef({ topology, positions, hoveredId: null as string | null });
+  const drawRef = useRef({
+    topology,
+    positions,
+    hoveredId: null as string | null,
+    agentMeshes,
+    selectedId,
+  });
 
   useEffect(() => {
-    drawRef.current = { topology, positions, hoveredId: hoveredIdRef.current };
-  }, [positions, topology]);
+    drawRef.current = {
+      topology,
+      positions,
+      hoveredId: hoveredIdRef.current,
+      agentMeshes,
+      selectedId,
+    };
+  }, [agentMeshes, positions, selectedId, topology]);
 
   const cameraToZoomTransform = useCallback((cam: Camera) => {
     const { w, h } = sizeRef.current;
@@ -408,6 +426,20 @@ export function TopologyCanvas({
 
       if (topo) {
         drawZones(ctx, topo.nodes, pos, now, cam.zoom);
+
+        // Only the mesh being engaged with is outlined; several at once would
+        // stack overlapping hulls across every cluster.
+        const focusedMesh =
+          findMeshForNode(drawRef.current.agentMeshes, hoveredId) ??
+          findMeshForNode(drawRef.current.agentMeshes, drawRef.current.selectedId);
+        if (focusedMesh) {
+          const memberPoints = focusedMesh.memberIds
+            .map((id) => pos.get(id))
+            .filter((p): p is NonNullable<typeof p> => !!p)
+            .map((p) => ({ x: p.x, y: p.y }));
+          drawAgentMesh(ctx, memberPoints, focusedMesh.id, cam.zoom);
+        }
+
         drawEdges(ctx, topo, pos, now);
 
         // Draw hosts first (background layer), then other nodes

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/TopologyCanvas.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { select } from 'd3-selection';
 import { zoom, zoomIdentity, type D3ZoomEvent, type ZoomBehavior } from 'd3-zoom';
-import type { Topology } from '../../domain';
+import type { EdgeLayer, Topology } from '../../domain';
+import { visibleEdges } from '../../domain';
 import { deriveAgentMeshes, findMeshForNode } from '../../domain/agentMesh';
 import {
   clampZoom,
@@ -33,6 +34,8 @@ export interface TopologyCanvasProps {
   onNodeClick?: (nodeId: string) => void;
   /** Currently selected node — drives which agent mesh is outlined. */
   selectedId?: string | null;
+  /** Connection layers the operator has switched off. */
+  hiddenLayers?: ReadonlySet<EdgeLayer>;
   /** Show the minimap panel (default true). */
   showMinimap?: boolean;
   /** Extra CSS class applied to the wrapper div. */
@@ -54,6 +57,7 @@ export function TopologyCanvas({
   topology,
   onNodeClick,
   selectedId = null,
+  hiddenLayers,
   showMinimap = true,
   className,
   style,
@@ -75,6 +79,14 @@ export function TopologyCanvas({
   // Compute layout whenever topology changes (memoised — pure function)
   const positions = useMemo(() => (topology ? computeLayout(topology) : new Map()), [topology]);
   const agentMeshes = useMemo(() => deriveAgentMeshes(topology), [topology]);
+
+  // Layers filter what is drawn, never the layout: hiding a connection must not
+  // make the nodes jump.
+  const drawnTopology = useMemo<Topology | null>(() => {
+    if (!topology) return null;
+    if (!hiddenLayers || hiddenLayers.size === 0) return topology;
+    return { ...topology, edges: visibleEdges(topology.edges, hiddenLayers) };
+  }, [hiddenLayers, topology]);
   const topologySignature = useMemo(() => {
     if (!topology) return 'empty';
     return topology.nodes
@@ -86,7 +98,7 @@ export function TopologyCanvas({
   // Stable reference to drawing data so the rAF loop always reads fresh values
   // without being re-subscribed on every state tick.
   const drawRef = useRef({
-    topology,
+    topology: drawnTopology,
     positions,
     hoveredId: null as string | null,
     agentMeshes,
@@ -95,13 +107,13 @@ export function TopologyCanvas({
 
   useEffect(() => {
     drawRef.current = {
-      topology,
+      topology: drawnTopology,
       positions,
       hoveredId: hoveredIdRef.current,
       agentMeshes,
       selectedId,
     };
-  }, [agentMeshes, positions, selectedId, topology]);
+  }, [agentMeshes, drawnTopology, positions, selectedId]);
 
   const cameraToZoomTransform = useCallback((cam: Camera) => {
     const { w, h } = sizeRef.current;

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/canvasMath.test.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/canvasMath.test.ts
@@ -8,6 +8,9 @@ import {
   defaultCamera,
   fitCameraToBounds,
   type Camera,
+  centroid,
+  convexHull,
+  expandFromCentroid,
 } from './canvasMath';
 import { CANVAS } from './config';
 
@@ -225,5 +228,92 @@ describe('fitCameraToBounds', () => {
 
   it('falls back to default camera for missing bounds', () => {
     expect(fitCameraToBounds(null, 1200, 800)).toEqual(defaultCamera());
+  });
+});
+
+// ── Hull geometry ─────────────────────────────────────────────────────────────
+
+describe('centroid', () => {
+  it('averages the points', () => {
+    expect(
+      centroid([
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+        { x: 10, y: 10 },
+        { x: 0, y: 10 },
+      ]),
+    ).toEqual({
+      x: 5,
+      y: 5,
+    });
+  });
+
+  it('returns the origin for an empty set rather than NaN', () => {
+    expect(centroid([])).toEqual({ x: 0, y: 0 });
+  });
+});
+
+describe('convexHull', () => {
+  it('drops a point enclosed by the others', () => {
+    const hull = convexHull([
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 10 },
+      { x: 5, y: 5 },
+    ]);
+    expect(hull).toHaveLength(4);
+    expect(hull).not.toContainEqual({ x: 5, y: 5 });
+  });
+
+  it('returns the input when there is no hull to compute', () => {
+    expect(convexHull([])).toEqual([]);
+    expect(convexHull([{ x: 1, y: 2 }])).toEqual([{ x: 1, y: 2 }]);
+    const pair = [
+      { x: 0, y: 0 },
+      { x: 4, y: 4 },
+    ];
+    expect(convexHull(pair)).toEqual(pair);
+  });
+
+  it('falls back to the input for collinear points instead of collapsing', () => {
+    const line = [
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+      { x: 2, y: 2 },
+    ];
+    expect(convexHull(line)).toEqual(line);
+  });
+
+  it('does not mutate its input', () => {
+    const points = [
+      { x: 3, y: 0 },
+      { x: 0, y: 0 },
+      { x: 0, y: 3 },
+    ];
+    const snapshot = JSON.stringify(points);
+    convexHull(points);
+    expect(JSON.stringify(points)).toBe(snapshot);
+  });
+});
+
+describe('expandFromCentroid', () => {
+  it('pushes each vertex outward by the padding', () => {
+    const origin = { x: 0, y: 0 };
+    const expanded = expandFromCentroid(
+      [
+        { x: 10, y: 0 },
+        { x: 0, y: 10 },
+      ],
+      origin,
+      5,
+    );
+    expect(expanded[0]).toEqual({ x: 15, y: 0 });
+    expect(expanded[1]).toEqual({ x: 0, y: 15 });
+  });
+
+  it('offsets a point sitting on the centroid rather than dividing by zero', () => {
+    const expanded = expandFromCentroid([{ x: 2, y: 2 }], { x: 2, y: 2 }, 6);
+    expect(expanded[0]).toEqual({ x: 8, y: 2 });
   });
 });

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/canvasMath.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/canvasMath.ts
@@ -143,3 +143,75 @@ export function fitCameraToBounds(
     zoom,
   };
 }
+
+// ── Hull geometry ─────────────────────────────────────────────────────────────
+
+/** Centroid of a point set; the origin for an empty set. */
+export function centroid(points: readonly Point[]): Point {
+  if (points.length === 0) return { x: 0, y: 0 };
+  let x = 0;
+  let y = 0;
+  for (const p of points) {
+    x += p.x;
+    y += p.y;
+  }
+  return { x: x / points.length, y: y / points.length };
+}
+
+/** Cross product of OA x OB — positive when OAB turns counter-clockwise. */
+function cross(o: Point, a: Point, b: Point): number {
+  return (a.x - o.x) * (b.y - o.y) - (a.y - o.y) * (b.x - o.x);
+}
+
+/**
+ * Convex hull by monotone chain, in O(n log n).
+ *
+ * Fewer than three points have no hull — the input is returned unchanged so
+ * callers can still draw a point or a line from the result.
+ */
+export function convexHull(points: readonly Point[]): Point[] {
+  if (points.length < 3) return [...points];
+
+  const sorted = [...points].sort((a, b) => a.x - b.x || a.y - b.y);
+
+  const lower: Point[] = [];
+  for (const p of sorted) {
+    while (lower.length >= 2 && cross(lower[lower.length - 2]!, lower[lower.length - 1]!, p) <= 0) {
+      lower.pop();
+    }
+    lower.push(p);
+  }
+
+  const upper: Point[] = [];
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const p = sorted[i]!;
+    while (upper.length >= 2 && cross(upper[upper.length - 2]!, upper[upper.length - 1]!, p) <= 0) {
+      upper.pop();
+    }
+    upper.push(p);
+  }
+
+  lower.pop();
+  upper.pop();
+  const hull = lower.concat(upper);
+  // Collinear input collapses to a degenerate hull; fall back to the points.
+  return hull.length >= 3 ? hull : [...points];
+}
+
+/**
+ * Push each hull vertex away from the centroid so the outline clears the nodes
+ * it surrounds rather than cutting through them.
+ */
+export function expandFromCentroid(
+  points: readonly Point[],
+  origin: Point,
+  padding: number,
+): Point[] {
+  return points.map((p) => {
+    const dx = p.x - origin.x;
+    const dy = p.y - origin.y;
+    const distance = Math.hypot(dx, dy);
+    if (distance === 0) return { x: p.x + padding, y: p.y };
+    return { x: p.x + (dx / distance) * padding, y: p.y + (dy / distance) * padding };
+  });
+}

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/config.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/config.ts
@@ -8,8 +8,15 @@ export const CANVAS = {
   WORLD_W: 4200,
   WORLD_H: 3600,
 
-  /** Zoom limits (task spec: 0.3×–3×). */
-  ZOOM_MIN: 0.3,
+  /**
+   * Zoom limits.
+   *
+   * The floor was 0.3×, which predates a topology of this size: eight clusters
+   * across five realms do not fit on screen at 0.3×, so "fit to bounds" clamped
+   * to the minimum and the whole graph could never be seen at once. The floor
+   * has to be low enough that fitting the full world is reachable.
+   */
+  ZOOM_MIN: 0.12,
   ZOOM_MAX: 3.0,
 
   /** Multiplicative zoom step per scroll tick. */

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/config.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/config.ts
@@ -131,6 +131,23 @@ export const LOD = {
   NODE_DETAIL: 1.15,
 } as const;
 
+/**
+ * Agent-mesh hull rendering.
+ *
+ * A mesh spans clusters by design, so several hulls drawn at once overlap each
+ * other and everything beneath them. Only the mesh under the cursor or the
+ * current selection is outlined.
+ */
+export const MESH_HULL = {
+  /** World units the outline stands off from its outermost member. */
+  PADDING: 46,
+  /** Corner rounding applied when tracing the expanded hull. */
+  CORNER_RADIUS: 26,
+  FILL_ALPHA: 0.05,
+  STROKE_ALPHA: 0.34,
+  DASH: [12, 9],
+} as const;
+
 /** Label sizes in screen pixels — held constant regardless of camera zoom. */
 export const LABEL_PX = {
   REALM: 13,

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/config.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/config.ts
@@ -109,6 +109,38 @@ export const LAYOUT = {
   MIMIR_RADIUS: 42,
 } as const;
 
+/**
+ * Level-of-detail thresholds.
+ *
+ * Labels are drawn at a constant *screen* size (see `worldFontSize`), so at low
+ * zoom a label occupies far more world space than the gap between the nodes it
+ * sits beside. Children on a cluster orbit are ~150–220 world units apart while
+ * a label is ~70–110px wide, so below these zoom levels neighbouring labels
+ * overlap by construction. Each tier is the zoom at which its labels start to
+ * fit; anything hovered or selected ignores the tier entirely so nothing
+ * becomes unreachable.
+ */
+export const LOD = {
+  /** Stat line under a realm/cluster name. */
+  CONTAINER_DETAIL: 0.3,
+  /** Residents, Mímir instances and workflow sessions. */
+  PRIMARY: 0.45,
+  /** Services, hosts, models and run agents. */
+  SECONDARY: 0.8,
+  /** The secondary line beneath any node label. */
+  NODE_DETAIL: 1.15,
+} as const;
+
+/** Label sizes in screen pixels — held constant regardless of camera zoom. */
+export const LABEL_PX = {
+  REALM: 13,
+  CLUSTER: 12,
+  CONTAINER_DETAIL: 9,
+  PRIMARY: 11,
+  SECONDARY: 10,
+  NODE_DETAIL: 9,
+} as const;
+
 /** Per-typeId hit radius for click / hover detection (world units). */
 export const HIT_RADIUS: Record<string, number> = {
   mimir: 42,

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.test.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.test.ts
@@ -7,10 +7,20 @@ import {
   drawMimir,
   drawMinimap,
   nodeIconGlyph,
+  labelTier,
+  labelTierThreshold,
+  shouldDrawLabel,
+  shouldDrawNodeDetail,
+  worldFontSize,
 } from './renderer';
+import { LOD } from './config';
 import type { Topology, TopologyNode } from '../../domain';
 import type { NodePosition } from './layoutEngine';
 import { makeCtxMock } from './test-helpers';
+
+/** A zoom at which every label tier is visible, so label assertions below
+ *  test placement and content rather than level-of-detail gating. */
+const DETAIL_ZOOM = 1.5;
 
 // ── Shared test data ──────────────────────────────────────────────────────────
 
@@ -102,24 +112,24 @@ describe('drawStars', () => {
 describe('drawZones', () => {
   it('does not throw with realm and cluster nodes', () => {
     const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
-    expect(() => drawZones(ctx, NODES, POSITIONS, 0)).not.toThrow();
+    expect(() => drawZones(ctx, NODES, POSITIONS, 0, DETAIL_ZOOM)).not.toThrow();
   });
 
   it('calls arc for realm circles', () => {
     const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
-    drawZones(ctx, NODES, POSITIONS, 0);
+    drawZones(ctx, NODES, POSITIONS, 0, DETAIL_ZOOM);
     expect((ctx.arc as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
   });
 
   it('draws realm labels with fillText', () => {
     const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
-    drawZones(ctx, NODES, POSITIONS, 0);
+    drawZones(ctx, NODES, POSITIONS, 0, DETAIL_ZOOM);
     expect((ctx.fillText as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
   });
 
   it('handles empty node list without throwing', () => {
     const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
-    expect(() => drawZones(ctx, [], new Map(), 0)).not.toThrow();
+    expect(() => drawZones(ctx, [], new Map(), 0, DETAIL_ZOOM)).not.toThrow();
   });
 
   it('skips nodes with no position entry', () => {
@@ -132,7 +142,7 @@ describe('drawZones', () => {
       status: 'healthy',
     };
     // orphan has no entry in POSITIONS — should not throw
-    expect(() => drawZones(ctx, [orphan], POSITIONS, 0)).not.toThrow();
+    expect(() => drawZones(ctx, [orphan], POSITIONS, 0, DETAIL_ZOOM)).not.toThrow();
   });
 });
 
@@ -347,7 +357,7 @@ describe('drawNode', () => {
         parentId: null,
         status: 'healthy',
       };
-      expect(() => drawNode(ctx, node, pos, false)).not.toThrow();
+      expect(() => drawNode(ctx, node, pos, false, DETAIL_ZOOM)).not.toThrow();
     });
 
     it(`renders typeId="${typeId}" hovered without throwing`, () => {
@@ -359,7 +369,7 @@ describe('drawNode', () => {
         parentId: null,
         status: 'healthy',
       };
-      expect(() => drawNode(ctx, node, pos, true)).not.toThrow();
+      expect(() => drawNode(ctx, node, pos, true, DETAIL_ZOOM)).not.toThrow();
     });
   }
 
@@ -372,7 +382,7 @@ describe('drawNode', () => {
       parentId: null,
       status: 'healthy',
     };
-    drawNode(ctx, node, pos, false);
+    drawNode(ctx, node, pos, false, DETAIL_ZOOM);
     // No drawing calls should have been made
     expect((ctx.beginPath as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
     expect((ctx.fillRect as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
@@ -387,7 +397,7 @@ describe('drawNode', () => {
       parentId: null,
       status: 'healthy',
     };
-    drawNode(ctx, host, pos, false);
+    drawNode(ctx, host, pos, false, DETAIL_ZOOM);
     expect((ctx.arc as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
     const calls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
     expect(calls.some(([text]) => text === 'tanngrisnir')).toBe(true);
@@ -403,7 +413,7 @@ describe('drawNode', () => {
       parentId: null,
       status: 'healthy',
     };
-    drawNode(ctx, node, pos, true);
+    drawNode(ctx, node, pos, true, DETAIL_ZOOM);
     // Hovered nodes use the same rounded swatch vocabulary as the legend.
     expect((ctx.roundRect as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(1);
     expect(ctx.stroke).toHaveBeenCalled();
@@ -418,7 +428,7 @@ describe('drawNode', () => {
       parentId: null,
       status: 'healthy',
     };
-    drawNode(ctx, node, pos, false);
+    drawNode(ctx, node, pos, false, DETAIL_ZOOM);
     expect((ctx.roundRect as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(0);
     const calls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
     expect(calls.some(([text]) => text === nodeIconGlyph('service'))).toBe(true);
@@ -433,7 +443,7 @@ describe('drawNode', () => {
       parentId: null,
       status: 'healthy',
     };
-    drawNode(ctx, node, pos, false);
+    drawNode(ctx, node, pos, false, DETAIL_ZOOM);
     const calls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
     expect(calls.some(([text]) => text === 'ᚦ')).toBe(true);
   });
@@ -447,7 +457,7 @@ describe('drawNode', () => {
       parentId: null,
       status: 'healthy',
     };
-    drawNode(ctx, node, pos, false);
+    drawNode(ctx, node, pos, false, DETAIL_ZOOM);
     const calls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
     expect(calls.some(([text]) => text === 'ᚨ')).toBe(true);
   });
@@ -543,5 +553,103 @@ describe('drawMinimap', () => {
     drawMinimap(ctx, 220, 165, TOPOLOGY, POSITIONS, 0, 0, 1, 800, 600, 4200, 3600);
     const calls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
     expect(calls.some(([text]) => /entities/.test(text))).toBe(true);
+  });
+});
+
+// ── Level of detail ───────────────────────────────────────────────────────────
+
+describe('labelTier', () => {
+  it('treats the entities an operator scans for first as primary', () => {
+    for (const typeId of ['mimir', 'ravn_long', 'valkyrie', 'run']) {
+      expect(labelTier(typeId)).toBe('primary');
+    }
+  });
+
+  it('treats supporting infrastructure as secondary', () => {
+    for (const typeId of ['service', 'model', 'host', 'ravn_run', 'bifrost']) {
+      expect(labelTier(typeId)).toBe('secondary');
+    }
+  });
+
+  it('gives primary types a lower zoom threshold than secondary ones', () => {
+    expect(labelTierThreshold('ravn_long')).toBe(LOD.PRIMARY);
+    expect(labelTierThreshold('service')).toBe(LOD.SECONDARY);
+    expect(labelTierThreshold('ravn_long')).toBeLessThan(labelTierThreshold('service'));
+  });
+});
+
+describe('shouldDrawLabel', () => {
+  it('hides every label at overview zoom', () => {
+    expect(shouldDrawLabel('ravn_long', LOD.PRIMARY - 0.01, false)).toBe(false);
+    expect(shouldDrawLabel('service', LOD.PRIMARY, false)).toBe(false);
+  });
+
+  it('reveals primary labels before secondary ones as the camera comes in', () => {
+    const between = (LOD.PRIMARY + LOD.SECONDARY) / 2;
+    expect(shouldDrawLabel('ravn_long', between, false)).toBe(true);
+    expect(shouldDrawLabel('service', between, false)).toBe(false);
+    expect(shouldDrawLabel('service', LOD.SECONDARY, false)).toBe(true);
+  });
+
+  it('always labels an emphasised node so detail is never unreachable', () => {
+    expect(shouldDrawLabel('service', 0.01, true)).toBe(true);
+    expect(shouldDrawLabel('beacon', 0, true)).toBe(true);
+  });
+});
+
+describe('shouldDrawNodeDetail', () => {
+  it('withholds the secondary line until there is room for it', () => {
+    expect(shouldDrawNodeDetail(LOD.NODE_DETAIL - 0.01, false)).toBe(false);
+    expect(shouldDrawNodeDetail(LOD.NODE_DETAIL, false)).toBe(true);
+  });
+
+  it('shows it for an emphasised node at any zoom', () => {
+    expect(shouldDrawNodeDetail(0.1, true)).toBe(true);
+  });
+});
+
+describe('worldFontSize', () => {
+  it('keeps text a constant screen size by cancelling the camera scale', () => {
+    expect(worldFontSize(10, 0.5)).toBe(20);
+    expect(worldFontSize(10, 2)).toBe(5);
+    expect(worldFontSize(10, 1)).toBe(10);
+  });
+
+  it('falls back to the screen size for a degenerate zoom rather than dividing by zero', () => {
+    expect(worldFontSize(10, 0)).toBe(10);
+    expect(worldFontSize(10, Number.NaN)).toBe(10);
+    expect(worldFontSize(10, Number.POSITIVE_INFINITY)).toBe(10);
+  });
+});
+
+describe('drawNode level of detail', () => {
+  const pos: NodePosition = { x: 0, y: 0 };
+
+  function labelsDrawnAt(zoom: number, typeId: string): string[] {
+    const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
+    const node: TopologyNode = {
+      id: `n-${typeId}`,
+      typeId,
+      label: 'sample-label',
+      parentId: null,
+      status: 'healthy',
+    };
+    drawNode(ctx, node, pos, false, zoom);
+    const calls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
+    return calls.map(([text]) => text);
+  }
+
+  it('draws no service label at overview zoom', () => {
+    expect(labelsDrawnAt(LOD.PRIMARY - 0.01, 'service')).not.toContain('sample-label');
+  });
+
+  it('draws the service label once zoomed past its tier', () => {
+    expect(labelsDrawnAt(LOD.SECONDARY, 'service')).toContain('sample-label');
+  });
+
+  it('draws a resident label at a zoom where a service still has none', () => {
+    const between = (LOD.PRIMARY + LOD.SECONDARY) / 2;
+    expect(labelsDrawnAt(between, 'ravn_long')).toContain('sample-label');
+    expect(labelsDrawnAt(between, 'service')).not.toContain('sample-label');
   });
 });

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.test.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.test.ts
@@ -12,6 +12,7 @@ import {
   shouldDrawLabel,
   shouldDrawNodeDetail,
   worldFontSize,
+  drawAgentMesh,
 } from './renderer';
 import { LOD } from './config';
 import type { Topology, TopologyNode } from '../../domain';
@@ -651,5 +652,54 @@ describe('drawNode level of detail', () => {
     const between = (LOD.PRIMARY + LOD.SECONDARY) / 2;
     expect(labelsDrawnAt(between, 'ravn_long')).toContain('sample-label');
     expect(labelsDrawnAt(between, 'service')).not.toContain('sample-label');
+  });
+});
+
+describe('drawAgentMesh', () => {
+  const A = { x: 0, y: 0 };
+  const B = { x: 100, y: 0 };
+  const C2 = { x: 100, y: 100 };
+  const D = { x: 0, y: 100 };
+
+  it('draws nothing for a mesh with fewer than two placed members', () => {
+    const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
+    drawAgentMesh(ctx, [], 'forge', 1);
+    drawAgentMesh(ctx, [A], 'forge', 1);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
+  it('outlines and fills a hull for three or more members', () => {
+    const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
+    drawAgentMesh(ctx, [A, B, C2, D], 'forge-mesh', 1);
+    expect(ctx.fill).toHaveBeenCalled();
+    expect(ctx.stroke).toHaveBeenCalled();
+    expect(ctx.quadraticCurveTo).toHaveBeenCalled();
+  });
+
+  it('draws a capsule rather than a polygon for exactly two members', () => {
+    const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
+    drawAgentMesh(ctx, [A, B], 'pair', 1);
+    expect(ctx.stroke).toHaveBeenCalled();
+    expect(ctx.fill).not.toHaveBeenCalled();
+  });
+
+  it('labels the mesh at its centroid in upper case', () => {
+    const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
+    drawAgentMesh(ctx, [A, B, C2, D], 'forge-mesh', 1);
+    const calls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [
+      string,
+      number,
+      number,
+    ][];
+    const entry = calls.find(([text]) => text.includes('FORGE'));
+    expect(entry).toBeDefined();
+    expect(entry?.[1]).toBe(50);
+    expect(entry?.[2]).toBe(50);
+  });
+
+  it('omits the label when the mesh has no name', () => {
+    const ctx = makeCtxMock() as unknown as CanvasRenderingContext2D;
+    drawAgentMesh(ctx, [A, B, C2, D], '', 1);
+    expect(ctx.fillText).not.toHaveBeenCalled();
   });
 });

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.ts
@@ -17,7 +17,9 @@ import type {
 import { humanizeObservatoryText } from '../displayLabels';
 import type { NodePosition } from './layoutEngine';
 import { zoneRadius, HOST_HALF_W, HOST_HALF_H } from './layoutEngine';
-import { NODE_SIZE, MIMIR_RUNES, LAYOUT, LOD, LABEL_PX } from './config';
+import { NODE_SIZE, MIMIR_RUNES, LAYOUT, LOD, LABEL_PX, MESH_HULL } from './config';
+import type { Point } from './canvasMath';
+import { centroid, convexHull, expandFromCentroid } from './canvasMath';
 
 // ── Level of detail ───────────────────────────────────────────────────────────
 
@@ -1223,4 +1225,68 @@ export function drawMinimap(
   ctx.fillText(`${topology.nodes.length} entities`, 4, H - 4);
   ctx.textAlign = 'right';
   ctx.fillText('MINIMAP', W - 4, H - 4);
+}
+
+// ── Agent mesh ────────────────────────────────────────────────────────────────
+
+/**
+ * Outline the agent mesh the operator is currently engaging with.
+ *
+ * Members are scattered across clusters, so the shape has to be derived from
+ * their positions rather than read off a container. Nothing is drawn for a
+ * mesh with fewer than two placed members.
+ */
+export function drawAgentMesh(
+  ctx: CanvasRenderingContext2D,
+  memberPoints: readonly Point[],
+  label: string,
+  zoom: number,
+): void {
+  if (memberPoints.length < 2) return;
+
+  const origin = centroid(memberPoints);
+  const outline = expandFromCentroid(convexHull(memberPoints), origin, MESH_HULL.PADDING);
+
+  ctx.save();
+  ctx.beginPath();
+  if (outline.length < 3) {
+    // Two members: a capsule reads better than a degenerate polygon.
+    const [a, b] = outline as [Point, Point];
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+  } else {
+    // Trace midpoint-to-midpoint with each vertex as the control point, which
+    // rounds the hull without needing a corner-by-corner arc solve.
+    const last = outline[outline.length - 1]!;
+    const first = outline[0]!;
+    ctx.moveTo((first.x + last.x) / 2, (first.y + last.y) / 2);
+    for (let i = 0; i < outline.length; i++) {
+      const current = outline[i]!;
+      const next = outline[(i + 1) % outline.length]!;
+      ctx.quadraticCurveTo(
+        current.x,
+        current.y,
+        (current.x + next.x) / 2,
+        (current.y + next.y) / 2,
+      );
+    }
+    ctx.closePath();
+    ctx.fillStyle = rgba(C.valk, MESH_HULL.FILL_ALPHA);
+    ctx.fill();
+  }
+
+  ctx.setLineDash(MESH_HULL.DASH.map((d) => d));
+  ctx.strokeStyle = rgba(C.valk, MESH_HULL.STROKE_ALPHA);
+  ctx.lineWidth = worldFontSize(1.4, zoom);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  if (label) {
+    const px = worldFontSize(LABEL_PX.PRIMARY, zoom);
+    ctx.fillStyle = rgba(C.valk, 0.7);
+    ctx.font = `600 ${px}px "JetBrains Mono", monospace`;
+    ctx.textAlign = 'center';
+    ctx.fillText(humanizeObservatoryText(label).toUpperCase(), origin.x, origin.y);
+  }
+  ctx.restore();
 }

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.ts
@@ -17,7 +17,52 @@ import type {
 import { humanizeObservatoryText } from '../displayLabels';
 import type { NodePosition } from './layoutEngine';
 import { zoneRadius, HOST_HALF_W, HOST_HALF_H } from './layoutEngine';
-import { NODE_SIZE, MIMIR_RUNES, LAYOUT } from './config';
+import { NODE_SIZE, MIMIR_RUNES, LAYOUT, LOD, LABEL_PX } from './config';
+
+// ── Level of detail ───────────────────────────────────────────────────────────
+
+/** Which zoom tier a node's label belongs to. */
+export type LabelTier = 'primary' | 'secondary';
+
+/**
+ * Entities that carry the story of the topology — the things an operator scans
+ * for first. They earn a label before anything else does.
+ */
+const PRIMARY_LABEL_TYPES: ReadonlySet<string> = new Set(['mimir', 'ravn_long', 'valkyrie', 'run']);
+
+export function labelTier(typeId: string): LabelTier {
+  return PRIMARY_LABEL_TYPES.has(typeId) ? 'primary' : 'secondary';
+}
+
+/** Zoom at which a given node type's label becomes legible without colliding. */
+export function labelTierThreshold(typeId: string): number {
+  return labelTier(typeId) === 'primary' ? LOD.PRIMARY : LOD.SECONDARY;
+}
+
+/**
+ * A label is drawn once the camera is zoomed far enough in that it fits beside
+ * its neighbours. Hovered and selected nodes always label, so detail is never
+ * unreachable — you can always point at a thing to find out what it is.
+ */
+export function shouldDrawLabel(typeId: string, zoom: number, emphasised: boolean): boolean {
+  if (emphasised) return true;
+  return zoom >= labelTierThreshold(typeId);
+}
+
+/** True once a node's secondary line has room to sit under its label. */
+export function shouldDrawNodeDetail(zoom: number, emphasised: boolean): boolean {
+  return emphasised || zoom >= LOD.NODE_DETAIL;
+}
+
+/**
+ * Convert a screen-pixel size into world units for the current camera, so text
+ * stays the same physical size however far out the camera sits. Without this a
+ * 10px font renders at 3px when zoomed to 0.3 and the overview is unreadable.
+ */
+export function worldFontSize(screenPx: number, zoom: number): number {
+  if (!Number.isFinite(zoom) || zoom <= 0) return screenPx;
+  return screenPx / zoom;
+}
 
 // ── Colour palette ────────────────────────────────────────────────────────────
 // These map directly to the ice-theme brand ramp used in the prototype.
@@ -176,23 +221,34 @@ function drawStructureLabel(
     font,
     color,
     uppercase = false,
+    scale = 1,
   }: {
     font: string;
     color: string;
     uppercase?: boolean;
+    /** World units per screen pixel, so the glyph and gaps track the font. */
+    scale?: number;
   },
 ): void {
   const label = uppercase ? structureLabel(node).toUpperCase() : structureLabel(node);
+  ctx.save();
+  ctx.font = font;
   const metrics = ctx.measureText?.(label);
-  const textWidth = metrics?.width ?? label.length * 7.2;
-  const glyphGap = 8;
-  const glyphWidth = 16;
+  const textWidth = metrics?.width ?? label.length * 7.2 * scale;
+  const glyphGap = 8 * scale;
+  const glyphWidth = 16 * scale;
   const startX = x - (textWidth + glyphGap + glyphWidth) / 2;
   const glyphX = startX + glyphWidth / 2;
   const textX = startX + glyphWidth + glyphGap;
 
-  ctx.save();
-  drawNodeSwatch(ctx, node.typeId, glyphX, y - 4, NODE_SIZE[node.typeId] ?? 6, false);
+  drawNodeSwatch(
+    ctx,
+    node.typeId,
+    glyphX,
+    y - 4 * scale,
+    (NODE_SIZE[node.typeId] ?? 6) * scale,
+    false,
+  );
   ctx.fillStyle = color;
   ctx.font = font;
   ctx.textAlign = 'left';
@@ -290,7 +346,10 @@ export function drawZones(
   nodes: TopologyNode[],
   positions: Map<string, NodePosition>,
   now: number,
+  zoom: number,
 ): void {
+  // World units per screen pixel — keeps container headings a constant size.
+  const scale = worldFontSize(1, zoom);
   // Draw larger structural groups first, then smaller containers on top.
   for (const typeId of ['realm', 'cluster', 'namespace'] as const) {
     for (const node of nodes) {
@@ -324,10 +383,11 @@ export function drawZones(
         ctx.arc(cx, cy, r, 0, Math.PI * 2);
         ctx.stroke();
 
-        drawStructureLabel(ctx, node, cx, cy - r - 8, {
-          font: '600 13px Inter, sans-serif',
+        drawStructureLabel(ctx, node, cx, cy - r - 8 * scale, {
+          font: `600 ${worldFontSize(LABEL_PX.REALM, zoom)}px Inter, sans-serif`,
           color: rgba(C.ice, 0.78),
           uppercase: true,
+          scale,
         });
       } else if (typeId === 'cluster') {
         const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
@@ -346,9 +406,10 @@ export function drawZones(
         ctx.stroke();
         ctx.setLineDash([]);
 
-        drawStructureLabel(ctx, node, cx, cy - r - 4, {
-          font: '10px "JetBrains Mono", monospace',
+        drawStructureLabel(ctx, node, cx, cy - r - 4 * scale, {
+          font: `${worldFontSize(LABEL_PX.CLUSTER, zoom)}px "JetBrains Mono", monospace`,
           color: rgba(C.ice, 0.58),
+          scale,
         });
       } else {
         const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
@@ -367,9 +428,10 @@ export function drawZones(
         ctx.stroke();
         ctx.setLineDash([]);
 
-        drawStructureLabel(ctx, node, cx, cy - r - 4, {
-          font: '10px "JetBrains Mono", monospace',
+        drawStructureLabel(ctx, node, cx, cy - r - 4 * scale, {
+          font: `${worldFontSize(LABEL_PX.CLUSTER, zoom)}px "JetBrains Mono", monospace`,
           color: rgba(C.ice, 0.62),
+          scale,
         });
       }
     }
@@ -1025,6 +1087,7 @@ export function drawNode(
   node: TopologyNode,
   pos: NodePosition,
   hovered: boolean,
+  zoom: number,
 ): void {
   if (node.typeId === 'mimir') return; // handled by drawMimir separately
   if (node.typeId === 'realm' || node.typeId === 'cluster' || node.typeId === 'namespace') return;
@@ -1060,10 +1123,13 @@ export function drawNode(
     ctx.stroke();
     ctx.setLineDash([]);
 
-    ctx.fillStyle = rgba(C.ice, 0.82);
-    ctx.font = `${hovered ? 600 : 500} 10px "JetBrains Mono", monospace`;
-    ctx.textAlign = 'center';
-    ctx.fillText(humanizeObservatoryText(node.label), x, y - runRadius - 8);
+    if (shouldDrawLabel(node.typeId, zoom, hovered)) {
+      const px = worldFontSize(LABEL_PX.PRIMARY, zoom);
+      ctx.fillStyle = rgba(C.ice, 0.82);
+      ctx.font = `${hovered ? 600 : 500} ${px}px "JetBrains Mono", monospace`;
+      ctx.textAlign = 'center';
+      ctx.fillText(humanizeObservatoryText(node.label), x, y - runRadius - px * 0.6);
+    }
     ctx.restore();
     return;
   }
@@ -1073,32 +1139,19 @@ export function drawNode(
 
   drawNodeSwatch(ctx, node.typeId, x, y, size, hovered);
 
-  // Label below node for key types and hovered nodes
-  const showLabel =
-    [
-      'ting',
-      'bifrost',
-      'volundr',
-      'valkyrie',
-      'ravn_long',
-      'trigger',
-      'stage',
-      'gate',
-      'cond',
-      'resource',
-      'end',
-    ].includes(node.typeId) ||
-    (node.typeId === 'service' && ['observatory', 'niuu', 'ravn'].includes(node.svcType ?? '')) ||
-    hovered;
-  if (showLabel) {
-    const placement = workflowLabelPlacement(node, size);
-    ctx.fillStyle = rgba(C.moon, hovered ? 0.95 : 0.75);
-    ctx.font = `${hovered ? 600 : 500} 10px Inter, sans-serif`;
-    ctx.textAlign = placement.align;
-    ctx.textBaseline = placement.baseline;
-    ctx.fillText(humanizeObservatoryText(node.label), x + placement.dx, y + placement.dy);
-    ctx.textBaseline = 'alphabetic';
-  }
+  // Labels resolve with the camera rather than from a fixed type allowlist:
+  // the graph is far too dense to label everything at overview zoom.
+  if (!shouldDrawLabel(node.typeId, zoom, hovered)) return;
+
+  const tier = labelTier(node.typeId);
+  const px = worldFontSize(tier === 'primary' ? LABEL_PX.PRIMARY : LABEL_PX.SECONDARY, zoom);
+  const placement = workflowLabelPlacement(node, size);
+  ctx.fillStyle = rgba(C.moon, hovered ? 0.95 : 0.75);
+  ctx.font = `${hovered ? 600 : 500} ${px}px Inter, sans-serif`;
+  ctx.textAlign = placement.align;
+  ctx.textBaseline = placement.baseline;
+  ctx.fillText(humanizeObservatoryText(node.label), x + placement.dx, y + placement.dy);
+  ctx.textBaseline = 'alphabetic';
 }
 
 // ── Minimap ───────────────────────────────────────────────────────────────────

--- a/web-next/packages/plugin-observatory/src/ui/overlays/AgentCardPanel.css
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/AgentCardPanel.css
@@ -1,0 +1,125 @@
+/* ── A2A card panel — rendered inside the entity drawer ── */
+.obs-agent-card {
+  border-top: 1px solid var(--color-border-subtle);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.obs-agent-card__title {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.obs-agent-card__kind {
+  font-size: var(--text-2xs, 0.625rem);
+  letter-spacing: 0.14em;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-brand);
+}
+
+.obs-agent-card__subtitle {
+  margin: var(--space-2) 0 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs, 0.625rem);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.obs-agent-card__description {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+}
+
+.obs-agent-card__muted {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.obs-agent-card__error {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-critical-fg);
+}
+
+.obs-agent-card__facts {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: var(--space-1) var(--space-3);
+  margin: 0;
+}
+
+.obs-agent-card__facts dt {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs, 0.625rem);
+  color: var(--color-text-muted);
+}
+
+.obs-agent-card__facts dd {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-primary);
+  overflow-wrap: anywhere;
+}
+
+.obs-agent-card__caps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.obs-agent-card__cap {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs, 0.625rem);
+  letter-spacing: 0.1em;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+}
+
+.obs-agent-card__cap--on {
+  color: var(--color-brand);
+  border-color: var(--color-brand);
+}
+
+.obs-agent-card__cap--sig-ok {
+  color: var(--color-brand);
+  border-color: var(--color-brand);
+}
+
+/* Red is reserved for failures — an invalid signature is one. */
+.obs-agent-card__cap--sig-bad {
+  color: var(--color-critical-fg);
+  border-color: var(--color-critical-bo);
+}
+
+.obs-agent-card__skills {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.obs-agent-card__skills li {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-secondary);
+}

--- a/web-next/packages/plugin-observatory/src/ui/overlays/AgentCardPanel.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/AgentCardPanel.test.tsx
@@ -1,0 +1,190 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ServicesProvider } from '@niuulabs/plugin-sdk';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { AgentCardPanel } from './AgentCardPanel';
+import type { AgentDirectoryEntry, AgentDirectoryPage, TopologyNode } from '../../domain';
+import type { IAgentDirectory } from '../../ports';
+
+const NODE: TopologyNode = {
+  id: 'ravn-huginn',
+  typeId: 'ravn_long',
+  label: 'huginn',
+  parentId: 'cluster-valaskjalf',
+  status: 'healthy',
+};
+
+function entry(overrides: Partial<AgentDirectoryEntry> = {}): AgentDirectoryEntry {
+  return {
+    id: 'agent-ravn-huginn',
+    canonicalId: 'niuu:agent:ravn-huginn',
+    sourceAgentId: 'ravn-huginn',
+    sourceInstanceId: 'observatory-asgard',
+    clusterId: 'asgard',
+    environmentId: null,
+    topologyNodeId: 'ravn-huginn',
+    name: 'huginn',
+    description: 'Cluster resident for the GPU estate.',
+    kind: 'resident',
+    cardUrl: 'https://huginn.asgard.niuu.world/.well-known/agent-card.json',
+    cardVersion: '0.0.1',
+    cardHash: 'sha256:abc',
+    signatureVerified: true,
+    signatureKeyIds: ['niuu-a2a-signing'],
+    signatureKeyFingerprints: ['SHA256:fp'],
+    skillIds: ['gpu_pressure_probe', 'replica_warm'],
+    tags: ['resident'],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    supportedInterfaces: [
+      {
+        url: 'https://huginn.asgard.niuu.world/a2a',
+        protocolBinding: 'JSONRPC',
+        protocolVersion: '0.3.0',
+        tenant: 'niuu.world',
+      },
+    ],
+    capabilities: { streaming: true, pushNotifications: false, stateTransitionHistory: true },
+    securitySchemes: {},
+    securityRequirements: [],
+    observedStatus: 'healthy',
+    activity: 'thinking',
+    lastSeen: '2026-08-01T12:00:00Z',
+    ownerId: null,
+    tenantId: 'niuu.world',
+    visibility: 'realm',
+    provenance: [],
+    ...overrides,
+  };
+}
+
+function page(items: AgentDirectoryEntry[]): AgentDirectoryPage {
+  return { items, warnings: [], sources: [], partial: false, revision: 'r1' };
+}
+
+function renderPanel(directory: IAgentDirectory, node: TopologyNode | null = NODE) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <ServicesProvider services={{ 'observatory.agents': directory }}>
+          {children}
+        </ServicesProvider>
+      </QueryClientProvider>
+    );
+  }
+  return render(<AgentCardPanel node={node} />, { wrapper: Wrapper });
+}
+
+function directoryReturning(items: AgentDirectoryEntry[]): IAgentDirectory {
+  return { listAgents: vi.fn(async () => page(items)), getAgent: vi.fn() };
+}
+
+describe('AgentCardPanel', () => {
+  it('renders nothing when no node is selected', () => {
+    const { container } = renderPanel(directoryReturning([entry()]), null);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows a loading note while the directory resolves', () => {
+    const directory = {
+      listAgents: vi.fn(() => new Promise<AgentDirectoryPage>(() => {})),
+      getAgent: vi.fn(),
+    } as IAgentDirectory;
+    renderPanel(directory);
+    expect(screen.getByTestId('agent-card-loading')).toBeInTheDocument();
+  });
+
+  it('reports an unavailable directory rather than failing silently', async () => {
+    const directory = {
+      listAgents: vi.fn(async () => {
+        throw new Error('directory offline');
+      }),
+      getAgent: vi.fn(),
+    } as IAgentDirectory;
+    renderPanel(directory);
+    await waitFor(() => expect(screen.getByTestId('agent-card-error')).toBeInTheDocument());
+    expect(screen.getByTestId('agent-card-error')).toHaveTextContent('directory offline');
+  });
+
+  it('renders nothing for a node that publishes no card', async () => {
+    const { container } = renderPanel(
+      directoryReturning([entry({ topologyNodeId: 'somewhere-else' })]),
+    );
+    // Wait for the fetch to settle, then assert the panel left no empty shell.
+    await waitFor(() => expect(screen.queryByTestId('agent-card-loading')).toBeNull());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the card for the selected node', async () => {
+    renderPanel(directoryReturning([entry()]));
+    await waitFor(() => expect(screen.getByTestId('agent-card')).toBeInTheDocument());
+
+    expect(screen.getByTestId('agent-card-kind')).toHaveTextContent('resident');
+    expect(screen.getByTestId('agent-card-url')).toHaveTextContent('.well-known/agent-card.json');
+    expect(screen.getByText('JSONRPC')).toBeInTheDocument();
+    expect(screen.getByText('A2A 0.3.0')).toBeInTheDocument();
+    expect(screen.getByText('realm')).toBeInTheDocument();
+  });
+
+  it('marks each declared capability as on or off', async () => {
+    renderPanel(directoryReturning([entry()]));
+    await waitFor(() => expect(screen.getByTestId('agent-card')).toBeInTheDocument());
+
+    expect(screen.getByTestId('agent-cap-streaming')).toHaveAttribute('data-enabled', 'true');
+    expect(screen.getByTestId('agent-cap-pushNotifications')).toHaveAttribute(
+      'data-enabled',
+      'false',
+    );
+    expect(screen.getByTestId('agent-cap-stateTransitionHistory')).toHaveAttribute(
+      'data-enabled',
+      'true',
+    );
+  });
+
+  it('distinguishes verified, invalid and unsigned cards', async () => {
+    const { unmount } = renderPanel(directoryReturning([entry()]));
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-card-signature')).toHaveTextContent('signature verified'),
+    );
+    unmount();
+
+    const invalid = renderPanel(directoryReturning([entry({ signatureVerified: false })]));
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-card-signature')).toHaveTextContent('signature invalid'),
+    );
+    invalid.unmount();
+
+    renderPanel(directoryReturning([entry({ signatureVerified: null })]));
+    await waitFor(() =>
+      expect(screen.getByTestId('agent-card-signature')).toHaveTextContent('unsigned'),
+    );
+  });
+
+  it('lists the advertised skills with a count', async () => {
+    renderPanel(directoryReturning([entry()]));
+    await waitFor(() => expect(screen.getByTestId('agent-card-skills')).toBeInTheDocument());
+
+    expect(screen.getByText('Skills · 2')).toBeInTheDocument();
+    expect(screen.getByText('gpu_pressure_probe')).toBeInTheDocument();
+  });
+
+  it('omits the skills block when the card advertises none', async () => {
+    renderPanel(directoryReturning([entry({ skillIds: [] })]));
+    await waitFor(() => expect(screen.getByTestId('agent-card')).toBeInTheDocument());
+    expect(screen.queryByTestId('agent-card-skills')).toBeNull();
+  });
+
+  it('tolerates a card that declares no interface', async () => {
+    renderPanel(directoryReturning([entry({ supportedInterfaces: [] })]));
+    await waitFor(() => expect(screen.getByTestId('agent-card')).toBeInTheDocument());
+    expect(screen.queryByText('JSONRPC')).toBeNull();
+  });
+
+  it('omits the description when the card carries none', async () => {
+    renderPanel(directoryReturning([entry({ description: '' })]));
+    await waitFor(() => expect(screen.getByTestId('agent-card')).toBeInTheDocument());
+    expect(screen.queryByText('Cluster resident for the GPU estate.')).toBeNull();
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/overlays/AgentCardPanel.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/AgentCardPanel.tsx
@@ -1,0 +1,134 @@
+import { useMemo } from 'react';
+import type { AgentDirectoryEntry, TopologyNode } from '../../domain';
+import { useAgents } from '../../application/useAgents';
+import './AgentCardPanel.css';
+
+export interface AgentCardPanelProps {
+  /** The node the drawer is showing. Null closes the panel. */
+  node: TopologyNode | null;
+}
+
+/** Capability flags every A2A card is expected to declare. */
+const CAPABILITY_LABELS: ReadonlyArray<[key: string, label: string]> = [
+  ['streaming', 'streaming'],
+  ['pushNotifications', 'push'],
+  ['stateTransitionHistory', 'history'],
+];
+
+function capabilityEnabled(capabilities: Record<string, unknown>, key: string): boolean {
+  return capabilities[key] === true;
+}
+
+function signatureLabel(entry: AgentDirectoryEntry): { text: string; state: string } {
+  if (entry.signatureVerified === true) return { text: 'signature verified', state: 'ok' };
+  if (entry.signatureVerified === false) return { text: 'signature invalid', state: 'bad' };
+  return { text: 'unsigned', state: 'unknown' };
+}
+
+/**
+ * The A2A card a topology node publishes.
+ *
+ * Not every node is an agent, so the panel renders nothing rather than an empty
+ * shell when the directory has no entry projecting this node.
+ */
+export function AgentCardPanel({ node }: AgentCardPanelProps) {
+  const { data, isLoading, isError, error } = useAgents();
+
+  const entry = useMemo<AgentDirectoryEntry | null>(() => {
+    if (!node || !data) return null;
+    return data.items.find((item) => item.topologyNodeId === node.id) ?? null;
+  }, [data, node]);
+
+  if (!node) return null;
+
+  if (isLoading) {
+    return (
+      <section className="obs-agent-card" data-testid="agent-card-loading">
+        <h3 className="obs-agent-card__title">A2A card</h3>
+        <p className="obs-agent-card__muted">Resolving agent directory…</p>
+      </section>
+    );
+  }
+
+  if (isError) {
+    return (
+      <section className="obs-agent-card" data-testid="agent-card-error">
+        <h3 className="obs-agent-card__title">A2A card</h3>
+        <p className="obs-agent-card__error">
+          Agent directory unavailable{error instanceof Error ? ` — ${error.message}` : ''}
+        </p>
+      </section>
+    );
+  }
+
+  // A host, a service or a realm simply has no card. Say nothing.
+  if (!entry) return null;
+
+  const iface = entry.supportedInterfaces[0];
+  const signature = signatureLabel(entry);
+
+  return (
+    <section className="obs-agent-card" data-testid="agent-card">
+      <h3 className="obs-agent-card__title">
+        A2A card
+        <span className="obs-agent-card__kind" data-testid="agent-card-kind">
+          {entry.kind}
+        </span>
+      </h3>
+
+      {entry.description ? (
+        <p className="obs-agent-card__description">{entry.description}</p>
+      ) : null}
+
+      <dl className="obs-agent-card__facts">
+        <dt>card</dt>
+        <dd data-testid="agent-card-url">{entry.cardUrl}</dd>
+        {iface ? (
+          <>
+            <dt>transport</dt>
+            <dd>{iface.protocolBinding}</dd>
+            <dt>protocol</dt>
+            <dd>A2A {iface.protocolVersion}</dd>
+          </>
+        ) : null}
+        <dt>visibility</dt>
+        <dd>{entry.visibility}</dd>
+        <dt>version</dt>
+        <dd>{entry.cardVersion}</dd>
+      </dl>
+
+      <div className="obs-agent-card__caps" data-testid="agent-card-capabilities">
+        {CAPABILITY_LABELS.map(([key, label]) => {
+          const on = capabilityEnabled(entry.capabilities, key);
+          return (
+            <span
+              key={key}
+              className={`obs-agent-card__cap${on ? ' obs-agent-card__cap--on' : ''}`}
+              data-testid={`agent-cap-${key}`}
+              data-enabled={on}
+            >
+              {label}
+            </span>
+          );
+        })}
+        <span
+          className={`obs-agent-card__cap obs-agent-card__cap--sig-${signature.state}`}
+          data-testid="agent-card-signature"
+        >
+          {signature.text}
+        </span>
+      </div>
+
+      {entry.skillIds.length > 0 ? (
+        <>
+          <h4 className="obs-agent-card__subtitle">Skills · {entry.skillIds.length}</h4>
+          <ul className="obs-agent-card__skills" data-testid="agent-card-skills">
+            {entry.skillIds.map((skill) => (
+              <li key={skill}>{skill}</li>
+            ))}
+          </ul>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.test.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { EntityDrawer } from './EntityDrawer';
-import { createMockTopologyStream, createMockRegistryRepository } from '../../adapters/mock';
+import { createMockRegistryRepository } from '../../adapters/mock';
 import type { TopologyNode, Topology, Registry } from '../../domain';
 
 // ---------------------------------------------------------------------------
@@ -13,7 +13,7 @@ let TOPOLOGY: Topology;
 
 beforeAll(async () => {
   REGISTRY = await createMockRegistryRepository().getRegistry();
-  TOPOLOGY = createMockTopologyStream().getSnapshot()!;
+  TOPOLOGY = fixtureTopology();
 });
 
 const REALM_NODE: TopologyNode = {
@@ -170,6 +170,35 @@ const MODEL_NODE: TopologyNode = {
   provider: 'Anthropic',
   location: 'us-east',
 };
+
+/**
+ * The drawer resolves parents, members and residents out of the topology it is
+ * handed, so these tests own a small fixture rather than reaching for the demo
+ * seed. Otherwise a seed edit breaks tests of a component it has nothing to do
+ * with — which is exactly what happened when the seed grew.
+ */
+function fixtureTopology(): Topology {
+  return {
+    timestamp: '2026-08-01T12:00:00Z',
+    nodes: [
+      REALM_NODE,
+      CLUSTER_NODE,
+      HOST_NODE,
+      TING_NODE,
+      RAVN_NODE,
+      BIFROST_NODE,
+      VOLUNDR_NODE,
+      RUN_NODE,
+      MIMIR_NODE,
+      VALKYRIE_NODE,
+      PRINTER_NODE,
+      VAETTIR_NODE,
+      MODEL_NODE,
+      DEGRADED_NODE,
+    ],
+    edges: [],
+  };
+}
 
 function renderDrawer(
   node: TopologyNode | null,

--- a/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
+++ b/web-next/packages/plugin-observatory/src/ui/overlays/EntityDrawer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, type ReactNode } from 'react';
 import { Sparkline, StateDot } from '@niuulabs/ui';
 import type { DotState } from '@niuulabs/ui';
 import type { TopologyNode, Topology, Registry, NodeActivity } from '../../domain';
@@ -12,6 +12,12 @@ export interface EntityDrawerProps {
   registry: Registry | null;
   onClose: () => void;
   onNodeSelect?: (node: TopologyNode) => void;
+  /**
+   * Slot rendered at the foot of the drawer. The drawer stays a pure function
+   * of its props; anything needing a service (such as the A2A card) is composed
+   * in by the page.
+   */
+  footer?: ReactNode;
 }
 
 // ── Activity dot ──────────────────────────────────────────────────────────────
@@ -395,6 +401,7 @@ export function EntityDrawer({
   registry,
   onClose,
   onNodeSelect,
+  footer,
 }: EntityDrawerProps) {
   const entityType = node ? registry?.types.find((t) => t.id === node.typeId) : undefined;
   const residents =
@@ -624,6 +631,7 @@ export function EntityDrawer({
           </div>
         </>
       )}
+      {footer}
     </aside>
   );
 }


### PR DESCRIPTION
Rebuilds the Observatory topology surface. Most of what this adds was already
described by the domain and the ports — it simply had nothing reading it.

## Why

The canvas drew labels from a fixed typeId allowlist at a fixed pixel size and
had no knowledge of the camera at all, so labels shrank to a few pixels when
zoomed out and collided when zoomed in. `flockId` had been on `TopologyNode`
since the domain was written and was never drawn. `IAgentDirectory` described a
complete A2A card surface that no component read. And `observatory.agents` was
the only observatory service without a mock, so demo mode had no agent data.

## What changed

| Commit | |
|---|---|
| `resolve topology labels with camera zoom` | Level-of-detail ladder; labels hold a constant screen size and each tier draws only once it fits |
| `render agent meshes from flock membership` | `deriveAgentMeshes()` + convex-hull outline for the mesh being engaged with |
| `serve the A2A agent directory in demo mode` | `createMockAgentDirectory`, projecting seed nodes through the existing port |
| `seed the real platform topology for demo mode` | 11 nodes → 5 realms, 8 clusters, the DGX Sparks, 2 workflow sessions |
| `show the A2A card a node publishes` | `AgentCardPanel` reading the directory entry for the selected node |
| `filter the topology by connection layer` | 10 `EdgeRelationType` values → 6 toggles |
| `make the rail sections collapsible` | `details`/`summary` |
| `cover the new canvas surface end to end` | Playwright spec + the three defects it found |

**No new backend types were needed.** `AgentKind` already included
`'workflow-session'`; `cardUrl`, `skillIds`, `capabilities`,
`supportedInterfaces`, `securitySchemes` and `provenance` were all already on
`AgentDirectoryEntry`.

## Decisions worth reviewing

- **`ZOOM_MIN` 0.3 → 0.12.** Eight clusters across five realms do not fit at
  0.3x, so fit-to-bounds clamped to the floor and the full graph could never be
  seen. Unit and e2e assertions now read the floor from config, not a literal.
- **Grafana Mimir is seeded as a `service`, not a `mimir` node.** It shares the
  name but stores no agent memory; conflating them is misleading.
- **Valhalla is seeded `status: 'unknown'`** with `confidence: 'declared'`
  edges — its cluster API rejects our credentials, so it is declared from chart
  values rather than observed.
- **The layer mapping is exhaustive over `EdgeRelationType`**, so adding a
  relation without placing it in a layer is a compile error rather than an edge
  that silently disappears.
- **`EntityDrawer` gained a `footer` slot** instead of a service dependency, so
  it stays a pure function of its props.

## Verification

- lint, format, typecheck clean
- 494 unit tests; coverage **93.08 / 85.31 / 92.35 / 94.64** against the 85% gate
- **35/35 observatory e2e passing** against a real browser and server

## Notes for whoever reviews

Three things found along the way that are **not** fixed here and deserve their
own tickets:

1. **Tests are excluded from typecheck** (`exclude: ["**/*.test.ts"]`). Changing
   `drawNode`'s signature did not fail typecheck — stale call sites silently
   passed `undefined`, turning label assertions into "labels off". Fixed by hand
   here; the exclusion will bite again.
2. **E2E `reuseExistingServer` grabs whatever is on :5173**, which on my machine
   was an unrelated project's dev server — so observatory e2e had been testing
   the wrong app entirely and failing silently.
3. **17 e2e failures exist on `dev`** in ravn, auth, smoke, login, ting, bifrost,
   mimir and volundr-catalog. Reproduced on a clean `dev` checkout (16/69).
   None are observatory.

The backend discovery adapters are still unwritten, so
`/observatory/topology/snapshot` returns empty and the page runs on the seed in
demo mode. The UI is written against the port, so live data drops in with no UI
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)