### PR TITLE
fix(a2a): authenticate callbacks with workload identity

### DIFF
--- a/charts/ting/templates/configmap.yaml
+++ b/charts/ting/templates/configmap.yaml
@@ -121,7 +121,7 @@ data:
       auto_approve_threshold: {{ .Values.review.autoApproveThreshold }}
       {{- end }}
     {{- end }}
-    {{- if or .Values.a2a.agentName .Values.a2a.agentDescription .Values.a2a.cardMaxAgeSeconds .Values.a2a.inlineArtifactMaxChars .Values.a2a.extraArtifactFiles .Values.a2a.publicBaseUrl }}
+    {{- if or .Values.a2a.agentName .Values.a2a.agentDescription .Values.a2a.cardMaxAgeSeconds .Values.a2a.inlineArtifactMaxChars .Values.a2a.extraArtifactFiles .Values.a2a.publicBaseUrl .Values.a2a.pushAuth.adapter }}
     a2a:
       {{- if .Values.a2a.agentName }}
       agent_name: {{ .Values.a2a.agentName | quote }}
@@ -141,6 +141,10 @@ data:
       {{- if .Values.a2a.publicBaseUrl }}
       public_base_url: {{ .Values.a2a.publicBaseUrl | quote }}
       {{- end }}
+      push_auth:
+        adapter: {{ .Values.a2a.pushAuth.adapter | quote }}
+        kwargs:
+          {{- toYaml .Values.a2a.pushAuth.kwargs | nindent 10 }}
     {{- end }}
 
     cerbos:

--- a/charts/ting/values.yaml
+++ b/charts/ting/values.yaml
@@ -165,6 +165,10 @@ a2a:
   extraArtifactFiles: []
   # -- Public origin for interface URLs on the card. Leave empty to use the request base URL.
   publicBaseUrl: ""
+  # -- Dynamic auth adapter used for outbound A2A push callbacks.
+  pushAuth:
+    adapter: "niuu.adapters.outbound.http_auth.NoAuthHeaderAdapter"
+    kwargs: {}
 
 # Review configuration
 review:

--- a/src/ravn/adapters/channels/gateway_http.py
+++ b/src/ravn/adapters/channels/gateway_http.py
@@ -29,6 +29,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, StreamingResponse
 from pydantic import BaseModel
 
+from niuu.ports.workload_identity import WorkloadIdentityVerifier
+from niuu.utils import resolve_secret_kwargs
 from ravn.adapters.channels.gateway import RavnGateway
 from ravn.config import HttpChannelConfig
 from ravn.domain.events import RavnEvent
@@ -77,15 +79,25 @@ class HttpGateway:
         config: HttpChannelConfig,
         gateway: RavnGateway,
         resident_runtime: Any | None = None,
+        a2a_push_verifier: WorkloadIdentityVerifier | None = None,
     ) -> None:
         self._config = config
         self._gateway = gateway
         self._resident_runtime = resident_runtime
+        self._a2a_push_verifier = a2a_push_verifier or self._build_a2a_push_verifier()
         self._resident_status_provider: (
             Callable[[], dict[str, Any] | Awaitable[dict[str, Any]]] | None
         ) = None
         self._translator_cls: type[EventTranslatorPort] = _import_class(config.translator)
         self._app = self._build_app()
+
+    def _build_a2a_push_verifier(self) -> WorkloadIdentityVerifier | None:
+        auth = self._config.a2a_push_auth
+        if not auth.adapter.strip():
+            return None
+        kwargs = resolve_secret_kwargs(auth.kwargs, auth.secret_kwargs_env)
+        verifier_class = _import_class(auth.adapter)
+        return verifier_class(**kwargs)
 
     @property
     def app(self) -> FastAPI:
@@ -183,22 +195,37 @@ class HttpGateway:
                 @app.post("/a2a/push")
                 async def a2a_push(
                     request: Request,
-                    x_a2a_notification_token: str | None = Header(default=None),
+                    authorization: str | None = Header(default=None),
                 ) -> dict[str, Any]:
-                    """Persist an authenticated A2A task update and wake the resident."""
-                    expected = self._config.a2a_push_notification_token.get_secret_value().strip()
-                    if not expected:
+                    """Persist a workload-authenticated A2A task update and wake the resident."""
+                    if self._a2a_push_verifier is None:
                         raise HTTPException(
                             status_code=503,
-                            detail="A2A push receiver is disabled because its token is missing",
+                            detail="A2A push receiver has no workload identity verifier",
                         )
-                    if not x_a2a_notification_token or not secrets.compare_digest(
-                        x_a2a_notification_token,
-                        expected,
-                    ):
+                    scheme, _, presented = (authorization or "").partition(" ")
+                    if scheme.casefold() != "bearer" or not presented.strip():
                         raise HTTPException(
-                            status_code=401, detail="Invalid A2A notification token"
+                            status_code=401,
+                            detail="A2A callback requires a bearer workload identity",
                         )
+                    try:
+                        claims = await self._a2a_push_verifier.verify(presented.strip())
+                    except Exception as exc:
+                        logger.warning(
+                            "Rejected A2A callback workload identity: %s",
+                            type(exc).__name__,
+                        )
+                        raise HTTPException(
+                            status_code=401,
+                            detail="Invalid A2A callback workload identity",
+                        ) from exc
+                    for claim, expected in self._config.a2a_push_required_claims.items():
+                        if claims.get(claim) != expected:
+                            raise HTTPException(
+                                status_code=403,
+                                detail="A2A callback workload is not authorized",
+                            )
                     raw = await request.body()
                     if len(raw) > self._config.a2a_push_max_body_bytes:
                         raise HTTPException(

--- a/src/ravn/adapters/tool_build/a2a.py
+++ b/src/ravn/adapters/tool_build/a2a.py
@@ -80,7 +80,6 @@ class A2AToolBuildBackend(ToolBuildBackend):
         model: str = "",
         connection_id: str = "",
         push_callback_url: str = "",
-        push_notification_token: str = "",
         max_poll_attempts: int = 120,
         poll_interval_seconds: float = 5.0,
         gate_reviewer: GateReviewer | None = None,
@@ -111,7 +110,6 @@ class A2AToolBuildBackend(ToolBuildBackend):
         self._model = model
         self._connection_id = connection_id
         self._push_callback_url = push_callback_url.strip()
-        self._push_notification_token = push_notification_token.strip()
         self._max_poll_attempts = max_poll_attempts
         self._poll_interval = poll_interval_seconds
         # INPUT_REQUIRED handling. A pending peer QUESTION (help_needed) is
@@ -1016,7 +1014,7 @@ class A2AToolBuildBackend(ToolBuildBackend):
                 "taskId": task_id,
                 "id": f"ravn-tool-build-{uuid4()}",
                 "url": self._push_callback_url,
-                "token": self._push_notification_token,
+                "authentication": {"scheme": "Bearer"},
             },
         )
 

--- a/src/ravn/adapters/tools/a2a_task.py
+++ b/src/ravn/adapters/tools/a2a_task.py
@@ -38,7 +38,6 @@ class A2ATaskTool(ToolPort):
         activity_emitter: Callable[[dict[str, object]], Awaitable[None]] | None = None,
         default_connection_id: str = "",
         push_callback_url: str = "",
-        push_notification_token: str = "",
     ) -> None:
         self._directory = agent_directory
         self._client = client
@@ -50,7 +49,6 @@ class A2ATaskTool(ToolPort):
         self._activity_emitter = activity_emitter
         self._default_connection_id = default_connection_id.strip()
         self._push_callback_url = push_callback_url.strip()
-        self._push_notification_token = push_notification_token.strip()
 
     @property
     def name(self) -> str:
@@ -261,7 +259,7 @@ class A2ATaskTool(ToolPort):
                 "taskId": task_id,
                 "id": f"ravn-{uuid4()}",
                 "url": self._push_callback_url,
-                "token": self._push_notification_token,
+                "authentication": {"scheme": "Bearer"},
             },
         )
 

--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -404,9 +404,6 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
             "activity_emitter": ctx.get("a2a_activity_emitter"),
             "default_connection_id": s.gateway.platform.a2a_default_connection_id,
             "push_callback_url": s.gateway.platform.a2a_push_callback_url,
-            "push_notification_token": (
-                s.gateway.platform.a2a_push_notification_token.get_secret_value().strip()
-            ),
         },
     ),
     "ting_plan": BuiltinToolDef(

--- a/src/ravn/cli/runtime_builders.py
+++ b/src/ravn/cli/runtime_builders.py
@@ -189,10 +189,6 @@ def _build_tool_build_backend(
         kwargs["activity_emitter"] = activity_emitter
     if _constructor_accepts_kwarg(cls, "push_callback_url"):
         kwargs["push_callback_url"] = settings.gateway.platform.a2a_push_callback_url
-    if _constructor_accepts_kwarg(cls, "push_notification_token"):
-        kwargs["push_notification_token"] = (
-            settings.gateway.platform.a2a_push_notification_token.get_secret_value().strip()
-        )
     return cls(**kwargs)
 
 

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import AliasChoices, BaseModel, Field, SecretStr, model_validator
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     EnvSettingsSource,
@@ -42,6 +42,7 @@ from pydantic_settings import (
     YamlConfigSettingsSource,
 )
 
+from niuu.config_models import WorkloadIdentityVerifierConfig
 from niuu.domain.observability import ObservabilityConfig
 from niuu.mesh.config import MeshNatsConfig
 
@@ -999,9 +1000,13 @@ class HttpChannelConfig(BaseModel):
         default=False,
         description="Accept authenticated A2A task callbacks and wake the resident.",
     )
-    a2a_push_notification_token: SecretStr = Field(
-        default=SecretStr(""),
-        description="A2A callback verification token; set through a secret config override.",
+    a2a_push_auth: WorkloadIdentityVerifierConfig = Field(
+        default_factory=lambda: WorkloadIdentityVerifierConfig(name="a2a-push", adapter=""),
+        description="JWT verifier used to authenticate A2A callback workloads.",
+    )
+    a2a_push_required_claims: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Exact JWT claims required on an authenticated A2A callback.",
     )
     a2a_push_max_body_bytes: int = Field(
         default=1_048_576,
@@ -1167,10 +1172,6 @@ class PlatformToolsConfig(BaseModel):
     a2a_push_callback_url: str = Field(
         default="",
         description=("Public HTTPS callback registered for A2A tasks that advertise push support."),
-    )
-    a2a_push_notification_token: SecretStr = Field(
-        default=SecretStr(""),
-        description="Token sent to the configured A2A callback; inject through secret config.",
     )
     a2a_message_max_chars: int = Field(
         default=12_000,

--- a/src/ting/adapters/a2a_push_dispatcher.py
+++ b/src/ting/adapters/a2a_push_dispatcher.py
@@ -11,6 +11,7 @@ import httpx
 from a2a.types import TaskPushNotificationConfig
 from google.protobuf.json_format import MessageToDict
 
+from niuu.ports.http_auth import HttpAuthPort
 from ting.domain.models import WorkflowCampaign
 from ting.ports.a2a_push import A2APushConfigRepositoryPort, A2APushDelivery
 
@@ -36,6 +37,7 @@ class A2APushDispatcher:
         self,
         *,
         repo: A2APushConfigRepositoryPort,
+        auth: HttpAuthPort,
         allowed_callback_origins: list[str],
         timeout_seconds: float,
         poll_seconds: float,
@@ -48,6 +50,7 @@ class A2APushDispatcher:
         max_configs_page_size: int,
     ) -> None:
         self._repo = repo
+        self._auth = auth
         self._allowed_origins = frozenset(
             callback_origin(origin) for origin in allowed_callback_origins
         )
@@ -84,9 +87,14 @@ class A2APushDispatcher:
         origin = callback_origin(config.url)
         if origin not in self._allowed_origins:
             raise ValueError(f"A2A push callback origin is not allowed: {origin}")
+        if config.token or config.authentication.credentials:
+            raise ValueError(
+                "A2A push callback inline credentials are not supported; "
+                "use the configured workload identity"
+            )
         scheme = config.authentication.scheme.strip().lower()
-        if scheme and scheme != "bearer":
-            raise ValueError("A2A push callback authentication supports bearer only")
+        if scheme != "bearer":
+            raise ValueError("A2A push callback authentication must declare bearer")
 
     async def save_config(
         self,
@@ -161,12 +169,15 @@ class A2APushDispatcher:
         config = delivery.config
         try:
             self.validate_config(config)
-            headers: dict[str, str] = {"A2A-Version": "1.0"}
-            if config.token:
-                headers["X-A2A-Notification-Token"] = config.token
-            if config.authentication.scheme.lower() == "bearer":
-                headers["Authorization"] = f"Bearer {config.authentication.credentials}"
+            headers: dict[str, str] = {"A2A-Version": "1.0", **self._auth.headers()}
             response = await self._client.post(config.url, json=delivery.payload, headers=headers)
+            if response.status_code == 401 and self._auth.invalidate():
+                headers = {"A2A-Version": "1.0", **self._auth.headers()}
+                response = await self._client.post(
+                    config.url,
+                    json=delivery.payload,
+                    headers=headers,
+                )
             response.raise_for_status()
         except Exception as exc:
             attempts = delivery.attempt_count + 1

--- a/src/ting/config.py
+++ b/src/ting/config.py
@@ -1088,6 +1088,13 @@ class A2AConfig(BaseModel):
         default_factory=list,
         description="Exact HTTPS origins allowed to receive A2A task callbacks.",
     )
+    push_auth: HttpAuthAdapterConfig = Field(
+        default_factory=HttpAuthAdapterConfig,
+        description=(
+            "Dynamic auth adapter used by Ting for A2A callbacks. Production "
+            "deployments should use short-lived workload identity credentials."
+        ),
+    )
     push_timeout_seconds: float = Field(
         default=10.0,
         ge=1.0,

--- a/src/ting/main.py
+++ b/src/ting/main.py
@@ -576,6 +576,7 @@ def create_app(
                 )
                 a2a_push_dispatcher = A2APushDispatcher(
                     repo=a2a_push_repo,
+                    auth=_create_http_auth_adapter(settings.a2a.push_auth),
                     allowed_callback_origins=settings.a2a.push_callback_allowed_origins,
                     timeout_seconds=settings.a2a.push_timeout_seconds,
                     poll_seconds=settings.a2a.push_poll_seconds,

--- a/tests/test_ravn/test_a2a_task_tool.py
+++ b/tests/test_ravn/test_a2a_task_tool.py
@@ -265,7 +265,6 @@ async def test_a2a_task_registers_push_and_reports_delivery_mode() -> None:
         agent_directory=_Directory(agent),
         client=client,
         push_callback_url="https://resident.example/a2a/push",
-        push_notification_token="notification-secret",
     )
 
     result = await tool.execute(
@@ -286,7 +285,8 @@ async def test_a2a_task_registers_push_and_reports_delivery_mode() -> None:
     registration = client.posts[1][1]["params"]
     assert registration["taskId"] == "task-push"
     assert registration["url"] == "https://resident.example/a2a/push"
-    assert registration["token"] == "notification-secret"
+    assert registration["authentication"] == {"scheme": "Bearer"}
+    assert "token" not in registration
 
 
 @pytest.mark.asyncio
@@ -300,7 +300,6 @@ async def test_a2a_task_keeps_polling_available_when_push_registration_fails() -
         agent_directory=_Directory(agent),
         client=client,
         push_callback_url="https://resident.example/a2a/push",
-        push_notification_token="notification-secret",
     )
 
     result = await tool.execute(

--- a/tests/test_ravn/test_gateway_http.py
+++ b/tests/test_ravn/test_gateway_http.py
@@ -87,7 +87,7 @@ def test_status_endpoint_no_sessions():
     assert resp.json()["session_count"] == 0
 
 
-def test_a2a_push_requires_token_and_wakes_resident():
+def test_a2a_push_requires_workload_identity_and_wakes_resident():
     runtime = MagicMock()
     runtime.submit_a2a_push = AsyncMock(
         return_value={
@@ -111,25 +111,54 @@ def test_a2a_push_requires_token_and_wakes_resident():
     }
 
     assert client.post("/a2a/push", json=payload).status_code == 503
+    verifier = MagicMock()
+    verifier.verify = AsyncMock(return_value={"workload_service": "ting"})
     configured_gateway = HttpGateway(
         _make_http_config(
             a2a_push_enabled=True,
-            a2a_push_notification_token="push-secret",
+            a2a_push_required_claims={"workload_service": "ting"},
         ),
         _make_gateway_mock(),
         resident_runtime=runtime,
+        a2a_push_verifier=verifier,
     )
     client = TestClient(configured_gateway.app)
     assert client.post("/a2a/push", json=payload).status_code == 401
     response = client.post(
         "/a2a/push",
         json=payload,
-        headers={"X-A2A-Notification-Token": "push-secret"},
+        headers={"Authorization": "Bearer workload-token"},
     )
 
     assert response.status_code == 200
     assert response.json()["queued"] is True
+    verifier.verify.assert_awaited_once_with("workload-token")
     runtime.submit_a2a_push.assert_awaited_once_with(payload)
+
+
+def test_a2a_push_rejects_non_ting_workload() -> None:
+    runtime = MagicMock()
+    runtime.submit_a2a_push = AsyncMock()
+    verifier = MagicMock()
+    verifier.verify = AsyncMock(return_value={"workload_service": "other"})
+    gateway = HttpGateway(
+        _make_http_config(
+            a2a_push_enabled=True,
+            a2a_push_required_claims={"workload_service": "ting"},
+        ),
+        _make_gateway_mock(),
+        resident_runtime=runtime,
+        a2a_push_verifier=verifier,
+    )
+
+    response = TestClient(gateway.app).post(
+        "/a2a/push",
+        json={"task": {"id": "task-1"}},
+        headers={"Authorization": "Bearer wrong-workload"},
+    )
+
+    assert response.status_code == 403
+    runtime.submit_a2a_push.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_signal_build_tool_wiring.py
+++ b/tests/test_ravn/test_signal_build_tool_wiring.py
@@ -184,7 +184,6 @@ def test_build_tool_build_backend_injects_a2a_activity_emitter() -> None:
         gateway={
             "platform": {
                 "a2a_push_callback_url": "https://ivaldi.example/a2a/push",
-                "a2a_push_notification_token": "push-secret",
             }
         },
         resident_evolution={
@@ -199,7 +198,6 @@ def test_build_tool_build_backend_injects_a2a_activity_emitter() -> None:
     assert backend is not None
     assert backend._activity_emitter is emitter
     assert backend._push_callback_url == "https://ivaldi.example/a2a/push"
-    assert backend._push_notification_token == "push-secret"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ravn/test_tool_build_backends.py
+++ b/tests/test_ravn/test_tool_build_backends.py
@@ -942,7 +942,6 @@ async def test_a2a_backend_suspends_for_push_and_resumes_with_one_get() -> None:
         client,
         workflow_id="wf-1",
         push_callback_url="https://ivaldi.example/a2a/push",
-        push_notification_token="callback-secret",
     )
 
     with pytest.raises(ToolBuildPendingError) as raised:
@@ -963,7 +962,8 @@ async def test_a2a_backend_suspends_for_push_and_resumes_with_one_get() -> None:
     registration = client.post_bodies[1]["params"]
     assert registration["taskId"] == "task-1"
     assert registration["url"] == "https://ivaldi.example/a2a/push"
-    assert registration["token"] == "callback-secret"
+    assert registration["authentication"] == {"scheme": "Bearer"}
+    assert "token" not in registration
 
     result = await backend.build(replace(_request(), continuation=raised.value.continuation))
 

--- a/tests/test_ting/test_a2a_push_dispatcher.py
+++ b/tests/test_ting/test_a2a_push_dispatcher.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 import respx
-from a2a.types import TaskPushNotificationConfig
+from a2a.types import AuthenticationInfo, TaskPushNotificationConfig
 from cryptography.fernet import Fernet
 
 from ting.adapters.a2a_push_dispatcher import A2APushDispatcher, callback_origin
@@ -18,7 +18,7 @@ def _config() -> TaskPushNotificationConfig:
         task_id="task-1",
         id="callback-1",
         url="https://resident.example/a2a/push",
-        token="notification-secret",
+        authentication=AuthenticationInfo(scheme="Bearer"),
     )
 
 
@@ -34,9 +34,13 @@ def _delivery() -> A2APushDelivery:
     )
 
 
-def _dispatcher(repo: MagicMock) -> A2APushDispatcher:
+def _dispatcher(repo: MagicMock, auth: MagicMock | None = None) -> A2APushDispatcher:
+    auth = auth or MagicMock()
+    auth.headers.return_value = {"Authorization": "Bearer workload-token"}
+    auth.invalidate.return_value = True
     return A2APushDispatcher(
         repo=repo,
+        auth=auth,
         allowed_callback_origins=["https://resident.example"],
         timeout_seconds=10.0,
         poll_seconds=1.0,
@@ -61,7 +65,7 @@ def test_callback_origin_requires_allowlisted_https_shape() -> None:
 
 
 @pytest.mark.asyncio
-async def test_push_delivery_uses_standard_token_header_and_marks_delivered() -> None:
+async def test_push_delivery_uses_workload_bearer_and_marks_delivered() -> None:
     repo = MagicMock()
     repo.mark_delivered = AsyncMock()
     repo.retry_later = AsyncMock()
@@ -73,7 +77,34 @@ async def test_push_delivery_uses_standard_token_header_and_marks_delivered() ->
         await dispatcher._deliver(_delivery())
 
     assert route.called
-    assert route.calls[0].request.headers["X-A2A-Notification-Token"] == ("notification-secret")
+    assert route.calls[0].request.headers["Authorization"] == "Bearer workload-token"
+    assert "X-A2A-Notification-Token" not in route.calls[0].request.headers
+    repo.mark_delivered.assert_awaited_once()
+    repo.retry_later.assert_not_awaited()
+    await dispatcher.stop()
+
+
+@pytest.mark.asyncio
+async def test_push_delivery_refreshes_rejected_workload_identity_once() -> None:
+    repo = MagicMock()
+    repo.mark_delivered = AsyncMock()
+    repo.retry_later = AsyncMock()
+    auth = MagicMock()
+    auth.headers.side_effect = [
+        {"Authorization": "Bearer expired-token"},
+        {"Authorization": "Bearer fresh-token"},
+    ]
+    auth.invalidate.return_value = True
+    dispatcher = _dispatcher(repo, auth)
+    with respx.mock:
+        route = respx.post("https://resident.example/a2a/push").mock(
+            side_effect=[httpx.Response(401), httpx.Response(204)]
+        )
+        await dispatcher._deliver(_delivery())
+
+    assert route.call_count == 2
+    assert route.calls[1].request.headers["Authorization"] == "Bearer fresh-token"
+    auth.invalidate.assert_called_once_with()
     repo.mark_delivered.assert_awaited_once()
     repo.retry_later.assert_not_awaited()
     await dispatcher.stop()
@@ -95,7 +126,7 @@ async def test_push_delivery_retries_without_dropping_failed_event() -> None:
 
 
 @pytest.mark.asyncio
-async def test_repository_encrypts_callback_credentials_before_storage() -> None:
+async def test_repository_encrypts_callback_config_before_storage() -> None:
     pool = MagicMock()
     pool.execute = AsyncMock(return_value="INSERT 0 1")
     repo = PostgresA2APushConfigRepository(
@@ -112,5 +143,15 @@ async def test_repository_encrypts_callback_credentials_before_storage() -> None
 
     encrypted = pool.execute.await_args.args[-1]
     assert isinstance(encrypted, bytes)
-    assert b"notification-secret" not in encrypted
+    assert b"resident.example" not in encrypted
     assert repo._decrypt(encrypted) == saved
+
+
+def test_push_config_rejects_inline_credentials() -> None:
+    repo = MagicMock()
+    dispatcher = _dispatcher(repo)
+    config = _config()
+    config.token = "legacy-token"
+
+    with pytest.raises(ValueError, match="inline credentials"):
+        dispatcher.validate_config(config)

--- a/tests/test_ting/test_a2a_tasks.py
+++ b/tests/test_ting/test_a2a_tasks.py
@@ -932,7 +932,7 @@ class TestPushNotifications:
                 "taskId": campaign.slug,
                 "id": "ivaldi-callback",
                 "url": "https://resident.example/a2a/push",
-                "token": "notification-secret",
+                "authentication": {"scheme": "Bearer"},
             },
         ).json()["result"]
 


### PR DESCRIPTION
# What changed

- removed the global A2A callback token from Ravn configuration and registrations
- made Ting authenticate callback delivery with a dynamic workload-identity adapter
- made the Ravn callback endpoint validate signed bearer JWTs and required workload claims
- rejected inline A2A callback credentials, including the legacy notification-token header
- added portable Ting Helm configuration for callback authentication

# Why

The previous implementation reused one long-lived Doppler secret as both an A2A correlation token and callback authentication credential. It did not provide workload identity, rotation, or useful claim checks.

Callbacks now use short-lived platform workload JWTs. Deployments can select the issuer, audience, and trusted workload claims without embedding a secret or a cluster-specific host in application code.

# Validation

- `uv run --frozen ruff check .`
- 175 targeted Ravn, Ting, and Helm chart tests
