### PR TITLE
fix(a2a): resume workflows from durable push events

### DIFF
--- a/src/cli/migrations/ting/000032_a2a_push_notifications.down.sql
+++ b/src/cli/migrations/ting/000032_a2a_push_notifications.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS a2a_push_notification_configs;

--- a/src/cli/migrations/ting/000032_a2a_push_notifications.up.sql
+++ b/src/cli/migrations/ting/000032_a2a_push_notifications.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS a2a_push_notification_configs (
+    task_id TEXT NOT NULL,
+    config_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    config_data BYTEA NOT NULL,
+    pending_event JSONB,
+    delivery_version TEXT,
+    next_attempt_at TIMESTAMPTZ,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    delivered_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (task_id, config_id, owner_id),
+    CONSTRAINT a2a_push_notification_task_fk
+        FOREIGN KEY (task_id) REFERENCES workflow_campaigns(slug) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_a2a_push_notification_due
+    ON a2a_push_notification_configs (next_attempt_at)
+    WHERE pending_event IS NOT NULL;

--- a/src/ravn/adapters/tool_build/a2a.py
+++ b/src/ravn/adapters/tool_build/a2a.py
@@ -35,6 +35,7 @@ from ravn.ports.tool_build_backend import (
     ToolBuildBackend,
     ToolBuildError,
     ToolBuildInputRequiredError,
+    ToolBuildPendingError,
     ToolBuildRequest,
     ToolBuildResult,
 )
@@ -78,6 +79,8 @@ class A2AToolBuildBackend(ToolBuildBackend):
         branch: str = "",
         model: str = "",
         connection_id: str = "",
+        push_callback_url: str = "",
+        push_notification_token: str = "",
         max_poll_attempts: int = 120,
         poll_interval_seconds: float = 5.0,
         gate_reviewer: GateReviewer | None = None,
@@ -107,6 +110,8 @@ class A2AToolBuildBackend(ToolBuildBackend):
         self._branch = branch
         self._model = model
         self._connection_id = connection_id
+        self._push_callback_url = push_callback_url.strip()
+        self._push_notification_token = push_notification_token.strip()
         self._max_poll_attempts = max_poll_attempts
         self._poll_interval = poll_interval_seconds
         # INPUT_REQUIRED handling. A pending peer QUESTION (help_needed) is
@@ -161,6 +166,20 @@ class A2AToolBuildBackend(ToolBuildBackend):
             telemetry.event("ravn.tool_build.requested", attributes=attributes, content=request)
             try:
                 result = await self._build_observed(request)
+            except ToolBuildPendingError as exc:
+                span.set_attribute("ravn.tool_build.outcome", "pending")
+                span.set_attribute("a2a.task.id", exc.task_id)
+                span.set_attribute("a2a.push.registered", exc.push_registered)
+                telemetry.event(
+                    "ravn.a2a.tool_build.pending",
+                    attributes={
+                        **attributes,
+                        "ravn.tool_build.outcome": "pending",
+                        "a2a.task.id": exc.task_id,
+                        "a2a.push.registered": exc.push_registered,
+                    },
+                )
+                raise
             except ToolBuildInputRequiredError as exc:
                 span.set_attribute("ravn.tool_build.outcome", "input_required")
                 span.set_attribute("a2a.task.id", exc.task_id)
@@ -229,24 +248,28 @@ class A2AToolBuildBackend(ToolBuildBackend):
             return result
 
     async def _build_observed(self, request: ToolBuildRequest) -> ToolBuildResult:
-        endpoint, workflow_id = await self._resolve_endpoint_and_workflow()
+        endpoint, workflow_id, push_supported = await self._resolve_endpoint_and_workflow()
         telemetry = get_observability()
         continuation = request.continuation
         task_id = str(continuation.get("task_id") or "")
         exchanges = _continuation_exchanges(continuation)
         rounds = int(continuation.get("round") or 0)
+        task: dict[str, Any]
         if task_id:
-            exchange = await self._resume_task_input(endpoint, request)
-            exchanges.append(exchange)
-            telemetry.event(
-                "ravn.a2a.task.resumed",
-                attributes={
-                    "a2a.task.id": task_id,
-                    "a2a.skill.id": workflow_id,
-                    "a2a.input.kind": str(continuation.get("input_kind") or ""),
-                },
-                content=exchange,
-            )
+            input_kind = str(continuation.get("input_kind") or "")
+            if input_kind and input_kind != "pending":
+                exchange = await self._resume_task_input(endpoint, request)
+                exchanges.append(exchange)
+                telemetry.event(
+                    "ravn.a2a.task.resumed",
+                    attributes={
+                        "a2a.task.id": task_id,
+                        "a2a.skill.id": workflow_id,
+                        "a2a.input.kind": input_kind,
+                    },
+                    content=exchange,
+                )
+            task = await self._get_task(endpoint, task_id)
         else:
             _system, initial_prompt = build_prompts(request)
             task = await self._find_task_by_context(endpoint, request.operation_id)
@@ -273,14 +296,37 @@ class A2AToolBuildBackend(ToolBuildBackend):
             }
         )
 
-        final, gate_exchanges = await self._poll_answering_gates(
-            endpoint,
-            task_id,
-            request,
-            workflow_id=workflow_id,
-            exchanges=exchanges,
-            rounds=rounds,
-        )
+        push_registered = bool(continuation.get("push_registered"))
+        if not push_registered and push_supported and self._push_callback_url:
+            try:
+                await self._register_push(endpoint, task_id)
+                push_registered = True
+            except ToolBuildError as exc:
+                logger.warning(
+                    "A2A tool-build push registration failed for task %s; "
+                    "using compatibility polling: %s",
+                    task_id,
+                    exc,
+                )
+
+        if push_registered:
+            final, gate_exchanges = await self._advance_push_task_once(
+                endpoint,
+                task,
+                request,
+                workflow_id=workflow_id,
+                exchanges=exchanges,
+                rounds=rounds,
+            )
+        else:
+            final, gate_exchanges = await self._poll_answering_gates(
+                endpoint,
+                task_id,
+                request,
+                workflow_id=workflow_id,
+                exchanges=exchanges,
+                rounds=rounds,
+            )
         state = _task_state(final)
         if state in _FAILED_STATES:
             raise ToolBuildError(f"A2A task {task_id} ended in state {state!r}")
@@ -312,6 +358,91 @@ class A2AToolBuildBackend(ToolBuildBackend):
             requirements=result.requirements,
             build_evidence=build_evidence,
             provenance=provenance,
+        )
+
+    async def _advance_push_task_once(
+        self,
+        endpoint: str,
+        task: dict[str, Any],
+        request: ToolBuildRequest,
+        *,
+        workflow_id: str,
+        exchanges: list[dict[str, Any]],
+        rounds: int,
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Process one callback-driven snapshot, then suspend if work continues."""
+        task_id = str(task.get("id") or "")
+        state = _task_state(task)
+        await self._emit_activity(
+            {
+                "agent_id": self._card_url,
+                "skill_id": workflow_id,
+                "task_id": task_id,
+                "state": state or "TASK_STATE_UNSPECIFIED",
+                "operation": "build",
+                "input_required": state == _INPUT_REQUIRED_STATE,
+                "question": _activity_question(task),
+                "prompt": request.build_request[:500],
+                "status_message": _task_status_message(task),
+                "source_tool": "build_tool",
+                "push_registered": True,
+            }
+        )
+        if state in _TERMINAL_STATES:
+            return task, exchanges
+        if state == _INPUT_REQUIRED_STATE:
+            rounds += 1
+            if rounds > self._max_gate_rounds:
+                raise ToolBuildError(
+                    f"A2A task {task_id} exceeded {self._max_gate_rounds} input rounds"
+                )
+            question = _first_pending_question(task)
+            if question:
+                if self._question_answerer is None:
+                    raise _input_required(
+                        task_id=task_id,
+                        input_kind="question",
+                        payload=question,
+                        exchanges=exchanges,
+                        round=rounds,
+                        push_registered=True,
+                    )
+                exchange = await self._answer_question(
+                    endpoint, task_id, question, request, round=rounds
+                )
+            else:
+                gate = _first_pending_gate(task)
+                if not gate:
+                    raise _input_required(
+                        task_id=task_id,
+                        input_kind="input",
+                        payload={},
+                        exchanges=exchanges,
+                        round=rounds,
+                        push_registered=True,
+                    )
+                if self._gate_reviewer is None:
+                    raise _input_required(
+                        task_id=task_id,
+                        input_kind="gate",
+                        payload=gate,
+                        exchanges=exchanges,
+                        round=rounds,
+                        push_registered=True,
+                    )
+                exchange = await self._answer_gate(endpoint, task_id, task, request, round=rounds)
+            exchanges.append(exchange)
+
+        raise ToolBuildPendingError(
+            task_id=task_id,
+            push_registered=True,
+            continuation={
+                "task_id": task_id,
+                "input_kind": "pending",
+                "round": rounds,
+                "exchanges": exchanges,
+                "push_registered": True,
+            },
         )
 
     # -- Gate-aware polling ------------------------------------------------ #
@@ -724,7 +855,7 @@ class A2AToolBuildBackend(ToolBuildBackend):
 
     # -- Card & skill resolution ---------------------------------------- #
 
-    async def _resolve_endpoint_and_workflow(self) -> tuple[str, str]:
+    async def _resolve_endpoint_and_workflow(self) -> tuple[str, str, bool]:
         telemetry = get_observability()
         attributes = {"a2a.card.url": self._card_url}
         with telemetry.span("ravn.a2a.discover", attributes=attributes) as span:
@@ -773,7 +904,9 @@ class A2AToolBuildBackend(ToolBuildBackend):
                     },
                     content=card,
                 )
-                return endpoint, workflow_id
+                capabilities = card.get("capabilities")
+                capabilities = capabilities if isinstance(capabilities, dict) else {}
+                return endpoint, workflow_id, bool(capabilities.get("pushNotifications"))
             except Exception as exc:
                 telemetry.mark_error(span, type(exc).__name__, str(exc))
                 telemetry.event(
@@ -874,6 +1007,18 @@ class A2AToolBuildBackend(ToolBuildBackend):
     async def _get_task(self, endpoint: str, task_id: str) -> dict[str, Any]:
         result = await self._rpc(endpoint, "GetTask", {"id": task_id})
         return result if isinstance(result, dict) else {}
+
+    async def _register_push(self, endpoint: str, task_id: str) -> None:
+        await self._rpc(
+            endpoint,
+            "CreateTaskPushNotificationConfig",
+            {
+                "taskId": task_id,
+                "id": f"ravn-tool-build-{uuid4()}",
+                "url": self._push_callback_url,
+                "token": self._push_notification_token,
+            },
+        )
 
     async def _rpc(
         self,
@@ -1141,6 +1286,7 @@ def _input_required(
     payload: dict[str, Any],
     exchanges: list[dict[str, Any]],
     round: int,  # noqa: A002
+    push_registered: bool = False,
 ) -> ToolBuildInputRequiredError:
     reply_metadata: dict[str, Any] = {}
     if input_kind == "question":
@@ -1166,6 +1312,7 @@ def _input_required(
         "reply_metadata": reply_metadata,
         "exchanges": exchanges,
         "round": round,
+        "push_registered": push_registered,
     }
     return ToolBuildInputRequiredError(
         task_id=task_id,

--- a/src/ravn/adapters/tools/build_tool.py
+++ b/src/ravn/adapters/tools/build_tool.py
@@ -19,6 +19,7 @@ from ravn.ports.tool import ToolPort
 from ravn.ports.tool_build_backend import (
     ToolBuildError,
     ToolBuildInputRequiredError,
+    ToolBuildPendingError,
 )
 from ravn.tool_observability import publish_learned_tool_inventory
 from ravn.valkyrie_evolution.adapters import PolicyCourtReviewer
@@ -142,7 +143,9 @@ class BuildTool(ToolPort):
             "Provide a manifest with name, description, input_schema, required_permission, "
             "and declared_reach. "
             + authoring
-            + "If a commissioned build returns status=input_required, either answer from "
+            + "If a commissioned build returns status=pending, stop and wait for its A2A "
+            "callback; on the callback turn, resume it with continuation_task_id only. "
+            "If it returns status=input_required, either answer from "
             "available evidence or ask the operator. Resume the same durable A2A task with "
             "continuation_task_id and continuation_answer; include continuation_metadata "
             "when the result requests a gate decision. "
@@ -264,7 +267,8 @@ class BuildTool(ToolPort):
                     "type": "string",
                     "description": (
                         "A durable commissioned-build task id returned by an earlier "
-                        "status=input_required result. Use it to resume that exact task."
+                        "status=pending or status=input_required result. Use it to resume "
+                        "that exact task after its callback."
                     ),
                 },
                 "continuation_answer": {
@@ -283,7 +287,7 @@ class BuildTool(ToolPort):
             },
             "anyOf": [
                 {"required": ["manifest"]},
-                {"required": ["continuation_task_id", "continuation_answer"]},
+                {"required": ["continuation_task_id"]},
             ],
         }
 
@@ -637,6 +641,8 @@ class BuildTool(ToolPort):
                 )
         except ToolBuildInputRequiredError as exc:
             return self._input_required_result(exc)
+        except ToolBuildPendingError as exc:
+            return self._pending_result(exc)
         except (LearnedToolError, ToolBuildError, TypeError, ValueError) as exc:
             return ToolResult(tool_call_id="", content=f"build_tool failed: {exc}", is_error=True)
 
@@ -756,7 +762,7 @@ class BuildTool(ToolPort):
         )
         try:
             result = await self._build_backend.build(request)
-        except ToolBuildInputRequiredError as exc:
+        except (ToolBuildInputRequiredError, ToolBuildPendingError) as exc:
             self._persist_pending_build(prepared, exc)
             if operation_id:
                 self._delete_commission(operation_id)
@@ -785,10 +791,6 @@ class BuildTool(ToolPort):
             raise LearnedToolError(
                 "continuation_task_id was given but no tool build backend is configured"
             )
-        answer = str(input.get("continuation_answer") or "").strip()
-        if not answer:
-            raise LearnedToolError("continuation_answer must be non-empty")
-
         pending = self._load_pending_build(task_id)
         original = pending.get("input")
         continuation = pending.get("continuation")
@@ -798,7 +800,12 @@ class BuildTool(ToolPort):
             raise LearnedToolError(f"pending build state does not match task {task_id!r}")
 
         continuation = dict(continuation)
-        continuation["answer"] = answer
+        input_kind = str(continuation.get("input_kind") or "")
+        answer = str(input.get("continuation_answer") or "").strip()
+        if input_kind != "pending" and not answer:
+            raise LearnedToolError("continuation_answer must be non-empty")
+        if answer:
+            continuation["answer"] = answer
         supplied_metadata = input.get("continuation_metadata")
         if supplied_metadata is not None and not isinstance(supplied_metadata, dict):
             raise LearnedToolError("continuation_metadata must be an object")
@@ -828,7 +835,7 @@ class BuildTool(ToolPort):
                 resumed,
                 signal_context_suffix="",
             )
-        except ToolBuildInputRequiredError:
+        except (ToolBuildInputRequiredError, ToolBuildPendingError):
             raise
         self._delete_pending_build(task_id)
         telemetry.event(
@@ -840,7 +847,7 @@ class BuildTool(ToolPort):
     def _persist_pending_build(
         self,
         input: dict,  # noqa: A002
-        required: ToolBuildInputRequiredError,
+        required: ToolBuildInputRequiredError | ToolBuildPendingError,
     ) -> None:
         """Atomically persist the minimum state needed to resume one build."""
         original = {
@@ -874,11 +881,11 @@ class BuildTool(ToolPort):
             "ravn.tool_build.continuation.suspended",
             attributes={
                 "a2a.task.id": required.task_id,
-                "a2a.input.kind": required.input_kind,
+                "a2a.input.kind": str(required.continuation.get("input_kind") or ""),
                 "ravn.tool_build.pending.path": str(path),
             },
             content={
-                "prompt": required.prompt,
+                "prompt": getattr(required, "prompt", ""),
                 "input_payload": required.continuation.get("input_payload", {}),
                 "reply_metadata": required.continuation.get("reply_metadata", {}),
             },
@@ -1119,6 +1126,28 @@ class BuildTool(ToolPort):
         return ToolResult(
             tool_call_id="",
             content=json.dumps(payload, indent=2, sort_keys=True),
+            is_error=False,
+        )
+
+    def _pending_result(self, pending: ToolBuildPendingError) -> ToolResult:
+        return ToolResult(
+            tool_call_id="",
+            content=json.dumps(
+                {
+                    "status": "pending",
+                    "backend": str(getattr(self._build_backend, "name", "unknown")),
+                    "task_id": pending.task_id,
+                    "push_registered": pending.push_registered,
+                    "resume_with": {"continuation_task_id": pending.task_id},
+                    "next_step": (
+                        "Do not poll. Sleep with reason=external_event. The A2A callback "
+                        "will wake this resident; then call build_tool once with the returned "
+                        "continuation_task_id to process the new task state."
+                    ),
+                },
+                indent=2,
+                sort_keys=True,
+            ),
             is_error=False,
         )
 

--- a/src/ravn/cli/runtime_builders.py
+++ b/src/ravn/cli/runtime_builders.py
@@ -187,6 +187,12 @@ def _build_tool_build_backend(
         kwargs["question_answerer"] = question_answerer
     if activity_emitter is not None and _constructor_accepts_kwarg(cls, "activity_emitter"):
         kwargs["activity_emitter"] = activity_emitter
+    if _constructor_accepts_kwarg(cls, "push_callback_url"):
+        kwargs["push_callback_url"] = settings.gateway.platform.a2a_push_callback_url
+    if _constructor_accepts_kwarg(cls, "push_notification_token"):
+        kwargs["push_notification_token"] = (
+            settings.gateway.platform.a2a_push_notification_token.get_secret_value().strip()
+        )
     return cls(**kwargs)
 
 

--- a/src/ravn/personas/ivaldi.yaml
+++ b/src/ravn/personas/ivaldi.yaml
@@ -31,6 +31,10 @@ system_prompt_template: |
   sleep with `next_action_timing: external_event`; the authenticated callback
   will wake you with the new task state. Do not poll that task repeatedly. If
   push registration is false or absent, schedule one bounded recheck instead.
+  A `build_tool` result with `status: pending` follows the same rule: sleep for
+  an external event, then call `build_tool` once with its
+  `continuation_task_id` after the callback wakes you. Never loop on that
+  continuation.
   `build_tool` is complete only after its build, tests, review, provenance, and
   adoption succeed. When its capability description says a build backend is
   configured, commission the build instead of authoring the implementation

--- a/src/ravn/ports/tool_build_backend.py
+++ b/src/ravn/ports/tool_build_backend.py
@@ -44,6 +44,22 @@ class ToolBuildInputRequiredError(ToolBuildError):
         super().__init__(f"A2A task {task_id} requires {input_kind} input: {prompt}")
 
 
+class ToolBuildPendingError(ToolBuildError):
+    """A commissioned build is running and will resume after an A2A callback."""
+
+    def __init__(
+        self,
+        *,
+        task_id: str,
+        continuation: dict[str, Any],
+        push_registered: bool,
+    ) -> None:
+        self.task_id = task_id
+        self.continuation = continuation
+        self.push_registered = push_registered
+        super().__init__(f"A2A task {task_id} is still running")
+
+
 @dataclass(frozen=True)
 class ToolBuildRequest:
     """What a resident wants built, handed to a build backend."""

--- a/src/ting/adapters/postgres_workflow_campaigns.py
+++ b/src/ting/adapters/postgres_workflow_campaigns.py
@@ -41,6 +41,38 @@ class PostgresWorkflowCampaignRepository(WorkflowCampaignRepository):
         )
         return [self._row_to_campaign(row) for row in rows]
 
+    async def list_active_owner_ids(self) -> list[str]:
+        rows = await self._pool.fetch(
+            """
+            SELECT DISTINCT owner_id
+            FROM workflow_campaigns
+            WHERE status IN ('pending', 'running', 'blocked')
+            ORDER BY owner_id
+            """
+        )
+        return [str(row["owner_id"]) for row in rows]
+
+    async def get_active_campaign_by_session(
+        self,
+        *,
+        owner_id: str,
+        session_id: str,
+    ) -> WorkflowCampaign | None:
+        row = await self._pool.fetchrow(
+            """
+            SELECT *
+            FROM workflow_campaigns
+            WHERE owner_id = $1
+              AND session_id = $2
+              AND status IN ('pending', 'running', 'blocked')
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """,
+            owner_id,
+            session_id,
+        )
+        return self._row_to_campaign(row) if row is not None else None
+
     async def get_campaign(self, campaign_id: UUID) -> WorkflowCampaign | None:
         row = await self._pool.fetchrow(
             "SELECT * FROM workflow_campaigns WHERE id = $1",

--- a/src/ting/domain/services/activity_subscriber.py
+++ b/src/ting/domain/services/activity_subscriber.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -37,7 +37,7 @@ from ting.ports.volundr import ActivityEvent, VolundrFactory, VolundrPort
 
 if TYPE_CHECKING:
     from ting.domain.services.review_engine import ReviewEngine
-    from ting.ports.workflow_campaign_repository import WorkflowCampaignRepository
+    from ting.domain.services.workflow_campaign_projector import WorkflowCampaignProjector
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ class SessionActivitySubscriber:
         review_engine: ReviewEngine | None = None,
         sleipnir_publisher: object | None = None,
         ravn_scope_adherence_threshold: float = 0.7,
-        workflow_campaign_repo: WorkflowCampaignRepository | None = None,
+        workflow_campaign_projector: WorkflowCampaignProjector | None = None,
     ) -> None:
         self._factory = volundr_factory
         self._tracker_factory = tracker_factory
@@ -81,7 +81,7 @@ class SessionActivitySubscriber:
         self._review_engine = review_engine
         self._sleipnir_publisher = sleipnir_publisher
         self._ravn_scope_adherence_threshold = ravn_scope_adherence_threshold
-        self._workflow_campaign_repo = workflow_campaign_repo
+        self._workflow_campaign_projector = workflow_campaign_projector
         self._running = False
         self._task: asyncio.Task[None] | None = None
         self._owner_tasks: dict[str, list[asyncio.Task[None]]] = {}
@@ -141,8 +141,10 @@ class SessionActivitySubscriber:
                 await asyncio.sleep(self._config.reconnect_delay)
 
     async def _sync_owner_subscriptions(self) -> None:
-        """Discover owners with active dispatchers, ensure each has SSE subs."""
+        """Discover owners with active work, ensure each has SSE subscriptions."""
         active_owners = set(await self._dispatcher_repo.list_active_owner_ids())
+        if self._workflow_campaign_projector is not None:
+            active_owners.update(await self._workflow_campaign_projector.list_active_owner_ids())
         logger.info(
             "Sync: active_owners=%s, existing_tasks=%s",
             active_owners,
@@ -166,6 +168,8 @@ class SessionActivitySubscriber:
             existing = self._owner_tasks.get(owner_id, [])
             all_done = not existing or all(t.done() for t in existing)
             if all_done:
+                if self._workflow_campaign_projector is not None:
+                    await self._workflow_campaign_projector.reconcile_owner(owner_id)
                 adapters = await self._resolve_owner_adapters(owner_id)
                 tasks = []
                 for idx, adapter in enumerate(adapters):
@@ -278,6 +282,21 @@ class SessionActivitySubscriber:
             event.session_status or "-",
             event.metadata,
         )
+        terminal_event = event.state == "error" or bool(event.session_status)
+        if (
+            terminal_event
+            and self._workflow_campaign_projector is not None
+            and await self._workflow_campaign_projector.handle_activity(event, owner_id)
+        ):
+            return
+        if await self._maybe_handle_help_needed(event, owner_id):
+            return
+        if (
+            not terminal_event
+            and self._workflow_campaign_projector is not None
+            and await self._workflow_campaign_projector.handle_activity(event, owner_id)
+        ):
+            return
         if await self._try_handle_authoritative_completion(event, volundr, owner_id):
             return
 
@@ -295,9 +314,6 @@ class SessionActivitySubscriber:
 
         if event.state == "error":
             await self._on_session_failed(event, volundr, owner_id)
-            return
-
-        if await self._maybe_handle_help_needed(event, owner_id):
             return
 
         if event.state != "idle":
@@ -565,60 +581,20 @@ class SessionActivitySubscriber:
         payload: dict[str, object],
         owner_id: str,
     ) -> bool:
-        if self._workflow_campaign_repo is None:
+        if self._workflow_campaign_projector is None:
             return False
 
         session_id = _help_needed_session_id(payload) or event.session_id
         if not session_id:
             return False
 
-        campaigns = await self._workflow_campaign_repo.list_active_campaigns()
-        campaign = next(
-            (
-                item
-                for item in campaigns
-                if item.owner_id == owner_id and item.session_id == session_id
-            ),
-            None,
-        )
-        if campaign is None:
-            return False
-
         gate = _workflow_gate_from_help_needed(payload)
-        metadata = dict(campaign.metadata)
-        metadata["pending_workflow_gates"] = [gate]
-        metadata["latest_help_needed"] = dict(payload)
-        now = datetime.now(UTC)
-        await self._workflow_campaign_repo.save_campaign(
-            replace(
-                campaign,
-                active_stage_id=str(gate.get("node_id") or campaign.active_stage_id or "") or None,
-                metadata=metadata,
-                updated_at=now,
-                last_activity_at=now,
-            )
+        return await self._workflow_campaign_projector.record_help_needed(
+            payload,
+            owner_id,
+            session_id=session_id,
+            gate=gate,
         )
-        await self._event_bus.emit(
-            TingEvent(
-                event="workflow.campaign.feedback_requested",
-                owner_id=owner_id,
-                data={
-                    "owner_id": owner_id,
-                    "campaign_id": str(campaign.id),
-                    "slug": campaign.slug,
-                    "session_id": session_id,
-                    "summary": payload.get("summary", ""),
-                    "reason": payload.get("reason", ""),
-                    "recommendation": payload.get("recommendation", ""),
-                },
-            )
-        )
-        logger.info(
-            "Recorded workflow campaign help-needed request for campaign=%s session=%s",
-            campaign.slug,
-            session_id[:8],
-        )
-        return True
 
     async def _try_handle_flock_completion(
         self,

--- a/src/ting/domain/services/workflow_campaign_projector.py
+++ b/src/ting/domain/services/workflow_campaign_projector.py
@@ -1,23 +1,27 @@
-"""Background projector that keeps workflow campaigns in sync with Volundr."""
+"""Event-driven projection of Volundr workflow sessions into A2A campaigns."""
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from contextlib import suppress
+from dataclasses import replace
 from datetime import UTC, datetime
 
 from ting.domain.models import WorkflowCampaign, WorkflowCampaignStatus
 from ting.ports.a2a_push import A2APushDispatcherPort
 from ting.ports.event_bus import EventBusPort, TingEvent
-from ting.ports.volundr import VolundrFactory
+from ting.ports.volundr import ActivityEvent, VolundrFactory
 from ting.ports.workflow_campaign_repository import WorkflowCampaignRepository
 
 logger = logging.getLogger(__name__)
 
 
 class WorkflowCampaignProjector:
-    """Poll active workflow campaigns and emit generic campaign events."""
+    """Project Volundr SSE events and reconnect reconciliation into campaigns.
+
+    Normal campaign transitions are driven by Volundr's activity stream.  A
+    one-shot read when an owner subscription starts closes the restart and
+    disconnect gap without continuously polling every campaign.
+    """
 
     def __init__(
         self,
@@ -26,60 +30,121 @@ class WorkflowCampaignProjector:
         volundr_factory: VolundrFactory,
         event_bus: EventBusPort,
         push_dispatcher: A2APushDispatcherPort | None = None,
-        interval_seconds: float = 15.0,
     ) -> None:
         self._repo = repo
         self._volundr_factory = volundr_factory
         self._event_bus = event_bus
         self._push_dispatcher = push_dispatcher
-        self._interval_seconds = interval_seconds
-        self._task: asyncio.Task[None] | None = None
-        self._stop_event = asyncio.Event()
+        self._running = False
 
     @property
     def running(self) -> bool:
-        return self._task is not None and not self._task.done()
+        return self._running
 
     async def start(self) -> None:
-        if self.running:
-            return
-        self._stop_event.clear()
-        self._task = asyncio.create_task(self._run(), name="workflow-campaign-projector")
-        logger.info("Workflow campaign projector started")
+        self._running = True
+        logger.info("Event-driven workflow campaign projector started")
 
     async def stop(self) -> None:
-        self._stop_event.set()
-        if self._task is not None:
-            self._task.cancel()
-            with suppress(asyncio.CancelledError):
-                await self._task
-            self._task = None
-        logger.info("Workflow campaign projector stopped")
+        self._running = False
+        logger.info("Event-driven workflow campaign projector stopped")
 
-    async def _run(self) -> None:
-        try:
-            while not self._stop_event.is_set():
-                await self._tick()
-                try:
-                    await asyncio.wait_for(self._stop_event.wait(), timeout=self._interval_seconds)
-                except TimeoutError:
-                    continue
-        except asyncio.CancelledError:
-            raise
+    async def list_active_owner_ids(self) -> list[str]:
+        return await self._repo.list_active_owner_ids()
 
-    async def _tick(self) -> None:
+    async def reconcile_owner(self, owner_id: str) -> None:
+        """Reconcile one owner's campaigns once before (re)subscribing to SSE."""
         campaigns = await self._repo.list_active_campaigns()
         for campaign in campaigns:
+            if campaign.owner_id != owner_id:
+                continue
             try:
                 await self._refresh_campaign(campaign)
             except Exception:
                 logger.warning(
-                    "Workflow campaign projector failed for campaign %s",
+                    "Workflow campaign reconnect reconciliation failed for %s",
                     campaign.slug,
                     exc_info=True,
                 )
 
+    async def handle_activity(self, event: ActivityEvent, owner_id: str) -> bool:
+        """Apply one Volundr stream event; return whether it was a campaign event."""
+        campaign = await self._active_campaign(owner_id, event.session_id)
+        if campaign is None:
+            return False
+
+        if event.state == "error" or event.session_status in {"failed", "cancelled", "canceled"}:
+            error = str(event.metadata.get("error") or event.metadata.get("message") or "").strip()
+            if not error:
+                error = f"Session {event.session_status or event.state or 'failed'}"
+            await self._save_transition(
+                campaign,
+                WorkflowCampaignStatus.FAILED,
+                failure_error=error,
+            )
+        elif event.session_status in {"stopped", "completed", "complete", "succeeded"}:
+            await self._save_transition(campaign, WorkflowCampaignStatus.COMPLETED)
+        elif campaign.status == WorkflowCampaignStatus.PENDING and event.state in {
+            "active",
+            "idle",
+            "tool_executing",
+        }:
+            await self._save_transition(campaign, WorkflowCampaignStatus.RUNNING)
+        return True
+
+    async def record_help_needed(
+        self,
+        payload: dict[str, object],
+        owner_id: str,
+        *,
+        session_id: str,
+        gate: dict[str, object],
+    ) -> bool:
+        """Persist an input-required event and immediately notify A2A callbacks."""
+        campaign = await self._active_campaign(owner_id, session_id)
+        if campaign is None:
+            return False
+
+        metadata = dict(campaign.metadata)
+        metadata["pending_workflow_gates"] = [gate]
+        metadata["latest_help_needed"] = dict(payload)
+        await self._save_transition(
+            campaign,
+            WorkflowCampaignStatus.BLOCKED,
+            metadata=metadata,
+            active_stage_id=str(gate.get("node_id") or campaign.active_stage_id or "") or None,
+            force=True,
+        )
+        await self._event_bus.emit(
+            TingEvent(
+                event="workflow.campaign.feedback_requested",
+                owner_id=owner_id,
+                data={
+                    "owner_id": owner_id,
+                    "campaign_id": str(campaign.id),
+                    "slug": campaign.slug,
+                    "session_id": session_id,
+                    "summary": payload.get("summary", ""),
+                    "reason": payload.get("reason", ""),
+                    "recommendation": payload.get("recommendation", ""),
+                },
+            )
+        )
+        logger.info(
+            "Recorded workflow campaign help-needed request for campaign=%s session=%s",
+            campaign.slug,
+            session_id[:8],
+        )
+        return True
+
+    async def _active_campaign(self, owner_id: str, session_id: str) -> WorkflowCampaign | None:
+        return await self._repo.get_active_campaign_by_session(
+            owner_id=owner_id,
+            session_id=session_id,
+        )
+
     async def _refresh_campaign(self, campaign: WorkflowCampaign) -> None:
+        """One-shot reconnect reconciliation; never called on a timer."""
         adapter = await self._campaign_adapter(campaign)
         if adapter is None:
             return
@@ -92,23 +157,25 @@ class WorkflowCampaignProjector:
             if activity_state == "error"
             else _status_from_session(session.status, fallback=campaign.status)
         )
-        if next_status == WorkflowCampaignStatus.RUNNING:
-            # Volundr's lifecycle status never says "waiting" — blocked-ness is
-            # a session-internal condition (a peer's pending help question or a
-            # pending workflow gate). Derive it from the live blockers so the
-            # A2A task honestly reports INPUT_REQUIRED when the flock is
-            # actually asking for input.
-            if await self._session_awaits_input(adapter, campaign.session_id):
-                next_status = WorkflowCampaignStatus.BLOCKED
+        if next_status == WorkflowCampaignStatus.RUNNING and await self._session_awaits_input(
+            adapter, campaign.session_id
+        ):
+            next_status = WorkflowCampaignStatus.BLOCKED
 
-        await self._apply_status(campaign, session, next_status)
+        activity_metadata = getattr(session, "activity_metadata", {}) or {}
+        failure_error = ""
+        if next_status == WorkflowCampaignStatus.FAILED:
+            failure_error = str(
+                activity_metadata.get("error") or activity_metadata.get("message") or ""
+            ).strip()
+        await self._save_transition(
+            campaign,
+            next_status,
+            session_name=session.name,
+            failure_error=failure_error,
+        )
 
     async def _campaign_adapter(self, campaign: WorkflowCampaign):
-        """Adapter for the connection the campaign's session lives on.
-
-        Owner-primary is only a fallback for pre-affinity campaigns; a
-        session on a non-default cluster does not exist on the primary.
-        """
         if campaign.connection_id:
             adapter = await self._volundr_factory.for_connection(
                 campaign.owner_id, campaign.connection_id
@@ -116,7 +183,7 @@ class WorkflowCampaignProjector:
             if adapter is not None:
                 return adapter
             logger.warning(
-                "Campaign %s connection %s no longer resolves; skipping refresh",
+                "Campaign %s connection %s no longer resolves; skipping reconciliation",
                 campaign.slug,
                 campaign.connection_id,
             )
@@ -124,61 +191,64 @@ class WorkflowCampaignProjector:
         return await self._volundr_factory.primary_for_owner(campaign.owner_id)
 
     async def _session_awaits_input(self, adapter, session_id: str) -> bool:
-        """True when the session has a pending help question or workflow gate.
-
-        Best-effort: a transient fetch failure reads as not-blocked; the next
-        tick retries. Failures are logged so silence is never mistaken for
-        health.
-        """
         try:
             if _has_pending_entry(await adapter.get_help_requests(session_id)):
                 return True
-            if _has_pending_entry(await adapter.get_workflow_gates(session_id)):
-                return True
+            return _has_pending_entry(await adapter.get_workflow_gates(session_id))
         except Exception:
             logger.warning(
-                "Workflow campaign projector could not fetch session blockers for %s",
+                "Could not reconcile session blockers for %s",
                 session_id,
                 exc_info=True,
             )
-        return False
+            return False
 
-    async def _apply_status(self, campaign: WorkflowCampaign, session, next_status) -> None:
-        if next_status == campaign.status and session.name == campaign.session_name:
+    async def _save_transition(
+        self,
+        campaign: WorkflowCampaign,
+        next_status: WorkflowCampaignStatus,
+        *,
+        session_name: str | None = None,
+        failure_error: str = "",
+        metadata: dict | None = None,
+        active_stage_id: str | None = None,
+        force: bool = False,
+    ) -> None:
+        resolved_name = session_name or campaign.session_name
+        if not force and next_status == campaign.status and resolved_name == campaign.session_name:
             return
 
         now = datetime.now(UTC)
-        metadata = dict(campaign.metadata)
-        if next_status == WorkflowCampaignStatus.FAILED:
-            activity_metadata = getattr(session, "activity_metadata", {}) or {}
-            failure_error = str(
-                activity_metadata.get("error") or activity_metadata.get("message") or ""
-            ).strip()
-            if failure_error:
-                metadata["failure_error"] = failure_error
-
-        updated = WorkflowCampaign(
-            **{
-                **campaign.__dict__,
-                "session_name": session.name,
-                "status": next_status,
-                "metadata": metadata,
-                "updated_at": now,
-                "last_activity_at": now,
-                "completed_at": now
-                if next_status == WorkflowCampaignStatus.COMPLETED and campaign.completed_at is None
-                else campaign.completed_at,
-            }
+        resolved_metadata = dict(campaign.metadata) if metadata is None else metadata
+        if failure_error:
+            resolved_metadata["failure_error"] = failure_error
+        saved = await self._repo.save_campaign(
+            replace(
+                campaign,
+                session_name=resolved_name,
+                status=next_status,
+                metadata=resolved_metadata,
+                active_stage_id=(
+                    active_stage_id if active_stage_id is not None else campaign.active_stage_id
+                ),
+                updated_at=now,
+                last_activity_at=now,
+                completed_at=(
+                    now
+                    if next_status == WorkflowCampaignStatus.COMPLETED
+                    and campaign.completed_at is None
+                    else campaign.completed_at
+                ),
+            )
         )
-        saved = await self._repo.save_campaign(updated)
-        event = "workflow.campaign.updated"
+        event_name = "workflow.campaign.updated"
         if next_status == WorkflowCampaignStatus.COMPLETED:
-            event = "workflow.campaign.completed"
+            event_name = "workflow.campaign.completed"
         elif next_status == WorkflowCampaignStatus.FAILED:
-            event = "workflow.campaign.failed"
+            event_name = "workflow.campaign.failed"
         await self._event_bus.emit(
             TingEvent(
-                event=event,
+                event=event_name,
                 owner_id=saved.owner_id,
                 data={
                     "campaign_id": str(saved.id),

--- a/src/ting/main.py
+++ b/src/ting/main.py
@@ -912,7 +912,7 @@ def create_app(
                 review_engine=review_engine,
                 sleipnir_publisher=sleipnir_bus,
                 ravn_scope_adherence_threshold=settings.ravn_outcome.scope_adherence_threshold,
-                workflow_campaign_repo=workflow_campaign_repo,
+                workflow_campaign_projector=workflow_campaign_projector,
             )
             app.state.subscriber = subscriber
             await subscriber.start()
@@ -988,6 +988,7 @@ def create_app(
                 await ravn_outcome_handler.stop()
             if event_trigger_adapter is not None:
                 await event_trigger_adapter.stop()
+            await subscriber.stop()
             if ting_sleipnir_bridge is not None:
                 await ting_sleipnir_bridge.stop()
             await workflow_campaign_projector.stop()
@@ -1006,7 +1007,6 @@ def create_app(
                 await guild_registry_client.close()
             if hasattr(llm_adapter, "close"):
                 await llm_adapter.close()
-            await subscriber.stop()
             logger.info("Ting shutting down")
 
     app.router.lifespan_context = lifespan

--- a/src/ting/ports/workflow_campaign_repository.py
+++ b/src/ting/ports/workflow_campaign_repository.py
@@ -19,6 +19,28 @@ class WorkflowCampaignRepository(ABC):
     async def list_active_campaigns(self) -> list[WorkflowCampaign]:
         """List campaigns that may still change at runtime."""
 
+    async def list_active_owner_ids(self) -> list[str]:
+        """List owners whose campaigns require an activity subscription."""
+        campaigns = await self.list_active_campaigns()
+        return sorted({campaign.owner_id for campaign in campaigns})
+
+    async def get_active_campaign_by_session(
+        self,
+        *,
+        owner_id: str,
+        session_id: str,
+    ) -> WorkflowCampaign | None:
+        """Fetch the active campaign associated with one Volundr session."""
+        campaigns = await self.list_active_campaigns()
+        return next(
+            (
+                campaign
+                for campaign in campaigns
+                if campaign.owner_id == owner_id and campaign.session_id == session_id
+            ),
+            None,
+        )
+
     @abstractmethod
     async def get_campaign(self, campaign_id: UUID) -> WorkflowCampaign | None:
         """Fetch a campaign by UUID."""

--- a/tests/test_ravn/test_build_tool_verify.py
+++ b/tests/test_ravn/test_build_tool_verify.py
@@ -9,7 +9,11 @@ from typing import Any
 
 import ravn.adapters.tools.build_tool as build_tool_mod
 from ravn.adapters.tools.build_tool import DEFAULT_MAX_REPAIR_ATTEMPTS, BuildTool
-from ravn.ports.tool_build_backend import ToolBuildInputRequiredError, ToolBuildResult
+from ravn.ports.tool_build_backend import (
+    ToolBuildInputRequiredError,
+    ToolBuildPendingError,
+    ToolBuildResult,
+)
 from ravn.valkyrie_evolution.tool_verification import VerificationResult
 
 _ECHO_TOOL = "def run(payload):\n    return {'echo': payload}\n"
@@ -324,6 +328,53 @@ async def test_commissioned_build_question_is_persisted_and_resumed(tmp_path) ->
             "continuation_answer": "All namespaces, read-only.",
         }
     )
+
+    assert resumed.is_error is False
+    assert len(requests) == 2
+    assert len(registered) == 1
+    assert list((tmp_path / "arts" / "pending-builds").glob("*.json")) == []
+
+
+async def test_commissioned_build_push_pending_resumes_without_answer(tmp_path) -> None:
+    requests: list[Any] = []
+
+    class _Backend:
+        name = "a2a"
+
+        async def build(self, request: Any) -> ToolBuildResult:
+            requests.append(request)
+            if not request.continuation:
+                raise ToolBuildPendingError(
+                    task_id="task-push-1",
+                    push_registered=True,
+                    continuation={
+                        "task_id": "task-push-1",
+                        "input_kind": "pending",
+                        "push_registered": True,
+                    },
+                )
+            assert request.continuation["input_kind"] == "pending"
+            assert "answer" not in request.continuation
+            return ToolBuildResult(
+                manifest=_manifest(),
+                tool_code=_ECHO_TOOL,
+                test_code=_ECHO_TEST,
+                requirements=[],
+                provenance={"builder": "remote"},
+            )
+
+    tool, registered = _tool(tmp_path, build_backend=_Backend())
+    first = await tool.execute({"manifest": _manifest(), "build_request": "build an echo tool"})
+
+    assert first.is_error is False
+    pending = json.loads(first.content)
+    assert pending["status"] == "pending"
+    assert pending["push_registered"] is True
+    assert pending["resume_with"] == {"continuation_task_id": "task-push-1"}
+    assert "Do not poll" in pending["next_step"]
+    assert registered == []
+
+    resumed = await tool.execute({"continuation_task_id": "task-push-1"})
 
     assert resumed.is_error is False
     assert len(requests) == 2

--- a/tests/test_ravn/test_signal_build_tool_wiring.py
+++ b/tests/test_ravn/test_signal_build_tool_wiring.py
@@ -181,10 +181,16 @@ def test_build_tool_build_backend_applies_realm_selector_override() -> None:
 
 def test_build_tool_build_backend_injects_a2a_activity_emitter() -> None:
     configured = Settings(
+        gateway={
+            "platform": {
+                "a2a_push_callback_url": "https://ivaldi.example/a2a/push",
+                "a2a_push_notification_token": "push-secret",
+            }
+        },
         resident_evolution={
             "tool_build_adapter": "ravn.adapters.tool_build.A2AToolBuildBackend",
             "tool_build_kwargs": {"card_url": "https://ting.example/.well-known/agent-card.json"},
-        }
+        },
     )
     emitter = AsyncMock()
 
@@ -192,6 +198,8 @@ def test_build_tool_build_backend_injects_a2a_activity_emitter() -> None:
 
     assert backend is not None
     assert backend._activity_emitter is emitter
+    assert backend._push_callback_url == "https://ivaldi.example/a2a/push"
+    assert backend._push_notification_token == "push-secret"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_tool_build_backends.py
+++ b/tests/test_ravn/test_tool_build_backends.py
@@ -33,6 +33,7 @@ from ravn.adapters.tool_build.ting_workflow import _decode_canonical_content
 from ravn.ports.tool_build_backend import (
     ToolBuildError,
     ToolBuildInputRequiredError,
+    ToolBuildPendingError,
     ToolBuildRequest,
 )
 
@@ -803,11 +804,17 @@ async def test_ting_canonical_artifact_transport_error_falls_back() -> None:
 _A2A_ENDPOINT = "https://ting.example/api/v1/ting/a2a"
 
 
-def _a2a_card(*, skills: list[dict] | None = None, interfaces: list[dict] | None = None) -> dict:
+def _a2a_card(
+    *,
+    skills: list[dict] | None = None,
+    interfaces: list[dict] | None = None,
+    push_notifications: bool = False,
+) -> dict:
     return {
         "name": "Niuu Workflows",
         "description": "Launchable workflows",
         "version": "1.0.0",
+        "capabilities": {"pushNotifications": push_notifications},
         "supportedInterfaces": interfaces
         if interfaces is not None
         else [
@@ -910,6 +917,62 @@ async def test_a2a_backend_builds_from_inline_canonical_artifact() -> None:
         "status_message": "",
         "source_tool": "build_tool",
     }
+
+
+async def test_a2a_backend_suspends_for_push_and_resumes_with_one_get() -> None:
+    artifacts = [
+        {
+            "artifactId": "research/campaigns/task-1/learned_tool.json",
+            "parts": [{"filename": "learned_tool.json", "text": _BUILT_CONTRACT}],
+        }
+    ]
+    client = _FakeHttpClient(
+        {
+            ("GET", "/.well-known/agent-card.json"): [
+                HttpResponse(200, _a2a_card(push_notifications=True))
+            ],
+            ("POST", "/api/v1/ting/a2a"): [
+                _rpc_result({"task": _a2a_task("TASK_STATE_SUBMITTED")}),
+                _rpc_result({"taskId": "task-1", "id": "push-1"}),
+                _rpc_result(_a2a_task("TASK_STATE_COMPLETED", artifacts=artifacts)),
+            ],
+        }
+    )
+    backend = _a2a_backend(
+        client,
+        workflow_id="wf-1",
+        push_callback_url="https://ivaldi.example/a2a/push",
+        push_notification_token="callback-secret",
+    )
+
+    with pytest.raises(ToolBuildPendingError) as raised:
+        await backend.build(_request())
+
+    assert raised.value.push_registered is True
+    assert raised.value.continuation == {
+        "task_id": "task-1",
+        "input_kind": "pending",
+        "round": 0,
+        "exchanges": [],
+        "push_registered": True,
+    }
+    assert [body["method"] for body in client.post_bodies] == [
+        "SendMessage",
+        "CreateTaskPushNotificationConfig",
+    ]
+    registration = client.post_bodies[1]["params"]
+    assert registration["taskId"] == "task-1"
+    assert registration["url"] == "https://ivaldi.example/a2a/push"
+    assert registration["token"] == "callback-secret"
+
+    result = await backend.build(replace(_request(), continuation=raised.value.continuation))
+
+    assert result.manifest["name"] == "mimir_metric_window"
+    assert [body["method"] for body in client.post_bodies] == [
+        "SendMessage",
+        "CreateTaskPushNotificationConfig",
+        "GetTask",
+    ]
 
 
 async def test_a2a_backend_closes_local_tracking_when_polling_is_exhausted() -> None:

--- a/tests/test_ting/test_activity_subscriber.py
+++ b/tests/test_ting/test_activity_subscriber.py
@@ -29,6 +29,7 @@ from ting.domain.services.activity_subscriber import (
     _coerce_str,
     _coerce_str_list,
 )
+from ting.domain.services.workflow_campaign_projector import WorkflowCampaignProjector
 from ting.ports.dispatcher_repository import DispatcherRepository
 from ting.ports.volundr import ActivityEvent, SpawnRequest, VolundrPort, VolundrSession
 from ting.ports.workflow_campaign_repository import WorkflowCampaignRepository
@@ -358,6 +359,15 @@ def _make_subscriber(
     e = event_bus or InMemoryEventBus()
     c = config or _default_config()
     factory = StubVolundrFactory(v)
+    campaign_projector = (
+        WorkflowCampaignProjector(
+            repo=workflow_campaign_repo,
+            volundr_factory=factory,  # type: ignore[arg-type]
+            event_bus=e,
+        )
+        if workflow_campaign_repo is not None
+        else None
+    )
     sub = SessionActivitySubscriber(
         volundr_factory=factory,
         tracker_factory=tf,
@@ -365,7 +375,7 @@ def _make_subscriber(
         event_bus=e,
         config=c,
         review_engine=review_engine,  # type: ignore[arg-type]
-        workflow_campaign_repo=workflow_campaign_repo,
+        workflow_campaign_projector=campaign_projector,
     )
     return sub, v, t, e
 
@@ -608,6 +618,7 @@ class TestActivityEventHandling:
         await sub._on_activity_event(event, _volundr, OWNER_ID)
 
         campaign = next(iter(campaign_repo.campaigns.values()))
+        assert campaign.status == WorkflowCampaignStatus.BLOCKED
         assert campaign.active_stage_id == "plan-review-gate"
         assert campaign.metadata["pending_workflow_gates"] == [
             {
@@ -620,6 +631,8 @@ class TestActivityEventHandling:
             }
         ]
         bus_event = await asyncio.wait_for(q.get(), timeout=1.0)
+        if bus_event.event == "workflow.campaign.updated":
+            bus_event = await asyncio.wait_for(q.get(), timeout=1.0)
         assert bus_event.event == "workflow.campaign.feedback_requested"
         assert bus_event.data["session_id"] == full_session_id
 

--- a/tests/test_ting/test_activity_subscriber.py
+++ b/tests/test_ting/test_activity_subscriber.py
@@ -431,6 +431,38 @@ class TestSubscriberLifecycle:
         sub, _, _, _ = _make_subscriber()
         await sub.stop()  # Should not raise
 
+    @pytest.mark.asyncio
+    async def test_campaign_owner_gets_subscription_without_dispatcher(self) -> None:
+        sub, volundr, _, _ = _make_subscriber(config=_default_config(reconnect_delay=0))
+        projector = AsyncMock()
+        projector.list_active_owner_ids.return_value = [OWNER_ID]
+        sub._workflow_campaign_projector = projector
+        stale = asyncio.create_task(asyncio.sleep(60))
+        sub._owner_tasks["stale-owner"] = [stale]
+        sub._owner_adapters["stale-owner"] = [volundr]
+
+        await sub._sync_owner_subscriptions()
+        await asyncio.sleep(0)
+
+        projector.reconcile_owner.assert_awaited_once_with(OWNER_ID)
+        assert OWNER_ID in sub._owner_tasks
+        assert "stale-owner" not in sub._owner_tasks
+        assert stale.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_no_active_work_clears_existing_subscriptions(self) -> None:
+        sub, volundr, _, _ = _make_subscriber(config=_default_config(reconnect_delay=0))
+        stale = asyncio.create_task(asyncio.sleep(60))
+        sub._owner_tasks[OWNER_ID] = [stale]
+        sub._owner_adapters[OWNER_ID] = [volundr]
+
+        await sub._sync_owner_subscriptions()
+        await asyncio.sleep(0)
+
+        assert sub._owner_tasks == {}
+        assert sub._owner_adapters == {}
+        assert stale.cancelled()
+
 
 # ---------------------------------------------------------------------------
 # Tests -- Activity event handling

--- a/tests/test_ting/test_postgres_workflow_campaigns.py
+++ b/tests/test_ting/test_postgres_workflow_campaigns.py
@@ -1,0 +1,161 @@
+"""PostgreSQL workflow campaign repository contract tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from ting.adapters.postgres_workflow_campaigns import PostgresWorkflowCampaignRepository
+from ting.domain.models import CampaignStageState, WorkflowCampaign, WorkflowCampaignStatus
+
+
+def _campaign() -> WorkflowCampaign:
+    now = datetime.now(UTC)
+    return WorkflowCampaign(
+        id=uuid4(),
+        slug="tool-build-test",
+        name="Tool build test",
+        owner_id="owner-1",
+        workflow_id=uuid4(),
+        workflow_version="1.0.0",
+        workflow_name="Tool Builder",
+        workflow_snapshot={"nodes": []},
+        session_id="session-1",
+        session_name="tool-build-test",
+        status=WorkflowCampaignStatus.RUNNING,
+        active_stage_id="build",
+        stage_state=[
+            CampaignStageState(
+                stage_id="build",
+                label="Build",
+                status="running",
+                started_at=now,
+                completed_at=None,
+                reason=None,
+            )
+        ],
+        metadata={"source": "a2a"},
+        created_at=now,
+        updated_at=now,
+        last_activity_at=now,
+        completed_at=None,
+        connection_id="Noatun",
+    )
+
+
+def _row(campaign: WorkflowCampaign) -> dict:
+    stage = campaign.stage_state[0]
+    return {
+        "id": campaign.id,
+        "slug": campaign.slug,
+        "name": campaign.name,
+        "owner_id": campaign.owner_id,
+        "workflow_id": campaign.workflow_id,
+        "workflow_version": campaign.workflow_version,
+        "workflow_name": campaign.workflow_name,
+        "workflow_snapshot": json.dumps(campaign.workflow_snapshot),
+        "session_id": campaign.session_id,
+        "session_name": campaign.session_name,
+        "status": campaign.status.value,
+        "active_stage_id": campaign.active_stage_id,
+        "stage_state": json.dumps(
+            [
+                {
+                    "stage_id": stage.stage_id,
+                    "label": stage.label,
+                    "status": stage.status,
+                    "started_at": stage.started_at.isoformat() if stage.started_at else None,
+                    "completed_at": None,
+                    "reason": None,
+                }
+            ]
+        ),
+        "metadata": json.dumps(campaign.metadata),
+        "created_at": campaign.created_at,
+        "updated_at": campaign.updated_at,
+        "last_activity_at": campaign.last_activity_at,
+        "completed_at": campaign.completed_at,
+        "connection_id": campaign.connection_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_lists_campaigns_and_active_owners() -> None:
+    campaign = _campaign()
+    pool = AsyncMock()
+    pool.fetch.side_effect = [[_row(campaign)], [_row(campaign)], [{"owner_id": "owner-1"}]]
+    repo = PostgresWorkflowCampaignRepository(pool)
+
+    listed = await repo.list_campaigns(owner_id="owner-1")
+    active = await repo.list_active_campaigns()
+    owners = await repo.list_active_owner_ids()
+
+    assert listed == [campaign]
+    assert active == [campaign]
+    assert owners == ["owner-1"]
+
+
+@pytest.mark.asyncio
+async def test_gets_active_campaign_by_owner_and_session() -> None:
+    campaign = _campaign()
+    pool = AsyncMock()
+    pool.fetchrow.side_effect = [_row(campaign), None]
+    repo = PostgresWorkflowCampaignRepository(pool)
+
+    found = await repo.get_active_campaign_by_session(
+        owner_id=campaign.owner_id,
+        session_id=campaign.session_id,
+    )
+    missing = await repo.get_active_campaign_by_session(
+        owner_id=campaign.owner_id,
+        session_id="missing",
+    )
+
+    assert found == campaign
+    assert missing is None
+    assert pool.fetchrow.await_args_list[0].args[-2:] == (
+        campaign.owner_id,
+        campaign.session_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_gets_campaign_by_id_and_scoped_or_unscoped_slug() -> None:
+    campaign = _campaign()
+    pool = AsyncMock()
+    pool.fetchrow.side_effect = [
+        _row(campaign),
+        None,
+        _row(campaign),
+        _row(campaign),
+        None,
+    ]
+    repo = PostgresWorkflowCampaignRepository(pool)
+
+    assert await repo.get_campaign(campaign.id) == campaign
+    assert await repo.get_campaign(uuid4()) is None
+    assert await repo.get_campaign_by_slug(campaign.slug) == campaign
+    assert await repo.get_campaign_by_slug(campaign.slug, owner_id=campaign.owner_id) == campaign
+    assert await repo.get_campaign_by_slug("missing", owner_id=campaign.owner_id) is None
+
+
+@pytest.mark.asyncio
+async def test_saves_and_deletes_campaign() -> None:
+    campaign = _campaign()
+    pool = AsyncMock()
+    pool.execute.side_effect = ["INSERT 0 1", "DELETE 1", "DELETE 0"]
+    repo = PostgresWorkflowCampaignRepository(pool)
+
+    assert await repo.save_campaign(campaign) == campaign
+    assert await repo.delete_campaign(campaign.id) is True
+    assert await repo.delete_campaign(uuid4()) is False
+
+    save_args = pool.execute.await_args_list[0].args
+    assert save_args[1] == campaign.id
+    assert json.loads(save_args[8]) == campaign.workflow_snapshot
+    assert json.loads(save_args[13])[0]["stage_id"] == "build"
+    assert json.loads(save_args[14]) == campaign.metadata

--- a/tests/test_ting/test_workflow_campaign_projector.py
+++ b/tests/test_ting/test_workflow_campaign_projector.py
@@ -11,6 +11,7 @@ import pytest
 
 from ting.domain.models import WorkflowCampaign, WorkflowCampaignStatus
 from ting.domain.services.workflow_campaign_projector import WorkflowCampaignProjector
+from ting.ports.volundr import ActivityEvent
 
 
 def _campaign(
@@ -199,6 +200,70 @@ async def test_terminal_activity_error_fails_running_campaign() -> None:
     emitted = event_bus.emit.await_args.args[0]
     assert emitted.event == "workflow.campaign.failed"
     assert emitted.data["error"] == "refresh token was already used"
+
+
+@pytest.mark.asyncio
+async def test_sse_terminal_event_completes_and_queues_push_without_session_read() -> None:
+    adapter = _Adapter()
+    campaign = _campaign()
+    repo = AsyncMock()
+    repo.get_active_campaign_by_session.return_value = campaign
+    repo.save_campaign = AsyncMock(side_effect=lambda value: value)
+    push_dispatcher = AsyncMock()
+    projector = WorkflowCampaignProjector(
+        repo=repo,
+        volundr_factory=_Factory(adapter),
+        event_bus=AsyncMock(),
+        push_dispatcher=push_dispatcher,
+    )
+
+    handled = await projector.handle_activity(
+        ActivityEvent(
+            session_id=campaign.session_id,
+            state="",
+            metadata={},
+            owner_id=campaign.owner_id,
+            session_status="stopped",
+        ),
+        campaign.owner_id,
+    )
+
+    assert handled is True
+    saved = repo.save_campaign.await_args.args[0]
+    assert saved.status == WorkflowCampaignStatus.COMPLETED
+    push_dispatcher.queue_campaign.assert_awaited_once_with(saved)
+
+
+@pytest.mark.asyncio
+async def test_sse_error_event_fails_and_queues_error_push() -> None:
+    campaign = _campaign()
+    repo = AsyncMock()
+    repo.get_active_campaign_by_session.return_value = campaign
+    repo.save_campaign = AsyncMock(side_effect=lambda value: value)
+    event_bus = AsyncMock()
+    push_dispatcher = AsyncMock()
+    projector = WorkflowCampaignProjector(
+        repo=repo,
+        volundr_factory=_Factory(_Adapter()),
+        event_bus=event_bus,
+        push_dispatcher=push_dispatcher,
+    )
+
+    await projector.handle_activity(
+        ActivityEvent(
+            session_id=campaign.session_id,
+            state="error",
+            metadata={"error": "refresh token was already used"},
+            owner_id=campaign.owner_id,
+        ),
+        campaign.owner_id,
+    )
+
+    saved = repo.save_campaign.await_args.args[0]
+    assert saved.status == WorkflowCampaignStatus.FAILED
+    assert saved.metadata["failure_error"] == "refresh token was already used"
+    assert event_bus.emit.await_args.args[0].event == "workflow.campaign.failed"
+    push_dispatcher.queue_campaign.assert_awaited_once_with(saved)
 
 
 class TestConnectionAffinity:

--- a/tests/test_ting/test_workflow_campaign_projector.py
+++ b/tests/test_ting/test_workflow_campaign_projector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -10,7 +11,10 @@ from uuid import uuid4
 import pytest
 
 from ting.domain.models import WorkflowCampaign, WorkflowCampaignStatus
-from ting.domain.services.workflow_campaign_projector import WorkflowCampaignProjector
+from ting.domain.services.workflow_campaign_projector import (
+    WorkflowCampaignProjector,
+    _status_from_session,
+)
 from ting.ports.volundr import ActivityEvent
 
 
@@ -110,6 +114,104 @@ def _projector(adapter: _Adapter) -> tuple[WorkflowCampaignProjector, AsyncMock,
         event_bus=event_bus,
     )
     return projector, repo, event_bus
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_and_active_owner_projection() -> None:
+    projector, repo, _ = _projector(_Adapter())
+    repo.list_active_owner_ids.return_value = ["owner-1", "owner-2"]
+
+    assert projector.running is False
+    await projector.start()
+    assert projector.running is True
+    assert await projector.list_active_owner_ids() == ["owner-1", "owner-2"]
+    await projector.stop()
+    assert projector.running is False
+
+
+@pytest.mark.asyncio
+async def test_reconcile_owner_isolated_and_best_effort() -> None:
+    projector, repo, _ = _projector(_Adapter())
+    first = _campaign()
+    second = _campaign()
+    other_owner = replace(_campaign(), owner_id="user-2")
+    repo.list_active_campaigns.return_value = [first, other_owner, second]
+    projector._refresh_campaign = AsyncMock(side_effect=[None, RuntimeError("unreachable")])
+
+    await projector.reconcile_owner("user-1")
+
+    assert projector._refresh_campaign.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_events_cover_missing_pending_and_failure_states() -> None:
+    projector, repo, _ = _projector(_Adapter())
+    repo.get_active_campaign_by_session.side_effect = [
+        None,
+        _campaign(WorkflowCampaignStatus.PENDING),
+        _campaign(),
+    ]
+
+    assert (
+        await projector.handle_activity(ActivityEvent("missing", "active", {}, "user-1"), "user-1")
+        is False
+    )
+    assert (
+        await projector.handle_activity(
+            ActivityEvent("session-123", "active", {}, "user-1"), "user-1"
+        )
+        is True
+    )
+    assert repo.save_campaign.await_args_list[0].args[0].status == WorkflowCampaignStatus.RUNNING
+
+    await projector.handle_activity(
+        ActivityEvent(
+            "session-123",
+            "",
+            {},
+            "user-1",
+            session_status="failed",
+        ),
+        "user-1",
+    )
+    failed = repo.save_campaign.await_args_list[1].args[0]
+    assert failed.status == WorkflowCampaignStatus.FAILED
+    assert failed.metadata["failure_error"] == "Session failed"
+
+
+@pytest.mark.asyncio
+async def test_missing_campaign_and_session_are_ignored() -> None:
+    adapter = _Adapter()
+    adapter.get_session = AsyncMock(return_value=None)
+    projector, repo, _ = _projector(adapter)
+    repo.get_active_campaign_by_session.return_value = None
+
+    assert (
+        await projector.record_help_needed(
+            {"summary": "help"},
+            "user-1",
+            session_id="missing",
+            gate={},
+        )
+        is False
+    )
+    await projector._refresh_campaign(_campaign())
+    repo.save_campaign.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("queued", WorkflowCampaignStatus.PENDING),
+        ("paused", WorkflowCampaignStatus.BLOCKED),
+        ("cancelled", WorkflowCampaignStatus.FAILED),
+        ("unknown", WorkflowCampaignStatus.RUNNING),
+    ],
+)
+def test_status_projection_covers_recovery_states(
+    raw: str, expected: WorkflowCampaignStatus
+) -> None:
+    assert _status_from_session(raw) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- drive Ting workflow campaign state from Volundr SSE and retain only reconnect reconciliation
- register durable A2A callbacks for commissioned build_tool tasks and resume with one bounded state read
- add the missing CLI migration bundle and callback-focused regression coverage

## Verification
- `uv run --frozen pytest -q` (17,757 passed, 4 skipped, 129 deselected, 1 xfailed)
- focused post-format Ting suite (60 passed)
- Ruff format/check and `git diff --check`