### PR TITLE
fix(observatory): say why a source is unreachable

### DIFF
--- a/src/niuu/domain/services/observatory_topology.py
+++ b/src/niuu/domain/services/observatory_topology.py
@@ -70,7 +70,12 @@ class ObservatoryTopologyAggregationService:
         pulled = await self._pull(instances, headers=headers)
         for instance, fragment, error in pulled:
             if error is not None or fragment is None:
-                message = str(error) if error else "Observatory returned no fragment"
+                # Several httpx transport errors stringify to "", which turned
+                # every unreachable source into "Observatory Ymir: " — a report
+                # that names the source and then says nothing about why. The
+                # class name is the minimum that distinguishes a DNS failure
+                # from a timeout from a refused connection.
+                message = self._describe(error) if error else "Observatory returned no fragment"
                 sources.append(
                     TopologySourceHealth(
                         source_id=instance.id,
@@ -134,6 +139,10 @@ class ObservatoryTopologyAggregationService:
             warnings=warnings,
             partial=any(source.status in {"failed", "stale"} for source in sources),
         )
+
+    @staticmethod
+    def _describe(error: BaseException) -> str:
+        return str(error) or type(error).__name__
 
     async def _pull(
         self,

--- a/tests/test_niuu/test_observatory_topology_aggregation.py
+++ b/tests/test_niuu/test_observatory_topology_aggregation.py
@@ -122,6 +122,22 @@ class TestPullAggregation:
         assert [warning.code for warning in snapshot.warnings] == ["source_unreachable"]
 
     @pytest.mark.asyncio
+    async def test_an_unreachable_source_says_what_went_wrong(self) -> None:
+        """Several httpx transport errors stringify to "".
+
+        That turned every unreachable source into "Observatory Ymir: " — a
+        warning that names the source and then says nothing, indistinguishable
+        between a DNS failure, a timeout and a refused connection. It blocked a
+        real diagnosis on ymir, so the class name is the floor.
+        """
+        service = _service({"obs-b": ConnectionResetError()})
+
+        snapshot = await service.get_snapshot([_instance("obs-b")], headers={})
+
+        assert snapshot.warnings[0].message.endswith("ConnectionResetError")
+        assert snapshot.sources[0].message == "ConnectionResetError"
+
+    @pytest.mark.asyncio
     async def test_health_records_node_counts_per_source(self) -> None:
         service = _service({"obs-a": _fragment("obs-a", node_ids=["a-1", "a-2"])})
 


### PR DESCRIPTION
The live aggregate reports `Observatory Ymir: ` — the source named, then nothing, because several httpx transport errors stringify to empty. A DNS failure, a timeout and a refused connection are indistinguishable, which is blocking diagnosis of why ymir drops out of the graph.

Falls back to the exception class name, same as #915 did for the Mímir adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)