### PR TITLE
fix(cli): embed the missing ting a2a push-notification migration

### DIFF
--- a/src/cli/migrations/ting/000032_a2a_push_notifications.down.sql
+++ b/src/cli/migrations/ting/000032_a2a_push_notifications.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS a2a_push_notification_configs;

--- a/src/cli/migrations/ting/000032_a2a_push_notifications.up.sql
+++ b/src/cli/migrations/ting/000032_a2a_push_notifications.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS a2a_push_notification_configs (
+    task_id TEXT NOT NULL,
+    config_id TEXT NOT NULL,
+    owner_id TEXT NOT NULL,
+    config_data BYTEA NOT NULL,
+    pending_event JSONB,
+    delivery_version TEXT,
+    next_attempt_at TIMESTAMPTZ,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    delivered_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (task_id, config_id, owner_id),
+    CONSTRAINT a2a_push_notification_task_fk
+        FOREIGN KEY (task_id) REFERENCES workflow_campaigns(slug) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_a2a_push_notification_due
+    ON a2a_push_notification_configs (next_attempt_at)
+    WHERE pending_event IS NOT NULL;


### PR DESCRIPTION
`dev` is currently red for every open PR. This unblocks it.

## What happened

#907 added `migrations/ting/000032_a2a_push_notifications.{up,down}.sql`
and rendered them into `charts/ting/templates/migrations-configmap.yaml`,
but did not add them to `src/cli/migrations/ting/` — the embedded copy the
CLI and container images actually ship at startup.

`TestMigrationDir::test_embedded_migrations_match_source` exists to catch
precisely this ("Container and binary startup must not ship stale
migration streams"), and it has been failing on `dev` ever since.

## The fix

Copies the two files verbatim. They are byte-identical to the source, as
every other pair in both streams is.

I then swept both migration streams for any other drift:

```
migrations         vs src/cli/migrations/volundr   IN SYNC  (118 files)
migrations/ting    vs src/cli/migrations/ting      IN SYNC  (63 files)
```

No other migration is out of sync, and the Helm configmap already carries
`000032` correctly — the embedded copy was the only gap.

## Verification

- Reproduced the failure on a clean `dev` checkout before changing anything
- `tests/test_cli/test_resources.py` — 10 passed
- `tests/test_cli` — 764 passed

## Why this is a separate PR

Found while investigating a CI failure on #908, which only touches
`web-next` and inherits this through the merge with `dev`. It is unrelated
to that work and blocks everyone, so it should land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)