### PR TITLE
fix(observatory): reserve the realm's rectangle, not its radius

### DIFF
--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/config.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/config.ts
@@ -40,6 +40,13 @@ export const LAYOUT = {
   /** Extra outward spacing when many realms need multiple bands. */
   REALM_RING_STEP: 340,
 
+  /**
+   * Padding between a realm's outermost content and its drawn rectangle.
+   * Shared with the renderer's `realmBounds`, so the space the layout
+   * reserves and the shape drawn into it cannot disagree.
+   */
+  REALM_HULL_PADDING: 78,
+
   /** Visual radius drawn for realm circles. */
   REALM_INNER_RADIUS: 320,
 

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/layoutEngine.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/layoutEngine.ts
@@ -566,7 +566,13 @@ export function computeLayout(topology: Topology): Map<string, NodePosition> {
 
   const worldContainerExtent: NodeExtentResolver = (node) => {
     if (node.typeId === 'realm') {
-      return (realmRadii.get(node.id) ?? LAYOUT.REALM_INNER_RADIUS) + 24;
+      // A realm is *drawn* as a rectangle bounding its contents, so the space
+      // it occupies is that rectangle's circumscribing circle — half-diagonal,
+      // not half-width. Reserving only the radius let the corners of a wide
+      // realm cross into its neighbour, which is what put SVARTALFHEIM
+      // through ASGARD.
+      const inner = realmRadii.get(node.id) ?? LAYOUT.REALM_INNER_RADIUS;
+      return (inner + LAYOUT.REALM_HULL_PADDING) * Math.SQRT2;
     }
     if (node.typeId === 'cluster') {
       return (clusterRadii.get(node.id) ?? LAYOUT.CLUSTER_INNER_RADIUS) + 20;

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/realmOverlap.test.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/realmOverlap.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { computeLayout } from './layoutEngine';
+import { realmBounds } from './renderer';
+import type { Topology, TopologyNode } from '../../domain';
+
+function node(id: string, typeId: string, parentId: string | null = null): TopologyNode {
+  return { id, typeId, label: id, parentId, status: 'healthy' } as TopologyNode;
+}
+
+/**
+ * A realm is drawn as a rectangle but was spaced as a circle, so the corners
+ * of a wide realm crossed into its neighbour. This is the regression guard:
+ * the shape the renderer draws has to fit the space the layout reserved.
+ */
+describe('realm hulls', () => {
+  it('do not overlap, however unevenly the realms are filled', () => {
+    const nodes: TopologyNode[] = [];
+    // Five realms, one of them holding four clusters and the rest holding one.
+    for (let r = 0; r < 5; r += 1) {
+      nodes.push(node(`realm-${r}`, 'realm'));
+      const clusters = r === 0 ? 4 : 1;
+      for (let c = 0; c < clusters; c += 1) {
+        nodes.push(node(`c-${r}-${c}`, 'cluster', `realm-${r}`));
+        for (let s = 0; s < 6; s += 1) {
+          nodes.push(node(`s-${r}-${c}-${s}`, 'service', `c-${r}-${c}`));
+        }
+      }
+    }
+    const topology: Topology = { timestamp: '2026-08-02T00:00:00Z', nodes, edges: [] };
+    const positions = computeLayout(topology);
+
+    const hulls = nodes
+      .filter((n) => n.typeId === 'realm')
+      .map((r) => ({ id: r.id, box: realmBounds(r, nodes, positions) }))
+      .filter((h): h is { id: string; box: NonNullable<typeof h.box> } => h.box !== null);
+
+    const overlaps: string[] = [];
+    for (let i = 0; i < hulls.length; i += 1) {
+      for (let j = i + 1; j < hulls.length; j += 1) {
+        const a = hulls[i]!.box;
+        const b = hulls[j]!.box;
+        if (a.x0 < b.x1 && b.x0 < a.x1 && a.y0 < b.y1 && b.y0 < a.y1) {
+          overlaps.push(`${hulls[i]!.id}×${hulls[j]!.id}`);
+        }
+      }
+    }
+
+    expect(hulls).toHaveLength(5);
+    expect(overlaps).toEqual([]);
+  });
+});

--- a/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.ts
+++ b/web-next/packages/plugin-observatory/src/ui/TopologyCanvas/renderer.ts
@@ -358,7 +358,7 @@ export function realmBounds(
   realm: TopologyNode,
   nodes: readonly TopologyNode[],
   positions: Map<string, NodePosition>,
-  padding = 78,
+  padding = LAYOUT.REALM_HULL_PADDING,
 ): RealmBounds | null {
   const childrenOf = new Map<string, TopologyNode[]>();
   for (const node of nodes) {


### PR DESCRIPTION
Realms are drawn as rectangles but were spaced as circles, so a wide realm's corners crossed into its neighbour. Root packing now reserves the circumscribing circle of the drawn rectangle, and the hull padding is one shared constant so layout and renderer cannot drift apart.

Regression test builds the uneven case that produced the collision and asserts no two hulls intersect; it fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)