### PR TITLE
Broker Codex subscription credentials through OpenBao

### DIFF
--- a/charts/skuld/templates/skuld-configmap.yaml
+++ b/charts/skuld/templates/skuld-configmap.yaml
@@ -35,6 +35,9 @@ data:
     skip_permissions: {{ .Values.broker.skipPermissions }}
     agent_teams: {{ .Values.broker.agentTeams | default false }}
     cli_type: {{ .Values.broker.cliType | default "claude" | quote }}
+    codex_auth:
+      adapter: {{ dig "codexAuth" "adapter" "skuld.codex_auth.HostCodexAuthProvider" .Values.broker | quote }}
+      kwargs: {{ dig "codexAuth" "kwargs" dict .Values.broker | toJson }}
     host: "0.0.0.0"
     port: 8081
     persistence_mount_path: {{ .Values.persistence.mountPath | default "/volundr/sessions" | quote }}

--- a/charts/volundr/README.md
+++ b/charts/volundr/README.md
@@ -688,14 +688,13 @@ Session definitions are Kubernetes custom resources that describe how session po
 | `sessionDefinitions.skuldCodex.helm.repo` | string | `"oci://ghcr.io/niuulabs/charts"` | Helm repository URL |
 | `sessionDefinitions.skuldCodex.helm.repoName` | string | `""` | Name of HelmRepository or OCIRepository CR in cluster |
 | `sessionDefinitions.skuldCodex.helm.version` | string | `"0.1.0"` | Chart version constraint |
-| `sessionDefinitions.skuldCodex.defaults.session.model` | string | `"o4-mini"` | Default Codex model |
-| `sessionDefinitions.skuldCodex.defaults.broker.cliType` | string | `"codex"` | AI CLI backend |
-| `sessionDefinitions.skuldCodex.defaults.broker.transport` | string | `"subprocess"` | Codex always uses subprocess transport |
-| `sessionDefinitions.skuldCodex.defaults.broker.transportAdapter` | string | `"skuld.transports.codex.CodexSubprocessTransport"` | Fully-qualified transport adapter class path |
+| `sessionDefinitions.skuldCodex.defaults.session.model` | string | `""` | Empty uses the subscription's Codex default model |
+| `sessionDefinitions.skuldCodex.defaults.broker.cliType` | string | `"codex-ws"` | Codex app-server WebSocket backend |
+| `sessionDefinitions.skuldCodex.defaults.broker.transportAdapter` | string | `"skuld.transports.codex_ws.CodexWebSocketTransport"` | Fully-qualified transport adapter class path |
 | `sessionDefinitions.skuldCodex.defaults.broker.skipPermissions` | bool | `true` | Skip prompts and use `approvalPolicy=never` with `danger-full-access` |
 | `sessionDefinitions.skuldCodex.defaults.image.repository` | string | `"ghcr.io/niuulabs/skuld"` | Session image repository |
 | `sessionDefinitions.skuldCodex.defaults.image.tag` | string | `"latest"` | Session image tag |
-| `sessionDefinitions.skuldCodex.defaults.homeVolume.credentialFiles.secretName` | string | `"codex-credentials"` | K8s secret containing Codex credential files |
+| `sessionDefinitions.skuldCodex.defaults.homeVolume.credentialFiles.secretName` | string | `""` | Intentionally empty; subscription auth is supplied by the central access-token broker |
 | `sessionDefinitions.skuldCodex.defaults.homeVolume.credentialFiles.destDir` | string | `".codex"` | Codex stores config under `.codex/` |
 
 > Remaining skuld-codex fields follow the same structure as skuld-claude. See `values.yaml` for full details.
@@ -869,7 +868,6 @@ This chart expects secrets to be created externally (via External Secrets or man
 | GitHub token (configurable) | `token` | `git.github.existingSecret` -- GitHub API access |
 | GitLab token (configurable) | `token` | `git.gitlab.existingSecret` -- GitLab API access |
 | `claude-credentials` | (credential files) | Session pods -- Claude credential files symlinked into `$HOME/.claude/` |
-| `codex-credentials` | (credential files) | Session pods -- Codex credential files symlinked into `$HOME/.codex/` |
 
 ### Creating Secrets
 

--- a/charts/volundr/README.md.gotmpl
+++ b/charts/volundr/README.md.gotmpl
@@ -109,7 +109,6 @@ This chart expects secrets to be created externally (via External Secrets or man
 | GitHub token (configurable) | `token` | `git.github.existingSecret` -- GitHub API access |
 | GitLab token (configurable) | `token` | `git.gitlab.existingSecret` -- GitLab API access |
 | `claude-credentials` | (credential files) | Session pods -- Claude credential files symlinked into `$HOME/.claude/` |
-| `codex-credentials` | (credential files) | Session pods -- Codex credential files symlinked into `$HOME/.codex/` |
 
 ## Storage Layout
 

--- a/charts/volundr/templates/configmap.yaml
+++ b/charts/volundr/templates/configmap.yaml
@@ -76,6 +76,30 @@ data:
       secret_kwargs_env: {}
       {{- end }}
 
+    codex_credential_broker:
+      adapter: {{ .Values.codexCredentialBroker.adapter | quote }}
+      kwargs: {{ .Values.codexCredentialBroker.kwargs | default dict | toJson }}
+      {{- if .Values.codexCredentialBroker.secretKwargs }}
+      secret_kwargs_env:
+        {{- range .Values.codexCredentialBroker.secretKwargs }}
+        {{ .kwarg }}: CODEX_CREDENTIAL_BROKER_SK_{{ .kwarg | upper }}
+        {{- end }}
+      {{- else }}
+      secret_kwargs_env: {}
+      {{- end }}
+
+    credential_enrollment_runner:
+      adapter: {{ .Values.credentialEnrollmentRunner.adapter | quote }}
+      kwargs: {{ .Values.credentialEnrollmentRunner.kwargs | default dict | toJson }}
+      {{- if .Values.credentialEnrollmentRunner.secretKwargs }}
+      secret_kwargs_env:
+        {{- range .Values.credentialEnrollmentRunner.secretKwargs }}
+        {{ .kwarg }}: CREDENTIAL_ENROLLMENT_RUNNER_SK_{{ .kwarg | upper }}
+        {{- end }}
+      {{- else }}
+      secret_kwargs_env: {}
+      {{- end }}
+
     resident_runtimes:
       reconciliation_interval_seconds: {{ .Values.residentRuntimeReconciliationIntervalSeconds | default 10.0 }}
       controllers:{{ if not .Values.residentRuntimeControllers }} []{{ else }}

--- a/charts/volundr/templates/deployment.yaml
+++ b/charts/volundr/templates/deployment.yaml
@@ -155,6 +155,20 @@ spec:
                   name: {{ .secretName }}
                   key: {{ .secretKey }}
             {{- end }}
+            {{- range .Values.codexCredentialBroker.secretKwargs }}
+            - name: CODEX_CREDENTIAL_BROKER_SK_{{ .kwarg | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+            {{- end }}
+            {{- range .Values.credentialEnrollmentRunner.secretKwargs }}
+            - name: CREDENTIAL_ENROLLMENT_RUNNER_SK_{{ .kwarg | upper }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+            {{- end }}
             {{- range $index, $controller := .Values.residentRuntimeControllers }}
             {{- range $controller.secretKwargs }}
             - name: RESIDENT_CONTROLLER_{{ $index }}_SK_{{ .kwarg | upper }}

--- a/charts/volundr/templates/migrations-configmap.yaml
+++ b/charts/volundr/templates/migrations-configmap.yaml
@@ -1581,4 +1581,36 @@ data:
         END IF;
     END
     $$;
+  000060_credential_enrollments.up.sql: |
+    CREATE TABLE IF NOT EXISTS credential_enrollments (
+        id                  UUID         PRIMARY KEY,
+        connection_id       UUID         NOT NULL REFERENCES integration_connections(id) ON DELETE CASCADE,
+        owner_id             TEXT         NOT NULL,
+        tenant_id            TEXT         NOT NULL,
+        provider_slug        VARCHAR(100) NOT NULL,
+        credential_name      VARCHAR(253) NOT NULL,
+        method               VARCHAR(64)  NOT NULL,
+        state                VARCHAR(32)  NOT NULL,
+        runner_ref           JSONB        NOT NULL DEFAULT '{}'::jsonb,
+        verification_uri     TEXT         NOT NULL DEFAULT '',
+        user_code            VARCHAR(128) NOT NULL DEFAULT '',
+        expires_at           TIMESTAMPTZ  NOT NULL,
+        error_code           VARCHAR(100) NOT NULL DEFAULT '',
+        created_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+        updated_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+        CONSTRAINT credential_enrollments_state_check CHECK (
+            state IN ('pending', 'awaiting_user', 'complete', 'failed', 'expired', 'cancelled')
+        )
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_credential_enrollments_owner
+        ON credential_enrollments (owner_id, created_at DESC);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_credential_enrollments_active_connection
+        ON credential_enrollments (connection_id)
+        WHERE state IN ('pending', 'awaiting_user');
+  000060_credential_enrollments.down.sql: |
+    DROP INDEX IF EXISTS idx_credential_enrollments_active_connection;
+    DROP INDEX IF EXISTS idx_credential_enrollments_owner;
+    DROP TABLE IF EXISTS credential_enrollments;
 {{- end }}

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -330,6 +330,23 @@ podManager:
   # Each entry: { kwarg: "name", secretName: "k8s-secret", secretKey: "key" }
   secretKwargs: []
 
+# Codex subscription credentials are centrally refreshed by Völundr. Session
+# workloads receive only the access token and account metadata.
+codexCredentialBroker:
+  adapter: "volundr.adapters.outbound.codex_credential_broker.OpenBaoCodexCredentialBroker"
+  kwargs:
+    oauth_token_url: "https://auth.openai.com/oauth/token"
+    oauth_client_id: "app_EMoamEEZ73f0CkXaXp7hrann"
+    refresh_skew_seconds: 300
+  secretKwargs: []
+
+# Trusted login runner is independent of the selected session pod manager.
+# Clusters with OpenShell configure OpenShellCredentialEnrollmentRunner here.
+credentialEnrollmentRunner:
+  adapter: "volundr.adapters.outbound.credential_enrollment_runner.UnsupportedCredentialEnrollmentRunner"
+  kwargs: {}
+  secretKwargs: []
+
 # Operator-approved resident deployment profiles for this target. Profiles are
 # hidden from the API until explicitly configured and enabled; backend-specific
 # deployment details remain server-side.
@@ -1242,17 +1259,15 @@ sessionDefinitions:
         enabled: true
         mountPath: "/volundr/home"
         credentialFiles:
-          # -- Pre-existing K8s secret containing Codex credential files
-          secretName: "codex-credentials"
+          # Codex subscription credentials are supplied access-only by the
+          # central broker; auth.json is never projected into the session.
+          secretName: ""
           # -- Codex stores config under .codex/
           destDir: ".codex"
           secretMountPath: "/volundr/secrets/credential-files"
 
-      # Secrets injected as env vars into the skuld broker container.
-      envSecrets:
-        - envVar: OPENAI_API_KEY
-          secretName: openai-api-key
-          secretKey: api-key
+      # Subscription sessions do not use a static OpenAI API key.
+      envSecrets: []
 
       # Plain env vars injected into the skuld broker container.
       envVars: []

--- a/docs/plans/multi-user-agent-credentials.md
+++ b/docs/plans/multi-user-agent-credentials.md
@@ -1,0 +1,126 @@
+# Multi-user agent credential lifecycle
+
+Status: Codex foundation implemented; deployment and live OpenShell validation pending.
+
+## Decision
+
+"Central" means one platform control plane for many users. It does **not** mean
+one shared Codex or Claude identity.
+
+Every interactive provider connection is owned by an authenticated user and is
+addressed by:
+
+```text
+(tenant_id, user_id, provider_slug, connection_id, credential_name)
+```
+
+The connection and enrollment metadata live in PostgreSQL. Secret material lives
+only in the user's OpenBao path. An administrator can inspect safe state metadata,
+but cannot retrieve a token or complete login for another user.
+
+## Codex flow
+
+The shared Integrations settings surface starts a trusted, workspace-free
+OpenShell sandbox. The sandbox runs `codex login --device-auth` with a temporary
+`CODEX_HOME` configured for file-backed credential storage. It receives only the
+network access required by the Codex binary; it receives no existing user
+credential, repository, workspace, or host home directory.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant UI as Shared Integrations UI
+    participant V as Völundr
+    participant DB as PostgreSQL
+    participant OS as OpenShell sandbox
+    participant OA as OpenAI
+    participant B as OpenBao
+
+    User->>UI: Reconnect Codex
+    UI->>V: Start enrollment (user JWT)
+    V->>DB: Persist user-owned enrollment
+    V->>OS: Launch codex login --device-auth
+    OS->>OA: Request device challenge
+    V-->>UI: Verification URL + one-time code
+    User->>OA: Complete login directly
+    OS->>OA: Complete device grant
+    UI->>V: Read enrollment status
+    V->>OS: Read completed auth document
+    V->>B: Store under users/{user_id}/{credential_name}
+    V->>OS: Destroy sandbox and provider grant
+    V->>DB: Mark enrollment complete
+```
+
+OpenAI documents device-code authentication for headless Codex environments and
+documents that `auth.json` contains sensitive access/refresh material. See
+[Codex authentication](https://developers.openai.com/codex/auth/).
+
+## Rotation and failure semantics
+
+- Runtime sandboxes never receive the refresh token.
+- OpenShell exchanges workload identity for a short-lived credential grant.
+- Völundr refreshes the stored Codex access token before expiry and writes a
+  rotated refresh token back to the same user's OpenBao document.
+- Refresh is serialized with a PostgreSQL advisory lock keyed by
+  `(owner_type, owner_id, credential_name)`, so separate Völundr replicas cannot
+  spend the same rotating refresh token concurrently.
+- An unrecoverable refresh sets safe metadata to `auth_required` with a stable
+  error code. Provider error bodies and secret values are not persisted.
+- Successful enrollment or refresh sets that credential back to `active`.
+
+Ting treats a terminal session authentication error as a failed run. Restoring a
+credential does not silently replay a failed workflow: the user retries the failed
+run explicitly, which avoids duplicating external side effects. A later assisted
+retry feature may list affected failed runs for the same user, but must keep the
+final retry action explicit.
+
+## Claude policy
+
+Claude Code is not the same protocol as Codex:
+
+- For multi-user product deployments, use a user-scoped Anthropic Console API
+  key or an approved enterprise provider such as Bedrock, Vertex, or Foundry.
+- Anthropic documents `claude setup-token` as a one-year, inference-only token
+  for CI/scripts. If an operator elects to support it, store one token per user in
+  OpenBao and expose it only through the OpenShell credential proxy; do not put it
+  in Doppler or a static Kubernetes Secret.
+- Do not offer a hosted Claude.ai subscription login on behalf of arbitrary
+  platform users. Anthropic's current legal guidance says third-party developers
+  must not route Free/Pro/Max plan credentials on users' behalf. See
+  [Claude Code authentication](https://code.claude.com/docs/en/authentication) and
+  [authentication and credential use](https://code.claude.com/docs/en/legal-and-compliance#authentication-and-credential-use).
+
+Consequently, Codex device login is implemented as an interactive user connection;
+Claude remains API-key/enterprise-provider based unless Anthropic supplies an
+approved multi-user OAuth product contract.
+
+## Security invariants
+
+1. Enrollment authorization always uses the current end-user principal; admin
+   role does not bypass enrollment ownership.
+2. PostgreSQL stores challenge and lifecycle metadata only, never provider tokens.
+   Terminal transitions erase the verification URI, user code, and runner reference.
+3. OpenBao paths remain owner-scoped.
+4. The enrollment sandbox has a 15-minute TTL, no workspace, no host home, and a
+   temporary credential home. A server-side reconciliation loop destroys expired
+   sandboxes and provider grants within the next 30-second pass even when the user
+   closes the UI.
+5. The UI receives only state, expiry, verification URI, and one-time user code.
+6. Completion destroys the OpenShell sandbox and its network provider grant.
+7. GitOps supplies configuration and deployment changes; no static secret
+   manifests are introduced.
+
+## Deployment acceptance
+
+- Apply migration `000060_credential_enrollments` through the normal chart/Fleet
+  rollout.
+- Confirm the Codex catalog entry appears in shared Integrations for two different
+  users.
+- Complete login independently for both users using the same credential name and
+  verify their OpenBao owner paths remain distinct.
+- Force near-expiry token refresh from two Völundr replicas and verify only one
+  provider refresh request occurs.
+- Revoke one user's refresh token and verify only that user's connection becomes
+  `auth_required` and only that user's workflow fails.
+- Reconnect that user, explicitly retry the failed workflow, and verify the other
+  user's connection and runs are unchanged.

--- a/migrations/000060_credential_enrollments.down.sql
+++ b/migrations/000060_credential_enrollments.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_credential_enrollments_active_connection;
+DROP INDEX IF EXISTS idx_credential_enrollments_owner;
+DROP TABLE IF EXISTS credential_enrollments;

--- a/migrations/000060_credential_enrollments.up.sql
+++ b/migrations/000060_credential_enrollments.up.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS credential_enrollments (
+    id                  UUID         PRIMARY KEY,
+    connection_id       UUID         NOT NULL REFERENCES integration_connections(id) ON DELETE CASCADE,
+    owner_id             TEXT         NOT NULL,
+    tenant_id            TEXT         NOT NULL,
+    provider_slug        VARCHAR(100) NOT NULL,
+    credential_name      VARCHAR(253) NOT NULL,
+    method               VARCHAR(64)  NOT NULL,
+    state                VARCHAR(32)  NOT NULL,
+    runner_ref           JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    verification_uri     TEXT         NOT NULL DEFAULT '',
+    user_code            VARCHAR(128) NOT NULL DEFAULT '',
+    expires_at           TIMESTAMPTZ  NOT NULL,
+    error_code           VARCHAR(100) NOT NULL DEFAULT '',
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT credential_enrollments_state_check CHECK (
+        state IN ('pending', 'awaiting_user', 'complete', 'failed', 'expired', 'cancelled')
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_credential_enrollments_owner
+    ON credential_enrollments (owner_id, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credential_enrollments_active_connection
+    ON credential_enrollments (connection_id)
+    WHERE state IN ('pending', 'awaiting_user');

--- a/src/cli/migrations/volundr/000060_credential_enrollments.down.sql
+++ b/src/cli/migrations/volundr/000060_credential_enrollments.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_credential_enrollments_active_connection;
+DROP INDEX IF EXISTS idx_credential_enrollments_owner;
+DROP TABLE IF EXISTS credential_enrollments;

--- a/src/cli/migrations/volundr/000060_credential_enrollments.up.sql
+++ b/src/cli/migrations/volundr/000060_credential_enrollments.up.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS credential_enrollments (
+    id                  UUID         PRIMARY KEY,
+    connection_id       UUID         NOT NULL REFERENCES integration_connections(id) ON DELETE CASCADE,
+    owner_id             TEXT         NOT NULL,
+    tenant_id            TEXT         NOT NULL,
+    provider_slug        VARCHAR(100) NOT NULL,
+    credential_name      VARCHAR(253) NOT NULL,
+    method               VARCHAR(64)  NOT NULL,
+    state                VARCHAR(32)  NOT NULL,
+    runner_ref           JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    verification_uri     TEXT         NOT NULL DEFAULT '',
+    user_code            VARCHAR(128) NOT NULL DEFAULT '',
+    expires_at           TIMESTAMPTZ  NOT NULL,
+    error_code           VARCHAR(100) NOT NULL DEFAULT '',
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at           TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT credential_enrollments_state_check CHECK (
+        state IN ('pending', 'awaiting_user', 'complete', 'failed', 'expired', 'cancelled')
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_credential_enrollments_owner
+    ON credential_enrollments (owner_id, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_credential_enrollments_active_connection
+    ON credential_enrollments (connection_id)
+    WHERE state IN ('pending', 'awaiting_user');

--- a/src/niuu/adapters/inbound/rest_integration_models.py
+++ b/src/niuu/adapters/inbound/rest_integration_models.py
@@ -25,6 +25,18 @@ class IntegrationResponse(BaseModel):
     created_at: str = Field(description="ISO 8601 creation timestamp")
     updated_at: str = Field(description="ISO 8601 last update timestamp")
     slug: str = Field(default="", description="Catalog entry slug")
+    credential_status: str = Field(
+        default="unknown",
+        description="Safe credential lifecycle state; secret values are never returned",
+    )
+    credential_error_code: str | None = Field(
+        default=None,
+        description="Machine-readable credential failure code",
+    )
+    credential_status_updated_at: str | None = Field(
+        default=None,
+        description="ISO 8601 timestamp of the latest credential state transition",
+    )
 
     @model_serializer(mode="wrap")
     def _serialize_with_camel_case_aliases(self, handler):
@@ -34,10 +46,20 @@ class IntegrationResponse(BaseModel):
         data["credentialName"] = data["credential_name"]
         data["createdAt"] = data["created_at"]
         data["updatedAt"] = data["updated_at"]
+        data["credentialStatus"] = data["credential_status"]
+        data["credentialErrorCode"] = data["credential_error_code"]
+        data["credentialStatusUpdatedAt"] = data["credential_status_updated_at"]
         return data
 
     @classmethod
-    def from_connection(cls, conn: IntegrationConnection) -> IntegrationResponse:
+    def from_connection(
+        cls,
+        conn: IntegrationConnection,
+        *,
+        credential_status: str = "unknown",
+        credential_error_code: str | None = None,
+        credential_status_updated_at: str | None = None,
+    ) -> IntegrationResponse:
         """Create response from domain model."""
         return cls(
             id=conn.id,
@@ -50,6 +72,9 @@ class IntegrationResponse(BaseModel):
             created_at=conn.created_at.isoformat(),
             updated_at=conn.updated_at.isoformat(),
             slug=conn.slug,
+            credential_status=credential_status,
+            credential_error_code=credential_error_code,
+            credential_status_updated_at=credential_status_updated_at,
         )
 
 

--- a/src/niuu/adapters/inbound/rest_integrations_settings.py
+++ b/src/niuu/adapters/inbound/rest_integrations_settings.py
@@ -47,6 +47,9 @@ def create_integrations_settings_router() -> APIRouter:
                             test_path="/api/v1/integrations/{id}/test",
                             oauth_authorize_path="/api/v1/integrations/oauth/{slug}/authorize",
                             oauth_disconnect_path="/api/v1/integrations/oauth/{slug}/disconnect",
+                            enrollment_start_path="/api/v1/integrations/enrollments",
+                            enrollment_status_path="/api/v1/integrations/enrollments/{id}",
+                            enrollment_cancel_path="/api/v1/integrations/enrollments/{id}",
                         )
                     ],
                 )

--- a/src/niuu/adapters/postgres_credential_refresh_lock.py
+++ b/src/niuu/adapters/postgres_credential_refresh_lock.py
@@ -1,0 +1,40 @@
+"""PostgreSQL advisory-lock adapter for credential refresh serialization."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import asyncpg
+
+from niuu.ports.credentials import CredentialRefreshLockPort
+
+_LOCK_NAMESPACE = b"niuu:credential-refresh:v1\0"
+
+
+class PostgresCredentialRefreshLock(CredentialRefreshLockPort):
+    """Hold a transaction-scoped advisory lock for one credential identity."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    @asynccontextmanager
+    async def hold(
+        self,
+        owner_type: str,
+        owner_id: str,
+        name: str,
+    ) -> AsyncIterator[None]:
+        lock_id = _credential_lock_id(owner_type, owner_id, name)
+        async with self._pool.acquire() as connection:
+            async with connection.transaction():
+                await connection.execute("SELECT pg_advisory_xact_lock($1)", lock_id)
+                yield
+
+
+def _credential_lock_id(owner_type: str, owner_id: str, name: str) -> int:
+    """Return a stable signed 64-bit PostgreSQL advisory-lock key."""
+    identity = "\0".join((owner_type, owner_id, name)).encode()
+    digest = hashlib.blake2b(_LOCK_NAMESPACE + identity, digest_size=8).digest()
+    return int.from_bytes(digest, byteorder="big", signed=True)

--- a/src/niuu/config_models.py
+++ b/src/niuu/config_models.py
@@ -118,15 +118,15 @@ def default_session_definitions() -> dict[str, SessionDefinitionConfig]:
             enabled=True,
             display_name="OpenAI Codex (Batch)",
             description=(
-                "OpenAI Codex — subprocess transport tuned for autonomous workflow execution"
+                "OpenAI Codex — app-server transport tuned for autonomous workflow execution"
             ),
             labels=["session", "codex", "batch"],
             default_model="",
             compatible_providers=["openai"],
             defaults={
                 "broker": {
-                    "cliType": "codex",
-                    "transportAdapter": "skuld.transports.codex.CodexSubprocessTransport",
+                    "cliType": "codex-ws",
+                    "transportAdapter": "skuld.transports.codex_ws.CodexWebSocketTransport",
                     "agentTeams": False,
                 },
             },

--- a/src/niuu/ports/__init__.py
+++ b/src/niuu/ports/__init__.py
@@ -1,7 +1,7 @@
 """Niuu shared port interfaces."""
 
 from niuu.ports.cli import CLITransport, EventCallback, TransportCapabilities
-from niuu.ports.credentials import CredentialStorePort
+from niuu.ports.credentials import CredentialRefreshLockPort, CredentialStorePort
 from niuu.ports.embedded_database import EmbeddedDatabasePort
 from niuu.ports.git import GitProvider
 from niuu.ports.graphql import GraphQLClientPort
@@ -11,6 +11,7 @@ from niuu.ports.model_catalog import ModelCatalogPort
 __all__ = [
     "CLITransport",
     "CredentialStorePort",
+    "CredentialRefreshLockPort",
     "EmbeddedDatabasePort",
     "EventCallback",
     "GitProvider",

--- a/src/niuu/ports/credentials.py
+++ b/src/niuu/ports/credentials.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from contextlib import AbstractAsyncContextManager
 
 from niuu.domain.models import SecretType, StoredCredential
 
@@ -61,3 +62,16 @@ class CredentialStorePort(ABC):
     @abstractmethod
     async def health_check(self) -> bool:
         """Check if the credential store backend is reachable."""
+
+
+class CredentialRefreshLockPort(ABC):
+    """Serialize rotation of one owner-scoped credential across replicas."""
+
+    @abstractmethod
+    def hold(
+        self,
+        owner_type: str,
+        owner_id: str,
+        name: str,
+    ) -> AbstractAsyncContextManager[None]:
+        """Hold the credential's distributed refresh lock for one critical section."""

--- a/src/niuu/settings_schema.py
+++ b/src/niuu/settings_schema.py
@@ -72,6 +72,9 @@ class SettingsIntegrationsResourceSchema(SettingsResourceSchemaBase):
     test_path: str = Field(serialization_alias="testPath")
     oauth_authorize_path: str = Field(serialization_alias="oauthAuthorizePath")
     oauth_disconnect_path: str = Field(serialization_alias="oauthDisconnectPath")
+    enrollment_start_path: str = Field(serialization_alias="enrollmentStartPath")
+    enrollment_status_path: str = Field(serialization_alias="enrollmentStatusPath")
+    enrollment_cancel_path: str = Field(serialization_alias="enrollmentCancelPath")
 
 
 SettingsResourceSchema = Annotated[

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -3032,6 +3032,12 @@ class Broker(
                 )
             )
             asyncio.create_task(
+                self._report_activity_state(
+                    "error",
+                    extra_metadata={"error": visible_error},
+                )
+            )
+            asyncio.create_task(
                 self._report_timeline_event(
                     {
                         "t": self._artifacts.duration_seconds,

--- a/src/skuld/codex_auth.py
+++ b/src/skuld/codex_auth.py
@@ -90,9 +90,7 @@ class VolundrCodexAuthProvider(CodexAuthProviderPort):
             response.raise_for_status()
             payload = response.json()
         except (httpx.HTTPError, ValueError) as exc:
-            raise CodexAuthProviderError(
-                "Codex authentication requires reconnection"
-            ) from exc
+            raise CodexAuthProviderError("Codex authentication requires reconnection") from exc
 
         access_token = str(payload.get("access_token") or "")
         account_id = str(payload.get("chatgpt_account_id") or "")

--- a/src/skuld/codex_auth.py
+++ b/src/skuld/codex_auth.py
@@ -1,0 +1,106 @@
+"""Configured Codex authentication adapters for Skuld transports."""
+
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+import httpx
+
+
+@dataclass(frozen=True)
+class CodexExternalTokens:
+    access_token: str
+    account_id: str
+    plan_type: str = ""
+
+    def app_server_payload(self) -> dict[str, str]:
+        payload = {
+            "accessToken": self.access_token,
+            "chatgptAccountId": self.account_id,
+        }
+        if self.plan_type:
+            payload["chatgptPlanType"] = self.plan_type
+        return payload
+
+
+class CodexAuthProviderError(RuntimeError):
+    """Raised when externally managed Codex authentication cannot continue."""
+
+
+class CodexAuthProviderPort(ABC):
+    """Supply external ChatGPT tokens, or defer entirely to host Codex auth."""
+
+    @abstractmethod
+    async def get_tokens(self, *, force_refresh: bool = False) -> CodexExternalTokens | None:
+        """Return external tokens, or None when Codex should use its host credential store."""
+
+
+class HostCodexAuthProvider(CodexAuthProviderPort):
+    """Non-Kubernetes adapter that preserves the existing host Codex login."""
+
+    def __init__(self, **_extra: object) -> None:
+        pass
+
+    async def get_tokens(self, *, force_refresh: bool = False) -> None:
+        del force_refresh
+        return None
+
+
+class VolundrCodexAuthProvider(CodexAuthProviderPort):
+    """Fetch access-only tokens through Skuld's existing authenticated Volundr client."""
+
+    def __init__(
+        self,
+        *,
+        http_client_provider: Callable[[], Awaitable[httpx.AsyncClient]],
+        credential_name: str = "codex-credentials",
+        credential_field: str = "auth.json",
+        token_path: str = "/api/v1/internal/credentials/codex/tokens",
+        **_extra: object,
+    ) -> None:
+        self._http_client_provider = http_client_provider
+        self._credential_name = credential_name
+        self._credential_field = credential_field
+        self._token_path = token_path
+        self._last_access_token = ""
+
+    async def get_tokens(
+        self,
+        *,
+        force_refresh: bool = False,
+    ) -> CodexExternalTokens:
+        client = await self._http_client_provider()
+        try:
+            response = await client.post(
+                self._token_path,
+                json={
+                    "credential_name": self._credential_name,
+                    "credential_field": self._credential_field,
+                    "force_refresh": force_refresh,
+                    "previous_access_token_sha256": (
+                        hashlib.sha256(self._last_access_token.encode()).hexdigest()
+                        if force_refresh and self._last_access_token
+                        else ""
+                    ),
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise CodexAuthProviderError(
+                "Codex authentication requires reconnection"
+            ) from exc
+
+        access_token = str(payload.get("access_token") or "")
+        account_id = str(payload.get("chatgpt_account_id") or "")
+        if not access_token or not account_id:
+            raise CodexAuthProviderError("Codex token broker returned an invalid response")
+        self._last_access_token = access_token
+        return CodexExternalTokens(
+            access_token=access_token,
+            account_id=account_id,
+            plan_type=str(payload.get("chatgpt_plan_type") or ""),
+        )

--- a/src/skuld/config.py
+++ b/src/skuld/config.py
@@ -470,6 +470,14 @@ class WorkloadIdentityConfig(BaseModel):
         return value
 
 
+class CodexAuthConfig(BaseModel):
+    """Dynamic Codex authentication adapter configuration."""
+
+    adapter: str = Field(default="skuld.codex_auth.HostCodexAuthProvider")
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+    secret_kwargs_env: dict[str, str] = Field(default_factory=dict)
+
+
 # Legacy bare env vars (pre config-first rule) that deployed charts still set.
 # Mapped into the workload_identity section by LegacyWorkloadIdentityEnvSource;
 # the config file is canonical, these are a compatibility override.
@@ -627,6 +635,7 @@ class SkuldSettings(BaseSettings):
         ),
     )
     workload_identity: WorkloadIdentityConfig = Field(default_factory=WorkloadIdentityConfig)
+    codex_auth: CodexAuthConfig = Field(default_factory=CodexAuthConfig)
     service_user_id: str = Field(default="skuld-broker")
     service_tenant_id: str = Field(default="default")
     persistence_mount_path: str = Field(default="/volundr/sessions")

--- a/src/skuld/transport_lifecycle.py
+++ b/src/skuld/transport_lifecycle.py
@@ -10,9 +10,10 @@ import uuid
 from pathlib import Path
 
 from niuu.ports.cli import CLITransport
-from niuu.utils import import_class
+from niuu.utils import import_class, resolve_secret_kwargs
 from skuld.broker_api import _rebuild_presented_registry
 from skuld.chronicle_watcher import ChronicleWatcher
+from skuld.codex_auth import CodexAuthProviderPort
 from skuld.conversation_models import ConversationTurn
 from skuld.service_manager import ServiceManager
 from skuld.session_artifacts import _capture_git_workspace_checkpoint
@@ -48,6 +49,18 @@ class TransportLifecycleMixin:
             "acp_prompt_timeout_s": self._settings.acp_prompt_timeout_s,
         }
 
+    def _create_codex_auth_provider(self) -> CodexAuthProviderPort:
+        """Build the configured auth adapter against Skuld's platform HTTP client."""
+        config = self._settings.codex_auth
+        cls = import_class(config.adapter)
+        kwargs = resolve_secret_kwargs(config.kwargs, config.secret_kwargs_env)
+        provider = cls(http_client_provider=self._get_http_client, **kwargs)
+        if not isinstance(provider, CodexAuthProviderPort):
+            raise TypeError(
+                f"Codex auth adapter {config.adapter} must implement CodexAuthProviderPort"
+            )
+        return provider
+
     def _create_transport(self) -> CLITransport:
         """Create the configured CLI transport via dynamic import.
 
@@ -68,8 +81,10 @@ class TransportLifecycleMixin:
         except (ImportError, AttributeError) as exc:
             raise ValueError(f"Cannot load transport adapter '{adapter_path}': {exc}") from exc
 
-        kwargs = self._build_transport_kwargs()
         sig = inspect.signature(cls)
+        kwargs = self._build_transport_kwargs()
+        if "codex_auth_provider" in sig.parameters:
+            kwargs["codex_auth_provider"] = self._create_codex_auth_provider()
         filtered = {k: v for k, v in kwargs.items() if k in sig.parameters}
         logger.info("Using %s (adapter: %s)", cls.__name__, adapter_path)
         return cls(**filtered)

--- a/src/skuld/transports/codex_ws.py
+++ b/src/skuld/transports/codex_ws.py
@@ -32,6 +32,7 @@ from niuu.adapters.cli.runtime import (
     stop_subprocess as _stop_process,
 )
 from niuu.ports.cli import CLITransport, TransportCapabilities
+from skuld.codex_auth import CodexAuthProviderError, CodexAuthProviderPort, HostCodexAuthProvider
 from skuld.transports.codex import (
     CodexSubprocessTransport,
     _map_codex_tool,
@@ -199,7 +200,9 @@ class CodexWebSocketTransport(CLITransport):
         4. User messages are sent via ``turn/start``
         5. Streaming events arrive as JSON-RPC notifications
 
-    Authentication: set ``OPENAI_API_KEY`` in the environment.
+    Authentication is selected by the configured ``CodexAuthProviderPort``.
+    Local sessions retain Codex's host login; Kubernetes sessions use externally
+    managed access-only ChatGPT tokens supplied by Völundr.
     """
 
     def __init__(
@@ -217,6 +220,7 @@ class CodexWebSocketTransport(CLITransport):
         resume_session_id: str = "",
         reasoning_effort: str = "",
         max_ws_message_bytes: int = _DEFAULT_MAX_WS_MESSAGE_BYTES,
+        codex_auth_provider: CodexAuthProviderPort | None = None,
         **_kwargs: object,
     ) -> None:
         super().__init__()
@@ -235,6 +239,7 @@ class CodexWebSocketTransport(CLITransport):
         self._resume_session_id = (resume_session_id or "").strip() or None
         self._max_ws_message_bytes = max(_MIN_MAX_WS_MESSAGE_BYTES, int(max_ws_message_bytes))
         self._env = dict(os.environ)
+        self._codex_auth_provider = codex_auth_provider or HostCodexAuthProvider()
 
         self._process: asyncio.subprocess.Process | None = None
         self._ws: ClientConnection | None = None
@@ -311,6 +316,10 @@ class CodexWebSocketTransport(CLITransport):
             await self._spawn_app_server()
             await self._connect_ws()
             await self._handshake()
+        except CodexAuthProviderError as exc:
+            await self._emit({"type": "error", "error": str(exc)})
+            await self.stop()
+            raise
         except Exception as exc:
             await self._start_fallback_transport(exc)
             return
@@ -498,6 +507,7 @@ class CodexWebSocketTransport(CLITransport):
         logger.info("Codex initialize response: %s", result)
 
         await self._send_notification("initialized")
+        await self._authenticate_codex()
 
         if self._resume_session_id:
             # Imported/external session — reattach to the existing thread
@@ -566,6 +576,16 @@ class CodexWebSocketTransport(CLITransport):
                 "model": self._model,
                 "tools": [],
             }
+        )
+
+    async def _authenticate_codex(self) -> None:
+        """Select host-managed or externally managed auth through the configured port."""
+        tokens = await self._codex_auth_provider.get_tokens()
+        if tokens is None:
+            return
+        await self._send_rpc(
+            "account/login/start",
+            {"type": "chatgptAuthTokens", **tokens.app_server_payload()},
         )
 
     # ------------------------------------------------------------------
@@ -930,6 +950,21 @@ class CodexWebSocketTransport(CLITransport):
         rid = data["id"]
         params = data.get("params", {})
 
+        if method == "account/chatgptAuthTokens/refresh":
+            try:
+                tokens = await self._codex_auth_provider.get_tokens(force_refresh=True)
+                if tokens is None:
+                    raise CodexAuthProviderError(
+                        "Codex requested external token refresh while host auth is configured"
+                    )
+            except CodexAuthProviderError as exc:
+                self._turn_error = str(exc)
+                await self._emit({"type": "error", "error": str(exc)})
+                await self._send_rpc_error(rid, -32001, str(exc))
+                return
+            await self._send_rpc_response(rid, tokens.app_server_payload())
+            return
+
         if method == "item/commandExecution/requestApproval":
             request_id = str(rid)
             command = params.get("command", "")
@@ -1016,6 +1051,13 @@ class CodexWebSocketTransport(CLITransport):
         if not self._ws:
             return
         msg = {"jsonrpc": "2.0", "id": rid, "result": result}
+        await self._ws.send(json.dumps(msg))
+
+    async def _send_rpc_error(self, rid: int, code: int, message: str) -> None:
+        """Reject a server request without logging credential material."""
+        if not self._ws:
+            return
+        msg = {"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": message}}
         await self._ws.send(json.dumps(msg))
 
     @staticmethod

--- a/src/volundr/adapters/inbound/rest_codex_credentials.py
+++ b/src/volundr/adapters/inbound/rest_codex_credentials.py
@@ -1,0 +1,64 @@
+"""Authenticated access-only Codex token broker endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel, Field
+
+from volundr.adapters.inbound.auth import extract_principal
+from volundr.adapters.outbound.codex_credential_broker import CodexCredentialBrokerError
+from volundr.domain.models import Principal
+from volundr.domain.ports import CodexCredentialBrokerPort
+
+
+class CodexTokenRequest(BaseModel):
+    credential_name: str = Field(default="codex-credentials", min_length=1, max_length=253)
+    credential_field: str = Field(default="auth.json", min_length=1, max_length=253)
+    force_refresh: bool = False
+    previous_access_token_sha256: str = Field(default="", max_length=64)
+
+
+class CodexTokenResponse(BaseModel):
+    access_token: str
+    chatgpt_account_id: str
+    expires_in: int
+    chatgpt_plan_type: str = ""
+
+
+def create_codex_credentials_router(
+    broker: CodexCredentialBrokerPort,
+    *,
+    prefix: str = "/api/v1/internal/credentials/codex",
+) -> APIRouter:
+    """Create the normal-authenticated broker route used by Skuld sessions."""
+    router = APIRouter(prefix=prefix, tags=["credentials-internal"])
+
+    @router.post("/tokens", response_model=CodexTokenResponse, include_in_schema=False)
+    async def get_tokens(
+        body: CodexTokenRequest,
+        response: Response,
+        principal: Principal = Depends(extract_principal),
+    ) -> CodexTokenResponse:
+        response.headers["Cache-Control"] = "no-store"
+        try:
+            tokens = await broker.get_tokens(
+                owner_id=principal.user_id,
+                credential_name=body.credential_name,
+                credential_field=body.credential_field,
+                force_refresh=body.force_refresh,
+                previous_access_token_sha256=body.previous_access_token_sha256,
+            )
+        except CodexCredentialBrokerError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=str(exc),
+                headers={"Cache-Control": "no-store"},
+            ) from exc
+        return CodexTokenResponse(
+            access_token=tokens.access_token,
+            chatgpt_account_id=tokens.account_id,
+            expires_in=tokens.expires_in,
+            chatgpt_plan_type=tokens.plan_type,
+        )
+
+    return router

--- a/src/volundr/adapters/inbound/rest_integrations.py
+++ b/src/volundr/adapters/inbound/rest_integrations.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response, status
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
@@ -15,12 +16,17 @@ from niuu.domain.models import SecretType
 from niuu.http_compat import LegacyRouteNotice, warn_on_legacy_route
 from volundr.adapters.inbound.auth import extract_principal
 from volundr.domain.models import (
+    CredentialEnrollment,
     IntegrationConnection,
     IntegrationDefinition,
     IntegrationType,
     Principal,
 )
 from volundr.domain.ports import CredentialStorePort, IntegrationRepository
+from volundr.domain.services.credential_enrollment import (
+    CredentialEnrollmentError,
+    CredentialEnrollmentService,
+)
 from volundr.domain.services.integration_registry import IntegrationRegistry
 from volundr.domain.services.tracker_factory import TrackerFactory
 
@@ -186,6 +192,10 @@ class CatalogEntryResponse(BaseModel):
         description="OAuth scopes if auth_type is OAuth",
         examples=[["read", "write"]],
     )
+    credential_enrollment: dict[str, str] | None = Field(
+        default=None,
+        description="Interactive credential enrollment metadata when supported",
+    )
 
     @classmethod
     def from_definition(
@@ -217,6 +227,63 @@ class CatalogEntryResponse(BaseModel):
             mcp_server=mcp,
             auth_type=defn.auth_type,
             oauth_scopes=oauth_scopes,
+            credential_enrollment=(
+                {
+                    "method": defn.credential_enrollment.method,
+                    "credential_field": defn.credential_enrollment.credential_field,
+                    "default_credential_name": (defn.credential_enrollment.default_credential_name),
+                }
+                if defn.credential_enrollment is not None
+                else None
+            ),
+        )
+
+
+class CredentialEnrollmentStartRequest(BaseModel):
+    """Start or resume one user-scoped interactive integration login."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    slug: str = Field(min_length=1, max_length=100)
+    credential_name: str = Field(
+        default="",
+        validation_alias=AliasChoices("credential_name", "credentialName"),
+        max_length=253,
+    )
+    connection_id: str = Field(
+        default="",
+        validation_alias=AliasChoices("connection_id", "connectionId"),
+        max_length=100,
+    )
+
+
+class CredentialEnrollmentResponse(BaseModel):
+    """Secret-free status for an interactive credential enrollment."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: UUID
+    connection_id: str = Field(serialization_alias="connectionId")
+    provider_slug: str = Field(serialization_alias="providerSlug")
+    credential_name: str = Field(serialization_alias="credentialName")
+    state: str
+    verification_uri: str = Field(serialization_alias="verificationUri")
+    user_code: str = Field(serialization_alias="userCode")
+    expires_at: datetime = Field(serialization_alias="expiresAt")
+    error_code: str = Field(serialization_alias="errorCode")
+
+    @classmethod
+    def from_domain(cls, enrollment: CredentialEnrollment) -> CredentialEnrollmentResponse:
+        return cls(
+            id=enrollment.id,
+            connection_id=enrollment.connection_id,
+            provider_slug=enrollment.provider_slug,
+            credential_name=enrollment.credential_name,
+            state=enrollment.state.value,
+            verification_uri=enrollment.verification_uri,
+            user_code=enrollment.user_code,
+            expires_at=enrollment.expires_at,
+            error_code=enrollment.error_code,
         )
 
 
@@ -254,12 +321,40 @@ def _build_integrations_router(
     canonical_prefix: str | None = None,
     registry: IntegrationRegistry | None = None,
     credential_store: CredentialStorePort | None = None,
+    credential_enrollment_service: CredentialEnrollmentService | None = None,
 ) -> APIRouter:
     """Create FastAPI router for integration management endpoints."""
     router = APIRouter(
         prefix=prefix,
         tags=["Integrations"],
     )
+
+    async def integration_response(connection: IntegrationConnection) -> IntegrationResponse:
+        if credential_store is None:
+            return IntegrationResponse.from_connection(connection)
+        credential = await credential_store.get(
+            "user",
+            connection.owner_id,
+            connection.credential_name,
+        )
+        if credential is None:
+            return IntegrationResponse.from_connection(
+                connection,
+                credential_status="missing",
+            )
+        metadata = credential.metadata
+        return IntegrationResponse.from_connection(
+            connection,
+            credential_status=str(metadata.get("auth_state") or "configured"),
+            credential_error_code=(
+                str(metadata["auth_error_code"]) if metadata.get("auth_error_code") else None
+            ),
+            credential_status_updated_at=(
+                str(metadata["auth_state_updated_at"])
+                if metadata.get("auth_state_updated_at")
+                else None
+            ),
+        )
 
     @router.get(
         "/catalog",
@@ -284,6 +379,72 @@ def _build_integrations_router(
         definitions = registry.list_definitions()
         return [CatalogEntryResponse.from_definition(d) for d in definitions]
 
+    @router.post(
+        "/enrollments",
+        response_model=CredentialEnrollmentResponse,
+        status_code=status.HTTP_201_CREATED,
+    )
+    async def start_credential_enrollment(
+        data: CredentialEnrollmentStartRequest,
+        principal: Principal = Depends(extract_principal),
+    ) -> CredentialEnrollmentResponse:
+        if credential_enrollment_service is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Interactive credential enrollment is unavailable",
+            )
+        try:
+            enrollment = await credential_enrollment_service.start(
+                principal=principal,
+                slug=data.slug,
+                credential_name=data.credential_name,
+                connection_id=data.connection_id,
+            )
+        except CredentialEnrollmentError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=str(exc),
+            ) from exc
+        return CredentialEnrollmentResponse.from_domain(enrollment)
+
+    @router.get(
+        "/enrollments/{enrollment_id}",
+        response_model=CredentialEnrollmentResponse,
+    )
+    async def get_credential_enrollment(
+        enrollment_id: UUID,
+        principal: Principal = Depends(extract_principal),
+    ) -> CredentialEnrollmentResponse:
+        if credential_enrollment_service is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Interactive credential enrollment is unavailable",
+            )
+        try:
+            enrollment = await credential_enrollment_service.get(enrollment_id, principal)
+        except CredentialEnrollmentError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        return CredentialEnrollmentResponse.from_domain(enrollment)
+
+    @router.delete(
+        "/enrollments/{enrollment_id}",
+        response_model=CredentialEnrollmentResponse,
+    )
+    async def cancel_credential_enrollment(
+        enrollment_id: UUID,
+        principal: Principal = Depends(extract_principal),
+    ) -> CredentialEnrollmentResponse:
+        if credential_enrollment_service is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Interactive credential enrollment is unavailable",
+            )
+        try:
+            enrollment = await credential_enrollment_service.cancel(enrollment_id, principal)
+        except CredentialEnrollmentError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        return CredentialEnrollmentResponse.from_domain(enrollment)
+
     @router.get(
         "",
         response_model=list[IntegrationResponse],
@@ -304,7 +465,7 @@ def _build_integrations_router(
                 ),
             )
         connections = await integration_repo.list_connections(principal.user_id)
-        return [IntegrationResponse.from_connection(c) for c in connections]
+        return list(await asyncio.gather(*(integration_response(c) for c in connections)))
 
     @router.get(
         "/{connection_id}",
@@ -332,7 +493,7 @@ def _build_integrations_router(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Integration not found: {connection_id}",
             )
-        return IntegrationResponse.from_connection(existing)
+        return await integration_response(existing)
 
     @router.post(
         "",
@@ -419,6 +580,7 @@ def _build_integrations_router(
                     "integration": definition.slug,
                     "integration_type": str(definition.integration_type),
                     "auth_type": definition.auth_type,
+                    "auth_state": "active",
                     **(
                         credential_metadata
                         if isinstance(credential_metadata, dict)
@@ -460,7 +622,7 @@ def _build_integrations_router(
             _sanitize_log(adapter),
             principal.user_id,
         )
-        return IntegrationResponse.from_connection(saved)
+        return await integration_response(saved)
 
     @router.put(
         "/{connection_id}",
@@ -508,7 +670,7 @@ def _build_integrations_router(
             slug=existing.slug,
         )
         saved = await integration_repo.save_connection(updated)
-        return IntegrationResponse.from_connection(saved)
+        return await integration_response(saved)
 
     @router.delete(
         "/{connection_id}",
@@ -624,6 +786,7 @@ def create_integrations_router(
     prefix: str = "/api/v1/integrations",
     registry: IntegrationRegistry | None = None,
     credential_store: CredentialStorePort | None = None,
+    credential_enrollment_service: CredentialEnrollmentService | None = None,
 ) -> APIRouter:
     """Create the canonical shared integrations router."""
     return _build_integrations_router(
@@ -632,6 +795,7 @@ def create_integrations_router(
         prefix=prefix,
         registry=registry,
         credential_store=credential_store,
+        credential_enrollment_service=credential_enrollment_service,
     )
 
 
@@ -641,6 +805,7 @@ def create_canonical_integrations_router(
     prefix: str = "/api/v1/integrations",
     registry: IntegrationRegistry | None = None,
     credential_store: CredentialStorePort | None = None,
+    credential_enrollment_service: CredentialEnrollmentService | None = None,
 ) -> APIRouter:
     """Backward-compatible alias for the canonical shared integrations router."""
     return create_integrations_router(
@@ -649,4 +814,5 @@ def create_canonical_integrations_router(
         prefix=prefix,
         registry=registry,
         credential_store=credential_store,
+        credential_enrollment_service=credential_enrollment_service,
     )

--- a/src/volundr/adapters/inbound/rest_oauth.py
+++ b/src/volundr/adapters/inbound/rest_oauth.py
@@ -167,7 +167,7 @@ def _build_oauth_router(
             name=credential_name,
             secret_type=SecretType.OAUTH_TOKEN,
             data=credentials,
-            metadata={"source": "oauth2", "integration": slug},
+            metadata={"source": "oauth2", "integration": slug, "auth_state": "active"},
         )
 
         now = datetime.now(UTC)

--- a/src/volundr/adapters/outbound/brokered_credentials.py
+++ b/src/volundr/adapters/outbound/brokered_credentials.py
@@ -39,9 +39,7 @@ class BrokeredCredentialPodManager:
 
     @staticmethod
     def _brokered_credential_environment(spec: SessionSpec) -> dict[str, str]:
-        return BrokeredCredentialPodManager._brokered_credential_environment_values(
-            spec.values
-        )
+        return BrokeredCredentialPodManager._brokered_credential_environment_values(spec.values)
 
     @staticmethod
     def _brokered_credential_environment_values(values: dict) -> dict[str, str]:

--- a/src/volundr/adapters/outbound/brokered_credentials.py
+++ b/src/volundr/adapters/outbound/brokered_credentials.py
@@ -1,0 +1,56 @@
+"""Shared credential-broker behavior for Kubernetes-backed pod managers."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+from volundr.domain.models import SessionSpec
+
+DEFAULT_CODEX_AUTH_ADAPTER = "skuld.codex_auth.VolundrCodexAuthProvider"
+
+
+class BrokeredCredentialPodManager:
+    """Project one common Skuld broker contract across Kubernetes pod managers."""
+
+    def _configure_brokered_credentials(
+        self,
+        *,
+        codex_auth_adapter: str = DEFAULT_CODEX_AUTH_ADAPTER,
+        codex_auth_kwargs: dict | None = None,
+    ) -> None:
+        self._codex_auth_adapter = codex_auth_adapter
+        self._codex_auth_kwargs = dict(codex_auth_kwargs or {})
+
+    def _with_brokered_credentials(self, spec: SessionSpec) -> SessionSpec:
+        values = self._with_brokered_credential_values(spec.values)
+        return SessionSpec(values=values, pod_spec=spec.pod_spec)
+
+    def _with_brokered_credential_values(self, source: dict) -> dict:
+        values = copy.deepcopy(source)
+        broker = values.setdefault("broker", {})
+        configured = broker.setdefault("codexAuth", {})
+        configured.setdefault("adapter", self._codex_auth_adapter)
+        kwargs = configured.setdefault("kwargs", {})
+        defaults = copy.deepcopy(self._codex_auth_kwargs)
+        defaults.update(kwargs)
+        configured["kwargs"] = defaults
+        return values
+
+    @staticmethod
+    def _brokered_credential_environment(spec: SessionSpec) -> dict[str, str]:
+        return BrokeredCredentialPodManager._brokered_credential_environment_values(
+            spec.values
+        )
+
+    @staticmethod
+    def _brokered_credential_environment_values(values: dict) -> dict[str, str]:
+        broker = values.get("broker")
+        configured = broker.get("codexAuth") if isinstance(broker, dict) else None
+        if not isinstance(configured, dict):
+            return {}
+        environment = {
+            "SKULD__CODEX_AUTH__ADAPTER": str(configured.get("adapter") or ""),
+            "SKULD__CODEX_AUTH__KWARGS": json.dumps(configured.get("kwargs") or {}),
+        }
+        return {name: value for name, value in environment.items() if value}

--- a/src/volundr/adapters/outbound/codex_credential_broker.py
+++ b/src/volundr/adapters/outbound/codex_credential_broker.py
@@ -1,0 +1,274 @@
+"""Codex OAuth credential broker backed by the configured credential store."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import jwt
+
+from volundr.domain.ports import (
+    CodexAuthTokens,
+    CodexCredentialBrokerPort,
+    CredentialRefreshLockPort,
+    CredentialStorePort,
+)
+
+DEFAULT_CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
+DEFAULT_CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+DEFAULT_CODEX_REFRESH_SKEW_SECONDS = 300
+DEFAULT_CODEX_OAUTH_TIMEOUT_SECONDS = 15.0
+
+CODEX_AUTH_STATE_METADATA_KEY = "auth_state"
+CODEX_AUTH_ERROR_CODE_METADATA_KEY = "auth_error_code"
+CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY = "auth_state_updated_at"
+CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY = "auth_last_refreshed_at"
+CODEX_AUTH_STATE_ACTIVE = "active"
+CODEX_AUTH_STATE_REQUIRED = "auth_required"
+CODEX_AUTH_REFRESH_FAILED = "refresh_failed"
+
+
+class CodexCredentialBrokerError(ValueError):
+    """Safe failure raised when brokered Codex authentication is unavailable."""
+
+
+class DisabledCodexCredentialBroker(CodexCredentialBrokerPort):
+    """Configured local-mode adapter that leaves Codex host authentication untouched."""
+
+    def __init__(self, **_extra: object) -> None:
+        pass
+
+    async def get_tokens(
+        self,
+        *,
+        owner_id: str,
+        credential_name: str,
+        credential_field: str,
+        force_refresh: bool = False,
+        previous_access_token_sha256: str = "",
+    ) -> CodexAuthTokens:
+        del (
+            owner_id,
+            credential_name,
+            credential_field,
+            force_refresh,
+            previous_access_token_sha256,
+        )
+        raise CodexCredentialBrokerError("Brokered Codex authentication is disabled")
+
+
+class OpenBaoCodexCredentialBroker(CodexCredentialBrokerPort):
+    """Keep refresh tokens in OpenBao and return access-only token envelopes."""
+
+    def __init__(
+        self,
+        *,
+        credential_store: CredentialStorePort,
+        refresh_lock: CredentialRefreshLockPort,
+        oauth_token_url: str = DEFAULT_CODEX_OAUTH_TOKEN_URL,
+        oauth_client_id: str = DEFAULT_CODEX_OAUTH_CLIENT_ID,
+        refresh_skew_seconds: int = DEFAULT_CODEX_REFRESH_SKEW_SECONDS,
+        oauth_timeout_seconds: float = DEFAULT_CODEX_OAUTH_TIMEOUT_SECONDS,
+        oauth_client: httpx.AsyncClient | None = None,
+        **_extra: object,
+    ) -> None:
+        self._credential_store = credential_store
+        self._refresh_lock = refresh_lock
+        self._oauth_token_url = oauth_token_url
+        self._oauth_client_id = oauth_client_id
+        self._refresh_skew_seconds = int(refresh_skew_seconds)
+        self._oauth_timeout_seconds = float(oauth_timeout_seconds)
+        self._oauth_client = oauth_client
+
+    async def get_tokens(
+        self,
+        *,
+        owner_id: str,
+        credential_name: str,
+        credential_field: str,
+        force_refresh: bool = False,
+        previous_access_token_sha256: str = "",
+    ) -> CodexAuthTokens:
+        if not owner_id or not credential_name or not credential_field:
+            raise CodexCredentialBrokerError("Codex credential reference is incomplete")
+
+        async with self._refresh_lock.hold("user", owner_id, credential_name):
+            stored = await self._credential_store.get("user", owner_id, credential_name)
+            values = await self._credential_store.get_value("user", owner_id, credential_name)
+            raw_auth = values.get(credential_field) if values else None
+            auth = parse_codex_auth_document(raw_auth)
+            access_token = str(auth["tokens"]["access_token"])
+            remaining = jwt_remaining_seconds(access_token)
+
+            forced_refresh_is_still_current = force_refresh and (
+                not previous_access_token_sha256
+                or hmac.compare_digest(
+                    hashlib.sha256(access_token.encode()).hexdigest(),
+                    previous_access_token_sha256,
+                )
+            )
+            if forced_refresh_is_still_current or remaining <= self._refresh_skew_seconds:
+                try:
+                    auth = await self._refresh(auth)
+                except CodexCredentialBrokerError as exc:
+                    if stored is not None and values is not None:
+                        await self._credential_store.store(
+                            "user",
+                            owner_id,
+                            credential_name,
+                            stored.secret_type,
+                            values,
+                            codex_auth_metadata(
+                                stored.metadata,
+                                state=CODEX_AUTH_STATE_REQUIRED,
+                                error_code=CODEX_AUTH_REFRESH_FAILED,
+                            ),
+                        )
+                    raise CodexCredentialBrokerError(
+                        "Codex authentication requires reconnection"
+                    ) from exc
+
+                if stored is None or values is None:
+                    raise CodexCredentialBrokerError("Codex credential metadata is unavailable")
+                access_token = str(auth["tokens"]["access_token"])
+                remaining = jwt_remaining_seconds(access_token)
+                updated_values = dict(values)
+                updated_values[credential_field] = json.dumps(auth, separators=(",", ":"))
+                await self._credential_store.store(
+                    "user",
+                    owner_id,
+                    credential_name,
+                    stored.secret_type,
+                    updated_values,
+                    codex_auth_metadata(
+                        stored.metadata,
+                        state=CODEX_AUTH_STATE_ACTIVE,
+                        refreshed=True,
+                    ),
+                )
+
+        tokens = auth["tokens"]
+        return CodexAuthTokens(
+            access_token=access_token,
+            account_id=str(tokens["account_id"]),
+            expires_in=max(remaining, 1),
+            plan_type=_codex_plan_type(auth, access_token),
+        )
+
+    async def _refresh(self, auth: dict[str, Any]) -> dict[str, Any]:
+        tokens = dict(auth["tokens"])
+        refresh_token = str(tokens.get("refresh_token") or "")
+        if not refresh_token:
+            raise CodexCredentialBrokerError("Codex OAuth refresh token is unavailable")
+
+        request_data = {
+            "grant_type": "refresh_token",
+            "client_id": self._oauth_client_id,
+            "refresh_token": refresh_token,
+        }
+        try:
+            if self._oauth_client is not None:
+                response = await self._oauth_client.post(self._oauth_token_url, data=request_data)
+            else:
+                async with httpx.AsyncClient(timeout=self._oauth_timeout_seconds) as client:
+                    response = await client.post(self._oauth_token_url, data=request_data)
+            response.raise_for_status()
+            payload = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise CodexCredentialBrokerError("Codex OAuth token refresh failed") from exc
+
+        access_token = str(payload.get("access_token") or "")
+        if not access_token:
+            raise CodexCredentialBrokerError(
+                "Codex OAuth token refresh returned no access token"
+            )
+        tokens["access_token"] = access_token
+        if payload.get("refresh_token"):
+            tokens["refresh_token"] = str(payload["refresh_token"])
+        if payload.get("id_token"):
+            tokens["id_token"] = str(payload["id_token"])
+
+        refreshed = dict(auth)
+        refreshed["tokens"] = tokens
+        refreshed["last_refresh"] = datetime.now(UTC).isoformat()
+        return refreshed
+
+
+def parse_codex_auth_document(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, str) or not raw.strip():
+        raise CodexCredentialBrokerError("Codex auth document is unavailable")
+    try:
+        auth = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise CodexCredentialBrokerError("Codex auth document is invalid JSON") from exc
+    if not isinstance(auth, dict) or not isinstance(auth.get("tokens"), dict):
+        raise CodexCredentialBrokerError("Codex auth document does not contain a token set")
+    required = ("access_token", "refresh_token", "account_id")
+    missing = [name for name in required if not str(auth["tokens"].get(name) or "")]
+    if missing:
+        raise CodexCredentialBrokerError("Codex auth document is missing required OAuth fields")
+    return auth
+
+
+def jwt_remaining_seconds(token: str) -> int:
+    try:
+        claims = jwt.decode(
+            token,
+            options={
+                "verify_signature": False,
+                "verify_aud": False,
+                "verify_exp": False,
+            },
+        )
+        expires_at = int(claims["exp"])
+    except (jwt.PyJWTError, KeyError, TypeError, ValueError) as exc:
+        raise CodexCredentialBrokerError(
+            "Codex OAuth access token is not a valid expiring JWT"
+        ) from exc
+    return expires_at - int(time.time())
+
+
+def codex_auth_metadata(
+    metadata: dict[str, Any],
+    *,
+    state: str,
+    error_code: str = "",
+    refreshed: bool = False,
+) -> dict[str, Any]:
+    now = datetime.now(UTC).isoformat()
+    updated = dict(metadata)
+    updated[CODEX_AUTH_STATE_METADATA_KEY] = state
+    updated[CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY] = now
+    if error_code:
+        updated[CODEX_AUTH_ERROR_CODE_METADATA_KEY] = error_code
+    else:
+        updated.pop(CODEX_AUTH_ERROR_CODE_METADATA_KEY, None)
+    if refreshed:
+        updated[CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY] = now
+    return updated
+
+
+def _codex_plan_type(auth: dict[str, Any], access_token: str) -> str:
+    explicit = str(auth.get("chatgpt_plan_type") or auth.get("plan_type") or "")
+    if explicit:
+        return explicit
+    try:
+        claims = jwt.decode(
+            access_token,
+            options={
+                "verify_signature": False,
+                "verify_aud": False,
+                "verify_exp": False,
+            },
+        )
+    except jwt.PyJWTError:
+        return ""
+    auth_claim = claims.get("https://api.openai.com/auth")
+    if not isinstance(auth_claim, dict):
+        return ""
+    return str(auth_claim.get("chatgpt_plan_type") or "")

--- a/src/volundr/adapters/outbound/codex_credential_broker.py
+++ b/src/volundr/adapters/outbound/codex_credential_broker.py
@@ -184,9 +184,7 @@ class OpenBaoCodexCredentialBroker(CodexCredentialBrokerPort):
 
         access_token = str(payload.get("access_token") or "")
         if not access_token:
-            raise CodexCredentialBrokerError(
-                "Codex OAuth token refresh returned no access token"
-            )
+            raise CodexCredentialBrokerError("Codex OAuth token refresh returned no access token")
         tokens["access_token"] = access_token
         if payload.get("refresh_token"):
             tokens["refresh_token"] = str(payload["refresh_token"])

--- a/src/volundr/adapters/outbound/contributors/secrets.py
+++ b/src/volundr/adapters/outbound/contributors/secrets.py
@@ -52,6 +52,30 @@ def _openshell_credential_values(mappings: list[CredentialMapping]) -> dict[str,
     }
 
 
+def _codex_auth_values(
+    context: SessionContext,
+    registry: IntegrationRegistry | None,
+) -> dict[str, object]:
+    if registry is None:
+        return {}
+    for connection in context.integration_connections:
+        definition = registry.get_definition(connection.slug)
+        enrollment = definition.credential_enrollment if definition is not None else None
+        if enrollment is None or enrollment.method != "codex_device":
+            continue
+        return {
+            "broker": {
+                "codexAuth": {
+                    "kwargs": {
+                        "credential_name": connection.credential_name,
+                        "credential_field": enrollment.credential_field,
+                    }
+                }
+            }
+        }
+    return {}
+
+
 class SecretInjectionContributor(SessionContributor):
     """Returns PodSpecAdditions for secret injection (agent injector, hostPath, etc.).
 
@@ -214,6 +238,9 @@ class SecretInjectionContributor(SessionContributor):
             return SessionContribution()
 
         values = _openshell_credential_values(mappings)
+        codex_values = _codex_auth_values(context, self._registry)
+        if codex_values:
+            values.update(codex_values)
         if context.runtime_backend == "openshell":
             return SessionContribution(values=values)
 

--- a/src/volundr/adapters/outbound/credential_enrollment_runner.py
+++ b/src/volundr/adapters/outbound/credential_enrollment_runner.py
@@ -1,0 +1,55 @@
+"""Configured trusted runtimes for interactive credential enrollment."""
+
+from __future__ import annotations
+
+from volundr.domain.models import CredentialEnrollment, CredentialEnrollmentPoll
+from volundr.domain.ports import CredentialEnrollmentRunnerPort
+
+
+class UnsupportedCredentialEnrollmentRunner(CredentialEnrollmentRunnerPort):
+    """Local/default adapter that deliberately does not launch a login runtime."""
+
+    def __init__(self, **_extra: object) -> None:
+        pass
+
+    def supports_enrollment(self, method: str) -> bool:
+        del method
+        return False
+
+    async def start_enrollment(self, enrollment: CredentialEnrollment) -> CredentialEnrollment:
+        del enrollment
+        raise ValueError("interactive credential enrollment is not configured")
+
+    async def poll_enrollment(
+        self,
+        enrollment: CredentialEnrollment,
+    ) -> CredentialEnrollmentPoll:
+        del enrollment
+        raise ValueError("interactive credential enrollment is not configured")
+
+    async def cancel_enrollment(self, enrollment: CredentialEnrollment) -> None:
+        del enrollment
+
+
+class OpenShellCredentialEnrollmentRunner(CredentialEnrollmentRunnerPort):
+    """Use a dedicated OpenShell adapter instance solely as the trusted login runner."""
+
+    def __init__(self, **kwargs: object) -> None:
+        from volundr.adapters.outbound.openshell_gateway import OpenShellGatewayPodManager
+
+        self._runner = OpenShellGatewayPodManager(**kwargs)
+
+    def supports_enrollment(self, method: str) -> bool:
+        return self._runner.supports_enrollment(method)
+
+    async def start_enrollment(self, enrollment: CredentialEnrollment) -> CredentialEnrollment:
+        return await self._runner.start_enrollment(enrollment)
+
+    async def poll_enrollment(
+        self,
+        enrollment: CredentialEnrollment,
+    ) -> CredentialEnrollmentPoll:
+        return await self._runner.poll_enrollment(enrollment)
+
+    async def cancel_enrollment(self, enrollment: CredentialEnrollment) -> None:
+        await self._runner.cancel_enrollment(enrollment)

--- a/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
+++ b/src/volundr/adapters/outbound/direct_k8s_pod_manager.py
@@ -19,6 +19,7 @@ import logging
 import re
 from typing import Any
 
+from volundr.adapters.outbound.brokered_credentials import BrokeredCredentialPodManager
 from volundr.domain.models import Session, SessionSpec, SessionStatus
 from volundr.domain.ports import CredentialStorePort, PodManager, PodStartResult
 
@@ -180,7 +181,7 @@ http {{
 """
 
 
-class DirectK8sPodManager(PodManager):
+class DirectK8sPodManager(BrokeredCredentialPodManager, PodManager):
     """Direct Kubernetes API implementation of PodManager.
 
     Creates Deployment + Service + Ingress resources for each session
@@ -212,6 +213,8 @@ class DirectK8sPodManager(PodManager):
         home_mount_path: str = "/volundr/home",
         poll_interval: float = DEFAULT_POLL_INTERVAL,
         readiness_timeout: float = DEFAULT_READINESS_TIMEOUT,
+        codex_auth_adapter: str = "skuld.codex_auth.VolundrCodexAuthProvider",
+        codex_auth_kwargs: dict | None = None,
         **_extra: object,
     ):
         self._namespace = namespace
@@ -233,6 +236,10 @@ class DirectK8sPodManager(PodManager):
         self._home_mount_path = home_mount_path
         self._poll_interval = poll_interval
         self._readiness_timeout = readiness_timeout
+        self._configure_brokered_credentials(
+            codex_auth_adapter=codex_auth_adapter,
+            codex_auth_kwargs=codex_auth_kwargs,
+        )
         self._credential_store: CredentialStorePort | None = None
         self._api_client = None
 
@@ -320,6 +327,10 @@ class DirectK8sPodManager(PodManager):
             {"name": "DATABASE__PASSWORD", "value": self._db_password},
             {"name": "DATABASE__NAME", "value": self._db_name},
         ]
+        env.extend(
+            {"name": name, "value": value}
+            for name, value in self._brokered_credential_environment(spec).items()
+        )
 
         # Handle git config from spec values.
         git_config = spec.values.get("git", {})
@@ -1145,6 +1156,7 @@ echo "Git credential helper configured"
         spec: SessionSpec,
     ) -> PodStartResult:
         """Start Deployment + Service + Ingress for the session."""
+        spec = self._with_brokered_credentials(spec)
         await self._ensure_client()
 
         release_name = self._release_name(session)

--- a/src/volundr/adapters/outbound/flux.py
+++ b/src/volundr/adapters/outbound/flux.py
@@ -10,6 +10,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
+from volundr.adapters.outbound.brokered_credentials import BrokeredCredentialPodManager
 from volundr.adapters.outbound.resident_container_spec import (
     resident_flock_labels,
     resident_flock_profile_configured,
@@ -45,7 +46,7 @@ HELMRELEASE_VERSION = "v2"
 HELMRELEASE_PLURAL = "helmreleases"
 
 
-class FluxPodManager(PodManager, ResidentRuntimeController):
+class FluxPodManager(BrokeredCredentialPodManager, PodManager, ResidentRuntimeController):
     """Flux-native implementation of PodManager.
 
     Creates / deletes HelmRelease CRs via the Kubernetes API.
@@ -72,6 +73,8 @@ class FluxPodManager(PodManager, ResidentRuntimeController):
         code_path: str = "/",
         gateway_domain: str | None = None,
         session_defaults: dict | None = None,
+        codex_auth_adapter: str = "skuld.codex_auth.VolundrCodexAuthProvider",
+        codex_auth_kwargs: dict | None = None,
         **_extra: object,
     ):
         self._namespace = namespace
@@ -89,6 +92,10 @@ class FluxPodManager(PodManager, ResidentRuntimeController):
         self._code_path = code_path
         self._gateway_domain = gateway_domain
         self._session_defaults = session_defaults or {}
+        self._configure_brokered_credentials(
+            codex_auth_adapter=codex_auth_adapter,
+            codex_auth_kwargs=codex_auth_kwargs,
+        )
         self._api_client = None
 
     async def _get_api(self):
@@ -260,6 +267,7 @@ class FluxPodManager(PodManager, ResidentRuntimeController):
         spec: SessionSpec,
     ) -> PodStartResult:
         """Create a HelmRelease CR for the session."""
+        spec = self._with_brokered_credentials(spec)
         release_name = self._release_name(session)
 
         # Merge session defaults with spec values from contributors
@@ -539,6 +547,7 @@ class FluxPodManager(PodManager, ResidentRuntimeController):
         if runtime.model:
             runtime_values["session"]["model"] = runtime.model
         _deep_merge(values, runtime_values)
+        values = self._with_brokered_credential_values(values)
         _inject_workload_exchange_env(values)
         return values
 

--- a/src/volundr/adapters/outbound/openshell_gateway.py
+++ b/src/volundr/adapters/outbound/openshell_gateway.py
@@ -8,6 +8,7 @@ removed; service/runtime auth belongs at this gateway boundary.
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import io
 import json
@@ -18,8 +19,9 @@ import socket
 import tarfile
 import threading
 import time
-from collections.abc import Sequence
-from dataclasses import dataclass
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -69,6 +71,9 @@ from volundr.adapters.outbound.resident_container_spec import (
     runtime_processes_from_values as _shared_runtime_processes_from_values,
 )
 from volundr.domain.models import (
+    CredentialEnrollment,
+    CredentialEnrollmentPoll,
+    CredentialEnrollmentState,
     ResidentBackend,
     ResidentCapability,
     ResidentCondition,
@@ -85,6 +90,8 @@ from volundr.domain.models import (
     SessionStatus,
 )
 from volundr.domain.ports import (
+    CredentialEnrollmentRunnerPort,
+    CredentialRefreshLockPort,
     CredentialStorePort,
     OpenShellCredentialGrantPort,
     OpenShellCredentialGrantToken,
@@ -131,10 +138,23 @@ DEFAULT_CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 DEFAULT_CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 DEFAULT_CODEX_REFRESH_SKEW_SECONDS = 300
 DEFAULT_CODEX_OAUTH_TIMEOUT_SECONDS = 15.0
+DEFAULT_CREDENTIAL_ENROLLMENT_CHALLENGE_TIMEOUT_SECONDS = 30.0
+CODEX_DEVICE_ENROLLMENT_METHOD = "codex_device"
+CODEX_ENROLLMENT_HOME = "/tmp/niuu-codex-enrollment"
+CODEX_ENROLLMENT_AUTH_PATH = f"{CODEX_ENROLLMENT_HOME}/auth.json"
+CODEX_ENROLLMENT_LOG_PATH = "/tmp/niuu-codex-enrollment.log"
+CODEX_ENROLLMENT_PID_PATH = "/tmp/niuu-codex-enrollment.pid"
 CODEX_AUTH_FORMAT = "codex_auth_json"
 CODEX_ACCESS_TOKEN_ENV = "CODEX_AUTH_ACCESS_TOKEN"
 CODEX_ACCOUNT_ID_ENV = "CODEX_AUTH_ACCOUNT_ID"
 CODEX_ACCESS_TOKEN_REFERENCE = f"openshell:resolve:env:{CODEX_ACCESS_TOKEN_ENV}"
+CODEX_AUTH_STATE_METADATA_KEY = "auth_state"
+CODEX_AUTH_ERROR_CODE_METADATA_KEY = "auth_error_code"
+CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY = "auth_state_updated_at"
+CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY = "auth_last_refreshed_at"
+CODEX_AUTH_STATE_ACTIVE = "active"
+CODEX_AUTH_STATE_REQUIRED = "auth_required"
+CODEX_AUTH_REFRESH_FAILED = "refresh_failed"
 HERMES_API_SERVER_KEY_ENV = "API_SERVER_KEY"
 HERMES_API_SERVER_DEFAULT_PORT = 8642
 HERMES_INTERNAL_SERVICE_URL = "http://hermes-api.internal"
@@ -748,6 +768,7 @@ class OpenShellTcpForwarder:
 
 class OpenShellGatewayPodManager(
     PodManager,
+    CredentialEnrollmentRunnerPort,
     OpenShellCredentialGrantPort,
     ResidentRuntimeController,
     ResidentRuntimeLogReader,
@@ -791,6 +812,9 @@ class OpenShellGatewayPodManager(
         codex_oauth_client_id: str = DEFAULT_CODEX_OAUTH_CLIENT_ID,
         codex_refresh_skew_seconds: int = DEFAULT_CODEX_REFRESH_SKEW_SECONDS,
         codex_oauth_timeout_seconds: float = DEFAULT_CODEX_OAUTH_TIMEOUT_SECONDS,
+        credential_enrollment_challenge_timeout_seconds: float = (
+            DEFAULT_CREDENTIAL_ENROLLMENT_CHALLENGE_TIMEOUT_SECONDS
+        ),
         codex_oauth_client: httpx.AsyncClient | None = None,
         sandbox_policy: dict[str, Any] | None = None,
         client: OpenShellGatewayClient | None = None,
@@ -827,8 +851,12 @@ class OpenShellGatewayPodManager(
         self._codex_oauth_client_id = codex_oauth_client_id
         self._codex_refresh_skew_seconds = int(codex_refresh_skew_seconds)
         self._codex_oauth_timeout_seconds = float(codex_oauth_timeout_seconds)
+        self._credential_enrollment_challenge_timeout_seconds = float(
+            credential_enrollment_challenge_timeout_seconds
+        )
         self._codex_oauth_client = codex_oauth_client
         self._codex_refresh_locks: dict[tuple[str, str], asyncio.Lock] = {}
+        self._credential_refresh_lock: CredentialRefreshLockPort | None = None
         self._spiffe_subject_prefix = spiffe_subject_prefix.rstrip("/") + "/"
         self._spiffe_verifier = JwtWorkloadIdentityVerifier(
             issuer=spiffe_issuer,
@@ -859,6 +887,10 @@ class OpenShellGatewayPodManager(
         """Inject credential store for resolving OpenShell launch credentials."""
         self._credential_store = store
 
+    def set_credential_refresh_lock(self, lock: CredentialRefreshLockPort) -> None:
+        """Inject the cross-replica coordinator for rotating user credentials."""
+        self._credential_refresh_lock = lock
+
     def set_session_repository(self, repository: SessionRepository) -> None:
         """Inject session persistence for sandbox-to-owner grant authorization."""
         self._session_repository = repository
@@ -873,6 +905,197 @@ class OpenShellGatewayPodManager(
     def set_workload_token_issuer(self, issuer: WorkloadTokenIssuer) -> None:
         """Inject the configured issuer for session-bound platform tokens."""
         self._workload_token_issuer = issuer
+
+    def supports_enrollment(self, method: str) -> bool:
+        """Return whether this OpenShell runner implements an enrollment method."""
+        return method == CODEX_DEVICE_ENROLLMENT_METHOD
+
+    async def start_enrollment(
+        self,
+        enrollment: CredentialEnrollment,
+    ) -> CredentialEnrollment:
+        """Start a Codex device-code login in a workspace-free OpenShell sandbox."""
+        if not self.supports_enrollment(enrollment.method):
+            raise ValueError("unsupported credential enrollment method")
+
+        sandbox_name = f"enroll-{enrollment.id.hex[:21]}"
+        provider_name = f"volundr-enroll-{enrollment.id.hex[:12]}"
+        profile = _codex_enrollment_profile(provider_name)
+        grant = OpenShellProviderGrant(provider_name=provider_name, profile_id=provider_name)
+        labels = {
+            "app.kubernetes.io/managed-by": "volundr",
+            "volundr.niuu.io/credential-enrollment": str(enrollment.id),
+            "volundr.niuu.io/integration-connection": enrollment.connection_id,
+        }
+        environment = {
+            "CODEX_HOME": CODEX_ENROLLMENT_HOME,
+            "HOME": "/tmp/niuu-enrollment-home",
+            "NO_COLOR": "1",
+        }
+        try:
+            await asyncio.to_thread(self._client.ensure_providers_v2)
+            await asyncio.to_thread(
+                self._client.create_provider_grant,
+                profile=profile,
+                provider_name=provider_name,
+                config={"volundr_enrollment_id": str(enrollment.id)},
+            )
+            sandbox = await asyncio.to_thread(
+                self._client.create_sandbox,
+                name=sandbox_name,
+                image=self._sandbox_image,
+                env=environment,
+                labels=labels,
+                providers=(provider_name,),
+                policy=self._sandbox_policy,
+            )
+            ready = await self._wait_for_sandbox_name(sandbox.name, self._ready_timeout)
+            config_exit, _ = await asyncio.to_thread(
+                self._client.exec_script,
+                sandbox_id=ready.id,
+                script=(
+                    "umask 077\n"
+                    f"mkdir -p {shlex.quote(CODEX_ENROLLMENT_HOME)} "
+                    f"{shlex.quote(environment['HOME'])}\n"
+                    f"printf '%s\\n' 'cli_auth_credentials_store = \"file\"' > "
+                    f"{shlex.quote(f'{CODEX_ENROLLMENT_HOME}/config.toml')}\n"
+                ),
+                env=environment,
+            )
+            if config_exit != 0:
+                raise RuntimeError("Codex enrollment home initialization failed")
+            launch_exit = await asyncio.to_thread(
+                self._client.exec_detached,
+                sandbox_id=ready.id,
+                command=("codex", "login", "--device-auth"),
+                env=environment,
+                log_path=CODEX_ENROLLMENT_LOG_PATH,
+                pid_path=CODEX_ENROLLMENT_PID_PATH,
+            )
+            if launch_exit != 0:
+                raise RuntimeError("Codex device login failed to start")
+            verification_uri, user_code = await self._wait_for_codex_device_challenge(
+                ready.id,
+                environment,
+            )
+        except Exception:
+            await self._cleanup_credential_enrollment(sandbox_name, grant)
+            raise
+
+        return replace(
+            enrollment,
+            state=CredentialEnrollmentState.AWAITING_USER,
+            runner_ref={
+                "sandbox_id": ready.id,
+                "sandbox_name": sandbox_name,
+                "provider_name": provider_name,
+                "profile_id": provider_name,
+            },
+            verification_uri=verification_uri,
+            user_code=user_code,
+            updated_at=datetime.now(UTC),
+        )
+
+    async def poll_enrollment(
+        self,
+        enrollment: CredentialEnrollment,
+    ) -> CredentialEnrollmentPoll:
+        """Inspect a Codex enrollment and return its secret only on completion."""
+        if not self.supports_enrollment(enrollment.method):
+            return CredentialEnrollmentPoll(
+                state=CredentialEnrollmentState.FAILED,
+                error_code="unsupported_method",
+            )
+        sandbox_id = enrollment.runner_ref.get("sandbox_id", "")
+        if not sandbox_id:
+            return CredentialEnrollmentPoll(
+                state=CredentialEnrollmentState.FAILED,
+                error_code="runner_missing",
+            )
+        script = (
+            f"if [ -s {shlex.quote(CODEX_ENROLLMENT_AUTH_PATH)} ]; then\n"
+            "  printf 'complete\\n'\n"
+            f"  base64 {shlex.quote(CODEX_ENROLLMENT_AUTH_PATH)} | tr -d '\\n'\n"
+            f"elif [ -s {shlex.quote(CODEX_ENROLLMENT_PID_PATH)} ] "
+            f'&& kill -0 "$(cat {shlex.quote(CODEX_ENROLLMENT_PID_PATH)})" 2>/dev/null; then\n'
+            "  printf 'awaiting_user\\n'\n"
+            "else\n"
+            "  printf 'failed\\n'\n"
+            "fi\n"
+        )
+        exit_code, output = await asyncio.to_thread(
+            self._client.exec_script,
+            sandbox_id=sandbox_id,
+            script=script,
+            env={"CODEX_HOME": CODEX_ENROLLMENT_HOME},
+        )
+        if exit_code != 0:
+            return CredentialEnrollmentPoll(
+                state=CredentialEnrollmentState.FAILED,
+                error_code="runner_unavailable",
+            )
+        state, _, payload = output.partition("\n")
+        if state.strip() == "awaiting_user":
+            return CredentialEnrollmentPoll(state=CredentialEnrollmentState.AWAITING_USER)
+        if state.strip() != "complete" or not payload.strip():
+            return CredentialEnrollmentPoll(
+                state=CredentialEnrollmentState.FAILED,
+                error_code="provider_login_failed",
+            )
+        try:
+            auth_json = base64.b64decode(payload.strip(), validate=True).decode("utf-8")
+            _parse_codex_auth_document(auth_json)
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise ValueError("Codex enrollment returned an invalid credential document") from exc
+        return CredentialEnrollmentPoll(
+            state=CredentialEnrollmentState.COMPLETE,
+            credential_data={"auth.json": auth_json},
+        )
+
+    async def cancel_enrollment(self, enrollment: CredentialEnrollment) -> None:
+        """Destroy the enrollment sandbox and its network-only provider grant."""
+        sandbox_name = enrollment.runner_ref.get("sandbox_name", "")
+        provider_name = enrollment.runner_ref.get("provider_name", "")
+        profile_id = enrollment.runner_ref.get("profile_id", provider_name)
+        if not sandbox_name:
+            return
+        grant = OpenShellProviderGrant(provider_name=provider_name, profile_id=profile_id)
+        await self._cleanup_credential_enrollment(sandbox_name, grant)
+
+    async def _wait_for_codex_device_challenge(
+        self,
+        sandbox_id: str,
+        environment: dict[str, str],
+    ) -> tuple[str, str]:
+        deadline = time.monotonic() + self._credential_enrollment_challenge_timeout_seconds
+        while time.monotonic() < deadline:
+            exit_code, output = await asyncio.to_thread(
+                self._client.exec_script,
+                sandbox_id=sandbox_id,
+                script=(
+                    f"if [ -f {shlex.quote(CODEX_ENROLLMENT_LOG_PATH)} ]; then "
+                    f"sed -n '1,120p' {shlex.quote(CODEX_ENROLLMENT_LOG_PATH)}; fi\n"
+                ),
+                env=environment,
+            )
+            if exit_code == 0:
+                challenge = _parse_codex_device_challenge(output)
+                if challenge is not None:
+                    return challenge
+            await asyncio.sleep(READY_POLL_INTERVAL)
+        raise TimeoutError("Codex device login did not produce a challenge in time")
+
+    async def _cleanup_credential_enrollment(
+        self,
+        sandbox_name: str,
+        grant: OpenShellProviderGrant,
+    ) -> None:
+        try:
+            await asyncio.to_thread(self._client.delete_sandbox, sandbox_name)
+            await self._wait_for_sandbox_deleted(sandbox_name)
+        finally:
+            if grant.provider_name:
+                await asyncio.to_thread(self._client.delete_provider_grant, grant)
 
     @staticmethod
     def _session_subject(session: Session) -> OpenShellWorkloadSubject:
@@ -1927,9 +2150,7 @@ class OpenShellGatewayPodManager(
         if self._credential_store is None or not workload.owner_id:
             raise ValueError("credential grant dependencies are unavailable")
 
-        lock_key = (workload.owner_id, credential_name)
-        lock = self._codex_refresh_locks.setdefault(lock_key, asyncio.Lock())
-        async with lock:
+        async with self._hold_credential_refresh_lock(workload.owner_id, credential_name):
             stored = await self._credential_store.get("user", workload.owner_id, credential_name)
             values = await self._credential_store.get_value(
                 "user", workload.owner_id, credential_name
@@ -1940,7 +2161,23 @@ class OpenShellGatewayPodManager(
             remaining = _jwt_remaining_seconds(access_token)
 
             if remaining <= self._codex_refresh_skew_seconds:
-                auth = await self._refresh_codex_auth(auth)
+                try:
+                    auth = await self._refresh_codex_auth(auth)
+                except ValueError as exc:
+                    if stored is not None and values is not None:
+                        await self._credential_store.store(
+                            "user",
+                            workload.owner_id,
+                            credential_name,
+                            stored.secret_type,
+                            values,
+                            _codex_auth_metadata(
+                                stored.metadata,
+                                state=CODEX_AUTH_STATE_REQUIRED,
+                                error_code=CODEX_AUTH_REFRESH_FAILED,
+                            ),
+                        )
+                    raise ValueError("Codex authentication requires reconnection") from exc
                 access_token = str(auth["tokens"]["access_token"])
                 remaining = _jwt_remaining_seconds(access_token)
                 if stored is None or values is None:
@@ -1953,13 +2190,37 @@ class OpenShellGatewayPodManager(
                     credential_name,
                     stored.secret_type,
                     updated_values,
-                    stored.metadata,
+                    _codex_auth_metadata(
+                        stored.metadata,
+                        state=CODEX_AUTH_STATE_ACTIVE,
+                        refreshed=True,
+                    ),
                 )
 
         return OpenShellCredentialGrantToken(
             access_token=access_token,
             expires_in=max(remaining, 1),
         )
+
+    @asynccontextmanager
+    async def _hold_credential_refresh_lock(
+        self,
+        owner_id: str,
+        credential_name: str,
+    ) -> AsyncIterator[None]:
+        if self._credential_refresh_lock is not None:
+            async with self._credential_refresh_lock.hold(
+                "user",
+                owner_id,
+                credential_name,
+            ):
+                yield
+            return
+
+        lock_key = (owner_id, credential_name)
+        lock = self._codex_refresh_locks.setdefault(lock_key, asyncio.Lock())
+        async with lock:
+            yield
 
     async def _refresh_codex_auth(self, auth: dict[str, Any]) -> dict[str, Any]:
         tokens = dict(auth["tokens"])
@@ -3211,6 +3472,32 @@ def _provider_profile(
     )
 
 
+def _codex_enrollment_profile(profile_id: str) -> Any:
+    """Network-only OpenShell provider used during a Codex device login."""
+    target = _provider_target(CODEX_ACCESS_TOKEN_ENV)
+    endpoints = [
+        sandbox_pb2.NetworkEndpoint(
+            host=host,
+            port=443,
+            protocol="rest",
+            tls="terminate",
+            enforcement="enforce",
+            access="full",
+        )
+        for host in target["hosts"]
+    ]
+    binaries = [sandbox_pb2.NetworkBinary(path=path) for path in target["binaries"]]
+    return openshell_pb2.ProviderProfile(
+        id=profile_id,
+        display_name="Niuu Codex device enrollment",
+        description="Workspace-free network access for one user-initiated Codex login",
+        category=openshell_pb2.PROVIDER_PROFILE_CATEGORY_AGENT,
+        credentials=[],
+        endpoints=endpoints,
+        binaries=binaries,
+    )
+
+
 def _platform_provider_profile(
     *,
     profile_id: str,
@@ -3594,6 +3881,44 @@ def _parse_codex_auth_document(raw: object) -> dict[str, Any]:
     if missing:
         raise ValueError("Codex auth document is missing required OAuth fields")
     return auth
+
+
+def _parse_codex_device_challenge(output: str) -> tuple[str, str] | None:
+    clean = re.sub(r"\x1b\[[0-?]*[ -/]*[@-~]", "", output)
+    verification_uri = ""
+    for candidate in re.findall(r"https://[^\s<>\"']+", clean):
+        candidate = candidate.rstrip(".,);]")
+        hostname = (urlparse(candidate).hostname or "").lower()
+        if hostname == "chatgpt.com" or hostname.endswith(".openai.com"):
+            verification_uri = candidate
+            break
+    code_match = re.search(
+        r"(?<![A-Z0-9])[A-Z0-9]{4,8}(?:-[A-Z0-9]{4,8})+(?![A-Z0-9])",
+        clean.upper(),
+    )
+    if not verification_uri or code_match is None:
+        return None
+    return verification_uri, code_match.group(0)
+
+
+def _codex_auth_metadata(
+    metadata: dict[str, Any],
+    *,
+    state: str,
+    error_code: str = "",
+    refreshed: bool = False,
+) -> dict[str, Any]:
+    now = datetime.now(UTC).isoformat()
+    updated = dict(metadata)
+    updated[CODEX_AUTH_STATE_METADATA_KEY] = state
+    updated[CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY] = now
+    if error_code:
+        updated[CODEX_AUTH_ERROR_CODE_METADATA_KEY] = error_code
+    else:
+        updated.pop(CODEX_AUTH_ERROR_CODE_METADATA_KEY, None)
+    if refreshed:
+        updated[CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY] = now
+    return updated
 
 
 def _jwt_remaining_seconds(token: str) -> int:

--- a/src/volundr/adapters/outbound/openshell_gateway.py
+++ b/src/volundr/adapters/outbound/openshell_gateway.py
@@ -19,8 +19,7 @@ import socket
 import tarfile
 import threading
 import time
-from collections.abc import AsyncIterator, Sequence
-from contextlib import asynccontextmanager
+from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
@@ -30,7 +29,6 @@ from uuid import UUID
 
 import grpc
 import httpx
-import jwt
 import yaml
 from google.protobuf import struct_pb2
 from openshell._proto import datamodel_pb2, openshell_pb2, openshell_pb2_grpc, sandbox_pb2
@@ -43,6 +41,7 @@ from niuu.domain.services.token_scope import (
 )
 from niuu.ports.session_proxy import SessionProxyTarget
 from niuu.ports.workload_identity import WorkloadTokenIssuer
+from volundr.adapters.outbound.brokered_credentials import BrokeredCredentialPodManager
 from volundr.adapters.outbound.local_process import LocalProcessPodManager
 from volundr.adapters.outbound.resident_container_spec import (
     image_from_values as _shared_image_from_values,
@@ -90,8 +89,6 @@ from volundr.domain.models import (
     SessionStatus,
 )
 from volundr.domain.ports import (
-    CredentialEnrollmentRunnerPort,
-    CredentialRefreshLockPort,
     CredentialStorePort,
     OpenShellCredentialGrantPort,
     OpenShellCredentialGrantToken,
@@ -134,27 +131,12 @@ DEFAULT_SPIFFE_JWKS_URI = (
 DEFAULT_SPIFFE_ISSUER = "https://spire-spiffe-oidc-discovery-provider.spire.svc.cluster.local"
 DEFAULT_SPIFFE_AUDIENCE = DEFAULT_CREDENTIAL_TOKEN_ENDPOINT
 DEFAULT_SPIFFE_SUBJECT_PREFIX = "spiffe://niuu.world/openshell/sandbox/"
-DEFAULT_CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
-DEFAULT_CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
-DEFAULT_CODEX_REFRESH_SKEW_SECONDS = 300
-DEFAULT_CODEX_OAUTH_TIMEOUT_SECONDS = 15.0
 DEFAULT_CREDENTIAL_ENROLLMENT_CHALLENGE_TIMEOUT_SECONDS = 30.0
 CODEX_DEVICE_ENROLLMENT_METHOD = "codex_device"
 CODEX_ENROLLMENT_HOME = "/tmp/niuu-codex-enrollment"
 CODEX_ENROLLMENT_AUTH_PATH = f"{CODEX_ENROLLMENT_HOME}/auth.json"
 CODEX_ENROLLMENT_LOG_PATH = "/tmp/niuu-codex-enrollment.log"
 CODEX_ENROLLMENT_PID_PATH = "/tmp/niuu-codex-enrollment.pid"
-CODEX_AUTH_FORMAT = "codex_auth_json"
-CODEX_ACCESS_TOKEN_ENV = "CODEX_AUTH_ACCESS_TOKEN"
-CODEX_ACCOUNT_ID_ENV = "CODEX_AUTH_ACCOUNT_ID"
-CODEX_ACCESS_TOKEN_REFERENCE = f"openshell:resolve:env:{CODEX_ACCESS_TOKEN_ENV}"
-CODEX_AUTH_STATE_METADATA_KEY = "auth_state"
-CODEX_AUTH_ERROR_CODE_METADATA_KEY = "auth_error_code"
-CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY = "auth_state_updated_at"
-CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY = "auth_last_refreshed_at"
-CODEX_AUTH_STATE_ACTIVE = "active"
-CODEX_AUTH_STATE_REQUIRED = "auth_required"
-CODEX_AUTH_REFRESH_FAILED = "refresh_failed"
 HERMES_API_SERVER_KEY_ENV = "API_SERVER_KEY"
 HERMES_API_SERVER_DEFAULT_PORT = 8642
 HERMES_INTERNAL_SERVICE_URL = "http://hermes-api.internal"
@@ -165,9 +147,9 @@ SECRET_ENV_KEYS = {
     "GH_TOKEN",
     "GITHUB_TOKEN",
     "GITHUB_PERSONAL_ACCESS_TOKEN",
-    CODEX_ACCESS_TOKEN_ENV,
+    "CODEX_AUTH_ACCESS_TOKEN",
     "CODEX_AUTH_REFRESH_TOKEN",
-    CODEX_ACCOUNT_ID_ENV,
+    "CODEX_AUTH_ACCOUNT_ID",
     "CODEX_AUTH_ID_TOKEN",
     PLATFORM_ACCESS_TOKEN_ENV,
     HERMES_API_SERVER_KEY_ENV,
@@ -767,8 +749,8 @@ class OpenShellTcpForwarder:
 
 
 class OpenShellGatewayPodManager(
+    BrokeredCredentialPodManager,
     PodManager,
-    CredentialEnrollmentRunnerPort,
     OpenShellCredentialGrantPort,
     ResidentRuntimeController,
     ResidentRuntimeLogReader,
@@ -808,14 +790,11 @@ class OpenShellGatewayPodManager(
         spiffe_audience: str = DEFAULT_SPIFFE_AUDIENCE,
         spiffe_subject_prefix: str = DEFAULT_SPIFFE_SUBJECT_PREFIX,
         spiffe_ca_cert_path: str = "",
-        codex_oauth_token_url: str = DEFAULT_CODEX_OAUTH_TOKEN_URL,
-        codex_oauth_client_id: str = DEFAULT_CODEX_OAUTH_CLIENT_ID,
-        codex_refresh_skew_seconds: int = DEFAULT_CODEX_REFRESH_SKEW_SECONDS,
-        codex_oauth_timeout_seconds: float = DEFAULT_CODEX_OAUTH_TIMEOUT_SECONDS,
         credential_enrollment_challenge_timeout_seconds: float = (
             DEFAULT_CREDENTIAL_ENROLLMENT_CHALLENGE_TIMEOUT_SECONDS
         ),
-        codex_oauth_client: httpx.AsyncClient | None = None,
+        codex_auth_adapter: str = "skuld.codex_auth.VolundrCodexAuthProvider",
+        codex_auth_kwargs: dict | None = None,
         sandbox_policy: dict[str, Any] | None = None,
         client: OpenShellGatewayClient | None = None,
         **_extra: object,
@@ -847,16 +826,13 @@ class OpenShellGatewayPodManager(
         self._workload_audience = workload_audience
         self._workload_audiences = tuple(workload_audiences or [workload_audience])
         self._workload_roles = tuple(workload_roles or ["volundr:developer"])
-        self._codex_oauth_token_url = codex_oauth_token_url
-        self._codex_oauth_client_id = codex_oauth_client_id
-        self._codex_refresh_skew_seconds = int(codex_refresh_skew_seconds)
-        self._codex_oauth_timeout_seconds = float(codex_oauth_timeout_seconds)
         self._credential_enrollment_challenge_timeout_seconds = float(
             credential_enrollment_challenge_timeout_seconds
         )
-        self._codex_oauth_client = codex_oauth_client
-        self._codex_refresh_locks: dict[tuple[str, str], asyncio.Lock] = {}
-        self._credential_refresh_lock: CredentialRefreshLockPort | None = None
+        self._configure_brokered_credentials(
+            codex_auth_adapter=codex_auth_adapter,
+            codex_auth_kwargs=codex_auth_kwargs,
+        )
         self._spiffe_subject_prefix = spiffe_subject_prefix.rstrip("/") + "/"
         self._spiffe_verifier = JwtWorkloadIdentityVerifier(
             issuer=spiffe_issuer,
@@ -886,10 +862,6 @@ class OpenShellGatewayPodManager(
     def set_credential_store(self, store: CredentialStorePort) -> None:
         """Inject credential store for resolving OpenShell launch credentials."""
         self._credential_store = store
-
-    def set_credential_refresh_lock(self, lock: CredentialRefreshLockPort) -> None:
-        """Inject the cross-replica coordinator for rotating user credentials."""
-        self._credential_refresh_lock = lock
 
     def set_session_repository(self, repository: SessionRepository) -> None:
         """Inject session persistence for sandbox-to-owner grant authorization."""
@@ -1215,6 +1187,7 @@ class OpenShellGatewayPodManager(
         )
 
     async def start(self, session: Session, spec: SessionSpec) -> PodStartResult:
+        spec = self._with_brokered_credentials(spec)
         sandbox_name = self._sandbox_name(session)
         session_id = str(session.id)
         env = self._build_env(session, spec)
@@ -1387,7 +1360,7 @@ class OpenShellGatewayPodManager(
     ) -> ResidentRuntimeObservation:
         if not self.supports(profile):
             raise RuntimeError(f"OpenShell does not support resident profile {profile.id!r}")
-        values = _resident_profile_values(profile)
+        values = self._with_brokered_credential_values(_resident_profile_values(profile))
         subject = self._resident_subject(runtime)
         sandbox_name = self._resident_sandbox_name(runtime)
         env = self._resident_environment(runtime, values)
@@ -1555,7 +1528,7 @@ class OpenShellGatewayPodManager(
                 ],
             )
         processes_ready = False
-        values = _resident_profile_values(profile)
+        values = self._with_brokered_credential_values(_resident_profile_values(profile))
         processes = self._resident_processes(runtime, values)
         service_name, service_port = _resident_service(
             values, self._service_name, self._service_port
@@ -1596,7 +1569,7 @@ class OpenShellGatewayPodManager(
     ) -> ResidentRuntimeObservation:
         if not self.supports(profile):
             raise RuntimeError(f"OpenShell does not support resident profile {profile.id!r}")
-        values = _resident_profile_values(profile)
+        values = self._with_brokered_credential_values(_resident_profile_values(profile))
         sandbox = await asyncio.to_thread(
             self._client.get_sandbox,
             self._resident_sandbox_name(runtime),
@@ -1620,10 +1593,7 @@ class OpenShellGatewayPodManager(
             sandbox_id=sandbox.id,
             files=files,
         )
-        env = {
-            **self._resident_environment(runtime, values),
-            **await self._resident_credential_environment(runtime, values),
-        }
+        env = self._resident_environment(runtime, values)
         if runtime.engine is ResidentEngine.OPENCLAW:
             if self._credential_store is None:
                 raise RuntimeError("OpenClaw residents require the configured credential store")
@@ -1923,6 +1893,7 @@ class OpenShellGatewayPodManager(
         broker = values.get("broker")
         if isinstance(broker, dict):
             env.update(_resident_broker_environment(broker))
+        env.update(self._brokered_credential_environment_values(values))
         extra_env = values.get("env")
         if isinstance(extra_env, dict):
             env.update(_string_dict(extra_env))
@@ -2091,14 +2062,6 @@ class OpenShellGatewayPodManager(
 
         if self._credential_store is None:
             raise ValueError("credential store is unavailable")
-        credential_format = str(config.get("volundr_credential_format") or "")
-        if credential_format == CODEX_AUTH_FORMAT:
-            return await self._exchange_codex_credential(
-                workload=workload,
-                credential_name=credential_name,
-                credential_field=credential_field,
-            )
-
         values = await self._credential_store.get_value("user", workload.owner_id, credential_name)
         value = values.get(credential_field) if values else None
         if not value or "\x00" in value or "\r" in value or "\n" in value:
@@ -2139,127 +2102,6 @@ class OpenShellGatewayPodManager(
             access_token=issued.token,
             expires_in=expires_in,
         )
-
-    async def _exchange_codex_credential(
-        self,
-        *,
-        workload: OpenShellWorkloadSubject,
-        credential_name: str,
-        credential_field: str,
-    ) -> OpenShellCredentialGrantToken:
-        if self._credential_store is None or not workload.owner_id:
-            raise ValueError("credential grant dependencies are unavailable")
-
-        async with self._hold_credential_refresh_lock(workload.owner_id, credential_name):
-            stored = await self._credential_store.get("user", workload.owner_id, credential_name)
-            values = await self._credential_store.get_value(
-                "user", workload.owner_id, credential_name
-            )
-            raw_auth = values.get(credential_field) if values else None
-            auth = _parse_codex_auth_document(raw_auth)
-            access_token = str(auth["tokens"]["access_token"])
-            remaining = _jwt_remaining_seconds(access_token)
-
-            if remaining <= self._codex_refresh_skew_seconds:
-                try:
-                    auth = await self._refresh_codex_auth(auth)
-                except ValueError as exc:
-                    if stored is not None and values is not None:
-                        await self._credential_store.store(
-                            "user",
-                            workload.owner_id,
-                            credential_name,
-                            stored.secret_type,
-                            values,
-                            _codex_auth_metadata(
-                                stored.metadata,
-                                state=CODEX_AUTH_STATE_REQUIRED,
-                                error_code=CODEX_AUTH_REFRESH_FAILED,
-                            ),
-                        )
-                    raise ValueError("Codex authentication requires reconnection") from exc
-                access_token = str(auth["tokens"]["access_token"])
-                remaining = _jwt_remaining_seconds(access_token)
-                if stored is None or values is None:
-                    raise ValueError("Codex credential metadata is unavailable")
-                updated_values = dict(values)
-                updated_values[credential_field] = json.dumps(auth, separators=(",", ":"))
-                await self._credential_store.store(
-                    "user",
-                    workload.owner_id,
-                    credential_name,
-                    stored.secret_type,
-                    updated_values,
-                    _codex_auth_metadata(
-                        stored.metadata,
-                        state=CODEX_AUTH_STATE_ACTIVE,
-                        refreshed=True,
-                    ),
-                )
-
-        return OpenShellCredentialGrantToken(
-            access_token=access_token,
-            expires_in=max(remaining, 1),
-        )
-
-    @asynccontextmanager
-    async def _hold_credential_refresh_lock(
-        self,
-        owner_id: str,
-        credential_name: str,
-    ) -> AsyncIterator[None]:
-        if self._credential_refresh_lock is not None:
-            async with self._credential_refresh_lock.hold(
-                "user",
-                owner_id,
-                credential_name,
-            ):
-                yield
-            return
-
-        lock_key = (owner_id, credential_name)
-        lock = self._codex_refresh_locks.setdefault(lock_key, asyncio.Lock())
-        async with lock:
-            yield
-
-    async def _refresh_codex_auth(self, auth: dict[str, Any]) -> dict[str, Any]:
-        tokens = dict(auth["tokens"])
-        refresh_token = str(tokens.get("refresh_token") or "")
-        if not refresh_token:
-            raise ValueError("Codex OAuth refresh token is unavailable")
-
-        request_data = {
-            "grant_type": "refresh_token",
-            "client_id": self._codex_oauth_client_id,
-            "refresh_token": refresh_token,
-        }
-        try:
-            if self._codex_oauth_client is not None:
-                response = await self._codex_oauth_client.post(
-                    self._codex_oauth_token_url,
-                    data=request_data,
-                )
-            else:
-                async with httpx.AsyncClient(timeout=self._codex_oauth_timeout_seconds) as client:
-                    response = await client.post(self._codex_oauth_token_url, data=request_data)
-            response.raise_for_status()
-            payload = response.json()
-        except (httpx.HTTPError, ValueError) as exc:
-            raise ValueError("Codex OAuth token refresh failed") from exc
-
-        access_token = str(payload.get("access_token") or "")
-        if not access_token:
-            raise ValueError("Codex OAuth token refresh returned no access token")
-        tokens["access_token"] = access_token
-        if payload.get("refresh_token"):
-            tokens["refresh_token"] = str(payload["refresh_token"])
-        if payload.get("id_token"):
-            tokens["id_token"] = str(payload["id_token"])
-
-        refreshed = dict(auth)
-        refreshed["tokens"] = tokens
-        refreshed["last_refresh"] = datetime.now(UTC).isoformat()
-        return refreshed
 
     async def _cleanup_resources(
         self,
@@ -2326,8 +2168,7 @@ class OpenShellGatewayPodManager(
         values: dict[str, Any],
     ) -> OpenShellCredentialContext:
         mappings = _credential_mappings_from_values(values)
-        codex_auth = _codex_auth_from_values(values)
-        if not mappings and not codex_auth:
+        if not mappings:
             return OpenShellCredentialContext(
                 files={}, providers=(), environment={}, process_environment={}
             )
@@ -2341,29 +2182,13 @@ class OpenShellGatewayPodManager(
         environment: dict[str, str] = {}
         process_environment: dict[str, str] = {}
         try:
-            if codex_auth:
-                await self._resolve_codex_auth(
-                    subject,
-                    codex_auth,
-                    providers=providers,
-                    environment=environment,
-                )
             for mapping in mappings:
-                mapping_credential_name = str(
-                    mapping.get("credentialName") or mapping.get("credential_name") or ""
-                )
-                if codex_auth and mapping_credential_name == codex_auth["credential_name"]:
-                    # codexAuth owns this credential through its scoped provider grant.
-                    mapping = dict(mapping)
-                    mapping.pop("env_mappings", None)
-                    mapping["envMappings"] = {}
                 await self._resolve_credential_mapping(
                     subject,
                     mapping,
                     files=files,
                     providers=providers,
                     process_environment=process_environment,
-                    excluded_env_names={"OPENAI_API_KEY"} if codex_auth else set(),
                 )
         except Exception:
             for provider_name in reversed(providers):
@@ -2418,75 +2243,6 @@ class OpenShellGatewayPodManager(
         )
         return (provider_name,)
 
-    async def _resolve_codex_auth(
-        self,
-        subject: OpenShellWorkloadSubject,
-        config: dict[str, str],
-        *,
-        providers: list[str],
-        environment: dict[str, str],
-    ) -> None:
-        credential_name = config["credential_name"]
-        credential_field = config["auth_field"]
-        environment.update(await self._codex_runtime_environment(subject, config))
-
-        provider_name = _provider_grant_name(
-            session_id=str(subject.id),
-            credential_name=credential_name,
-            field_name=credential_field,
-            env_name=CODEX_ACCESS_TOKEN_ENV,
-        )
-        profile = _provider_profile(
-            profile_id=provider_name,
-            env_name=CODEX_ACCESS_TOKEN_ENV,
-            token_endpoint=self._credential_token_endpoint,
-            cache_ttl_seconds=0,
-        )
-        providers.append(provider_name)
-        await asyncio.to_thread(
-            self._client.create_provider_grant,
-            profile=profile,
-            provider_name=provider_name,
-            config=self._grant_binding(
-                subject,
-                volundr_credential_name=credential_name,
-                volundr_credential_field=credential_field,
-                volundr_credential_format=CODEX_AUTH_FORMAT,
-            ),
-        )
-
-    async def _resident_credential_environment(
-        self,
-        runtime: ResidentRuntime,
-        values: dict[str, Any],
-    ) -> dict[str, str]:
-        codex_auth = _codex_auth_from_values(values)
-        if not codex_auth:
-            return {}
-        return await self._codex_runtime_environment(
-            self._resident_subject(runtime),
-            codex_auth,
-        )
-
-    async def _codex_runtime_environment(
-        self,
-        subject: OpenShellWorkloadSubject,
-        config: dict[str, str],
-    ) -> dict[str, str]:
-        if self._credential_store is None or not subject.owner_id:
-            raise RuntimeError("OpenShell Codex auth requires an owned workload")
-        values = await self._credential_store.get_value(
-            "user",
-            subject.owner_id,
-            config["credential_name"],
-        )
-        raw_auth = values.get(config["auth_field"]) if values else None
-        auth = _parse_codex_auth_document(raw_auth)
-        return {
-            CODEX_ACCESS_TOKEN_ENV: CODEX_ACCESS_TOKEN_REFERENCE,
-            CODEX_ACCOUNT_ID_ENV: str(auth["tokens"]["account_id"]),
-        }
-
     async def _resolve_credential_mapping(
         self,
         subject: OpenShellWorkloadSubject,
@@ -2495,18 +2251,11 @@ class OpenShellGatewayPodManager(
         files: dict[str, bytes],
         providers: list[str],
         process_environment: dict[str, str],
-        excluded_env_names: set[str] | None = None,
     ) -> None:
         credential_name = str(mapping.get("credentialName") or mapping.get("credential_name") or "")
         if not credential_name:
             return
         env_mappings = _string_dict(mapping.get("envMappings") or mapping.get("env_mappings") or {})
-        if excluded_env_names:
-            env_mappings = {
-                env_name: field_name
-                for env_name, field_name in env_mappings.items()
-                if env_name not in excluded_env_names
-            }
         file_mappings = _string_dict(
             mapping.get("fileMappings") or mapping.get("file_mappings") or {}
         )
@@ -2645,6 +2394,7 @@ class OpenShellGatewayPodManager(
 
     def _build_env(self, session: Session, spec: SessionSpec) -> dict[str, str]:
         env = LocalProcessPodManager._build_env(spec, Path(self._sandbox_workspace))
+        env.update(self._brokered_credential_environment(spec))
         env["SKULD__SESSION__ID"] = str(session.id)
         env["SKULD__SESSION__NAME"] = session.name
         env["SKULD__SESSION__WORKSPACE_DIR"] = self._sandbox_workspace
@@ -3474,7 +3224,22 @@ def _provider_profile(
 
 def _codex_enrollment_profile(profile_id: str) -> Any:
     """Network-only OpenShell provider used during a Codex device login."""
-    target = _provider_target(CODEX_ACCESS_TOKEN_ENV)
+    target = {
+        "hosts": (
+            "api.openai.com",
+            "auth.openai.com",
+            "chatgpt.com",
+            "ab.chatgpt.com",
+            "files.openai.com",
+            "*.oaiusercontent.com",
+        ),
+        "binaries": (
+            "/usr/bin/codex",
+            "/usr/local/bin/codex",
+            "/opt/niuu/bin/codex",
+            "/usr/lib/node_modules/@openai/**",
+        ),
+    }
     endpoints = [
         sandbox_pb2.NetworkEndpoint(
             host=host,
@@ -3601,26 +3366,6 @@ def _provider_target(env_name: str, config: Any = None) -> dict[str, Any]:
             ),
             "endpoints": endpoints,
             "binaries": binaries,
-            "category": openshell_pb2.PROVIDER_PROFILE_CATEGORY_AGENT,
-        }
-    if env_name == CODEX_ACCESS_TOKEN_ENV:
-        return {
-            "auth_style": "bearer",
-            "header_name": "Authorization",
-            "hosts": (
-                "api.openai.com",
-                "auth.openai.com",
-                "chatgpt.com",
-                "ab.chatgpt.com",
-                "files.openai.com",
-                "*.oaiusercontent.com",
-            ),
-            "binaries": (
-                "/usr/bin/codex",
-                "/usr/local/bin/codex",
-                "/opt/niuu/bin/codex",
-                "/usr/lib/node_modules/@openai/**",
-            ),
             "category": openshell_pb2.PROVIDER_PROFILE_CATEGORY_AGENT,
         }
     if env_name == "OPENAI_API_KEY":
@@ -3848,24 +3593,6 @@ def _credential_mappings_from_values(values: dict[str, Any]) -> list[dict[str, A
     return [mapping for mapping in raw_mappings if isinstance(mapping, dict)]
 
 
-def _codex_auth_from_spec(spec: SessionSpec) -> dict[str, str]:
-    return _codex_auth_from_values(spec.values)
-
-
-def _codex_auth_from_values(values: dict[str, Any]) -> dict[str, str]:
-    openshell_values = values.get("openshell")
-    if not isinstance(openshell_values, dict):
-        return {}
-    raw = openshell_values.get("codexAuth") or openshell_values.get("codex_auth")
-    if not isinstance(raw, dict):
-        return {}
-    credential_name = str(raw.get("credentialName") or raw.get("credential_name") or "").strip()
-    auth_field = str(raw.get("authField") or raw.get("auth_field") or "").strip()
-    if not credential_name or not auth_field:
-        raise RuntimeError("OpenShell codexAuth requires credentialName and authField")
-    return {"credential_name": credential_name, "auth_field": auth_field}
-
-
 def _parse_codex_auth_document(raw: object) -> dict[str, Any]:
     if not isinstance(raw, str) or not raw.strip():
         raise ValueError("Codex auth document is unavailable")
@@ -3899,42 +3626,6 @@ def _parse_codex_device_challenge(output: str) -> tuple[str, str] | None:
     if not verification_uri or code_match is None:
         return None
     return verification_uri, code_match.group(0)
-
-
-def _codex_auth_metadata(
-    metadata: dict[str, Any],
-    *,
-    state: str,
-    error_code: str = "",
-    refreshed: bool = False,
-) -> dict[str, Any]:
-    now = datetime.now(UTC).isoformat()
-    updated = dict(metadata)
-    updated[CODEX_AUTH_STATE_METADATA_KEY] = state
-    updated[CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY] = now
-    if error_code:
-        updated[CODEX_AUTH_ERROR_CODE_METADATA_KEY] = error_code
-    else:
-        updated.pop(CODEX_AUTH_ERROR_CODE_METADATA_KEY, None)
-    if refreshed:
-        updated[CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY] = now
-    return updated
-
-
-def _jwt_remaining_seconds(token: str) -> int:
-    try:
-        claims = jwt.decode(
-            token,
-            options={
-                "verify_signature": False,
-                "verify_aud": False,
-                "verify_exp": False,
-            },
-        )
-        expires_at = int(claims["exp"])
-    except (jwt.PyJWTError, KeyError, TypeError, ValueError) as exc:
-        raise ValueError("Codex OAuth access token is not a valid expiring JWT") from exc
-    return expires_at - int(time.time())
 
 
 def _string_dict(value: object) -> dict[str, str]:

--- a/src/volundr/adapters/outbound/postgres_credential_enrollments.py
+++ b/src/volundr/adapters/outbound/postgres_credential_enrollments.py
@@ -1,0 +1,124 @@
+"""PostgreSQL adapter for durable credential enrollment attempts."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import UUID
+
+import asyncpg
+
+from volundr.domain.models import CredentialEnrollment, CredentialEnrollmentState
+from volundr.domain.ports import CredentialEnrollmentRepository
+
+
+class PostgresCredentialEnrollmentRepository(CredentialEnrollmentRepository):
+    """Raw-SQL credential enrollment repository."""
+
+    def __init__(self, pool: asyncpg.Pool) -> None:
+        self._pool = pool
+
+    async def save(self, enrollment: CredentialEnrollment) -> CredentialEnrollment:
+        await self._pool.execute(
+            """
+            INSERT INTO credential_enrollments
+                (id, connection_id, owner_id, tenant_id, provider_slug, credential_name,
+                 method, state, runner_ref, verification_uri, user_code, expires_at,
+                 error_code, created_at, updated_at)
+            VALUES
+                ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, $12,
+                 $13, $14, $15)
+            ON CONFLICT (id) DO UPDATE SET
+                state = EXCLUDED.state,
+                runner_ref = EXCLUDED.runner_ref,
+                verification_uri = EXCLUDED.verification_uri,
+                user_code = EXCLUDED.user_code,
+                expires_at = EXCLUDED.expires_at,
+                error_code = EXCLUDED.error_code,
+                updated_at = EXCLUDED.updated_at
+            """,
+            enrollment.id,
+            enrollment.connection_id,
+            enrollment.owner_id,
+            enrollment.tenant_id,
+            enrollment.provider_slug,
+            enrollment.credential_name,
+            enrollment.method,
+            enrollment.state.value,
+            json.dumps(enrollment.runner_ref),
+            enrollment.verification_uri,
+            enrollment.user_code,
+            enrollment.expires_at,
+            enrollment.error_code,
+            enrollment.created_at,
+            enrollment.updated_at,
+        )
+        return enrollment
+
+    async def get(self, enrollment_id: UUID) -> CredentialEnrollment | None:
+        row = await self._pool.fetchrow(
+            "SELECT * FROM credential_enrollments WHERE id = $1",
+            enrollment_id,
+        )
+        return self._row_to_enrollment(row) if row is not None else None
+
+    async def find_active(self, connection_id: str) -> CredentialEnrollment | None:
+        row = await self._pool.fetchrow(
+            """
+            SELECT * FROM credential_enrollments
+            WHERE connection_id = $1::uuid
+              AND state IN ('pending', 'awaiting_user')
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            connection_id,
+        )
+        return self._row_to_enrollment(row) if row is not None else None
+
+    async def list_expired_active(self, now: datetime) -> list[CredentialEnrollment]:
+        rows = await self._pool.fetch(
+            """
+            SELECT * FROM credential_enrollments
+            WHERE state IN ('pending', 'awaiting_user')
+              AND expires_at <= $1
+            ORDER BY expires_at
+            LIMIT 100
+            """,
+            now,
+        )
+        return [self._row_to_enrollment(row) for row in rows]
+
+    @staticmethod
+    def _row_to_enrollment(row: asyncpg.Record) -> CredentialEnrollment:
+        runner_ref_raw = row["runner_ref"]
+        runner_ref = (
+            json.loads(runner_ref_raw)
+            if isinstance(runner_ref_raw, str)
+            else dict(runner_ref_raw or {})
+        )
+        expires_at = row["expires_at"]
+        created_at = row["created_at"]
+        updated_at = row["updated_at"]
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=UTC)
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=UTC)
+        if updated_at.tzinfo is None:
+            updated_at = updated_at.replace(tzinfo=UTC)
+        return CredentialEnrollment(
+            id=row["id"],
+            connection_id=str(row["connection_id"]),
+            owner_id=row["owner_id"],
+            tenant_id=row["tenant_id"],
+            provider_slug=row["provider_slug"],
+            credential_name=row["credential_name"],
+            method=row["method"],
+            state=CredentialEnrollmentState(row["state"]),
+            runner_ref=runner_ref,
+            verification_uri=row["verification_uri"],
+            user_code=row["user_code"],
+            expires_at=expires_at,
+            error_code=row["error_code"],
+            created_at=created_at,
+            updated_at=updated_at,
+        )

--- a/src/volundr/composition_builders.py
+++ b/src/volundr/composition_builders.py
@@ -44,8 +44,7 @@ def _create_codex_credential_broker(
     )
     if not isinstance(instance, CodexCredentialBrokerPort):
         raise TypeError(
-            f"Codex credential broker {config.adapter} must implement "
-            "CodexCredentialBrokerPort"
+            f"Codex credential broker {config.adapter} must implement CodexCredentialBrokerPort"
         )
     logger.info("Codex credential broker: %s", config.adapter.rsplit(".", 1)[-1])
     return instance

--- a/src/volundr/composition_builders.py
+++ b/src/volundr/composition_builders.py
@@ -10,6 +10,9 @@ from volundr.config import Settings
 from volundr.domain.ports import (
     ArchiveStorePort,
     AuthorizationPort,
+    CodexCredentialBrokerPort,
+    CredentialEnrollmentRunnerPort,
+    CredentialRefreshLockPort,
     CredentialStorePort,
     ExternalSessionProvider,
     GatewayPort,
@@ -22,6 +25,45 @@ from volundr.domain.ports import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _create_codex_credential_broker(
+    settings: Settings,
+    *,
+    credential_store: CredentialStorePort,
+    refresh_lock: CredentialRefreshLockPort,
+) -> CodexCredentialBrokerPort:
+    """Create the configured central Codex token broker adapter."""
+    config = settings.codex_credential_broker
+    cls = import_class(config.adapter)
+    kwargs = resolve_secret_kwargs(config.kwargs, config.secret_kwargs_env)
+    instance = cls(
+        credential_store=credential_store,
+        refresh_lock=refresh_lock,
+        **kwargs,
+    )
+    if not isinstance(instance, CodexCredentialBrokerPort):
+        raise TypeError(
+            f"Codex credential broker {config.adapter} must implement "
+            "CodexCredentialBrokerPort"
+        )
+    logger.info("Codex credential broker: %s", config.adapter.rsplit(".", 1)[-1])
+    return instance
+
+
+def _create_credential_enrollment_runner(settings: Settings) -> CredentialEnrollmentRunnerPort:
+    """Create the configured trusted login runner independently of PodManager."""
+    config = settings.credential_enrollment_runner
+    cls = import_class(config.adapter)
+    kwargs = resolve_secret_kwargs(config.kwargs, config.secret_kwargs_env)
+    instance = cls(**kwargs)
+    if not isinstance(instance, CredentialEnrollmentRunnerPort):
+        raise TypeError(
+            f"Credential enrollment runner {config.adapter} must implement "
+            "CredentialEnrollmentRunnerPort"
+        )
+    logger.info("Credential enrollment runner: %s", config.adapter.rsplit(".", 1)[-1])
+    return instance
 
 
 def _create_pod_manager(settings: Settings) -> PodManager:

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -264,6 +264,24 @@ class PodManagerConfig(BaseModel):
     )
 
 
+def _default_codex_credential_broker() -> DynamicAdapterConfig:
+    return DynamicAdapterConfig(
+        adapter=(
+            "volundr.adapters.outbound.codex_credential_broker."
+            "DisabledCodexCredentialBroker"
+        )
+    )
+
+
+def _default_credential_enrollment_runner() -> DynamicAdapterConfig:
+    return DynamicAdapterConfig(
+        adapter=(
+            "volundr.adapters.outbound.credential_enrollment_runner."
+            "UnsupportedCredentialEnrollmentRunner"
+        )
+    )
+
+
 class ResidentProfileConfig(BaseModel):
     """One operator-approved resident backend and engine combination."""
 
@@ -1675,6 +1693,17 @@ class Settings(BaseSettings):
     identity: IdentityConfig = Field(default_factory=IdentityConfig)
     authorization: AuthorizationConfig = Field(default_factory=AuthorizationConfig)
     credential_store: CredentialStoreConfig = Field(default_factory=CredentialStoreConfig)
+    codex_credential_broker: DynamicAdapterConfig = Field(
+        default_factory=_default_codex_credential_broker,
+        description=(
+            "Configured Codex token broker. Local mode defaults to the disabled adapter so "
+            "the host Codex login remains authoritative."
+        ),
+    )
+    credential_enrollment_runner: DynamicAdapterConfig = Field(
+        default_factory=_default_credential_enrollment_runner,
+        description="Trusted interactive-login runner, independent of the session pod manager.",
+    )
     gateway: GatewayConfig = Field(default_factory=GatewayConfig)
     secret_injection: SecretInjectionConfig = Field(default_factory=SecretInjectionConfig)
     resource_provider: ResourceProviderConfig = Field(default_factory=ResourceProviderConfig)

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -939,6 +939,7 @@ class IntegrationDefinitionConfig(BaseModel):
     auth_type: str = "api_key"
     oauth: OAuthSpecConfig | None = None
     file_mounts: dict[str, str] = Field(default_factory=dict)
+    credential_enrollment: dict[str, str] | None = None
 
 
 def _default_integration_definitions() -> list[IntegrationDefinitionConfig]:
@@ -1048,6 +1049,20 @@ def _default_integration_definitions() -> list[IntegrationDefinitionConfig]:
                 "properties": {"api_key": {"label": "API Key", "type": "password"}},
             },
             env_from_credentials={"OPENAI_API_KEY": "api_key"},
+        ),
+        IntegrationDefinitionConfig(
+            slug="codex",
+            name="OpenAI Codex (ChatGPT)",
+            description="User-scoped ChatGPT subscription login for Codex runtimes",
+            integration_type="ai_provider",
+            icon="openai",
+            credential_schema={},
+            auth_type="device_code",
+            credential_enrollment={
+                "method": "codex_device",
+                "credential_field": "auth.json",
+                "default_credential_name": "codex-credentials",
+            },
         ),
         IntegrationDefinitionConfig(
             slug="telegram",

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -266,10 +266,7 @@ class PodManagerConfig(BaseModel):
 
 def _default_codex_credential_broker() -> DynamicAdapterConfig:
     return DynamicAdapterConfig(
-        adapter=(
-            "volundr.adapters.outbound.codex_credential_broker."
-            "DisabledCodexCredentialBroker"
-        )
+        adapter=("volundr.adapters.outbound.codex_credential_broker.DisabledCodexCredentialBroker")
     )
 
 

--- a/src/volundr/domain/models.py
+++ b/src/volundr/domain/models.py
@@ -1082,6 +1082,56 @@ class OAuthSpec:
 
 
 @dataclass(frozen=True)
+class CredentialEnrollmentSpec:
+    """Config-driven interactive credential enrollment contract."""
+
+    method: str
+    credential_field: str
+    default_credential_name: str
+
+
+class CredentialEnrollmentState(StrEnum):
+    """Durable lifecycle for one interactive provider enrollment."""
+
+    PENDING = "pending"
+    AWAITING_USER = "awaiting_user"
+    COMPLETE = "complete"
+    FAILED = "failed"
+    EXPIRED = "expired"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class CredentialEnrollment:
+    """Public and runner metadata for one user-scoped enrollment attempt."""
+
+    id: UUID
+    connection_id: str
+    owner_id: str
+    tenant_id: str
+    provider_slug: str
+    credential_name: str
+    method: str
+    state: CredentialEnrollmentState
+    runner_ref: dict[str, str]
+    verification_uri: str
+    user_code: str
+    expires_at: datetime
+    error_code: str
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class CredentialEnrollmentPoll:
+    """Transient runner result; credential data is never persisted with the enrollment."""
+
+    state: CredentialEnrollmentState
+    credential_data: dict[str, str] = field(default_factory=dict)
+    error_code: str = ""
+
+
+@dataclass(frozen=True)
 class IntegrationDefinition:
     """A known integration type in the catalog.
 
@@ -1106,6 +1156,7 @@ class IntegrationDefinition:
     auth_type: str = "api_key"
     oauth: OAuthSpec | None = None
     file_mounts: dict[str, str] = ()  # type: ignore[assignment]
+    credential_enrollment: CredentialEnrollmentSpec | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.credential_schema, dict):

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -24,7 +24,7 @@ from credentials.ports import (  # noqa: F401
 from identity.models import Resource  # noqa: F401
 from identity.ports import AuthorizationPort, TenantRepository, UserRepository  # noqa: F401
 from niuu.domain.outcome import OutcomeField
-from niuu.ports.credentials import CredentialStorePort  # noqa: F401
+from niuu.ports.credentials import CredentialRefreshLockPort, CredentialStorePort  # noqa: F401
 from niuu.ports.git import (
     GitAuthError,  # noqa: F401
     GitProvider,  # noqa: F401
@@ -43,6 +43,8 @@ from volundr.domain.models import (  # noqa: F401
     Chronicle,
     ClusterResourceInfo,
     CommunicationRoute,
+    CredentialEnrollment,
+    CredentialEnrollmentPoll,
     CredentialMapping,
     DeviceToken,
     ExternalSessionRecord,
@@ -97,6 +99,7 @@ from volundr.domain.models import (  # noqa: F401
 __all__ = [
     "AuthorizationPort",
     "CredentialStorePort",
+    "CredentialRefreshLockPort",
     "GitAuthError",
     "GitProvider",
     "GitRepoNotFoundError",
@@ -180,6 +183,52 @@ class OpenShellCredentialGrantPort(ABC):
         scope: str,
     ) -> OpenShellCredentialGrantToken:
         """Validate the sandbox identity and return a short-lived credential value."""
+
+
+class CredentialEnrollmentRepository(ABC):
+    """Persistence boundary for interactive credential enrollment attempts."""
+
+    @abstractmethod
+    async def save(self, enrollment: CredentialEnrollment) -> CredentialEnrollment:
+        """Create or update an enrollment."""
+
+    @abstractmethod
+    async def get(self, enrollment_id: UUID) -> CredentialEnrollment | None:
+        """Get one enrollment by ID."""
+
+    @abstractmethod
+    async def find_active(self, connection_id: str) -> CredentialEnrollment | None:
+        """Return the active enrollment for a connection, if one exists."""
+
+    @abstractmethod
+    async def list_expired_active(self, now: datetime) -> list[CredentialEnrollment]:
+        """Return active enrollments whose user challenge has expired."""
+
+
+class CredentialEnrollmentRunnerPort(ABC):
+    """Launch and inspect a trusted interactive provider-login runtime."""
+
+    @abstractmethod
+    def supports_enrollment(self, method: str) -> bool:
+        """Return whether this runner implements the configured enrollment method."""
+
+    @abstractmethod
+    async def start_enrollment(
+        self,
+        enrollment: CredentialEnrollment,
+    ) -> CredentialEnrollment:
+        """Launch the runtime and return the user-facing challenge."""
+
+    @abstractmethod
+    async def poll_enrollment(
+        self,
+        enrollment: CredentialEnrollment,
+    ) -> CredentialEnrollmentPoll:
+        """Inspect the runtime without exposing secret values to the caller."""
+
+    @abstractmethod
+    async def cancel_enrollment(self, enrollment: CredentialEnrollment) -> None:
+        """Destroy any runtime resources belonging to the enrollment."""
 
 
 class ExternalSessionProvider(ABC):

--- a/src/volundr/domain/ports.py
+++ b/src/volundr/domain/ports.py
@@ -169,6 +169,32 @@ class OpenShellCredentialGrantToken:
     token_type: str = "Bearer"
 
 
+@dataclass(frozen=True)
+class CodexAuthTokens:
+    """Externally managed ChatGPT tokens safe to expose to one user workload."""
+
+    access_token: str
+    account_id: str
+    expires_in: int
+    plan_type: str = ""
+
+
+class CodexCredentialBrokerPort(ABC):
+    """Resolve and rotate a user's Codex credential without exposing its refresh token."""
+
+    @abstractmethod
+    async def get_tokens(
+        self,
+        *,
+        owner_id: str,
+        credential_name: str,
+        credential_field: str,
+        force_refresh: bool = False,
+        previous_access_token_sha256: str = "",
+    ) -> CodexAuthTokens:
+        """Return an access token and account metadata for one user credential."""
+
+
 class OpenShellCredentialGrantPort(ABC):
     """Exchange an OpenShell sandbox JWT-SVID for one authorized credential."""
 

--- a/src/volundr/domain/services/credential_enrollment.py
+++ b/src/volundr/domain/services/credential_enrollment.py
@@ -1,0 +1,371 @@
+"""User-scoped interactive credential enrollment orchestration."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from uuid import UUID, uuid4
+
+from niuu.domain.models import SecretType
+from volundr.domain.models import (
+    CredentialEnrollment,
+    CredentialEnrollmentPoll,
+    CredentialEnrollmentState,
+    IntegrationConnection,
+    Principal,
+)
+from volundr.domain.ports import (
+    CredentialEnrollmentRepository,
+    CredentialEnrollmentRunnerPort,
+    CredentialStorePort,
+    IntegrationRepository,
+)
+from volundr.domain.services.integration_registry import IntegrationRegistry
+
+DEFAULT_CREDENTIAL_ENROLLMENT_TTL_SECONDS = 900
+
+logger = logging.getLogger(__name__)
+
+
+class CredentialEnrollmentError(ValueError):
+    """Raised for a safe, user-actionable enrollment failure."""
+
+
+class CredentialEnrollmentService:
+    """Coordinate catalog, connection, runner, and OpenBao state per user."""
+
+    def __init__(
+        self,
+        *,
+        repository: CredentialEnrollmentRepository,
+        runner: CredentialEnrollmentRunnerPort,
+        integration_repository: IntegrationRepository,
+        integration_registry: IntegrationRegistry,
+        credential_store: CredentialStorePort,
+        ttl_seconds: int = DEFAULT_CREDENTIAL_ENROLLMENT_TTL_SECONDS,
+    ) -> None:
+        self._repository = repository
+        self._runner = runner
+        self._integration_repository = integration_repository
+        self._integration_registry = integration_registry
+        self._credential_store = credential_store
+        self._ttl_seconds = int(ttl_seconds)
+
+    async def start(
+        self,
+        *,
+        principal: Principal,
+        slug: str,
+        credential_name: str = "",
+        connection_id: str = "",
+    ) -> CredentialEnrollment:
+        definition = self._integration_registry.get_definition(slug)
+        spec = definition.credential_enrollment if definition is not None else None
+        if definition is None or spec is None:
+            raise CredentialEnrollmentError("Integration does not support interactive enrollment")
+        if not self._runner.supports_enrollment(spec.method):
+            raise CredentialEnrollmentError("Interactive enrollment is unavailable on this runtime")
+
+        connection = await self._resolve_connection(
+            principal=principal,
+            slug=slug,
+            connection_id=connection_id,
+            credential_name=credential_name or spec.default_credential_name,
+        )
+        active = await self._repository.find_active(connection.id)
+        if active is not None:
+            return active
+
+        now = datetime.now(UTC)
+        enrollment = CredentialEnrollment(
+            id=uuid4(),
+            connection_id=connection.id,
+            owner_id=principal.user_id,
+            tenant_id=principal.tenant_id,
+            provider_slug=slug,
+            credential_name=connection.credential_name,
+            method=spec.method,
+            state=CredentialEnrollmentState.PENDING,
+            runner_ref={},
+            verification_uri="",
+            user_code="",
+            expires_at=now + timedelta(seconds=self._ttl_seconds),
+            error_code="",
+            created_at=now,
+            updated_at=now,
+        )
+        await self._mark_credential_state(connection, state="enrolling")
+        await self._repository.save(enrollment)
+        try:
+            started = await self._runner.start_enrollment(enrollment)
+        except Exception as exc:
+            failed = self._with_state(
+                enrollment,
+                CredentialEnrollmentState.FAILED,
+                error_code="runner_start_failed",
+            )
+            await self._repository.save(failed)
+            await self._mark_credential_state(
+                connection,
+                state="auth_required",
+                error_code="enrollment_failed",
+            )
+            raise CredentialEnrollmentError("Could not start provider login") from exc
+        return await self._repository.save(started)
+
+    async def get(self, enrollment_id: UUID, principal: Principal) -> CredentialEnrollment:
+        enrollment = await self._repository.get(enrollment_id)
+        if enrollment is None or enrollment.owner_id != principal.user_id:
+            raise CredentialEnrollmentError("Credential enrollment not found")
+        if enrollment.state not in {
+            CredentialEnrollmentState.PENDING,
+            CredentialEnrollmentState.AWAITING_USER,
+        }:
+            return enrollment
+
+        now = datetime.now(UTC)
+        connection = await self._integration_repository.get_connection(enrollment.connection_id)
+        if connection is None or connection.owner_id != principal.user_id:
+            raise CredentialEnrollmentError("Credential enrollment connection not found")
+        if now >= enrollment.expires_at:
+            expired = self._with_state(enrollment, CredentialEnrollmentState.EXPIRED)
+            await self._runner.cancel_enrollment(enrollment)
+            await self._mark_credential_state(
+                connection,
+                state="auth_required",
+                error_code="enrollment_expired",
+            )
+            return await self._repository.save(expired)
+
+        try:
+            poll = await self._runner.poll_enrollment(enrollment)
+        except Exception:
+            failed = self._with_state(
+                enrollment,
+                CredentialEnrollmentState.FAILED,
+                error_code="runner_poll_failed",
+            )
+            await self._runner.cancel_enrollment(enrollment)
+            await self._mark_credential_state(
+                connection,
+                state="auth_required",
+                error_code="enrollment_failed",
+            )
+            return await self._repository.save(failed)
+        if poll.state == CredentialEnrollmentState.COMPLETE:
+            definition = self._integration_registry.get_definition(enrollment.provider_slug)
+            spec = definition.credential_enrollment if definition is not None else None
+            if spec is None or not poll.credential_data.get(spec.credential_field):
+                poll = CredentialEnrollmentPoll(
+                    state=CredentialEnrollmentState.FAILED,
+                    error_code="credential_missing",
+                )
+            else:
+                stored = await self._credential_store.get(
+                    "user",
+                    enrollment.owner_id,
+                    enrollment.credential_name,
+                )
+                existing_values = await self._credential_store.get_value(
+                    "user",
+                    enrollment.owner_id,
+                    enrollment.credential_name,
+                )
+                updated_values = dict(existing_values or {})
+                updated_values.update(poll.credential_data)
+                metadata = dict(stored.metadata) if stored is not None else {}
+                metadata.update(
+                    {
+                        "source": "credential_enrollment",
+                        "integration": enrollment.provider_slug,
+                        "auth_type": "device_code",
+                        "auth_state": "active",
+                        "auth_state_updated_at": now.isoformat(),
+                    }
+                )
+                metadata.pop("auth_error_code", None)
+                await self._credential_store.store(
+                    "user",
+                    enrollment.owner_id,
+                    enrollment.credential_name,
+                    stored.secret_type if stored is not None else SecretType.OAUTH_TOKEN,
+                    updated_values,
+                    metadata,
+                )
+                completed = self._with_state(enrollment, CredentialEnrollmentState.COMPLETE)
+                await self._runner.cancel_enrollment(enrollment)
+                return await self._repository.save(completed)
+
+        if poll.state in {
+            CredentialEnrollmentState.FAILED,
+            CredentialEnrollmentState.EXPIRED,
+            CredentialEnrollmentState.CANCELLED,
+        }:
+            terminal = self._with_state(
+                enrollment,
+                poll.state,
+                error_code=poll.error_code,
+            )
+            await self._runner.cancel_enrollment(enrollment)
+            await self._mark_credential_state(
+                connection,
+                state="auth_required",
+                error_code=poll.error_code or "enrollment_failed",
+            )
+            return await self._repository.save(terminal)
+
+        return enrollment
+
+    async def cancel(self, enrollment_id: UUID, principal: Principal) -> CredentialEnrollment:
+        enrollment = await self._repository.get(enrollment_id)
+        if enrollment is None or enrollment.owner_id != principal.user_id:
+            raise CredentialEnrollmentError("Credential enrollment not found")
+        if enrollment.state in {
+            CredentialEnrollmentState.PENDING,
+            CredentialEnrollmentState.AWAITING_USER,
+        }:
+            await self._runner.cancel_enrollment(enrollment)
+            enrollment = self._with_state(enrollment, CredentialEnrollmentState.CANCELLED)
+            await self._repository.save(enrollment)
+            connection = await self._integration_repository.get_connection(enrollment.connection_id)
+            if connection is not None and connection.owner_id == principal.user_id:
+                await self._mark_credential_state(
+                    connection,
+                    state="auth_required",
+                    error_code="enrollment_cancelled",
+                )
+        return enrollment
+
+    async def expire_stale(self, now: datetime | None = None) -> int:
+        """Destroy expired enrollment runtimes even when the initiating UI is gone."""
+        expired_count = 0
+        for enrollment in await self._repository.list_expired_active(now or datetime.now(UTC)):
+            try:
+                await self._runner.cancel_enrollment(enrollment)
+            except Exception:
+                # Leave it active so this or another replica retries cleanup on the
+                # next reconciliation pass. The enrollment sandbox is workspace-free
+                # and never receives an existing credential.
+                logger.exception(
+                    "Credential enrollment cleanup failed for %s",
+                    enrollment.id,
+                )
+                continue
+
+            connection = await self._integration_repository.get_connection(enrollment.connection_id)
+            if connection is not None and connection.owner_id == enrollment.owner_id:
+                await self._mark_credential_state(
+                    connection,
+                    state="auth_required",
+                    error_code="enrollment_expired",
+                )
+            await self._repository.save(
+                self._with_state(enrollment, CredentialEnrollmentState.EXPIRED)
+            )
+            expired_count += 1
+        return expired_count
+
+    async def _resolve_connection(
+        self,
+        *,
+        principal: Principal,
+        slug: str,
+        connection_id: str,
+        credential_name: str,
+    ) -> IntegrationConnection:
+        if connection_id:
+            connection = await self._integration_repository.get_connection(connection_id)
+            if (
+                connection is None
+                or connection.owner_id != principal.user_id
+                or connection.slug != slug
+            ):
+                raise CredentialEnrollmentError("Integration connection not found")
+            return connection
+
+        existing = await self._integration_repository.list_connections(principal.user_id)
+        matching = next((item for item in existing if item.slug == slug), None)
+        if matching is not None:
+            return matching
+
+        definition = self._integration_registry.get_definition(slug)
+        if definition is None:
+            raise CredentialEnrollmentError("Integration definition not found")
+        now = datetime.now(UTC)
+        connection = IntegrationConnection(
+            id=str(uuid4()),
+            owner_id=principal.user_id,
+            integration_type=definition.integration_type,
+            adapter=definition.adapter,
+            credential_name=credential_name,
+            config={},
+            enabled=True,
+            created_at=now,
+            updated_at=now,
+            slug=slug,
+        )
+        return await self._integration_repository.save_connection(connection)
+
+    async def _mark_credential_state(
+        self,
+        connection: IntegrationConnection,
+        *,
+        state: str,
+        error_code: str = "",
+    ) -> None:
+        stored = await self._credential_store.get(
+            "user",
+            connection.owner_id,
+            connection.credential_name,
+        )
+        values = await self._credential_store.get_value(
+            "user",
+            connection.owner_id,
+            connection.credential_name,
+        )
+        metadata = dict(stored.metadata) if stored is not None else {}
+        metadata.update(
+            {
+                "source": "credential_enrollment",
+                "integration": connection.slug,
+                "auth_type": "device_code",
+                "auth_state": state,
+                "auth_state_updated_at": datetime.now(UTC).isoformat(),
+            }
+        )
+        if error_code:
+            metadata["auth_error_code"] = error_code
+        else:
+            metadata.pop("auth_error_code", None)
+        await self._credential_store.store(
+            "user",
+            connection.owner_id,
+            connection.credential_name,
+            stored.secret_type if stored is not None else SecretType.OAUTH_TOKEN,
+            values or {},
+            metadata,
+        )
+
+    @staticmethod
+    def _with_state(
+        enrollment: CredentialEnrollment,
+        state: CredentialEnrollmentState,
+        *,
+        error_code: str = "",
+    ) -> CredentialEnrollment:
+        terminal = state in {
+            CredentialEnrollmentState.COMPLETE,
+            CredentialEnrollmentState.FAILED,
+            CredentialEnrollmentState.EXPIRED,
+            CredentialEnrollmentState.CANCELLED,
+        }
+        return replace(
+            enrollment,
+            state=state,
+            error_code=error_code,
+            runner_ref={} if terminal else enrollment.runner_ref,
+            verification_uri="" if terminal else enrollment.verification_uri,
+            user_code="" if terminal else enrollment.user_code,
+            updated_at=datetime.now(UTC),
+        )

--- a/src/volundr/domain/services/integration_registry.py
+++ b/src/volundr/domain/services/integration_registry.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 
 from volundr.domain.models import (
+    CredentialEnrollmentSpec,
     IntegrationConnection,
     IntegrationDefinition,
     IntegrationType,
@@ -128,6 +129,15 @@ def definitions_from_config(
                 extra_token_params=oauth_raw.get("extra_token_params", {}),
             )
 
+        enrollment_raw = item.get("credential_enrollment")
+        enrollment_spec: CredentialEnrollmentSpec | None = None
+        if enrollment_raw and isinstance(enrollment_raw, dict):
+            enrollment_spec = CredentialEnrollmentSpec(
+                method=enrollment_raw["method"],
+                credential_field=enrollment_raw["credential_field"],
+                default_credential_name=enrollment_raw["default_credential_name"],
+            )
+
         defn = IntegrationDefinition(
             slug=item["slug"],
             name=item["name"],
@@ -142,6 +152,7 @@ def definitions_from_config(
             auth_type=item.get("auth_type", "api_key"),
             oauth=oauth_spec,
             file_mounts=item.get("file_mounts", {}),
+            credential_enrollment=enrollment_spec,
         )
         result.append(defn)
         logger.debug("Loaded integration definition: %s", defn.slug)

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -12,6 +12,7 @@ from niuu.adapters.inbound.rest_credentials_settings import create_credentials_s
 from niuu.adapters.inbound.rest_integrations_settings import create_integrations_settings_router
 from niuu.adapters.inbound.rest_pats import create_pats_router
 from niuu.adapters.inbound.rest_realms import create_realms_router
+from niuu.adapters.postgres_credential_refresh_lock import PostgresCredentialRefreshLock
 from niuu.adapters.postgres_realms import PostgresRealmRepository
 from niuu.cors import apply_cors_middleware
 from niuu.domain.services.pat import PATService
@@ -76,6 +77,9 @@ from volundr.adapters.outbound.postgres_communication_cursors import (
 from volundr.adapters.outbound.postgres_communication_routes import (
     PostgresCommunicationRouteRepository,
 )
+from volundr.adapters.outbound.postgres_credential_enrollments import (
+    PostgresCredentialEnrollmentRepository,
+)
 from volundr.adapters.outbound.postgres_device_tokens import PostgresDeviceTokenRepository
 from volundr.adapters.outbound.postgres_integrations import PostgresIntegrationRepository
 from volundr.adapters.outbound.postgres_launch_specs import PostgresLaunchSpecRepository
@@ -111,7 +115,7 @@ from volundr.composition_builders import (  # noqa: F401
 )
 from volundr.config import Settings
 from volundr.domain.models import SessionStatus
-from volundr.domain.ports import OpenShellCredentialGrantPort
+from volundr.domain.ports import CredentialEnrollmentRunnerPort, OpenShellCredentialGrantPort
 from volundr.domain.services import (
     ChronicleService,
     ExternalSessionService,
@@ -127,6 +131,7 @@ from volundr.domain.services import (
 from volundr.domain.services.attention_notifier import PushAttentionNotifier
 from volundr.domain.services.communication_ingress import CommunicationIngressService
 from volundr.domain.services.credential import CredentialService
+from volundr.domain.services.credential_enrollment import CredentialEnrollmentService
 from volundr.domain.services.event_ingestion import EventIngestionService
 from volundr.domain.services.mount_strategies import SecretMountStrategyRegistry
 from volundr.domain.services.resident_runtime import (
@@ -141,6 +146,7 @@ from volundr.infrastructure.database import database_pool
 
 # Interval for periodic stats and heartbeat broadcasts (seconds)
 BROADCAST_INTERVAL = 30
+CREDENTIAL_ENROLLMENT_RECONCILE_INTERVAL_SECONDS = 30
 
 logger = logging.getLogger(__name__)
 
@@ -336,6 +342,30 @@ async def _reconcile_resident_runtimes_loop(
             logger.exception("Resident runtime reconcile iteration failed")
 
 
+async def _reconcile_credential_enrollments_loop(
+    service: CredentialEnrollmentService,
+    *,
+    interval_seconds: float = CREDENTIAL_ENROLLMENT_RECONCILE_INTERVAL_SECONDS,
+) -> None:
+    """Destroy expired interactive-login sandboxes independently of the UI."""
+    logger.info(
+        "Credential enrollment reconciliation started, interval=%.1fs",
+        interval_seconds,
+    )
+    while True:
+        try:
+            count = await service.expire_stale()
+            if count:
+                logger.info("Expired %d stale credential enrollment(s)", count)
+            await asyncio.sleep(interval_seconds)
+        except asyncio.CancelledError:
+            logger.info("Credential enrollment reconciliation task cancelled")
+            break
+        except Exception:
+            logger.exception("Credential enrollment reconciliation iteration failed")
+            await asyncio.sleep(interval_seconds)
+
+
 def _create_otel_providers(otel_cfg):  # pragma: no cover
     """Build OTel TracerProvider + MeterProvider from config.
 
@@ -452,11 +482,18 @@ def create_app(
             workload_identity_service = create_workload_identity_service(settings.workload_identity)
             pod_manager = _create_pod_manager(settings)
             resident_controllers = _create_resident_controllers(settings, pod_manager)
+            credential_refresh_lock = PostgresCredentialRefreshLock(pool)
+            if hasattr(pod_manager, "set_credential_refresh_lock"):
+                pod_manager.set_credential_refresh_lock(credential_refresh_lock)
             if hasattr(pod_manager, "set_session_repository"):
                 pod_manager.set_session_repository(repository)
             if hasattr(pod_manager, "set_workload_token_issuer"):
                 pod_manager.set_workload_token_issuer(workload_identity_service)
             for controller in resident_controllers:
+                if controller is not pod_manager and hasattr(
+                    controller, "set_credential_refresh_lock"
+                ):
+                    controller.set_credential_refresh_lock(credential_refresh_lock)
                 if hasattr(controller, "set_resident_runtime_repository"):
                     controller.set_resident_runtime_repository(resident_runtime_repository)
                 if controller is not pod_manager and hasattr(
@@ -626,6 +663,17 @@ def create_app(
             integration_repo = PostgresIntegrationRepository(pool)
             mapping_repository = PostgresMappingRepository(pool)
             tracker_factory = TrackerFactory(credential_store)
+            credential_enrollment_service = (
+                CredentialEnrollmentService(
+                    repository=PostgresCredentialEnrollmentRepository(pool),
+                    runner=pod_manager,
+                    integration_repository=integration_repo,
+                    integration_registry=integration_registry,
+                    credential_store=credential_store,
+                )
+                if isinstance(pod_manager, CredentialEnrollmentRunnerPort)
+                else None
+            )
             default_tracker = (
                 LinearAdapter(api_key=settings.linear.api_key)
                 if settings.linear.enabled and settings.linear.api_key
@@ -924,6 +972,7 @@ def create_app(
                     tracker_factory,
                     registry=integration_registry,
                     credential_store=credential_store,
+                    credential_enrollment_service=credential_enrollment_service,
                 )
             )
             app.include_router(
@@ -1204,6 +1253,13 @@ def create_app(
                     flock_adapter=resident_flock_adapter,
                 )
             )
+            credential_enrollment_reconcile_task = (
+                asyncio.create_task(
+                    _reconcile_credential_enrollments_loop(credential_enrollment_service)
+                )
+                if credential_enrollment_service is not None
+                else None
+            )
             if settings.telegram_ingress.enabled:
                 await telegram_ingress.start()
             else:
@@ -1247,6 +1303,12 @@ def create_app(
                     await resident_reconcile_task
                 except asyncio.CancelledError:
                     pass
+                if credential_enrollment_reconcile_task is not None:
+                    credential_enrollment_reconcile_task.cancel()
+                    try:
+                        await credential_enrollment_reconcile_task
+                    except asyncio.CancelledError:
+                        pass
                 if resident_flock_adapter is not None:
                     await resident_flock_adapter.stop()
                 await resident_runtime_service.close()

--- a/src/volundr/main.py
+++ b/src/volundr/main.py
@@ -42,6 +42,7 @@ from volundr.adapters.inbound.rest_audit import (
     create_audit_router,
     create_canonical_audit_router,
 )
+from volundr.adapters.inbound.rest_codex_credentials import create_codex_credentials_router
 from volundr.adapters.inbound.rest_credentials import create_canonical_credentials_router
 from volundr.adapters.inbound.rest_events import create_events_router
 from volundr.adapters.inbound.rest_git import create_git_router
@@ -102,7 +103,9 @@ from volundr.catalog import build_catalog
 from volundr.composition_builders import (  # noqa: F401
     _create_archive_store,
     _create_authorization_adapter,
+    _create_codex_credential_broker,
     _create_contributors,
+    _create_credential_enrollment_runner,
     _create_external_session_providers,
     _create_gateway_adapter,
     _create_http_auth_adapter,
@@ -115,7 +118,7 @@ from volundr.composition_builders import (  # noqa: F401
 )
 from volundr.config import Settings
 from volundr.domain.models import SessionStatus
-from volundr.domain.ports import CredentialEnrollmentRunnerPort, OpenShellCredentialGrantPort
+from volundr.domain.ports import OpenShellCredentialGrantPort
 from volundr.domain.services import (
     ChronicleService,
     ExternalSessionService,
@@ -483,17 +486,11 @@ def create_app(
             pod_manager = _create_pod_manager(settings)
             resident_controllers = _create_resident_controllers(settings, pod_manager)
             credential_refresh_lock = PostgresCredentialRefreshLock(pool)
-            if hasattr(pod_manager, "set_credential_refresh_lock"):
-                pod_manager.set_credential_refresh_lock(credential_refresh_lock)
             if hasattr(pod_manager, "set_session_repository"):
                 pod_manager.set_session_repository(repository)
             if hasattr(pod_manager, "set_workload_token_issuer"):
                 pod_manager.set_workload_token_issuer(workload_identity_service)
             for controller in resident_controllers:
-                if controller is not pod_manager and hasattr(
-                    controller, "set_credential_refresh_lock"
-                ):
-                    controller.set_credential_refresh_lock(credential_refresh_lock)
                 if hasattr(controller, "set_resident_runtime_repository"):
                     controller.set_resident_runtime_repository(resident_runtime_repository)
                 if controller is not pod_manager and hasattr(
@@ -611,6 +608,12 @@ def create_app(
 
             # Credential store (pluggable: memory, Vault, Infisical)
             credential_store = _create_credential_store(settings)
+            codex_credential_broker = _create_codex_credential_broker(
+                settings,
+                credential_store=credential_store,
+                refresh_lock=credential_refresh_lock,
+            )
+            credential_enrollment_runner = _create_credential_enrollment_runner(settings)
             credential_service = CredentialService(
                 store=credential_store,
                 strategies=SecretMountStrategyRegistry(),
@@ -663,16 +666,12 @@ def create_app(
             integration_repo = PostgresIntegrationRepository(pool)
             mapping_repository = PostgresMappingRepository(pool)
             tracker_factory = TrackerFactory(credential_store)
-            credential_enrollment_service = (
-                CredentialEnrollmentService(
-                    repository=PostgresCredentialEnrollmentRepository(pool),
-                    runner=pod_manager,
-                    integration_repository=integration_repo,
-                    integration_registry=integration_registry,
-                    credential_store=credential_store,
-                )
-                if isinstance(pod_manager, CredentialEnrollmentRunnerPort)
-                else None
+            credential_enrollment_service = CredentialEnrollmentService(
+                repository=PostgresCredentialEnrollmentRepository(pool),
+                runner=credential_enrollment_runner,
+                integration_repository=integration_repo,
+                integration_registry=integration_registry,
+                credential_store=credential_store,
             )
             default_tracker = (
                 LinearAdapter(api_key=settings.linear.api_key)
@@ -926,6 +925,7 @@ def create_app(
             app.include_router(forge_router)
             app.include_router(create_resident_runtimes_router(resident_runtime_service))
             app.state.resident_runtime_service = resident_runtime_service
+            app.include_router(create_codex_credentials_router(codex_credential_broker))
             credential_grant_brokers = {
                 id(adapter): adapter
                 for adapter in [pod_manager, *resident_controllers]

--- a/tests/test_adapters/test_brokered_credentials.py
+++ b/tests/test_adapters/test_brokered_credentials.py
@@ -1,0 +1,51 @@
+"""Tests for shared Kubernetes pod-manager credential configuration."""
+
+from __future__ import annotations
+
+from volundr.adapters.outbound.brokered_credentials import BrokeredCredentialPodManager
+from volundr.adapters.outbound.direct_k8s_pod_manager import DirectK8sPodManager
+from volundr.adapters.outbound.flux import FluxPodManager
+from volundr.adapters.outbound.local_process import LocalProcessPodManager
+from volundr.domain.models import PodSpecAdditions, SessionSpec
+
+
+class _Manager(BrokeredCredentialPodManager):
+    pass
+
+
+def test_shared_mixin_projects_one_skuld_auth_contract() -> None:
+    manager = _Manager()
+    manager._configure_brokered_credentials(
+        codex_auth_kwargs={"credential_name": "codex-default"}
+    )
+
+    projected = manager._with_brokered_credentials(
+        SessionSpec(
+            values={
+                "broker": {
+                    "codexAuth": {"kwargs": {"credential_field": "auth.json"}}
+                }
+            },
+            pod_spec=PodSpecAdditions(),
+        )
+    )
+
+    assert projected.values["broker"]["codexAuth"] == {
+        "adapter": "skuld.codex_auth.VolundrCodexAuthProvider",
+        "kwargs": {
+            "credential_name": "codex-default",
+            "credential_field": "auth.json",
+        },
+    }
+    assert manager._brokered_credential_environment(projected) == {
+        "SKULD__CODEX_AUTH__ADAPTER": "skuld.codex_auth.VolundrCodexAuthProvider",
+        "SKULD__CODEX_AUTH__KWARGS": (
+            '{"credential_name": "codex-default", "credential_field": "auth.json"}'
+        ),
+    }
+
+
+def test_kubernetes_managers_share_mixin_while_local_process_keeps_host_auth() -> None:
+    assert issubclass(FluxPodManager, BrokeredCredentialPodManager)
+    assert issubclass(DirectK8sPodManager, BrokeredCredentialPodManager)
+    assert not issubclass(LocalProcessPodManager, BrokeredCredentialPodManager)

--- a/tests/test_adapters/test_brokered_credentials.py
+++ b/tests/test_adapters/test_brokered_credentials.py
@@ -15,17 +15,11 @@ class _Manager(BrokeredCredentialPodManager):
 
 def test_shared_mixin_projects_one_skuld_auth_contract() -> None:
     manager = _Manager()
-    manager._configure_brokered_credentials(
-        codex_auth_kwargs={"credential_name": "codex-default"}
-    )
+    manager._configure_brokered_credentials(codex_auth_kwargs={"credential_name": "codex-default"})
 
     projected = manager._with_brokered_credentials(
         SessionSpec(
-            values={
-                "broker": {
-                    "codexAuth": {"kwargs": {"credential_field": "auth.json"}}
-                }
-            },
+            values={"broker": {"codexAuth": {"kwargs": {"credential_field": "auth.json"}}}},
             pod_spec=PodSpecAdditions(),
         )
     )

--- a/tests/test_adapters/test_codex_credential_broker.py
+++ b/tests/test_adapters/test_codex_credential_broker.py
@@ -208,18 +208,14 @@ async def test_concurrent_forced_refresh_reuses_rotation_completed_under_lock() 
             credential_name="codex-main",
             credential_field="auth.json",
             force_refresh=True,
-            previous_access_token_sha256=hashlib.sha256(
-                previous_access_token.encode()
-            ).hexdigest(),
+            previous_access_token_sha256=hashlib.sha256(previous_access_token.encode()).hexdigest(),
         ),
         broker.get_tokens(
             owner_id="owner-1",
             credential_name="codex-main",
             credential_field="auth.json",
             force_refresh=True,
-            previous_access_token_sha256=hashlib.sha256(
-                previous_access_token.encode()
-            ).hexdigest(),
+            previous_access_token_sha256=hashlib.sha256(previous_access_token.encode()).hexdigest(),
         ),
     )
 

--- a/tests/test_adapters/test_codex_credential_broker.py
+++ b/tests/test_adapters/test_codex_credential_broker.py
@@ -1,0 +1,255 @@
+"""Tests for the central access-only Codex credential broker."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import time
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import httpx
+import jwt
+import pytest
+
+from volundr.adapters.outbound.codex_credential_broker import (
+    CODEX_AUTH_ERROR_CODE_METADATA_KEY,
+    CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY,
+    CODEX_AUTH_REFRESH_FAILED,
+    CODEX_AUTH_STATE_ACTIVE,
+    CODEX_AUTH_STATE_METADATA_KEY,
+    CODEX_AUTH_STATE_REQUIRED,
+    CodexCredentialBrokerError,
+    OpenBaoCodexCredentialBroker,
+)
+from volundr.domain.models import SecretType
+
+
+def _access_token(*, expires_in: int) -> str:
+    return jwt.encode(
+        {"sub": "user", "exp": int(time.time()) + expires_in},
+        key="",
+        algorithm="none",
+    )
+
+
+def _auth_document(*, access_token: str) -> str:
+    return json.dumps(
+        {
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "access_token": access_token,
+                "refresh_token": "refresh-from-openbao",
+                "account_id": "account-from-openbao",
+                "id_token": "id-token-from-openbao",
+            },
+        }
+    )
+
+
+class _Store:
+    def __init__(self, auth_document: str) -> None:
+        self.values = {
+            "auth.json": auth_document,
+            "config.toml": 'model = "gpt-5"',
+        }
+        self.metadata: dict = {}
+        self.stores: list[dict] = []
+
+    async def get(self, owner_type: str, owner_id: str, name: str):
+        del owner_type, owner_id, name
+        return SimpleNamespace(secret_type=SecretType.GENERIC, metadata=dict(self.metadata))
+
+    async def get_value(self, owner_type: str, owner_id: str, name: str):
+        del owner_type, owner_id, name
+        return dict(self.values)
+
+    async def store(
+        self,
+        owner_type: str,
+        owner_id: str,
+        name: str,
+        secret_type: SecretType,
+        data: dict,
+        metadata: dict,
+    ):
+        self.values = dict(data)
+        self.metadata = dict(metadata)
+        self.stores.append(
+            {
+                "owner_type": owner_type,
+                "owner_id": owner_id,
+                "name": name,
+                "secret_type": secret_type,
+                "data": dict(data),
+                "metadata": dict(metadata),
+            }
+        )
+        return SimpleNamespace(secret_type=secret_type, metadata=dict(metadata))
+
+
+class _RefreshLock:
+    def __init__(self) -> None:
+        self._locks: dict[tuple[str, str, str], asyncio.Lock] = {}
+        self.held: list[tuple[str, str, str]] = []
+
+    @asynccontextmanager
+    async def hold(self, owner_type: str, owner_id: str, name: str):
+        key = (owner_type, owner_id, name)
+        lock = self._locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            self.held.append(key)
+            yield
+
+
+class _OAuthResponse:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return dict(self._payload)
+
+
+class _OAuthClient:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.posts: list[dict] = []
+
+    async def post(self, url: str, data: dict):
+        self.posts.append({"url": url, "data": dict(data)})
+        await asyncio.sleep(0)
+        return _OAuthResponse(self._payload)
+
+
+def _broker(store: _Store, lock: _RefreshLock, oauth_client) -> OpenBaoCodexCredentialBroker:
+    return OpenBaoCodexCredentialBroker(
+        credential_store=store,
+        refresh_lock=lock,
+        oauth_client=oauth_client,
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_existing_access_token_until_refresh_window() -> None:
+    access_token = _access_token(expires_in=3600)
+    store = _Store(_auth_document(access_token=access_token))
+    lock = _RefreshLock()
+    oauth = _OAuthClient({})
+
+    tokens = await _broker(store, lock, oauth).get_tokens(
+        owner_id="owner-1",
+        credential_name="codex-main",
+        credential_field="auth.json",
+    )
+
+    assert tokens.access_token == access_token
+    assert tokens.account_id == "account-from-openbao"
+    assert tokens.expires_in > 3000
+    assert oauth.posts == []
+    assert store.stores == []
+    assert lock.held == [("user", "owner-1", "codex-main")]
+
+
+@pytest.mark.asyncio
+async def test_refreshes_expiring_token_and_persists_full_rotated_document() -> None:
+    store = _Store(_auth_document(access_token=_access_token(expires_in=-60)))
+    lock = _RefreshLock()
+    refreshed_access_token = _access_token(expires_in=7200)
+    oauth = _OAuthClient(
+        {
+            "access_token": refreshed_access_token,
+            "refresh_token": "rotated-refresh-token",
+            "id_token": "rotated-id-token",
+        }
+    )
+
+    tokens = await _broker(store, lock, oauth).get_tokens(
+        owner_id="owner-1",
+        credential_name="codex-main",
+        credential_field="auth.json",
+    )
+
+    assert tokens.access_token == refreshed_access_token
+    assert oauth.posts[0]["data"] == {
+        "grant_type": "refresh_token",
+        "client_id": "app_EMoamEEZ73f0CkXaXp7hrann",
+        "refresh_token": "refresh-from-openbao",
+    }
+    persisted = json.loads(store.values["auth.json"])
+    assert persisted["tokens"]["access_token"] == refreshed_access_token
+    assert persisted["tokens"]["refresh_token"] == "rotated-refresh-token"
+    assert persisted["tokens"]["id_token"] == "rotated-id-token"
+    assert store.values["config.toml"] == 'model = "gpt-5"'
+    assert store.metadata[CODEX_AUTH_STATE_METADATA_KEY] == CODEX_AUTH_STATE_ACTIVE
+    assert CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY in store.metadata
+
+
+@pytest.mark.asyncio
+async def test_concurrent_forced_refresh_reuses_rotation_completed_under_lock() -> None:
+    previous_access_token = _access_token(expires_in=3600)
+    store = _Store(_auth_document(access_token=previous_access_token))
+    lock = _RefreshLock()
+    refreshed_access_token = _access_token(expires_in=7200)
+    oauth = _OAuthClient(
+        {
+            "access_token": refreshed_access_token,
+            "refresh_token": "single-use-rotated-refresh-token",
+        }
+    )
+    broker = _broker(store, lock, oauth)
+
+    first, second = await asyncio.gather(
+        broker.get_tokens(
+            owner_id="owner-1",
+            credential_name="codex-main",
+            credential_field="auth.json",
+            force_refresh=True,
+            previous_access_token_sha256=hashlib.sha256(
+                previous_access_token.encode()
+            ).hexdigest(),
+        ),
+        broker.get_tokens(
+            owner_id="owner-1",
+            credential_name="codex-main",
+            credential_field="auth.json",
+            force_refresh=True,
+            previous_access_token_sha256=hashlib.sha256(
+                previous_access_token.encode()
+            ).hexdigest(),
+        ),
+    )
+
+    assert first.access_token == second.access_token == refreshed_access_token
+    assert len(oauth.posts) == 1
+    assert len(store.stores) == 1
+    assert lock.held == [
+        ("user", "owner-1", "codex-main"),
+        ("user", "owner-1", "codex-main"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_marks_only_owners_credential_for_reconnection() -> None:
+    store = _Store(_auth_document(access_token=_access_token(expires_in=-60)))
+    lock = _RefreshLock()
+
+    class FailingOAuthClient:
+        async def post(self, _url: str, data: dict):
+            raise httpx.HTTPError(f"refresh rejected for {data['refresh_token'][:3]}")
+
+    with pytest.raises(CodexCredentialBrokerError, match="requires reconnection"):
+        await _broker(store, lock, FailingOAuthClient()).get_tokens(
+            owner_id="owner-1",
+            credential_name="codex-main",
+            credential_field="auth.json",
+        )
+
+    assert len(store.stores) == 1
+    assert store.stores[0]["owner_id"] == "owner-1"
+    assert store.stores[0]["name"] == "codex-main"
+    assert store.metadata[CODEX_AUTH_STATE_METADATA_KEY] == CODEX_AUTH_STATE_REQUIRED
+    assert store.metadata[CODEX_AUTH_ERROR_CODE_METADATA_KEY] == CODEX_AUTH_REFRESH_FAILED

--- a/tests/test_adapters/test_openshell_gateway.py
+++ b/tests/test_adapters/test_openshell_gateway.py
@@ -11,7 +11,6 @@ import sys
 import tarfile
 import time
 import types
-from contextlib import asynccontextmanager
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
@@ -404,6 +403,18 @@ def test_native_tcp_forward_uses_authenticated_sandbox_relay(
     bridge.close()
 
 
+def test_openshell_uses_shared_kubernetes_credential_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _import_adapter(monkeypatch)
+    brokered = importlib.import_module("volundr.adapters.outbound.brokered_credentials")
+
+    assert issubclass(
+        adapter.OpenShellGatewayPodManager,
+        brokered.BrokeredCredentialPodManager,
+    )
+
+
 class _FakeWorkloadTokenIssuer:
     def __init__(self) -> None:
         self.requests: list[dict] = []
@@ -617,12 +628,7 @@ def _resident_profile() -> ResidentDeploymentProfile:
                     "skipPermissions": True,
                 },
                 "session": {"reasoningEffort": "high"},
-                "openshell": {
-                    "codexAuth": {
-                        "credentialName": "codex-credentials",
-                        "authField": "auth.json",
-                    },
-                },
+                "openshell": {},
                 "resident": {
                     "dailyBudgetUsd": "100.0",
                     "platform": {
@@ -1163,7 +1169,7 @@ async def test_resident_controller_deploys_real_sandbox_and_processes(
         "volundr.niuu.io/resident": str(runtime.id),
         "volundr.niuu.io/runtime": "ravn",
     }
-    assert len(client.provider_grants) == 2
+    assert len(client.provider_grants) == 1
     assert all(
         grant["config"]["volundr_subject_kind"] == "resident"
         and grant["config"]["volundr_subject_id"] == str(runtime.id)
@@ -1187,6 +1193,10 @@ async def test_resident_controller_deploys_real_sandbox_and_processes(
     ]
     assert client.execs[0]["env"]["SKULD_BOOTSTRAP_FOREGROUND"] == "true"
     assert client.execs[0]["env"]["NIUU_CONFIG"] == "/sandbox/.volundr/skuld.yaml"
+    assert client.execs[0]["env"]["SKULD__CODEX_AUTH__ADAPTER"] == (
+        "skuld.codex_auth.VolundrCodexAuthProvider"
+    )
+    assert client.execs[0]["env"]["SKULD__CODEX_AUTH__KWARGS"] == "{}"
     assert "SKULD_CONFIG" not in client.execs[0]["env"]
     assert client.execs[1]["env"]["SKULD__TRANSPORT_ADAPTER"] == (
         "skuld.transports.codex_ws.CodexWebSocketTransport"
@@ -1383,10 +1393,10 @@ async def test_resident_restart_reuses_sandbox_and_dynamic_provider_environment(
         "/sandbox/.volundr/ravn.yaml",
         "/sandbox/.volundr/skuld.yaml",
     }
-    assert client.execs[-1]["env"][adapter.CODEX_ACCESS_TOKEN_ENV] == (
-        adapter.CODEX_ACCESS_TOKEN_REFERENCE
+    assert client.execs[-1]["env"]["SKULD__CODEX_AUTH__ADAPTER"] == (
+        "skuld.codex_auth.VolundrCodexAuthProvider"
     )
-    assert client.execs[-1]["env"][adapter.CODEX_ACCOUNT_ID_ENV] == "account-from-openbao"
+    assert client.execs[-1]["env"]["SKULD__CODEX_AUTH__KWARGS"] == "{}"
     assert client.execs[-1]["env"]["RESIDENT_MODE"] == "active"
     assert client.execs[-1]["env"]["SKULD__TRANSPORT_ADAPTER"] == (
         "skuld.transports.codex_ws.CodexWebSocketTransport"
@@ -1732,7 +1742,7 @@ async def test_start_rejects_platform_reporting_without_workload_issuer(
 
 
 @pytest.mark.asyncio
-async def test_start_uses_dynamic_codex_grant_without_projecting_oauth_file(
+async def test_start_uses_central_codex_broker_without_openshell_token_grant(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     adapter = _import_adapter(monkeypatch)
@@ -1750,23 +1760,16 @@ async def test_start_uses_dynamic_codex_grant_without_projecting_oauth_file(
     )
     spec = SessionSpec(
         values={
-            "openshell": {
+            "broker": {
                 "codexAuth": {
-                    "credentialName": "codex-credentials",
-                    "authField": "auth.json",
-                },
+                    "kwargs": {
+                        "credential_name": "codex-credentials",
+                        "credential_field": "auth.json",
+                    }
+                }
+            },
+            "openshell": {
                 "credentialMappings": [
-                    {
-                        "credentialName": "codex-credentials",
-                        "envMappings": {
-                            "CODEX_CREDENTIALS_AUTH.JSON": "auth.json",
-                            "CODEX_CREDENTIALS_CONFIG.TOML": "config.toml",
-                        },
-                    },
-                    {
-                        "credentialName": "openai-credential",
-                        "envMappings": {"OPENAI_API_KEY": "api_key"},
-                    },
                     {
                         "credentialName": "github-credential",
                         "envMappings": {"GITHUB_PERSONAL_ACCESS_TOKEN": "token"},
@@ -1781,30 +1784,17 @@ async def test_start_uses_dynamic_codex_grant_without_projecting_oauth_file(
 
     assert client.written_files == []
     assert client.created is not None
-    assert client.created["env"][adapter.CODEX_ACCESS_TOKEN_ENV] == (
-        adapter.CODEX_ACCESS_TOKEN_REFERENCE
+    assert client.created["env"]["SKULD__CODEX_AUTH__ADAPTER"] == (
+        "skuld.codex_auth.VolundrCodexAuthProvider"
     )
-    assert client.created["env"][adapter.CODEX_ACCOUNT_ID_ENV] == "account-from-openbao"
-    assert len(client.provider_grants) == 2
-    assert {grant["profile"].credentials[0].env_vars[0] for grant in client.provider_grants} == {
-        adapter.CODEX_ACCESS_TOKEN_ENV,
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
+    assert json.loads(client.created["env"]["SKULD__CODEX_AUTH__KWARGS"]) == {
+        "credential_name": "codex-credentials",
+        "credential_field": "auth.json",
     }
-    grant = next(
-        grant
-        for grant in client.provider_grants
-        if grant["profile"].credentials[0].env_vars == [adapter.CODEX_ACCESS_TOKEN_ENV]
-    )
-    assert grant["profile"].credentials[0].env_vars == [adapter.CODEX_ACCESS_TOKEN_ENV]
-    assert grant["profile"].credentials[0].token_grant.cache_ttl_seconds == 0
-    assert {endpoint.host for endpoint in grant["profile"].endpoints} >= {
-        "api.openai.com",
-        "auth.openai.com",
-        "chatgpt.com",
-        "*.oaiusercontent.com",
-    }
-    assert grant["config"]["volundr_credential_format"] == adapter.CODEX_AUTH_FORMAT
-    assert grant["config"]["volundr_credential_field"] == "auth.json"
+    assert len(client.provider_grants) == 1
+    assert client.provider_grants[0]["profile"].credentials[0].env_vars == [
+        "GITHUB_PERSONAL_ACCESS_TOKEN"
+    ]
 
 
 @pytest.mark.asyncio
@@ -2408,247 +2398,6 @@ async def test_platform_grant_mints_resident_bound_workload_token(
     assert issuer.requests[0]["claims"] == {
         "resident_id": str(runtime.id),
         "sandbox_id": sandbox_id,
-    }
-
-
-@pytest.mark.asyncio
-async def test_codex_credential_grant_reads_access_token_from_openbao_document(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    adapter = _import_adapter(monkeypatch)
-    session = _session()
-    sandbox_id = str(uuid4())
-    provider_name = f"volundr-{session.id.hex[:12]}-codexgrant"
-    audience = f"{adapter.GRANT_AUDIENCE_PREFIX}{provider_name}"
-    client = _FakeOpenShellGatewayClient(adapter)
-    client.grant_sandbox = adapter.OpenShellSandbox(
-        id=sandbox_id,
-        name="forge-test",
-        phase=adapter.openshell_pb2.SANDBOX_PHASE_READY,
-        labels={"volundr.niuu.io/session": str(session.id)},
-        providers=(provider_name,),
-    )
-    client.grant_provider = types.SimpleNamespace(
-        type=provider_name,
-        config={
-            "volundr_session_id": str(session.id),
-            "volundr_credential_name": "codex-credentials",
-            "volundr_credential_field": "auth.json",
-            "volundr_credential_format": adapter.CODEX_AUTH_FORMAT,
-        },
-    )
-
-    class Credential:
-        token_grant = types.SimpleNamespace(audience=audience)
-
-        def HasField(self, name: str) -> bool:  # noqa: N802
-            return name == "token_grant"
-
-    client.grant_profile = types.SimpleNamespace(credentials=[Credential()])
-    store = _FakeCredentialStore(
-        {"codex-credentials": {"auth.json": _codex_auth_document(expires_in=3600)}}
-    )
-    manager = adapter.OpenShellGatewayPodManager(client=client)
-    manager.set_session_repository(_FakeSessionRepository(session))
-    manager.set_credential_store(store)
-
-    class Verifier:
-        async def verify(self, _token: str):
-            return {"sub": f"{adapter.DEFAULT_SPIFFE_SUBJECT_PREFIX}{sandbox_id}"}
-
-    manager._spiffe_verifier = Verifier()
-    expected_access_token = json.loads(store.values["codex-credentials"]["auth.json"])["tokens"][
-        "access_token"
-    ]
-
-    token = await manager.exchange_credential_grant(
-        client_assertion="signed-svid",
-        client_assertion_type=adapter.OAUTH_CLIENT_ASSERTION_TYPE,
-        grant_type="client_credentials",
-        audience=audience,
-        scope="",
-    )
-
-    assert token.access_token == expected_access_token
-    assert token.expires_in > 3000
-    assert store.stores == []
-
-
-@pytest.mark.asyncio
-async def test_codex_credential_grant_refreshes_and_persists_rotated_oauth_tokens(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    adapter = _import_adapter(monkeypatch)
-    session = _session()
-    sandbox_id = str(uuid4())
-    provider_name = f"volundr-{session.id.hex[:12]}-codexgrant"
-    audience = f"{adapter.GRANT_AUDIENCE_PREFIX}{provider_name}"
-    client = _FakeOpenShellGatewayClient(adapter)
-    client.grant_sandbox = adapter.OpenShellSandbox(
-        id=sandbox_id,
-        name="forge-test",
-        phase=adapter.openshell_pb2.SANDBOX_PHASE_READY,
-        labels={"volundr.niuu.io/session": str(session.id)},
-        providers=(provider_name,),
-    )
-    client.grant_provider = types.SimpleNamespace(
-        type=provider_name,
-        config={
-            "volundr_session_id": str(session.id),
-            "volundr_credential_name": "codex-credentials",
-            "volundr_credential_field": "auth.json",
-            "volundr_credential_format": adapter.CODEX_AUTH_FORMAT,
-        },
-    )
-
-    class Credential:
-        token_grant = types.SimpleNamespace(audience=audience)
-
-        def HasField(self, name: str) -> bool:  # noqa: N802
-            return name == "token_grant"
-
-    client.grant_profile = types.SimpleNamespace(credentials=[Credential()])
-    store = _FakeCredentialStore(
-        {
-            "codex-credentials": {
-                "auth.json": _codex_auth_document(expires_in=-60),
-                "config.toml": 'model = "gpt-5"',
-            }
-        }
-    )
-    refreshed_access_token = jwt.encode(
-        {"sub": "user", "exp": int(time.time()) + 7200},
-        key="",
-        algorithm="none",
-    )
-
-    class OAuthResponse:
-        def raise_for_status(self) -> None:
-            return None
-
-        def json(self) -> dict:
-            return {
-                "access_token": refreshed_access_token,
-                "refresh_token": "rotated-refresh-token",
-                "id_token": "rotated-id-token",
-            }
-
-    class OAuthClient:
-        def __init__(self) -> None:
-            self.posts: list[dict] = []
-
-        async def post(self, url: str, data: dict):
-            self.posts.append({"url": url, "data": dict(data)})
-            return OAuthResponse()
-
-    oauth_client = OAuthClient()
-    manager = adapter.OpenShellGatewayPodManager(
-        client=client,
-        codex_oauth_client=oauth_client,
-    )
-    manager.set_session_repository(_FakeSessionRepository(session))
-    manager.set_credential_store(store)
-
-    class Verifier:
-        async def verify(self, _token: str):
-            return {"sub": f"{adapter.DEFAULT_SPIFFE_SUBJECT_PREFIX}{sandbox_id}"}
-
-    manager._spiffe_verifier = Verifier()
-
-    token = await manager.exchange_credential_grant(
-        client_assertion="signed-svid",
-        client_assertion_type=adapter.OAUTH_CLIENT_ASSERTION_TYPE,
-        grant_type="client_credentials",
-        audience=audience,
-        scope="",
-    )
-
-    assert token.access_token == refreshed_access_token
-    assert token.expires_in > 7000
-    assert oauth_client.posts == [
-        {
-            "url": adapter.DEFAULT_CODEX_OAUTH_TOKEN_URL,
-            "data": {
-                "grant_type": "refresh_token",
-                "client_id": adapter.DEFAULT_CODEX_OAUTH_CLIENT_ID,
-                "refresh_token": "refresh-from-openbao",
-            },
-        }
-    ]
-    assert len(store.stores) == 1
-    persisted = json.loads(store.stores[0]["data"]["auth.json"])
-    assert persisted["tokens"]["access_token"] == refreshed_access_token
-    assert persisted["tokens"]["refresh_token"] == "rotated-refresh-token"
-    assert persisted["tokens"]["id_token"] == "rotated-id-token"
-    assert store.stores[0]["data"]["config.toml"] == 'model = "gpt-5"'
-    assert store.stores[0]["metadata"][adapter.CODEX_AUTH_STATE_METADATA_KEY] == "active"
-    assert adapter.CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY in store.stores[0]["metadata"]
-
-
-@pytest.mark.asyncio
-async def test_codex_credential_refresh_uses_distributed_owner_scoped_lock(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    adapter = _import_adapter(monkeypatch)
-    manager = adapter.OpenShellGatewayPodManager(client=_FakeOpenShellGatewayClient(adapter))
-    held: list[tuple[str, str, str]] = []
-
-    class RefreshLock:
-        @asynccontextmanager
-        async def hold(self, owner_type: str, owner_id: str, name: str):
-            held.append((owner_type, owner_id, name))
-            yield
-
-    manager.set_credential_refresh_lock(RefreshLock())
-
-    async with manager._hold_credential_refresh_lock("owner-1", "codex-main"):
-        pass
-
-    assert held == [("user", "owner-1", "codex-main")]
-
-
-@pytest.mark.asyncio
-async def test_codex_refresh_failure_marks_only_owners_credential_auth_required(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    adapter = _import_adapter(monkeypatch)
-    store = _FakeCredentialStore(
-        {"codex-main": {"auth.json": _codex_auth_document(expires_in=-60)}}
-    )
-
-    class FailingOAuthClient:
-        async def post(self, _url: str, data: dict):
-            raise adapter.httpx.HTTPError(f"refresh rejected for {data['refresh_token'][:3]}")
-
-    manager = adapter.OpenShellGatewayPodManager(
-        client=_FakeOpenShellGatewayClient(adapter),
-        codex_oauth_client=FailingOAuthClient(),
-    )
-    manager.set_credential_store(store)
-    workload = adapter.OpenShellWorkloadSubject(
-        id=uuid4(),
-        kind="session",
-        name="test",
-        owner_id="owner-1",
-        tenant_id="tenant-1",
-    )
-
-    with pytest.raises(ValueError, match="requires reconnection"):
-        await manager._exchange_codex_credential(
-            workload=workload,
-            credential_name="codex-main",
-            credential_field="auth.json",
-        )
-
-    assert len(store.stores) == 1
-    assert store.stores[0]["owner_id"] == "owner-1"
-    assert store.stores[0]["name"] == "codex-main"
-    assert store.stores[0]["metadata"] == {
-        adapter.CODEX_AUTH_STATE_METADATA_KEY: adapter.CODEX_AUTH_STATE_REQUIRED,
-        adapter.CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY: store.stores[0]["metadata"][
-            adapter.CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY
-        ],
-        adapter.CODEX_AUTH_ERROR_CODE_METADATA_KEY: adapter.CODEX_AUTH_REFRESH_FAILED,
     }
 
 

--- a/tests/test_adapters/test_openshell_gateway.py
+++ b/tests/test_adapters/test_openshell_gateway.py
@@ -1775,7 +1775,7 @@ async def test_start_uses_central_codex_broker_without_openshell_token_grant(
                         "envMappings": {"GITHUB_PERSONAL_ACCESS_TOKEN": "token"},
                     },
                 ],
-            }
+            },
         },
         pod_spec=PodSpecAdditions(),
     )

--- a/tests/test_adapters/test_openshell_gateway.py
+++ b/tests/test_adapters/test_openshell_gateway.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import importlib
 import io
 import json
@@ -10,6 +11,9 @@ import sys
 import tarfile
 import time
 import types
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -22,6 +26,8 @@ from volundr.adapters.outbound.hermes_gateway import (
     HERMES_LEGACY_CREDENTIAL_NAME,
 )
 from volundr.domain.models import (
+    CredentialEnrollment,
+    CredentialEnrollmentState,
     GitSource,
     PodSpecAdditions,
     ResidentBackend,
@@ -431,6 +437,111 @@ def _codex_auth_document(*, expires_in: int = 3600) -> str:
             },
         }
     )
+
+
+def _credential_enrollment() -> CredentialEnrollment:
+    now = datetime.now(UTC)
+    return CredentialEnrollment(
+        id=uuid4(),
+        connection_id=str(uuid4()),
+        owner_id="owner-1",
+        tenant_id="tenant-1",
+        provider_slug="codex",
+        credential_name="codex-credentials",
+        method="codex_device",
+        state=CredentialEnrollmentState.PENDING,
+        runner_ref={},
+        verification_uri="",
+        user_code="",
+        expires_at=now + timedelta(minutes=15),
+        error_code="",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_parses_codex_device_login_challenge_without_ansi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _import_adapter(monkeypatch)
+    output = (
+        "\x1b[1mOpen https://auth.openai.com/codex/device in your browser\x1b[0m\n"
+        "Enter code ABCD-EFGH\n"
+    )
+
+    assert adapter._parse_codex_device_challenge(output) == (
+        "https://auth.openai.com/codex/device",
+        "ABCD-EFGH",
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_device_enrollment_runs_in_workspace_free_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _import_adapter(monkeypatch)
+    client = _FakeOpenShellGatewayClient(adapter)
+    outputs = iter(
+        [
+            (0, ""),
+            (
+                0,
+                "Open https://auth.openai.com/codex/device\nEnter code ABCD-EFGH\n",
+            ),
+        ]
+    )
+
+    def exec_script(**kwargs):
+        client.bootstrap_execs.append(kwargs)
+        return next(outputs)
+
+    client.exec_script = exec_script
+    manager = adapter.OpenShellGatewayPodManager(client=client)
+    enrollment = _credential_enrollment()
+
+    started = await manager.start_enrollment(enrollment)
+
+    assert started.state == CredentialEnrollmentState.AWAITING_USER
+    assert started.verification_uri == "https://auth.openai.com/codex/device"
+    assert started.user_code == "ABCD-EFGH"
+    assert client.created is not None
+    assert client.created["providers"] == (started.runner_ref["provider_name"],)
+    assert "workspace" not in client.created
+    assert "owner-1" not in str(client.created["labels"])
+    assert client.provider_grants[0]["profile"].credentials == []
+    assert client.execs[0]["command"] == ("codex", "login", "--device-auth")
+
+
+@pytest.mark.asyncio
+async def test_codex_device_enrollment_returns_auth_document_only_when_complete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _import_adapter(monkeypatch)
+    client = _FakeOpenShellGatewayClient(adapter)
+    auth_document = _codex_auth_document()
+    encoded = base64.b64encode(auth_document.encode()).decode()
+    client.exec_script = lambda **_kwargs: (0, f"complete\n{encoded}")
+    manager = adapter.OpenShellGatewayPodManager(client=client)
+    enrollment = replace(
+        _credential_enrollment(),
+        state=CredentialEnrollmentState.AWAITING_USER,
+        runner_ref={
+            "sandbox_id": "sandbox-id",
+            "sandbox_name": "enroll-1",
+            "provider_name": "provider-1",
+            "profile_id": "provider-1",
+        },
+    )
+
+    result = await manager.poll_enrollment(enrollment)
+
+    assert result.state == CredentialEnrollmentState.COMPLETE
+    assert result.credential_data == {"auth.json": auth_document}
+
+    await manager.cancel_enrollment(enrollment)
+
+    assert client.deleted == ["enroll-1"]
+    assert len(client.deleted_grants) == 1
 
 
 class _FakeSessionRepository:
@@ -2470,6 +2581,75 @@ async def test_codex_credential_grant_refreshes_and_persists_rotated_oauth_token
     assert persisted["tokens"]["refresh_token"] == "rotated-refresh-token"
     assert persisted["tokens"]["id_token"] == "rotated-id-token"
     assert store.stores[0]["data"]["config.toml"] == 'model = "gpt-5"'
+    assert store.stores[0]["metadata"][adapter.CODEX_AUTH_STATE_METADATA_KEY] == "active"
+    assert adapter.CODEX_AUTH_LAST_REFRESHED_AT_METADATA_KEY in store.stores[0]["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_codex_credential_refresh_uses_distributed_owner_scoped_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _import_adapter(monkeypatch)
+    manager = adapter.OpenShellGatewayPodManager(client=_FakeOpenShellGatewayClient(adapter))
+    held: list[tuple[str, str, str]] = []
+
+    class RefreshLock:
+        @asynccontextmanager
+        async def hold(self, owner_type: str, owner_id: str, name: str):
+            held.append((owner_type, owner_id, name))
+            yield
+
+    manager.set_credential_refresh_lock(RefreshLock())
+
+    async with manager._hold_credential_refresh_lock("owner-1", "codex-main"):
+        pass
+
+    assert held == [("user", "owner-1", "codex-main")]
+
+
+@pytest.mark.asyncio
+async def test_codex_refresh_failure_marks_only_owners_credential_auth_required(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _import_adapter(monkeypatch)
+    store = _FakeCredentialStore(
+        {"codex-main": {"auth.json": _codex_auth_document(expires_in=-60)}}
+    )
+
+    class FailingOAuthClient:
+        async def post(self, _url: str, data: dict):
+            raise adapter.httpx.HTTPError(f"refresh rejected for {data['refresh_token'][:3]}")
+
+    manager = adapter.OpenShellGatewayPodManager(
+        client=_FakeOpenShellGatewayClient(adapter),
+        codex_oauth_client=FailingOAuthClient(),
+    )
+    manager.set_credential_store(store)
+    workload = adapter.OpenShellWorkloadSubject(
+        id=uuid4(),
+        kind="session",
+        name="test",
+        owner_id="owner-1",
+        tenant_id="tenant-1",
+    )
+
+    with pytest.raises(ValueError, match="requires reconnection"):
+        await manager._exchange_codex_credential(
+            workload=workload,
+            credential_name="codex-main",
+            credential_field="auth.json",
+        )
+
+    assert len(store.stores) == 1
+    assert store.stores[0]["owner_id"] == "owner-1"
+    assert store.stores[0]["name"] == "codex-main"
+    assert store.stores[0]["metadata"] == {
+        adapter.CODEX_AUTH_STATE_METADATA_KEY: adapter.CODEX_AUTH_STATE_REQUIRED,
+        adapter.CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY: store.stores[0]["metadata"][
+            adapter.CODEX_AUTH_STATE_UPDATED_AT_METADATA_KEY
+        ],
+        adapter.CODEX_AUTH_ERROR_CODE_METADATA_KEY: adapter.CODEX_AUTH_REFRESH_FAILED,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_adapters/test_postgres_credential_enrollments.py
+++ b/tests/test_adapters/test_postgres_credential_enrollments.py
@@ -1,0 +1,85 @@
+"""Tests for PostgreSQL credential enrollment persistence."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from volundr.adapters.outbound.postgres_credential_enrollments import (
+    PostgresCredentialEnrollmentRepository,
+)
+from volundr.domain.models import CredentialEnrollment, CredentialEnrollmentState
+
+
+def _enrollment() -> CredentialEnrollment:
+    now = datetime.now(UTC)
+    return CredentialEnrollment(
+        id=uuid4(),
+        connection_id=str(uuid4()),
+        owner_id="user-1",
+        tenant_id="tenant-1",
+        provider_slug="codex",
+        credential_name="codex-credentials",
+        method="codex_device",
+        state=CredentialEnrollmentState.AWAITING_USER,
+        runner_ref={"sandbox_name": "enroll-1"},
+        verification_uri="https://auth.openai.com/codex/device",
+        user_code="ABCD-EFGH",
+        expires_at=now + timedelta(minutes=15),
+        error_code="",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def test_save_uses_upsert_without_secret_payload() -> None:
+    pool = AsyncMock()
+    repository = PostgresCredentialEnrollmentRepository(pool)
+    enrollment = _enrollment()
+
+    result = await repository.save(enrollment)
+
+    assert result is enrollment
+    sql = pool.execute.await_args.args[0]
+    assert "INSERT INTO credential_enrollments" in sql
+    assert "ON CONFLICT (id) DO UPDATE" in sql
+    assert "credential_data" not in sql
+    assert "auth.json" not in str(pool.execute.await_args.args)
+
+
+async def test_get_and_find_active_map_durable_state() -> None:
+    enrollment = _enrollment()
+    row_data = {
+        "id": enrollment.id,
+        "connection_id": enrollment.connection_id,
+        "owner_id": enrollment.owner_id,
+        "tenant_id": enrollment.tenant_id,
+        "provider_slug": enrollment.provider_slug,
+        "credential_name": enrollment.credential_name,
+        "method": enrollment.method,
+        "state": enrollment.state.value,
+        "runner_ref": enrollment.runner_ref,
+        "verification_uri": enrollment.verification_uri,
+        "user_code": enrollment.user_code,
+        "expires_at": enrollment.expires_at,
+        "error_code": enrollment.error_code,
+        "created_at": enrollment.created_at,
+        "updated_at": enrollment.updated_at,
+    }
+    row = MagicMock()
+    row.__getitem__ = lambda _self, key: row_data[key]
+    pool = AsyncMock()
+    pool.fetchrow.return_value = row
+    repository = PostgresCredentialEnrollmentRepository(pool)
+
+    fetched = await repository.get(enrollment.id)
+    active = await repository.find_active(enrollment.connection_id)
+    pool.fetch.return_value = [row]
+    expired = await repository.list_expired_active(datetime.now(UTC))
+
+    assert fetched == enrollment
+    assert active == enrollment
+    assert expired == [enrollment]
+    assert "state IN ('pending', 'awaiting_user')" in pool.fetchrow.await_args_list[1].args[0]
+    assert "expires_at <= $1" in pool.fetch.await_args.args[0]

--- a/tests/test_adapters/test_postgres_credential_refresh_lock.py
+++ b/tests/test_adapters/test_postgres_credential_refresh_lock.py
@@ -1,0 +1,49 @@
+"""Tests for PostgreSQL credential refresh locking."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock
+
+from niuu.adapters.postgres_credential_refresh_lock import (
+    PostgresCredentialRefreshLock,
+    _credential_lock_id,
+)
+
+
+async def test_holds_transaction_scoped_advisory_lock() -> None:
+    connection = MagicMock()
+    connection.execute = AsyncMock()
+    transaction = MagicMock()
+    transaction.__aenter__ = AsyncMock()
+    transaction.__aexit__ = AsyncMock()
+    connection.transaction.return_value = transaction
+
+    @asynccontextmanager
+    async def acquire():
+        yield connection
+
+    pool = MagicMock()
+    pool.acquire = acquire
+    lock = PostgresCredentialRefreshLock(pool)
+
+    entered = False
+    async with lock.hold("user", "user-1", "codex-main"):
+        entered = True
+
+    assert entered is True
+    connection.execute.assert_awaited_once_with(
+        "SELECT pg_advisory_xact_lock($1)",
+        _credential_lock_id("user", "user-1", "codex-main"),
+    )
+    transaction.__aenter__.assert_awaited_once()
+    transaction.__aexit__.assert_awaited_once()
+
+
+def test_lock_identity_is_stable_and_owner_scoped() -> None:
+    first = _credential_lock_id("user", "user-1", "codex-main")
+
+    assert first == _credential_lock_id("user", "user-1", "codex-main")
+    assert first != _credential_lock_id("user", "user-2", "codex-main")
+    assert first != _credential_lock_id("user", "user-1", "codex-secondary")
+    assert -(2**63) <= first < 2**63

--- a/tests/test_adapters/test_rest_codex_credentials.py
+++ b/tests/test_adapters/test_rest_codex_credentials.py
@@ -1,0 +1,85 @@
+"""Tests for the authenticated access-only Codex token route."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from volundr.adapters.inbound.auth import extract_principal
+from volundr.adapters.inbound.rest_codex_credentials import create_codex_credentials_router
+from volundr.adapters.outbound.codex_credential_broker import CodexCredentialBrokerError
+from volundr.domain.models import Principal
+from volundr.domain.ports import CodexAuthTokens
+
+
+class _Broker:
+    def __init__(self, *, error: bool = False) -> None:
+        self.error = error
+        self.calls: list[dict] = []
+
+    async def get_tokens(self, **kwargs) -> CodexAuthTokens:
+        self.calls.append(kwargs)
+        if self.error:
+            raise CodexCredentialBrokerError("Codex authentication requires reconnection")
+        return CodexAuthTokens(
+            access_token="access-only-token",
+            account_id="account-1",
+            expires_in=1800,
+            plan_type="pro",
+        )
+
+
+def _client(broker: _Broker) -> TestClient:
+    app = FastAPI()
+    app.include_router(create_codex_credentials_router(broker))
+    app.dependency_overrides[extract_principal] = lambda: Principal(
+        user_id="owner-1",
+        tenant_id="tenant-1",
+        email="owner@example.test",
+        roles=["volundr:developer"],
+    )
+    return TestClient(app)
+
+
+def test_route_scopes_broker_exchange_to_authenticated_user() -> None:
+    broker = _Broker()
+
+    response = _client(broker).post(
+        "/api/v1/internal/credentials/codex/tokens",
+        json={
+            "credential_name": "codex-main",
+            "credential_field": "auth.json",
+            "force_refresh": True,
+            "previous_access_token_sha256": "a" * 64,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    assert response.json() == {
+        "access_token": "access-only-token",
+        "chatgpt_account_id": "account-1",
+        "expires_in": 1800,
+        "chatgpt_plan_type": "pro",
+    }
+    assert broker.calls == [
+        {
+            "owner_id": "owner-1",
+            "credential_name": "codex-main",
+            "credential_field": "auth.json",
+            "force_refresh": True,
+            "previous_access_token_sha256": "a" * 64,
+        }
+    ]
+
+
+def test_route_returns_reconnect_conflict_without_refresh_token() -> None:
+    response = _client(_Broker(error=True)).post(
+        "/api/v1/internal/credentials/codex/tokens",
+        json={},
+    )
+
+    assert response.status_code == 409
+    assert response.headers["cache-control"] == "no-store"
+    assert response.json() == {"detail": "Codex authentication requires reconnection"}
+    assert "refresh" not in response.text.lower()

--- a/tests/test_charts/test_volundr_chart.py
+++ b/tests/test_charts/test_volundr_chart.py
@@ -218,12 +218,14 @@ class TestValuesDefaults:
         assert len(secrets) == 1
         assert secrets[0]["envVar"] == "ANTHROPIC_API_KEY"
 
-    def test_skuld_codex_env_secrets_has_openai_key(self, values_yaml):
-        """Test skuld-codex defaults have OPENAI_API_KEY in envSecrets."""
+    def test_skuld_codex_has_no_static_auth_projection(self, values_yaml):
+        """Codex subscription auth comes from the access-only broker."""
         secrets = values_yaml["sessionDefinitions"]["skuldCodex"]["defaults"]["envSecrets"]
-        assert isinstance(secrets, list)
-        assert len(secrets) == 1
-        assert secrets[0]["envVar"] == "OPENAI_API_KEY"
+        credential_files = values_yaml["sessionDefinitions"]["skuldCodex"]["defaults"][
+            "homeVolume"
+        ]["credentialFiles"]
+        assert secrets == []
+        assert credential_files["secretName"] == ""
 
 
 class TestHelpersTemplate:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,6 +90,12 @@ class TestSettings:
         settings = Settings()
 
         assert isinstance(settings.database, DatabaseConfig)
+        assert settings.codex_credential_broker.adapter.endswith(
+            ".DisabledCodexCredentialBroker"
+        )
+        assert settings.credential_enrollment_runner.adapter.endswith(
+            ".UnsupportedCredentialEnrollmentRunner"
+        )
 
     def test_nested_configuration(self):
         """Test nested configuration."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -90,9 +90,7 @@ class TestSettings:
         settings = Settings()
 
         assert isinstance(settings.database, DatabaseConfig)
-        assert settings.codex_credential_broker.adapter.endswith(
-            ".DisabledCodexCredentialBroker"
-        )
+        assert settings.codex_credential_broker.adapter.endswith(".DisabledCodexCredentialBroker")
         assert settings.credential_enrollment_runner.adapter.endswith(
             ".UnsupportedCredentialEnrollmentRunner"
         )

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 from fastapi import FastAPI
@@ -19,11 +20,17 @@ from volundr.adapters.inbound.rest_integrations import (
 from volundr.adapters.outbound.jira import JiraAdapter
 from volundr.adapters.outbound.memory_integrations import InMemoryIntegrationRepository
 from volundr.domain.models import (
+    CredentialEnrollment,
+    CredentialEnrollmentState,
     IntegrationConnection,
     Principal,
     TrackerIssue,
 )
 from volundr.domain.ports import CredentialStorePort
+from volundr.domain.services.credential_enrollment import (
+    CredentialEnrollmentError,
+    CredentialEnrollmentService,
+)
 from volundr.domain.services.integration_registry import (
     IntegrationRegistry,
     definitions_from_config,
@@ -681,6 +688,7 @@ class TestIntegrationEndpoints:
                 },
                 "auth_type": "oauth2_authorization_code",
                 "oauth_scopes": ["read", "write"],
+                "credential_enrollment": None,
             }
         ]
 
@@ -691,6 +699,94 @@ class TestIntegrationEndpoints:
         response = integration_client.get("/api/v1/integrations/catalog")
         assert response.status_code == 200
         assert response.json() == []
+
+    def test_device_enrollment_endpoint_returns_secret_free_challenge(
+        self,
+        integration_repo: InMemoryIntegrationRepository,
+        tracker_factory: TrackerFactory,
+        mock_principal: Principal,
+    ):
+        now = datetime.now(UTC)
+        enrollment = CredentialEnrollment(
+            id=uuid4(),
+            connection_id=str(uuid4()),
+            owner_id=mock_principal.user_id,
+            tenant_id=mock_principal.tenant_id,
+            provider_slug="codex",
+            credential_name="codex-credentials",
+            method="codex_device",
+            state=CredentialEnrollmentState.AWAITING_USER,
+            runner_ref={"sandbox_id": "private-runner-ref"},
+            verification_uri="https://auth.openai.com/codex/device",
+            user_code="ABCD-EFGH",
+            expires_at=now + timedelta(minutes=15),
+            error_code="",
+            created_at=now,
+            updated_at=now,
+        )
+        enrollment_service = AsyncMock(spec=CredentialEnrollmentService)
+        enrollment_service.start.return_value = enrollment
+        app = FastAPI()
+
+        async def mock_extract_principal():
+            return mock_principal
+
+        app.include_router(
+            create_integrations_router(
+                integration_repo,
+                tracker_factory,
+                credential_enrollment_service=enrollment_service,
+            )
+        )
+        from volundr.adapters.inbound.auth import extract_principal
+
+        app.dependency_overrides[extract_principal] = mock_extract_principal
+
+        response = TestClient(app).post(
+            "/api/v1/integrations/enrollments",
+            json={"slug": "codex", "credentialName": "codex-credentials"},
+        )
+
+        assert response.status_code == 201
+        assert response.json()["verificationUri"] == enrollment.verification_uri
+        assert response.json()["userCode"] == "ABCD-EFGH"
+        assert "runner_ref" not in response.json()
+        enrollment_service.start.assert_awaited_once_with(
+            principal=mock_principal,
+            slug="codex",
+            credential_name="codex-credentials",
+            connection_id="",
+        )
+
+    def test_device_enrollment_lookup_hides_foreign_or_missing_attempts(
+        self,
+        integration_repo: InMemoryIntegrationRepository,
+        tracker_factory: TrackerFactory,
+        mock_principal: Principal,
+    ):
+        enrollment_service = AsyncMock(spec=CredentialEnrollmentService)
+        enrollment_service.get.side_effect = CredentialEnrollmentError(
+            "Credential enrollment not found"
+        )
+        app = FastAPI()
+
+        async def mock_extract_principal():
+            return mock_principal
+
+        app.include_router(
+            create_integrations_router(
+                integration_repo,
+                tracker_factory,
+                credential_enrollment_service=enrollment_service,
+            )
+        )
+        from volundr.adapters.inbound.auth import extract_principal
+
+        app.dependency_overrides[extract_principal] = mock_extract_principal
+
+        response = TestClient(app).get(f"/api/v1/integrations/enrollments/{uuid4()}")
+
+        assert response.status_code == 404
 
 
 class TestIntegrationTestEndpointBranches:

--- a/tests/test_services/test_credential_enrollment.py
+++ b/tests/test_services/test_credential_enrollment.py
@@ -1,0 +1,252 @@
+"""Tests for user-scoped interactive credential enrollment."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from volundr.adapters.outbound.memory_integrations import InMemoryIntegrationRepository
+from volundr.domain.models import (
+    CredentialEnrollmentPoll,
+    CredentialEnrollmentState,
+    Principal,
+)
+from volundr.domain.services.credential_enrollment import (
+    CredentialEnrollmentError,
+    CredentialEnrollmentService,
+)
+from volundr.domain.services.integration_registry import (
+    IntegrationRegistry,
+    definitions_from_config,
+)
+
+
+class _EnrollmentRepository:
+    def __init__(self) -> None:
+        self.items = {}
+
+    async def save(self, enrollment):
+        self.items[enrollment.id] = enrollment
+        return enrollment
+
+    async def get(self, enrollment_id):
+        return self.items.get(enrollment_id)
+
+    async def find_active(self, connection_id):
+        return next(
+            (
+                item
+                for item in self.items.values()
+                if item.connection_id == connection_id
+                and item.state
+                in {CredentialEnrollmentState.PENDING, CredentialEnrollmentState.AWAITING_USER}
+            ),
+            None,
+        )
+
+    async def list_expired_active(self, now):
+        return [
+            item
+            for item in self.items.values()
+            if item.state
+            in {CredentialEnrollmentState.PENDING, CredentialEnrollmentState.AWAITING_USER}
+            and item.expires_at <= now
+        ]
+
+
+class _CredentialStore:
+    def __init__(self) -> None:
+        self.items: dict[tuple[str, str, str], dict] = {}
+
+    async def get(self, owner_type, owner_id, name):
+        item = self.items.get((owner_type, owner_id, name))
+        if item is None:
+            return None
+        return SimpleNamespace(secret_type=item["secret_type"], metadata=item["metadata"])
+
+    async def get_value(self, owner_type, owner_id, name):
+        item = self.items.get((owner_type, owner_id, name))
+        return dict(item["data"]) if item is not None else None
+
+    async def store(self, owner_type, owner_id, name, secret_type, data, metadata=None):
+        self.items[(owner_type, owner_id, name)] = {
+            "secret_type": secret_type,
+            "data": dict(data),
+            "metadata": dict(metadata or {}),
+        }
+        return await self.get(owner_type, owner_id, name)
+
+
+class _Runner:
+    def __init__(self) -> None:
+        self.poll_result = CredentialEnrollmentPoll(state=CredentialEnrollmentState.AWAITING_USER)
+        self.cancelled = []
+
+    def supports_enrollment(self, method: str) -> bool:
+        return method == "codex_device"
+
+    async def start_enrollment(self, enrollment):
+        return replace(
+            enrollment,
+            state=CredentialEnrollmentState.AWAITING_USER,
+            runner_ref={"sandbox_name": f"enroll-{enrollment.id}"},
+            verification_uri="https://auth.openai.com/codex/device",
+            user_code="ABCD-EFGH",
+        )
+
+    async def poll_enrollment(self, _enrollment):
+        return self.poll_result
+
+    async def cancel_enrollment(self, enrollment):
+        self.cancelled.append(enrollment.id)
+
+
+def _principal(user_id: str) -> Principal:
+    return Principal(
+        user_id=user_id,
+        email=f"{user_id}@example.test",
+        tenant_id="tenant-1",
+        roles=["volundr:developer"],
+    )
+
+
+def _service():
+    enrollment_repository = _EnrollmentRepository()
+    integration_repository = InMemoryIntegrationRepository()
+    credential_store = _CredentialStore()
+    runner = _Runner()
+    registry = IntegrationRegistry(
+        definitions_from_config(
+            [
+                {
+                    "slug": "codex",
+                    "name": "Codex",
+                    "integration_type": "ai_provider",
+                    "auth_type": "device_code",
+                    "credential_enrollment": {
+                        "method": "codex_device",
+                        "credential_field": "auth.json",
+                        "default_credential_name": "codex-credentials",
+                    },
+                }
+            ]
+        )
+    )
+    service = CredentialEnrollmentService(
+        repository=enrollment_repository,
+        runner=runner,
+        integration_repository=integration_repository,
+        integration_registry=registry,
+        credential_store=credential_store,
+    )
+    return service, enrollment_repository, integration_repository, credential_store, runner
+
+
+async def test_same_credential_name_is_isolated_for_each_user() -> None:
+    service, _, integration_repository, credential_store, _ = _service()
+
+    first = await service.start(principal=_principal("user-1"), slug="codex")
+    second = await service.start(principal=_principal("user-2"), slug="codex")
+
+    assert first.connection_id != second.connection_id
+    assert first.credential_name == second.credential_name == "codex-credentials"
+    assert len(await integration_repository.list_connections("user-1")) == 1
+    assert len(await integration_repository.list_connections("user-2")) == 1
+    assert ("user", "user-1", "codex-credentials") in credential_store.items
+    assert ("user", "user-2", "codex-credentials") in credential_store.items
+
+
+async def test_completed_login_persists_only_to_enrollment_owner() -> None:
+    service, _, _, credential_store, runner = _service()
+    principal = _principal("user-1")
+    enrollment = await service.start(principal=principal, slug="codex")
+    credential_store.items[("user", "user-1", "codex-credentials")]["data"] = {
+        "config.toml": 'model = "gpt-5"'
+    }
+    runner.poll_result = CredentialEnrollmentPoll(
+        state=CredentialEnrollmentState.COMPLETE,
+        credential_data={"auth.json": '{"tokens":{"access_token":"a"}}'},
+    )
+
+    completed = await service.get(enrollment.id, principal)
+
+    assert completed.state == CredentialEnrollmentState.COMPLETE
+    assert completed.runner_ref == {}
+    assert completed.verification_uri == ""
+    assert completed.user_code == ""
+    stored = credential_store.items[("user", "user-1", "codex-credentials")]
+    assert stored["data"] == {
+        "auth.json": '{"tokens":{"access_token":"a"}}',
+        "config.toml": 'model = "gpt-5"',
+    }
+    assert stored["metadata"]["auth_state"] == "active"
+    assert runner.cancelled == [enrollment.id]
+
+
+async def test_other_user_cannot_read_or_complete_enrollment() -> None:
+    service, _, _, credential_store, runner = _service()
+    enrollment = await service.start(principal=_principal("user-1"), slug="codex")
+    runner.poll_result = CredentialEnrollmentPoll(
+        state=CredentialEnrollmentState.COMPLETE,
+        credential_data={"auth.json": "secret"},
+    )
+
+    with pytest.raises(CredentialEnrollmentError, match="not found"):
+        await service.get(enrollment.id, _principal("user-2"))
+
+    assert ("user", "user-2", "codex-credentials") not in credential_store.items
+
+
+async def test_start_is_idempotent_while_login_is_active() -> None:
+    service, _, _, _, _ = _service()
+    principal = _principal("user-1")
+
+    first = await service.start(principal=principal, slug="codex")
+    second = await service.start(principal=principal, slug="codex")
+
+    assert second.id == first.id
+
+
+async def test_expired_login_is_reaped_without_a_ui_poll() -> None:
+    service, enrollment_repository, _, credential_store, runner = _service()
+    principal = _principal("user-1")
+    enrollment = await service.start(principal=principal, slug="codex")
+    expired = replace(enrollment, expires_at=datetime.now(UTC) - timedelta(seconds=1))
+    await enrollment_repository.save(expired)
+
+    count = await service.expire_stale()
+
+    stored = await enrollment_repository.get(enrollment.id)
+    assert count == 1
+    assert stored.state == CredentialEnrollmentState.EXPIRED
+    assert stored.runner_ref == {}
+    assert stored.user_code == ""
+    assert runner.cancelled == [enrollment.id]
+    assert credential_store.items[("user", "user-1", "codex-credentials")]["metadata"] == {
+        "source": "credential_enrollment",
+        "integration": "codex",
+        "auth_type": "device_code",
+        "auth_state": "auth_required",
+        "auth_state_updated_at": credential_store.items[("user", "user-1", "codex-credentials")][
+            "metadata"
+        ]["auth_state_updated_at"],
+        "auth_error_code": "enrollment_expired",
+    }
+
+
+async def test_cancelled_login_leaves_connection_reconnectable() -> None:
+    service, _, _, credential_store, runner = _service()
+    principal = _principal("user-1")
+    enrollment = await service.start(principal=principal, slug="codex")
+
+    cancelled = await service.cancel(enrollment.id, principal)
+
+    assert cancelled.state == CredentialEnrollmentState.CANCELLED
+    assert cancelled.user_code == ""
+    assert runner.cancelled == [enrollment.id]
+    metadata = credential_store.items[("user", "user-1", "codex-credentials")]["metadata"]
+    assert metadata["auth_state"] == "auth_required"
+    assert metadata["auth_error_code"] == "enrollment_cancelled"

--- a/tests/test_skuld/test_broker.py
+++ b/tests/test_skuld/test_broker.py
@@ -1049,13 +1049,23 @@ class TestBroker:
         test_broker._transport.capabilities = TransportCapabilities(steering_mode="live")
         mock_channel = self._pending_user_turn(test_broker, "m-err")
 
-        await test_broker._handle_cli_event({"type": "error", "error": "boom"})
+        with patch.object(
+            test_broker,
+            "_report_activity_state",
+            new=AsyncMock(),
+        ) as report_activity:
+            await test_broker._handle_cli_event({"type": "error", "error": "boom"})
+            await asyncio.sleep(0)
 
         turn = next(t for t in test_broker._conversation_turns if t.id == "m-err")
         assert turn.metadata["steering_state"] == "active"
         assert any(
             c.args[0].get("type") == "user_active" and c.args[0].get("id") == "m-err"
             for c in mock_channel.send_event.await_args_list
+        )
+        report_activity.assert_awaited_once_with(
+            "error",
+            extra_metadata={"error": "boom"},
         )
 
     def test_assistant_has_content(self):

--- a/tests/test_skuld/test_codex_auth.py
+++ b/tests/test_skuld/test_codex_auth.py
@@ -66,9 +66,7 @@ async def test_volundr_provider_uses_current_token_then_requests_one_rotation() 
             "credential_name": "codex-user",
             "credential_field": "auth.json",
             "force_refresh": True,
-            "previous_access_token_sha256": hashlib.sha256(
-                b"access-token-1"
-            ).hexdigest(),
+            "previous_access_token_sha256": hashlib.sha256(b"access-token-1").hexdigest(),
         },
     ]
 

--- a/tests/test_skuld/test_codex_auth.py
+++ b/tests/test_skuld/test_codex_auth.py
@@ -1,0 +1,94 @@
+"""Tests for configured Codex authentication providers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+import httpx
+import pytest
+
+from skuld.codex_auth import (
+    CodexAuthProviderError,
+    HostCodexAuthProvider,
+    VolundrCodexAuthProvider,
+)
+
+
+@pytest.mark.asyncio
+async def test_host_provider_leaves_existing_codex_auth_untouched() -> None:
+    assert await HostCodexAuthProvider().get_tokens() is None
+    assert await HostCodexAuthProvider().get_tokens(force_refresh=True) is None
+
+
+@pytest.mark.asyncio
+async def test_volundr_provider_uses_current_token_then_requests_one_rotation() -> None:
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        requests.append(body)
+        access_token = "access-token-2" if body["force_refresh"] else "access-token-1"
+        return httpx.Response(
+            200,
+            json={
+                "access_token": access_token,
+                "chatgpt_account_id": "account-1",
+                "chatgpt_plan_type": "pro",
+                "expires_in": 3600,
+            },
+        )
+
+    async with httpx.AsyncClient(
+        base_url="https://volundr.internal",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        provider = VolundrCodexAuthProvider(
+            http_client_provider=lambda: _return(client),
+            credential_name="codex-user",
+            credential_field="auth.json",
+        )
+        current = await provider.get_tokens()
+        refreshed = await provider.get_tokens(force_refresh=True)
+
+    assert current.access_token == "access-token-1"
+    assert refreshed.access_token == "access-token-2"
+    assert refreshed.account_id == "account-1"
+    assert refreshed.plan_type == "pro"
+    assert requests == [
+        {
+            "credential_name": "codex-user",
+            "credential_field": "auth.json",
+            "force_refresh": False,
+            "previous_access_token_sha256": "",
+        },
+        {
+            "credential_name": "codex-user",
+            "credential_field": "auth.json",
+            "force_refresh": True,
+            "previous_access_token_sha256": hashlib.sha256(
+                b"access-token-1"
+            ).hexdigest(),
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_volundr_provider_surfaces_reconnect_failure() -> None:
+    async with httpx.AsyncClient(
+        base_url="https://volundr.internal",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                409,
+                json={"detail": "Codex authentication requires reconnection"},
+            )
+        ),
+    ) as client:
+        provider = VolundrCodexAuthProvider(http_client_provider=lambda: _return(client))
+
+        with pytest.raises(CodexAuthProviderError, match="requires reconnection"):
+            await provider.get_tokens()
+
+
+async def _return(client: httpx.AsyncClient) -> httpx.AsyncClient:
+    return client

--- a/tests/test_skuld/test_codex_ws_transport.py
+++ b/tests/test_skuld/test_codex_ws_transport.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from skuld.codex_auth import CodexAuthProviderError, CodexExternalTokens
 from skuld.transports.codex_ws import (
     CodexWebSocketTransport,
     _codex_effort_for_model,
@@ -81,6 +82,16 @@ class FakeRunningProcess:
     returncode = None
 
 
+class FakeCodexAuthProvider:
+    def __init__(self, tokens: CodexExternalTokens | None) -> None:
+        self.tokens = tokens
+        self.calls: list[bool] = []
+
+    async def get_tokens(self, *, force_refresh: bool = False):
+        self.calls.append(force_refresh)
+        return self.tokens
+
+
 # ---------------------------------------------------------------------------
 # Unit tests: RPC helpers
 # ---------------------------------------------------------------------------
@@ -138,6 +149,42 @@ class TestConstruction:
         assert caps.mcp_set_servers is False
         assert caps.slash_commands is True
         assert caps.skills is False
+
+    @pytest.mark.asyncio
+    async def test_external_auth_logs_in_with_access_only_token_envelope(self, tmp_path):
+        provider = FakeCodexAuthProvider(
+            CodexExternalTokens(
+                access_token="access-token",
+                account_id="account-1",
+                plan_type="pro",
+            )
+        )
+        t = _make_transport(tmp_path, codex_auth_provider=provider)
+        t._send_rpc = AsyncMock(return_value={})
+
+        await t._authenticate_codex()
+
+        t._send_rpc.assert_awaited_once_with(
+            "account/login/start",
+            {
+                "type": "chatgptAuthTokens",
+                "accessToken": "access-token",
+                "chatgptAccountId": "account-1",
+                "chatgptPlanType": "pro",
+            },
+        )
+        assert provider.calls == [False]
+
+    @pytest.mark.asyncio
+    async def test_host_auth_provider_does_not_start_external_login(self, tmp_path):
+        provider = FakeCodexAuthProvider(None)
+        t = _make_transport(tmp_path, codex_auth_provider=provider)
+        t._send_rpc = AsyncMock(return_value={})
+
+        await t._authenticate_codex()
+
+        t._send_rpc.assert_not_awaited()
+        assert provider.calls == [False]
 
     def test_init_with_mcp_servers(self, tmp_path):
         t = _make_transport(
@@ -1527,6 +1574,60 @@ class TestControl:
 
 
 class TestApprovals:
+    @pytest.mark.asyncio
+    async def test_app_server_refresh_request_uses_central_provider(self, tmp_path):
+        provider = FakeCodexAuthProvider(
+            CodexExternalTokens(access_token="rotated-token", account_id="account-1")
+        )
+        t = _make_transport(tmp_path, codex_auth_provider=provider)
+        t._ws = FakeWebSocket()
+
+        await t._handle_server_request(
+            {
+                "id": 40,
+                "method": "account/chatgptAuthTokens/refresh",
+                "params": {"previousAccountId": "account-1"},
+            }
+        )
+
+        sent = json.loads(t._ws.sent[0])
+        assert sent == {
+            "jsonrpc": "2.0",
+            "id": 40,
+            "result": {
+                "accessToken": "rotated-token",
+                "chatgptAccountId": "account-1",
+            },
+        }
+        assert provider.calls == [True]
+
+    @pytest.mark.asyncio
+    async def test_app_server_refresh_failure_errors_the_turn(self, tmp_path):
+        class FailingProvider:
+            async def get_tokens(self, *, force_refresh: bool = False):
+                assert force_refresh is True
+                raise CodexAuthProviderError("Codex authentication requires reconnection")
+
+        t = _make_transport(tmp_path, codex_auth_provider=FailingProvider())
+        t._ws = FakeWebSocket()
+        emit = _collect_emits(t)
+
+        await t._handle_server_request(
+            {
+                "id": 41,
+                "method": "account/chatgptAuthTokens/refresh",
+                "params": {},
+            }
+        )
+
+        assert t._turn_error == "Codex authentication requires reconnection"
+        assert _events_of_type(emit, "error") == [
+            {"type": "error", "error": "Codex authentication requires reconnection"}
+        ]
+        sent = json.loads(t._ws.sent[0])
+        assert sent["id"] == 41
+        assert sent["error"]["code"] == -32001
+
     @pytest.mark.asyncio
     async def test_command_approval_emits_control_request(self, tmp_path):
         t = _make_transport(tmp_path)

--- a/tests/test_skuld/test_config.py
+++ b/tests/test_skuld/test_config.py
@@ -53,6 +53,7 @@ class TestSkuldSettings:
         assert s.volundr_api_url == ""
         assert s.session.id == "unknown"
         assert s.session.name == "unknown"
+        assert s.codex_auth.adapter == "skuld.codex_auth.HostCodexAuthProvider"
         assert s.session.model == "claude-opus-4-8"
         assert s.observability.service_name == "skuld"
         assert s.persistence_mount_path == "/volundr/sessions"

--- a/tests/test_volundr/test_session_definition_contributor.py
+++ b/tests/test_volundr/test_session_definition_contributor.py
@@ -202,6 +202,13 @@ class TestDefaultSessionDefinitions:
         assert codex.display_name == "OpenAI Codex"
         assert codex.defaults["broker"]["cliType"] == "codex-ws"
 
+        batch = default_session_definitions()["skuldCodexExec"]
+        assert batch.defaults["broker"]["cliType"] == "codex-ws"
+        assert (
+            batch.defaults["broker"]["transportAdapter"]
+            == "skuld.transports.codex_ws.CodexWebSocketTransport"
+        )
+
     def test_opencode_defaults(self):
         opencode = default_session_definitions()["skuldOpenCode"]
         assert opencode.display_name == "OpenCode"

--- a/web-next/apps/niuu/src/SettingsPage.test.tsx
+++ b/web-next/apps/niuu/src/SettingsPage.test.tsx
@@ -6,9 +6,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SettingsPage } from './SettingsPage';
 
 const apiMocks = vi.hoisted(() => ({
-  get: vi.fn(),
+  get: vi.fn<(path: string) => Promise<unknown>>(),
   patch: vi.fn(async () => null),
-  post: vi.fn(async (path: string) => {
+  post: vi.fn<(path: string, body?: unknown) => Promise<unknown>>(async (path: string) => {
     if (path === '/api/v1/tokens') {
       return {
         id: 'tok-2',
@@ -570,6 +570,108 @@ describe('SettingsPage', () => {
 
     expect(await screen.findByRole('button', { name: 'Connect with OAuth' })).toBeTruthy();
     expect(screen.getByText('Connected as github-oauth')).toBeTruthy();
+    expect(screen.queryByText('Create a new credential')).toBeNull();
+  });
+
+  it('starts a user-scoped Codex device login from shared Integrations', async () => {
+    routerMocks.params = { providerId: 'integrations', sectionId: 'connections' };
+    const challenge = {
+      id: 'enrollment-1',
+      connectionId: 'codex-connection-1',
+      providerSlug: 'codex',
+      credentialName: 'codex-credentials',
+      state: 'awaiting_user',
+      verificationUri: 'https://auth.openai.com/codex/device',
+      userCode: 'ABCD-EFGH',
+      expiresAt: '2026-08-01T12:15:00Z',
+      errorCode: '',
+    };
+    apiMocks.post.mockImplementation(async (path: string) => {
+      if (path === '/api/v1/integrations/enrollments') return challenge;
+      return null;
+    });
+    apiMocks.get.mockImplementation(async (path: string) => {
+      if (path === '/settings') {
+        return {
+          title: 'Integrations',
+          scope: 'user',
+          sections: [
+            {
+              id: 'connections',
+              label: 'Connections',
+              fields: [],
+              resources: [
+                {
+                  id: 'integration_connections',
+                  type: 'integrations',
+                  label: 'Integration connections',
+                  listPath: '/api/v1/integrations',
+                  catalogPath: '/api/v1/integrations/catalog',
+                  createPath: '/api/v1/integrations',
+                  deletePath: '/api/v1/integrations/{id}',
+                  credentialListPath: '/api/v1/credentials/user',
+                  testPath: '/api/v1/integrations/{id}/test',
+                  oauthAuthorizePath: '/api/v1/integrations/oauth/{slug}/authorize',
+                  oauthDisconnectPath: '/api/v1/integrations/oauth/{slug}/disconnect',
+                  enrollmentStartPath: '/api/v1/integrations/enrollments',
+                  enrollmentStatusPath: '/api/v1/integrations/enrollments/{id}',
+                  enrollmentCancelPath: '/api/v1/integrations/enrollments/{id}',
+                },
+              ],
+            },
+          ],
+        };
+      }
+      if (path === '/api/v1/credentials/user') return { credentials: [] };
+      if (path === '/api/v1/integrations') {
+        return [
+          {
+            id: 'codex-connection-1',
+            slug: 'codex',
+            integrationType: 'ai_provider',
+            credentialName: 'codex-credentials',
+            credentialStatus: 'auth_required',
+            enabled: true,
+          },
+        ];
+      }
+      if (path === '/api/v1/integrations/catalog') {
+        return [
+          {
+            id: 'codex',
+            slug: 'codex',
+            name: 'OpenAI Codex (ChatGPT)',
+            integration_type: 'ai_provider',
+            auth_type: 'device_code',
+            credential_schema: {},
+            config_schema: {},
+            credential_enrollment: {
+              method: 'codex_device',
+              credential_field: 'auth.json',
+              default_credential_name: 'codex-credentials',
+            },
+          },
+        ];
+      }
+      if (path === '/api/v1/integrations/enrollments/enrollment-1') return challenge;
+      throw new Error(`Unexpected GET ${path}`);
+    });
+
+    wrap(<SettingsPage />);
+
+    const reconnect = await screen.findByRole('button', { name: 'Reconnect Codex' });
+    expect(screen.getByText('Reconnect required')).toBeTruthy();
+    fireEvent.click(reconnect);
+
+    expect(await screen.findByText('ABCD-EFGH')).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'the provider login page' }).getAttribute('href')).toBe(
+      challenge.verificationUri,
+    );
+    expect(apiMocks.post).toHaveBeenCalledWith('/api/v1/integrations/enrollments', {
+      slug: 'codex',
+      credential_name: 'codex-credentials',
+      connection_id: 'codex-connection-1',
+    });
     expect(screen.queryByText('Create a new credential')).toBeNull();
   });
 

--- a/web-next/apps/niuu/src/SettingsPage.tsx
+++ b/web-next/apps/niuu/src/SettingsPage.tsx
@@ -33,6 +33,14 @@ function buildInitialDraft(section: RemoteSettingsSectionSchema | null): Record<
 
 type ProviderStatus = 'ready' | 'loading' | 'missing' | 'idle' | 'error';
 
+const CREDENTIAL_ENROLLMENT_STATUS_INTERVAL_MS = 2000;
+const TERMINAL_CREDENTIAL_ENROLLMENT_STATES = new Set([
+  'complete',
+  'failed',
+  'expired',
+  'cancelled',
+]);
+
 interface PersonalAccessTokenRecord {
   id: string;
   name: string;
@@ -101,6 +109,16 @@ interface IntegrationCatalogEntry {
   credentialSchema?: IntegrationCatalogSchema;
   config_schema?: IntegrationCatalogSchema;
   configSchema?: IntegrationCatalogSchema;
+  credential_enrollment?: CredentialEnrollmentCatalogSpec | null;
+  credentialEnrollment?: CredentialEnrollmentCatalogSpec | null;
+}
+
+interface CredentialEnrollmentCatalogSpec {
+  method: string;
+  credential_field?: string;
+  credentialField?: string;
+  default_credential_name?: string;
+  defaultCredentialName?: string;
 }
 
 interface IntegrationConnectionRecord {
@@ -116,6 +134,24 @@ interface IntegrationConnectionRecord {
   updatedAt?: string;
   updated_at?: string;
   config?: Record<string, unknown>;
+  credentialStatus?: string;
+  credential_status?: string;
+  credentialErrorCode?: string | null;
+  credential_error_code?: string | null;
+  credentialStatusUpdatedAt?: string | null;
+  credential_status_updated_at?: string | null;
+}
+
+interface CredentialEnrollmentRecord {
+  id: string;
+  connectionId: string;
+  providerSlug: string;
+  credentialName: string;
+  state: 'pending' | 'awaiting_user' | 'complete' | 'failed' | 'expired' | 'cancelled';
+  verificationUri: string;
+  userCode: string;
+  expiresAt: string;
+  errorCode: string;
 }
 
 interface NormalizedSettingsSection {
@@ -232,6 +268,17 @@ function isOauthIntegration(entry: IntegrationCatalogEntry | null): boolean {
   return authType === 'oauth2_authorization_code' || authType === 'oauth_token';
 }
 
+function isDeviceCodeIntegration(entry: IntegrationCatalogEntry | null): boolean {
+  if (!entry) return false;
+  return (entry.authType ?? entry.auth_type) === 'device_code';
+}
+
+function enrollmentSpec(
+  entry: IntegrationCatalogEntry | null,
+): CredentialEnrollmentCatalogSpec | null {
+  return entry?.credentialEnrollment ?? entry?.credential_enrollment ?? null;
+}
+
 function formatTimestamp(value?: string | null): string {
   if (!value) return '—';
   const date = new Date(value);
@@ -268,6 +315,11 @@ function normalizeIntegrationRecord(integration: IntegrationConnectionRecord) {
     enabled: integration.enabled !== false,
     createdAt: integration.createdAt ?? integration.created_at ?? '',
     updatedAt: integration.updatedAt ?? integration.updated_at ?? '',
+    credentialStatus: integration.credentialStatus ?? integration.credential_status ?? 'unknown',
+    credentialErrorCode:
+      integration.credentialErrorCode ?? integration.credential_error_code ?? null,
+    credentialStatusUpdatedAt:
+      integration.credentialStatusUpdatedAt ?? integration.credential_status_updated_at ?? null,
   };
 }
 
@@ -967,6 +1019,8 @@ function IntegrationsResourceCard({
   const [credentialValues, setCredentialValues] = useState<Record<string, string>>({});
   const [configValues, setConfigValues] = useState<Record<string, string>>({});
   const [oauthPendingSlug, setOauthPendingSlug] = useState<string | null>(null);
+  const [credentialEnrollment, setCredentialEnrollment] =
+    useState<CredentialEnrollmentRecord | null>(null);
   const [lastTestStatus, setLastTestStatus] = useState<Record<string, string>>({});
 
   const catalogQuery = useQuery({
@@ -1000,6 +1054,7 @@ function IntegrationsResourceCard({
   const selectedConnection =
     integrationsQuery.data?.find((integration) => (integration.slug ?? '') === selectedCatalogId) ??
     null;
+  const selectedEnrollmentSpec = enrollmentSpec(selectedEntry);
 
   const credentialSchema = useMemo(
     () =>
@@ -1011,7 +1066,10 @@ function IntegrationsResourceCard({
     [selectedEntry],
   );
   const effectiveCredentialName =
-    credentialName || (selectedEntry ? `${selectedCatalogId}-credential` : '');
+    credentialName ||
+    selectedEnrollmentSpec?.defaultCredentialName ||
+    selectedEnrollmentSpec?.default_credential_name ||
+    (selectedEntry ? `${selectedCatalogId}-credential` : '');
   const effectiveCredentialValues =
     Object.keys(credentialValues).length > 0
       ? credentialValues
@@ -1145,7 +1203,75 @@ function IntegrationsResourceCard({
     },
   });
 
+  const enrollmentMutation = useMutation({
+    mutationFn: async () => {
+      if (!selectedEntry || !resource.enrollmentStartPath) {
+        throw new Error('Interactive credential enrollment is unavailable');
+      }
+      return client.post<CredentialEnrollmentRecord>(resource.enrollmentStartPath, {
+        slug: selectedEntry.slug ?? selectedEntry.id,
+        credential_name: effectiveCredentialName,
+        connection_id: selectedConnection?.id ?? '',
+      });
+    },
+    onSuccess: (enrollment) => {
+      setCredentialEnrollment(enrollment);
+    },
+  });
+
+  const enrollmentQuery = useQuery({
+    queryKey: [
+      'settings-resource',
+      providerId,
+      resource.id,
+      'credential-enrollment',
+      credentialEnrollment?.id,
+    ],
+    enabled: Boolean(
+      credentialEnrollment?.id &&
+      resource.enrollmentStatusPath &&
+      !TERMINAL_CREDENTIAL_ENROLLMENT_STATES.has(credentialEnrollment.state),
+    ),
+    queryFn: () =>
+      client.get<CredentialEnrollmentRecord>(
+        resource.enrollmentStatusPath!.replace('{id}', credentialEnrollment!.id),
+      ),
+    refetchInterval: (query) => {
+      const state = (query.state.data as CredentialEnrollmentRecord | undefined)?.state;
+      return state && TERMINAL_CREDENTIAL_ENROLLMENT_STATES.has(state)
+        ? false
+        : CREDENTIAL_ENROLLMENT_STATUS_INTERVAL_MS;
+    },
+  });
+
+  const currentEnrollment = enrollmentQuery.data ?? credentialEnrollment;
+
+  useEffect(() => {
+    if (currentEnrollment?.state !== 'complete') return;
+    void queryClient.invalidateQueries({
+      queryKey: ['settings-resource', providerId, resource.id, 'integrations'],
+    });
+  }, [currentEnrollment?.state, providerId, queryClient, resource.id]);
+
+  const cancelEnrollmentMutation = useMutation({
+    mutationFn: async (enrollmentId: string) => {
+      if (!resource.enrollmentCancelPath) {
+        throw new Error('Interactive credential enrollment is unavailable');
+      }
+      return client.delete<CredentialEnrollmentRecord>(
+        resource.enrollmentCancelPath.replace('{id}', enrollmentId),
+      );
+    },
+    onSuccess: (enrollment) => {
+      setCredentialEnrollment(enrollment);
+    },
+  });
+
   const selectedIsOauth = isOauthIntegration(selectedEntry);
+  const selectedIsDeviceCode = isDeviceCodeIntegration(selectedEntry);
+  const selectedCredentialReady = ['active', 'configured'].includes(
+    selectedConnection?.credentialStatus ?? '',
+  );
   const availableCredentials = credentialsQuery.data ?? [];
 
   return (
@@ -1173,7 +1299,13 @@ function IntegrationsResourceCard({
               )}
               onClick={() => {
                 setSelectedId(key);
-                setCredentialName(`${key}-credential`);
+                const spec = enrollmentSpec(entry);
+                setCredentialName(
+                  spec?.defaultCredentialName ??
+                    spec?.default_credential_name ??
+                    `${key}-credential`,
+                );
+                setCredentialEnrollment(null);
                 setSelectedExistingCredential('');
                 setCredentialValues(
                   buildInitialResourceValues(
@@ -1205,6 +1337,7 @@ function IntegrationsResourceCard({
           onSubmit={(event) => {
             event.preventDefault();
             if (!selectedEntry) return;
+            if (selectedIsDeviceCode || selectedIsOauth) return;
             if (!selectedIsOauth && createInlineCredential && !credentialName.trim()) return;
             if (!selectedIsOauth && !createInlineCredential && !selectedExistingCredential) return;
             void createMutation.mutateAsync();
@@ -1221,7 +1354,91 @@ function IntegrationsResourceCard({
             </div>
           </div>
 
-          {selectedIsOauth ? (
+          {selectedIsDeviceCode ? (
+            <div className="settings-resource__actions">
+              {selectedConnection ? (
+                <span
+                  className={cn(
+                    'settings-shell__status',
+                    selectedCredentialReady
+                      ? 'settings-shell__status--success'
+                      : 'settings-shell__status--error',
+                  )}
+                >
+                  {selectedCredentialReady
+                    ? `Connected as ${selectedConnection.credentialName}`
+                    : 'Reconnect required'}
+                </span>
+              ) : null}
+              {currentEnrollment?.state === 'awaiting_user' ? (
+                <div className="settings-resource__row-note">
+                  Open{' '}
+                  <a href={currentEnrollment.verificationUri} target="_blank" rel="noreferrer">
+                    the provider login page
+                  </a>{' '}
+                  and enter code <strong>{currentEnrollment.userCode}</strong>.
+                </div>
+              ) : null}
+              {currentEnrollment?.state === 'complete' ? (
+                <span className="settings-shell__status settings-shell__status--success">
+                  Codex account connected.
+                </span>
+              ) : null}
+              {currentEnrollment &&
+              TERMINAL_CREDENTIAL_ENROLLMENT_STATES.has(currentEnrollment.state) &&
+              currentEnrollment.state !== 'complete' ? (
+                <span className="settings-shell__status settings-shell__status--error">
+                  Login {currentEnrollment.state.replace('_', ' ')}. Start it again to retry.
+                </span>
+              ) : null}
+              {enrollmentMutation.isError ? (
+                <span className="settings-shell__status settings-shell__status--error">
+                  Could not start the Codex login. Retry or contact an administrator.
+                </span>
+              ) : null}
+              {enrollmentQuery.isError ? (
+                <span className="settings-shell__status settings-shell__status--error">
+                  Could not read the Codex login status. The login remains safe to retry.
+                </span>
+              ) : null}
+              {cancelEnrollmentMutation.isError ? (
+                <span className="settings-shell__status settings-shell__status--error">
+                  Could not cancel the Codex login. It will be removed automatically after expiry.
+                </span>
+              ) : null}
+              <button
+                type="button"
+                className="settings-shell__save-button settings-shell__save-button--secondary"
+                disabled={
+                  enrollmentMutation.isPending ||
+                  currentEnrollment?.state === 'pending' ||
+                  currentEnrollment?.state === 'awaiting_user' ||
+                  !resource.enrollmentStartPath
+                }
+                onClick={() => {
+                  enrollmentMutation.mutate();
+                }}
+              >
+                {enrollmentMutation.isPending
+                  ? 'Starting…'
+                  : selectedConnection
+                    ? 'Reconnect Codex'
+                    : 'Connect Codex'}
+              </button>
+              {currentEnrollment?.state === 'awaiting_user' ? (
+                <button
+                  type="button"
+                  className="settings-resource__row-action"
+                  disabled={cancelEnrollmentMutation.isPending}
+                  onClick={() => {
+                    cancelEnrollmentMutation.mutate(currentEnrollment.id);
+                  }}
+                >
+                  Cancel login
+                </button>
+              ) : null}
+            </div>
+          ) : selectedIsOauth ? (
             <div className="settings-resource__actions">
               {selectedConnection ? (
                 <span className="settings-shell__status settings-shell__status--success">
@@ -1369,7 +1586,8 @@ function IntegrationsResourceCard({
                 </div>
                 <div className="settings-resource__row-meta">
                   {formatIntegrationType(integration.integrationType)} ·{' '}
-                  {integration.credentialName} · {integration.enabled ? 'enabled' : 'disabled'}
+                  {integration.credentialName} · {integration.enabled ? 'enabled' : 'disabled'} ·{' '}
+                  {integration.credentialStatus.replace(/_/g, ' ')}
                 </div>
                 {lastTestStatus[integration.id] ? (
                   <div className="settings-resource__row-note">

--- a/web-next/apps/niuu/src/SettingsRegistry.tsx
+++ b/web-next/apps/niuu/src/SettingsRegistry.tsx
@@ -61,6 +61,9 @@ export interface RemoteSettingsIntegrationsResource {
   testPath: string;
   oauthAuthorizePath: string;
   oauthDisconnectPath: string;
+  enrollmentStartPath?: string;
+  enrollmentStatusPath?: string;
+  enrollmentCancelPath?: string;
 }
 
 export type RemoteSettingsResource =


### PR DESCRIPTION
## Summary\n- separate trusted Codex enrollment from session pod managers\n- broker access-only ChatGPT tokens through authenticated Völundr/OpenBao\n- share one configured auth projection across Flux, direct Kubernetes, and OpenShell\n- retain host Codex auth outside Kubernetes\n- make refresh failures terminal workflow errors\n\n## Validation\n- ruff check src tests\n- helm lint charts/skuld\n- helm lint charts/volundr\n- focused suites: 666 passed\n- repository suite: 17,802 passed, 4 skipped, 1 expected failure; one discovered regression fixed and affected broker suite rerun 297/297