### PR TITLE
test(volundr): fix flaky SessionTerminalLive websocket tests

### DIFF
--- a/web-next/packages/plugin-volundr/src/ui/SessionTerminalLive.test.tsx
+++ b/web-next/packages/plugin-volundr/src/ui/SessionTerminalLive.test.tsx
@@ -114,6 +114,25 @@ function setDocumentFonts(value: Document['fonts'] | undefined) {
   });
 }
 
+/**
+ * Wait until the component has opened its websocket.
+ *
+ * Every driver below reaches for `latestWebSocketOptions?.`, so if the effect
+ * that registers it has not run yet the call silently does nothing and the
+ * assertion after it fails. Rendered output does not imply that effect has
+ * run — they are separate effects — which made these tests fail
+ * intermittently under CI load.
+ */
+async function waitForSocket(): Promise<void> {
+  await waitFor(() => expect(latestWebSocketOptions).toBeDefined());
+}
+
+/** Wait for the websocket *and* the attached terminal, for tests driving both. */
+async function waitForTerminalWiring(): Promise<void> {
+  await waitForSocket();
+  await waitFor(() => expect(xtermInstances.length).toBeGreaterThan(0));
+}
+
 describe('SessionTerminalLive helpers', () => {
   const originalFetch = global.fetch;
 
@@ -451,6 +470,7 @@ describe('SessionTerminalLive', () => {
     render(<SessionTerminalLive url="ws://localhost:8080/terminal/ws" />);
 
     await waitFor(() => expect(screen.getByRole('tab', { name: /shell 1/i })).toBeInTheDocument());
+    await waitForTerminalWiring();
     expect(xtermInstances).toHaveLength(1);
 
     latestWebSocketOptions?.onOpen?.();
@@ -483,6 +503,7 @@ describe('SessionTerminalLive', () => {
 
     await waitFor(() => expect(screen.getByRole('tab', { name: /shell 1/i })).toBeInTheDocument());
 
+    await waitForTerminalWiring();
     latestWebSocketOptions?.onMessage?.(JSON.stringify({ type: 'output', data: 'hello' }));
     latestWebSocketOptions?.onMessage?.(JSON.stringify({ type: 'exit' }));
     latestWebSocketOptions?.onMessage?.('not-json');
@@ -507,6 +528,7 @@ describe('SessionTerminalLive', () => {
     render(<SessionTerminalLive url="ws://localhost:8080/terminal/ws" />);
 
     await waitFor(() => expect(screen.getByText('connecting…')).toBeInTheDocument());
+    await waitForSocket();
     latestWebSocketOptions?.onOpen?.();
     await waitFor(() => expect(screen.getByText('connected')).toBeInTheDocument());
 
@@ -545,6 +567,8 @@ describe('SessionTerminalLive', () => {
     await waitFor(() => expect(screen.getByRole('tab', { name: /shell 1/i })).toBeInTheDocument());
     expect(mockXtermOpen).not.toHaveBeenCalled();
 
+    // Socket only: this test is precisely about there being no terminal yet.
+    await waitForSocket();
     latestWebSocketOptions?.onOpen?.();
     latestWebSocketOptions?.onMessage?.('{"type":"output","data":"ignored"}');
 


### PR DESCRIPTION
`sends resize and terminal input events through the websocket for the active
tab` fails intermittently in CI. It took down the Test job on an unrelated
backend PR (#912) that changes no web-next files at all, while passing 6/6
locally on the same commit.

## Cause

The tests drive the component through the mocked websocket:

```ts
latestWebSocketOptions?.onOpen?.();
expect(mockSendJson).toHaveBeenCalledWith({ type: 'resize', cols: 80, rows: 24 });
```

Nothing waits for `latestWebSocketOptions` to be assigned. The optional
chaining means that when the effect registering it has not run yet, the call
silently does nothing — and the assertion on the next line fails with no hint
that a callback was skipped.

The preceding `waitFor` only waits for a tab to render. That is a different
effect, so it does not imply the socket effect has run. The ordering happens
to hold on a fast machine and slips under CI load.

## Fix

An explicit wait for the wiring each test is about to drive — the socket, and
where relevant the attached terminal.

`ignores websocket events until there is an active terminal instance` waits
for the socket **only**: the absence of a terminal instance is precisely what
that test asserts, so waiting for one there is wrong. (I got this wrong first
time and the test failed consistently, which is how it surfaced.)

## Verification

- The previously flaky file: 8 consecutive clean runs
- Full web-next suite: 5,515 passed
- typecheck, eslint and prettier clean

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)