### PR TITLE
fix(adapters): stop degrading a missing workload token to an anonymous call

### DIFF
--- a/src/niuu/adapters/outbound/http_auth.py
+++ b/src/niuu/adapters/outbound/http_auth.py
@@ -11,6 +11,8 @@ import httpx
 
 from niuu.ports.http_auth import HttpAuthPort
 
+_DEFAULT_SERVICE_ACCOUNT_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
 
 class NoAuthHeaderAdapter(HttpAuthPort):
     """Emit no auth headers."""
@@ -94,16 +96,35 @@ class WorkloadIdentityBearerTokenAuthAdapter(HttpAuthPort):
         if self._token and now < self._expires_at:
             return self._token
 
+        # An operator who named a token file asked for workload identity, so a
+        # file that is not there is a misconfiguration and must be loud. These
+        # used to return "", which sent the request out unsigned — the failure
+        # then surfaced only as a 401 in the *callee's* sidecar log, attributed
+        # to nothing, which is how whole clusters ran their discovery
+        # unauthenticated with no warning on the side that was broken.
+        #
+        # Nothing configured at all is different: the caller never asked for
+        # workload identity (a Ravn outside Kubernetes, a local shell), and
+        # staying quiet there is what lets those deployments keep working.
         proof_path = self._proof_path()
         if proof_path is None:
-            return ""
+            if not self._token_file_is_configured():
+                return ""
+            raise RuntimeError(
+                "workload identity proof token not found at "
+                f"{self._configured_token_file()!r} — is the projected "
+                "serviceAccountToken volume mounted?"
+            )
         proof = proof_path.read_text(encoding="utf-8").strip()
         if not proof:
-            return ""
+            raise RuntimeError(f"workload identity proof token at {str(proof_path)!r} is empty")
 
         exchange_url = self._resolved_exchange_url()
         if not exchange_url:
-            return ""
+            raise RuntimeError(
+                "workload identity exchange URL is not configured "
+                f"(set exchange_url, base_url, or ${self._exchange_url_env})"
+            )
 
         body: dict[str, object] = {"token": proof, "audiences": self._audiences}
         if self._scopes:
@@ -125,11 +146,15 @@ class WorkloadIdentityBearerTokenAuthAdapter(HttpAuthPort):
         self._expires_at = now + max(0.0, expires_in - self._refresh_skew_seconds)
         return token
 
-    def _proof_path(self) -> Path | None:
+    def _token_file_is_configured(self) -> bool:
+        return bool(self._token_file or os.environ.get(self._token_file_env, ""))
+
+    def _configured_token_file(self) -> str:
         configured = self._token_file or os.environ.get(self._token_file_env, "")
-        if not configured:
-            configured = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-        path = Path(configured).expanduser()
+        return configured or _DEFAULT_SERVICE_ACCOUNT_TOKEN_FILE
+
+    def _proof_path(self) -> Path | None:
+        path = Path(self._configured_token_file()).expanduser()
         return path if path.exists() else None
 
     def _resolved_exchange_url(self) -> str:

--- a/tests/test_adapters/test_http_auth.py
+++ b/tests/test_adapters/test_http_auth.py
@@ -179,3 +179,61 @@ def test_workload_identity_adapter_env_names_remain_fallback(
 
     assert adapter.headers() == {"Authorization": "Bearer env-jwt"}
     assert seen[0] == "https://env-host/exchange"
+
+
+def test_workload_identity_adapter_names_the_missing_proof_token(tmp_path) -> None:
+    """A missing projected token must be loud, not an unsigned request.
+
+    Returning no header sent the call out anonymously, so the failure only ever
+    surfaced as a 401 in the *callee's* sidecar log — which is how two clusters
+    ran their whole Observatory discovery unauthenticated without a single
+    warning on the side that was actually broken.
+    """
+    adapter = WorkloadIdentityBearerTokenAuthAdapter(
+        exchange_url="https://volundr.test/api/v1/tokens/workload/exchange",
+        token_file=str(tmp_path / "absent" / "token"),
+    )
+
+    with pytest.raises(RuntimeError, match="projected"):
+        adapter.headers()
+
+
+def test_workload_identity_adapter_rejects_an_empty_proof_token(tmp_path) -> None:
+    proof_file = tmp_path / "token"
+    proof_file.write_text("   ", encoding="utf-8")
+    adapter = WorkloadIdentityBearerTokenAuthAdapter(
+        exchange_url="https://volundr.test/api/v1/tokens/workload/exchange",
+        token_file=str(proof_file),
+    )
+
+    with pytest.raises(RuntimeError, match="empty"):
+        adapter.headers()
+
+
+def test_workload_identity_adapter_requires_an_exchange_url(tmp_path) -> None:
+    proof_file = tmp_path / "token"
+    proof_file.write_text("proof-jwt", encoding="utf-8")
+    adapter = WorkloadIdentityBearerTokenAuthAdapter(token_file=str(proof_file))
+
+    with pytest.raises(RuntimeError, match="exchange URL"):
+        adapter.headers()
+
+
+def test_workload_identity_adapter_stays_quiet_when_nothing_was_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller that never asked for workload identity is not misconfigured.
+
+    Ravn outside Kubernetes constructs this adapter by default; there is no
+    projected token there and none was ever requested, so it must degrade to
+    "no header" rather than fail the call.
+    """
+    monkeypatch.delenv("NIUU_WORKLOAD_IDENTITY_TOKEN_FILE", raising=False)
+    monkeypatch.setattr(
+        "niuu.adapters.outbound.http_auth._DEFAULT_SERVICE_ACCOUNT_TOKEN_FILE",
+        "/nonexistent/serviceaccount/token",
+    )
+
+    adapter = WorkloadIdentityBearerTokenAuthAdapter(base_url="https://volundr.test")
+
+    assert adapter.headers() == {}

--- a/tests/test_ravn/test_personas/test_http.py
+++ b/tests/test_ravn/test_personas/test_http.py
@@ -365,15 +365,22 @@ class TestAuth:
         assert auth == "Bearer workload-jwt"
 
     @respx.mock
-    def test_no_auth_header_when_env_var_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_configured_but_missing_workload_token_is_not_sent_unauthenticated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Naming a token file that isn't mounted must not degrade to anonymous.
+
+        It used to: the request went out with no Authorization header and came
+        back 401, so the only evidence lived in the callee's logs.
+        """
         monkeypatch.delenv("NIUU_WORKLOAD_IDENTITY_TOKEN_FILE", raising=False)
         route = respx.get(f"{_BASE}/api/v1/personas/coder").mock(
             return_value=httpx.Response(200, json=_DETAIL_CODER)
         )
-        _adapter(workload_token_file="/tmp/definitely-missing-niuu-workload-token").load("coder")
+        adapter = _adapter(workload_token_file="/tmp/definitely-missing-niuu-workload-token")
 
-        assert route.calls.last is not None
-        assert "authorization" not in route.calls.last.request.headers
+        assert adapter.load("coder") is None
+        assert not route.calls
 
     @respx.mock
     def test_external_token_env_name_is_explicit(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What was broken

`WorkloadIdentityBearerTokenAuthAdapter` returned `{}` when the projected
serviceAccountToken volume named in config was not mounted. The request then
went out **unsigned**, the callee's Envoy sidecar answered 401, and the only
evidence of the fault lived on the far side of the call.

## What that cost, live

`valhalla` and `noatun` name `/var/run/secrets/niuu-workload/token` in every
Observatory service adapter but never mounted the volume (`ymir` does). Result,
from the callees' sidecar logs on valhalla:

| endpoint | status |
|---|---|
| `/api/v1/ravn/ravens` | 72 × **401** |
| `/api/v1/ting/runs/summary` | 70 × **401** |
| `/api/v1/bifrost/models` | 34 × **401** |

`ymir`, which mounts the volume, is 200 across the board. So those two clusters
contributed no residents, no meshes and no flock edges to the aggregate — with
**no warning in the Observatory's own logs**, because from its side the calls
"succeeded" at making a request.

## The fix

Naming a token file is asking for workload identity, so a file that isn't there
now raises, and `_HttpServiceDiscoveryAdapter.discover` turns that into a named
discovery warning instead of a silent 401 elsewhere.

Configuring nothing at all still stays quiet — a Ravn outside Kubernetes never
asked for workload identity, and failing it would be a regression. That
distinction is covered by tests in both directions.

The matching volume mounts for valhalla and noatun go in via GitOps in the
infrastructure repo.

## Verification

- `uv run --extra dev pytest -q` → 17824 passed, 0 failed
- `ruff check` clean, formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)