### PR TITLE
fix(ravn): bound the resident inbox with an archive and a coalescing queue

### DIFF
--- a/docs/ravn-resident-attention.md
+++ b/docs/ravn-resident-attention.md
@@ -1,0 +1,363 @@
+# Resident Attention
+
+Status: stages 1 and 2 implemented on `feat/resident-inbox-coalescing`. Stage 3
+remains a proposal.
+
+## Implementation status
+
+| Stage | State |
+|---|---|
+| 1 — subscription scope | Verified as a config-only change; see §3 |
+| 2 — archive and coalescing queue | Implemented for `LocalResidentInbox` |
+| 3 — learned attention | Not started; unchanged proposal |
+
+Two contract changes landed with stage 2 and are worth knowing before reading
+the rest:
+
+- **A slot's reference changes when it is judged**, because the record moves
+  from `pending/` to `processed/`. Reference resolution follows a judged slot,
+  so references held in older turn records still resolve.
+- **A payload that retypes a field is a different shape.** `progress: 99` and
+  `progress: 99.0` do not share a slot. This is the intended fail-open
+  behaviour — a schema change wakes the resident rather than folding away — but
+  it does mean an inconsistent producer creates more slots than expected.
+
+## 1. What is actually wrong
+
+Three separate statements, in order of how much they explain:
+
+1. **A telemetry stream is being fed into an attention queue.** Ivaldi receives
+   every tick of a machine reporting its own state — progress, temperature, task
+   phase. A print at 41%, 42%, 43% is state being *published*, not events that
+   happened. State should be read; events should be queued. The system currently
+   has only the queue, so everything goes there.
+2. **The queue is also the archive.** One markdown file per tick, retained
+   forever while unjudged, scanned on every write. 84,066 files.
+3. **Judgment is not reusable.** Ivaldi can conclude a family of observations is
+   routine and promote that as prose, but nothing turns it into behaviour.
+
+The first explains the volume, the second explains the IO and the growth, the
+third explains why it never recovers. They need different fixes and the first two
+do not need any learning system.
+
+## 2. The shape of the fix
+
+> **The archive is append-only and complete. The queue is coalescing and
+> bounded.**
+
+Every raw observation is written, forever, to a cheap append-only log that is
+never read on the hot path. The *queue* holds at most one slot per distinct
+observation shape per source. A new observation folds into its slot, updating a
+count and aggregates, until the resident looks at it.
+
+This is a coalescing queue — a standard, entirely domain-neutral data structure.
+It makes no claim about what any signal means. It only says: the resident has
+not looked at the previous observation of this shape yet, so it does not need a
+second queue slot.
+
+The property that makes it right: **it only collapses what the resident has not
+yet seen.** When the resident is keeping up, the coalescing rate is zero and
+nothing is collapsed. When it falls behind, the queue stays bounded instead of
+growing. The collapse rate is a direct measure of how far behind it is, which
+makes it a metric worth watching rather than a behaviour to be nervous about.
+
+## 3. Stage 1 — check what Ivaldi is subscribed to
+
+Config, not code. Hours, not weeks. Do this before anything else.
+
+**Verified:** `NatsJetStreamSignalAdapter.__init__` takes `subject` as a required
+constructor kwarg, and `EnvironmentSignalRuntime._build_adapter` passes
+`SignalSourceConfig.kwargs` straight through as `cls(**kwargs)`
+(`src/ravn/environment_signal_runtime.py:186-191`). Narrowing what a resident
+watches is a values-file change with no code involved.
+
+Ivaldi's deployed signal-source config is not in this repository, so the actual
+narrowing is an operator action against its values file.
+
+This is legitimate and is not the operator authoring a filtering rule. Two
+different things get conflated:
+
+- *"Temperature telemetry is unimportant"* — a claim about meaning. The
+  resident's call. Operators must not write this.
+- *"This resident is responsible for job lifecycle, not sensor telemetry"* — a
+  job description. The operator's call, always.
+
+A steward whose mandate is "everything the machine ever says" is misconfigured,
+and no amount of learned attention repairs a bad mandate.
+
+## 4. Stage 2 — archive and coalescing queue
+
+Scope: `LocalResidentInbox` and the resident-home selection path. The
+`ResidentInboxBackend` port is unchanged. Mimir is out of scope — it already
+throttles retention off the write path, and atomic rename is a local-filesystem
+operation that does not transfer to page semantics.
+
+### 4.1 Layout
+
+```
+resident/inbox/raw/YYYY-MM-DD.ndjson   append-only, complete, never on hot path
+resident/inbox/pending/<shape>.md      one coalescing slot per shape, bounded
+resident/inbox/processed/<...>.md      judged slots, normal retention
+```
+
+Date-partitioned NDJSON replaces one-file-per-tick: a single append per
+observation, no directory growth, no glob, no parse, trivially compressible and
+trivially greppable — which is what "raw evidence remains searchable" should
+have meant all along. 84,066 files become roughly one per day.
+
+### 4.2 Shape key
+
+Derived, never configured, never inferred from meaning:
+
+```
+shape = (source_id, kind, sorted field-path set, per-path value types)
+```
+
+Two observations share a slot only if they are structurally identical. A payload
+that gains, loses or retypes a field gets its own slot — so schema drift and
+novel structure surface immediately rather than being folded away.
+
+### 4.3 What a slot carries
+
+- `observation_count`, first and last observed time
+- first and last raw archive offsets (the exact range this slot covers)
+- per-numeric-path min/max
+- per-categorical-path distinct value set, up to a configured cardinality cap;
+  above the cap the path is recorded as high-cardinality with the cap noted
+- the newest full payload, plus the payloads at each numeric extreme
+
+Aggregates only summarize *within* an identical shape. They never merge across
+shapes and never decide relevance.
+
+### 4.4 Ingestion
+
+Append to the archive, then upsert the slot. No scan, no parse of other
+records, no lock held over a directory walk. Cost is independent of history size
+and of pending size.
+
+### 4.5 Acknowledgement
+
+Listing captures each slot's `last_offset`. Acknowledge is a compare-and-set:
+
+- unchanged since listing → move the slot to `processed/`;
+- advanced since listing → write a `processed/` record covering the judged
+  range, and rewrite the slot to cover only the newer delta.
+
+The resident therefore always acknowledges exactly what it saw, and observations
+that arrived mid-turn are never silently swallowed. No lease, no claim record,
+no expiry — the slot *is* the boundary.
+
+### 4.6 Selection, retention, invalid outcomes
+
+- Selection is oldest-slot-first, bounded; operator-directed messages bypass.
+  With a bounded queue, fairness is no longer an interesting problem.
+- Retention reads `processed/` only. It never opens a pending slot and **never
+  touches `raw/`** — that exclusion is an invariant with its own test, because
+  JetStream retains roughly two hours and the archive is the only surviving copy
+  of this history.
+- Invalid outcomes are *completed* turns, not failed enqueues. Count attempts in
+  the invalid-outcome completion path after the turn record is durable; on
+  exhaustion mark the slot `BLOCKED`, keep all evidence, and emit one bounded
+  operator notification. A metric alone is not enough — a slot that can never be
+  judged needs a human.
+
+### 4.7 Migrating the existing 84,066
+
+One-time, resumable, non-destructive, operator-invoked:
+
+1. Stream every existing file into the raw NDJSON archive in observed order.
+2. Rebuild slots from the archive; judged records go to `processed/`.
+3. Reconcile: every one of the 84,066 accounts for exactly one archive record.
+4. Only then remove the old flat files.
+
+The pending queue afterwards is a handful of slots, not 82,900 records — so
+there is no backlog to drain and no archive-versus-drain decision to make.
+
+### 4.8 Acceptance and tests
+
+- Write cost independent of archive and queue size at 100k observations.
+- Pending slot count bounded by distinct shapes, verified under sustained
+  ingress with no resident running.
+- Retention never opens a pending slot and never touches `raw/`, at any setting.
+- Acknowledge is exact under concurrent arrival (the compare-and-set case).
+- Schema change creates a new slot rather than folding.
+- High-cardinality categorical paths degrade to a marker, not unbounded growth.
+- Migration is resumable and reconciles every record; no file is deleted before
+  reconciliation succeeds.
+- Attempt bound triggers on invalid outcomes, not enqueue failures, and
+  escalates once.
+- Archive remains greppable after migration.
+
+## 5. Stage 3 — learned attention, with receipts
+
+Only after stage 2, and only if telemetry shows the resident repeatedly reaching
+the same conclusion about the same shapes.
+
+### 5.1 The design difference
+
+A matched slot is **not** suppressed silently. It does not create a turn, but its
+aggregate appears in a receipt block on the resident's *next* turn regardless:
+
+```
+Since you last thought:
+  pattern P (v3, expires in 4h): 3,412 observations across 2 shapes
+    progress 0–100, temperature 31.4–58.9, phases {heating, printing, cooling}
+    2 observations outside the pattern's ranges — payloads attached
+```
+
+The resident sees everything the pattern suppressed, in aggregate, every time it
+thinks. This is what makes the rest small:
+
+- **No shadow mode as a separate stage.** Replay plus a short expiry plus
+  receipts already gives live feedback from the first activation.
+- **No sampling machinery, no health floors.** Coverage is 100%, not a sampled
+  fraction. The failure mode both earlier designs spent the most machinery on —
+  a pattern destroying the evidence that would falsify it — cannot occur.
+- **Contradiction is ordinary judgment.** The resident reads a receipt and says
+  the range is wrong. That is the mechanism; there is no protocol.
+
+A pattern that misbehaves is visible in the next receipt, not in a dashboard
+nobody reads.
+
+### 5.2 Evaluation point
+
+Patterns are evaluated **per slot at selection time**, never per observation at
+ingestion. Coalescing has already done the volume work; the pattern only decides
+whether a bounded slot needs a turn. Fewer evaluations, richer input (the slot
+carries ranges and distributions), and nothing added to the ingestion path.
+
+### 5.3 Record
+
+Stored via the existing resident-state port, as a typed record beside
+`ResidentPolicyObservation` (which stays as it is).
+
+```
+pattern_id, version, matcher_hash
+resident_id, environment_id
+matcher
+expires_at                              # mandatory, bounded by config
+authored_by_case_id
+evidence_positive, evidence_negative
+observed_field_paths, observed_numeric_ranges
+retired_reason, blocked_matcher_hash
+```
+
+There is **no effect field** — not an enum with one value. The single possible
+consequence of an active pattern is that a matching slot does not create a turn.
+Counters live in metrics and receipts, never in the artifact.
+
+### 5.4 Matcher
+
+Operators: `equals`, `in`, `present`, `absent`, `numeric_between`, composed only
+by `all_of`. No regex, no free-text or summary matching, no `any_of`, no
+unbounded `not`, no expressions.
+
+Mandatory fail-open rules — any of these means *no match*, which means the
+resident wakes:
+
+1. Field paths must come from observed positive or negative evidence.
+2. An unknown incoming field path.
+3. A missing expected field.
+4. A type mismatch or parse failure.
+5. A numeric value outside the evidence-derived range. Because patterns match
+   slots, this tests the slot's min/max — a single excursion inside a bucket of
+   ten thousand normal readings still wakes the resident.
+6. Fields present only in counterexamples become mandatory absence constraints.
+7. Matcher size and depth are bounded.
+8. Transport metadata — event id, offsets, timestamps, trace context — is
+   excluded from the matchable document.
+9. Directed operator messages are structurally ineligible.
+
+Rule 5 is what keeps a temperature excursion from being swallowed. Rule 6 is
+what keeps `error` a wake condition without anyone writing down that errors
+matter.
+
+### 5.5 Lifecycle
+
+`active → retired`, plus expiry derived at evaluation time so no sweeper exists.
+Quarantine is retirement with a blocked matcher hash.
+
+- **Authoring:** post-session reflection, which is confirmed to process
+  resident-home sessions. The model authors matcher content only; Ravn owns
+  validation and enforcement.
+- **Validation:** replay against the archive. A candidate must match nothing the
+  resident acted on or escalated, and nothing in its own negative evidence.
+- **Activation:** short mandatory expiry. Renewal requires a fresh resident
+  judgment on a receipt, not a timer.
+- **Retirement:** immediate on contradiction, with the matcher hash blocked so
+  the same matcher cannot be re-proposed unchanged.
+
+### 5.6 Tests
+
+Operator truth tables; every fail-open rule; a single out-of-range observation
+inside a large matching slot still wakes the resident; negative evidence never
+matches; stable serialization hash; complexity limits reject oversized matchers;
+the type cannot express an action or authority change; expiry is lazy;
+contradiction retires within one turn; a retired hash cannot be recreated;
+**every suppressed slot appears in the next turn's receipt**; the existing
+stewardship wake still fires under total suppression.
+
+Replay fixture from the archive: routine observations, task transitions, schema
+differences, temperature boundaries, error and anomaly examples, and existing
+ignore / non-ignore judgments.
+
+## 6. Where judgment lives
+
+The model authors matcher content, from its own prior judgments, and nothing
+else. Runtime code owns coalescing, evaluation, fail-open rules and expiry — all
+domain-neutral mechanism. Operators choose what a resident watches; they author
+no rule about what any signal means. No file in the tree should contain a
+sentence resembling "status signals are routine."
+
+Placement: a pure evaluator in Ravn above the inbox adapter. Nothing in
+`LocalResidentInbox`, `MimirResidentInbox`, Niuu, Skuld or Volundr. Storage
+adapters persist outcomes; they do not decide attention.
+`ResidentLearningRuntime` does not install these as skills.
+
+## 7. Not doing now
+
+- **Broker-side last-value-per-subject.** JetStream can collapse state streams
+  before Ravn sees them (`max_msgs_per_subject`, or a KV bucket). It is the
+  cheapest possible version of this and remains worth doing — but it needs the
+  producer and the stream config to change, so it complements agent-side
+  coalescing rather than replacing it. Agent-side works for every source
+  regardless of what its producer can do.
+- **A nano-tier triage model.** Attention triage is a far smaller decision than
+  resident judgment; a nano model or embedding check could consider every slot
+  cheaply and escalate only on novelty. More in the spirit of "Ravn owns
+  judgment" than a frozen matcher, but it is a bigger change and stage 2 may
+  make it unnecessary.
+- Matcher language beyond the six operators; cross-resident or Flock sharing; a
+  policy service, installer or registry; new APIs or dashboards; a judgment
+  database; queue leases; multiple pattern effects; authorization integration.
+- `classify.py` is an existing hand-written keyword table mapping domain terms to
+  classifications. Out of scope, but do not extend it.
+
+## 8. Risks
+
+- **Coalescing hides a transition between two routine observations.** Mitigated
+  structurally: a differing field-path set never folds, numeric extremes keep
+  their full payloads, and the raw archive keeps everything. Worth an explicit
+  test against real Ivaldi transitions.
+- **Archive loss.** `raw/` is the only surviving copy — JetStream holds ~2h.
+  Every retention path must exclude it, by construction rather than by config.
+- **A >2h Ravn outage loses raw signals outright**, since JetStream is the only
+  upstream buffer at 32 MiB. Out of scope here; raise it with whoever owns the
+  stream configuration.
+- **Homogeneous evidence.** Many near-identical observations are not many
+  independent ones. Rules 5 and 6, plus requiring evidence across distinct cases
+  and time windows before synthesis.
+
+## 9. Verified facts
+
+- Ivaldi uses `LocalResidentInbox`.
+- 84,066 signal files; ~1,200 `remembered`.
+- Eitri wakes with 50 signals per turn.
+- Laevateinn payloads carry no explicit event id, so the generic adapter falls
+  back to hashing the full changing payload — every tick becomes unique.
+- Post-session reflection does process resident-home sessions.
+- JetStream is capped at 32 MiB, retaining roughly two hours at observed rate.
+- `MimirResidentInbox` already throttles retention off the write path;
+  `LocalResidentInbox` sweeps synchronously on every write.
+- `SignalSourceConfig.kwargs` passes `subject` to the NATS adapter, so
+  subscription scope is already configurable.

--- a/src/ravn/cli/commands.py
+++ b/src/ravn/cli/commands.py
@@ -1044,6 +1044,42 @@ def approvals_revoke(
 
 
 # ---------------------------------------------------------------------------
+# Resident inbox maintenance
+# ---------------------------------------------------------------------------
+
+
+@app.command("inbox-migrate")
+def inbox_migrate(
+    root: str = typer.Argument(help="Resident inbox root directory to migrate."),
+) -> None:
+    """Move flat resident inbox signal files into the archive and slot queue.
+
+    One-time, resumable and non-destructive: each record is archived and re-filed
+    before its original file is removed, so an interrupted run simply resumes.
+    Reports counts so the operator can reconcile before and after.
+    """
+    import asyncio  # noqa: PLC0415
+
+    from ravn.resident_inbox import LocalResidentInbox  # noqa: PLC0415
+
+    inbox = LocalResidentInbox(root)
+    counts = asyncio.run(inbox.migrate_flat_layout())
+    archived = inbox.archive.count()
+    typer.echo(f"read       : {counts['read']}")
+    typer.echo(f"archived   : {counts['archived']}")
+    typer.echo(f"  pending  : {counts['pending']}")
+    typer.echo(f"  processed: {counts['processed']}")
+    typer.echo(f"unreadable : {counts['unreadable']}")
+    typer.echo(f"archive records now: {archived}")
+    if counts["unreadable"]:
+        typer.echo(
+            f"{counts['unreadable']} file(s) could not be parsed and were left in place.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+
+# ---------------------------------------------------------------------------
 # Resume CLI (NIU-537)
 # ---------------------------------------------------------------------------
 

--- a/src/ravn/cli/resident_runtime_wiring.py
+++ b/src/ravn/cli/resident_runtime_wiring.py
@@ -128,6 +128,14 @@ def _build_resident_inbox(
             "retention_sweep_interval_seconds",
             cfg.signal_retention_sweep_interval_seconds,
         )
+    for name, value in (
+        ("max_distinct_values", cfg.signal_max_distinct_values),
+        ("max_extreme_payloads", cfg.signal_max_extreme_payloads),
+        ("max_invalid_attempts", cfg.signal_max_invalid_attempts),
+        ("pending_slot_warn_threshold", cfg.signal_pending_slot_warn_threshold),
+    ):
+        if name in params:
+            kwargs.setdefault(name, value)
     return cls(**kwargs)
 
 

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -2922,6 +2922,37 @@ class ResidentInboxConfig(BaseModel):
             "how often the signals directory is rescanned."
         ),
     )
+    signal_max_distinct_values: int = Field(
+        default=24,
+        description=(
+            "Distinct values a coalescing slot keeps per categorical field path. "
+            "Above this the path is recorded as high-cardinality instead of "
+            "growing without bound."
+        ),
+    )
+    signal_max_extreme_payloads: int = Field(
+        default=16,
+        description=(
+            "Full payloads a coalescing slot keeps at numeric extremes, so an "
+            "excursion is never summarised away. Bounds slot size."
+        ),
+    )
+    signal_max_invalid_attempts: int = Field(
+        default=3,
+        description=(
+            "Invalid resident outcomes tolerated for one observation slot before "
+            "it is marked blocked and escalated. Stops a slot no turn can judge "
+            "from being retried forever."
+        ),
+    )
+    signal_pending_slot_warn_threshold: int = Field(
+        default=200,
+        description=(
+            "Pending shape slots above which the inbox warns once. A large count "
+            "means a source is emitting variable field names, which defeats "
+            "coalescing and lets the queue grow with volume."
+        ),
+    )
 
 
 class ResidentStateConfig(BaseModel):

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -382,6 +382,10 @@ class AgentTask:
     resident_started_at: str = ""
     resident_parent_turn_ref: str = ""
     resident_inbox_refs: list[str] = field(default_factory=list)
+    #: Archive reference each inbox slot carried when this task was built. The
+    #: inbox acknowledges against it so observations that arrive mid-turn stay
+    #: pending instead of being acknowledged unseen.
+    resident_inbox_expected: dict[str, str] = field(default_factory=dict)
     resident_answer_ref: str = ""
     resident_wake_ref: str = ""
     resident_help_published: bool = False

--- a/src/ravn/resident_inbox/__init__.py
+++ b/src/ravn/resident_inbox/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .archive import RawSignalArchive, archive_ref_sort_key
 from .backend import LocalResidentInbox, MimirResidentInbox
 from .classify import classify_text
 from .models import (
@@ -20,10 +21,17 @@ from .serialization import (
     signal_from_directed_message,
     signal_from_event,
 )
+from .shape import ShapeAggregate, aggregate_summary_lines, field_paths, shape_key
 
 __all__ = [
     "MimirResidentInbox",
     "LocalResidentInbox",
+    "RawSignalArchive",
+    "ShapeAggregate",
+    "aggregate_summary_lines",
+    "archive_ref_sort_key",
+    "field_paths",
+    "shape_key",
     "ResidentInboxBackend",
     "ResidentInboxClassification",
     "ResidentInboxConfig",

--- a/src/ravn/resident_inbox/archive.py
+++ b/src/ravn/resident_inbox/archive.py
@@ -1,0 +1,163 @@
+"""Append-only raw observation archive for the resident inbox.
+
+Every observation the resident receives is appended here before any queue work
+happens, and nothing ever deletes from it.  The archive is date-partitioned
+NDJSON: one append per observation, no directory growth, no parse on the write
+path, and plain text that stays greppable for research.
+
+The queue upstream of this is *coalescing* — many observations can share one
+pending slot.  That is only safe because this archive keeps every one of them,
+so a slot's aggregate is a summary of durable records rather than a replacement
+for them.
+
+References are ``YYYY-MM-DD:<byte offset>``.  They sort monotonically in arrival
+order and address the exact line, so a slot can name the precise range of raw
+records it covers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ARCHIVE_PREFIX = "resident/inbox/raw"
+
+#: Sorts before every real reference, for callers with nothing acknowledged yet.
+EMPTY_ARCHIVE_REF = ""
+
+
+def archive_ref_sort_key(ref: str) -> tuple[str, int]:
+    """Order references by arrival.
+
+    Malformed references sort *before* every real one, deliberately.  The key
+    decides how much of a slot a caller has already judged, and treating an
+    unreadable reference as "judged nothing" leaves observations pending.  The
+    opposite default would acknowledge observations the resident never saw.
+    """
+    date, _, offset = str(ref or "").partition(":")
+    try:
+        return (date, int(offset))
+    except ValueError:
+        return ("", -1)
+
+
+class RawSignalArchive:
+    """Date-partitioned append-only NDJSON log of raw observations."""
+
+    def __init__(self, root: Path | str, *, prefix: str = ARCHIVE_PREFIX) -> None:
+        self._root = Path(root).expanduser().resolve()
+        self._prefix = prefix.strip("/").strip() or ARCHIVE_PREFIX
+
+    @property
+    def directory(self) -> Path:
+        return self._root / self._prefix
+
+    def append(self, record: dict[str, Any], *, arrived_at: datetime | None = None) -> str:
+        """Append one record and return its reference.
+
+        Partitioning uses *arrival* time, not the observation's own timestamp: a
+        late-arriving observation must still append at the end of the log, or
+        references would stop being monotonic.
+        """
+        moment = arrived_at or datetime.now(UTC)
+        path = self.directory / f"{moment.strftime('%Y-%m-%d')}.ndjson"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(
+            {"archived_at": moment.isoformat(), **record},
+            sort_keys=True,
+            default=str,
+            ensure_ascii=False,
+        )
+        offset = path.stat().st_size if path.exists() else 0
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line + "\n")
+        return f"{moment.strftime('%Y-%m-%d')}:{offset}"
+
+    def read(self, ref: str) -> dict[str, Any] | None:
+        """Return the archived record at ``ref``, or None when unreadable."""
+        date, _, offset = str(ref or "").partition(":")
+        if not date or not offset.isdigit():
+            return None
+        path = self.directory / f"{date}.ndjson"
+        if not path.is_file():
+            return None
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                handle.seek(int(offset))
+                line = handle.readline()
+        except OSError:
+            logger.warning("resident inbox archive: unreadable reference %s", ref, exc_info=True)
+            return None
+        if not line.strip():
+            return None
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            logger.warning("resident inbox archive: malformed record at %s", ref)
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    def read_range(
+        self,
+        *,
+        after: str,
+        through: str,
+        limit: int,
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Return records with ``after < ref <= through``, oldest first.
+
+        Used when a slot advanced while the resident was judging it: the delta
+        is rebuilt from durable records rather than guessed from the aggregate.
+        """
+        if limit <= 0:
+            return []
+        low = archive_ref_sort_key(after) if after else ("", -1)
+        high = archive_ref_sort_key(through)
+        directory = self.directory
+        if not directory.is_dir():
+            return []
+        collected: list[tuple[str, dict[str, Any]]] = []
+        for path in sorted(directory.glob("*.ndjson")):
+            date = path.stem
+            if date < low[0] or date > high[0]:
+                continue
+            offset = 0
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    for line in handle:
+                        ref = f"{date}:{offset}"
+                        offset += len(line.encode("utf-8"))
+                        key = archive_ref_sort_key(ref)
+                        if key <= low or key > high:
+                            continue
+                        try:
+                            parsed = json.loads(line)
+                        except json.JSONDecodeError:
+                            logger.warning("resident inbox archive: malformed record at %s", ref)
+                            continue
+                        if isinstance(parsed, dict):
+                            collected.append((ref, parsed))
+                        if len(collected) >= limit:
+                            return collected
+            except OSError:
+                logger.warning(
+                    "resident inbox archive: unreadable partition %s", path, exc_info=True
+                )
+                continue
+        return collected
+
+    def count(self) -> int:
+        """Total archived records. Reconciliation only — never on the hot path."""
+        directory = self.directory
+        if not directory.is_dir():
+            return 0
+        total = 0
+        for path in sorted(directory.glob("*.ndjson")):
+            with path.open("r", encoding="utf-8") as handle:
+                total += sum(1 for line in handle if line.strip())
+        return total

--- a/src/ravn/resident_inbox/archive.py
+++ b/src/ravn/resident_inbox/archive.py
@@ -108,11 +108,18 @@ class RawSignalArchive:
         after: str,
         through: str,
         limit: int,
+        shape_key: str = "",
     ) -> list[tuple[str, dict[str, Any]]]:
         """Return records with ``after < ref <= through``, oldest first.
 
         Used when a slot advanced while the resident was judging it: the delta
         is rebuilt from durable records rather than guessed from the aggregate.
+
+        ``shape_key`` restricts the result *before* ``limit`` applies.  Without
+        it, a burst of unrelated observations inside the same range would fill
+        the limit and truncate the caller's own tail — which would acknowledge
+        observations the resident never saw.  Records that predate shape
+        tracking carry no key and are always returned for the caller to judge.
         """
         if limit <= 0:
             return []
@@ -140,8 +147,11 @@ class RawSignalArchive:
                         except json.JSONDecodeError:
                             logger.warning("resident inbox archive: malformed record at %s", ref)
                             continue
-                        if isinstance(parsed, dict):
-                            collected.append((ref, parsed))
+                        if not isinstance(parsed, dict):
+                            continue
+                        if shape_key and str(parsed.get("shape_key") or shape_key) != shape_key:
+                            continue
+                        collected.append((ref, parsed))
                         if len(collected) >= limit:
                             return collected
             except OSError:

--- a/src/ravn/resident_inbox/backend.py
+++ b/src/ravn/resident_inbox/backend.py
@@ -139,9 +139,7 @@ class LocalResidentInbox(ResidentInboxBackend):
         # decision, so a coalesced slot always summarises records that exist.
         identity = _slot_identity(signal)
         key = _shape_of(signal)
-        archive_ref = self._archive.append(
-            {"shape_key": key, "signal": _signal_to_dict(signal)}
-        )
+        archive_ref = self._archive.append({"shape_key": key, "signal": _signal_to_dict(signal)})
 
         if signal.status != ResidentInboxStatus.NEW.value:
             # Already-judged records are history, not queue work.
@@ -354,6 +352,7 @@ class LocalResidentInbox(ResidentInboxBackend):
             after=judged_through,
             through=slot.last_archive_ref,
             limit=max(1, slot.observation_count),
+            shape_key=slot.shape_key,
         )
         rebuilt: ResidentInboxSignal | None = None
         for archive_ref, record in records:

--- a/src/ravn/resident_inbox/backend.py
+++ b/src/ravn/resident_inbox/backend.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -14,10 +15,14 @@ from ravn.ports.mimir import MimirPort
 from ravn.resident_text import slug as _slug
 from ravn.resident_text import timestamp_slug
 
+from .archive import ARCHIVE_PREFIX, RawSignalArchive, archive_ref_sort_key
 from .models import (
     _INBOX_DECISION_PREFIX,
+    _INBOX_PENDING_PREFIX,
+    _INBOX_PROCESSED_PREFIX,
     _INBOX_SIGNAL_PREFIX,
     _INBOX_TRIAGE_PREFIX,
+    _OPERATOR_DIRECTED_MESSAGE_KIND,
     ResidentInboxBackend,
     ResidentInboxSignal,
     ResidentInboxStatus,
@@ -25,21 +30,43 @@ from .models import (
 )
 from .serialization import (
     _signal_filename,
+    _signal_from_dict,
+    _signal_to_dict,
     parse_inbox_signal,
     render_inbox_signal,
     render_inbox_triage,
     signal_from_directed_message,
     signal_from_event,
 )
+from .shape import ShapeAggregate, fold_aggregate, shape_key
 
 logger = logging.getLogger(__name__)
 
 
 class LocalResidentInbox(ResidentInboxBackend):
-    """Durable filesystem inbox for residents that do not use Mimir.
+    """Durable filesystem inbox with an append-only archive and a bounded queue.
 
-    References deliberately use the same ``resident/inbox/...`` namespace as
-    the Mimir adapter.  The runtime therefore depends only on
+    Two stores with different jobs:
+
+    ``raw/``
+        Append-only NDJSON of every observation ever received.  Nothing deletes
+        from it and nothing reads it on the write path.  It is the durable
+        evidence the queue's aggregates summarise.
+
+    ``pending/`` and ``processed/``
+        The operational queue.  ``pending/`` holds at most one *slot* per
+        structural shape: a further observation of a shape the resident has not
+        looked at yet folds into the existing slot instead of taking another
+        queue position.  Judged slots move to ``processed/`` and become subject
+        to retention.
+
+    Coalescing only ever merges observations the resident has not yet seen, so
+    when the resident is keeping up nothing is coalesced at all.  The collapse
+    rate measures how far behind it is; it never decides that anything is
+    unimportant.
+
+    References deliberately use the same ``resident/inbox/...`` namespace as the
+    Mimir adapter.  The runtime therefore depends only on
     :class:`ResidentInboxBackend`; choosing local files or Mimir is composition
     configuration, not resident behavior.
     """
@@ -49,18 +76,43 @@ class LocalResidentInbox(ResidentInboxBackend):
         root: Path | str,
         *,
         signal_prefix: str = _INBOX_SIGNAL_PREFIX,
+        pending_prefix: str = _INBOX_PENDING_PREFIX,
+        processed_prefix: str = _INBOX_PROCESSED_PREFIX,
+        archive_prefix: str = ARCHIVE_PREFIX,
         triage_prefix: str = _INBOX_TRIAGE_PREFIX,
         decision_prefix: str = _INBOX_DECISION_PREFIX,
         retention_max_pages: int = 500,
         retention_max_age_days: float = 7.0,
+        retention_sweep_interval_seconds: float = 900.0,
+        max_distinct_values: int = 24,
+        max_extreme_payloads: int = 16,
+        max_invalid_attempts: int = 3,
+        pending_slot_warn_threshold: int = 200,
     ) -> None:
         self._root = Path(root).expanduser().resolve()
         self._signal_prefix = signal_prefix.strip("/").strip() or _INBOX_SIGNAL_PREFIX
+        self._pending_prefix = pending_prefix.strip("/").strip() or _INBOX_PENDING_PREFIX
+        self._processed_prefix = processed_prefix.strip("/").strip() or _INBOX_PROCESSED_PREFIX
         self._triage_prefix = triage_prefix.strip("/").strip() or _INBOX_TRIAGE_PREFIX
         self._decision_prefix = decision_prefix.strip("/").strip() or _INBOX_DECISION_PREFIX
         self._retention_max_pages = max(0, int(retention_max_pages))
         self._retention_max_age_days = max(0.0, float(retention_max_age_days))
+        self._retention_sweep_interval_seconds = max(0.0, float(retention_sweep_interval_seconds))
+        self._max_distinct_values = max(1, int(max_distinct_values))
+        self._max_extreme_payloads = max(1, int(max_extreme_payloads))
+        self._max_invalid_attempts = max(1, int(max_invalid_attempts))
+        self._pending_slot_warn_threshold = max(1, int(pending_slot_warn_threshold))
+        self._archive = RawSignalArchive(self._root, prefix=archive_prefix)
+        self._last_retention_sweep: float | None = None
+        self._warned_pending_slots = False
         self._lock = asyncio.Lock()
+
+    @property
+    def archive(self) -> RawSignalArchive:
+        """The append-only record of every observation this inbox received."""
+        return self._archive
+
+    # -- intake ---------------------------------------------------------
 
     async def write_event(self, event: Any) -> str:
         return await self.write_signal(signal_from_event(event))
@@ -77,23 +129,105 @@ class LocalResidentInbox(ResidentInboxBackend):
         )
 
     async def write_signal(self, signal: ResidentInboxSignal) -> str:
-        ref = f"{self._signal_prefix}/{_signal_filename(signal)}"
         async with self._lock:
-            await asyncio.to_thread(self._write_signal_sync, ref, signal)
-            await asyncio.to_thread(self._prune_signals_sync)
+            ref = await asyncio.to_thread(self._write_signal_sync, signal)
+        await self._maybe_prune_signals()
         return ref
 
-    def _write_signal_sync(self, ref: str, signal: ResidentInboxSignal) -> None:
+    def _write_signal_sync(self, signal: ResidentInboxSignal) -> str:
+        # Durability first: the observation is archived before any queue
+        # decision, so a coalesced slot always summarises records that exist.
+        identity = _slot_identity(signal)
+        key = _shape_of(signal)
+        archive_ref = self._archive.append(
+            {"shape_key": key, "signal": _signal_to_dict(signal)}
+        )
+
+        if signal.status != ResidentInboxStatus.NEW.value:
+            # Already-judged records are history, not queue work.
+            ref = f"{self._processed_prefix}/{_signal_filename(signal)}"
+            self._atomic_write(
+                self._path(ref),
+                render_inbox_signal(
+                    signal.with_updates(
+                        first_archive_ref=archive_ref,
+                        last_archive_ref=archive_ref,
+                        first_observed_at=signal.observed_at,
+                    )
+                ),
+            )
+            return ref
+
+        ref = f"{self._pending_prefix}/{key}.md"
         path = self._path(ref)
-        if path.exists():
+
+        if identity:
+            # Identity-scoped slots (directed operator messages) dedupe by
+            # identity rather than coalescing: a replayed message is the same
+            # message, and an already-judged one must not be resurrected.
+            judged = self._find_processed_slot(key)
+            if judged is not None:
+                return judged
+
+        existing = None
+        if path.is_file():
             existing = parse_inbox_signal(path.read_text(encoding="utf-8"))
-            if (
-                existing is not None
-                and existing.status != ResidentInboxStatus.NEW.value
-                and signal.status == ResidentInboxStatus.NEW.value
-            ):
-                return
-        self._atomic_write(path, render_inbox_signal(signal))
+        slot = self._fold_slot(existing, signal, archive_ref, shape=key)
+        self._atomic_write(path, render_inbox_signal(slot))
+        if existing is None:
+            # Only a brand new shape can grow the queue, so this is the only
+            # write that needs to count slots. Folding writes stay O(1).
+            self._warn_on_unbounded_shapes()
+        return ref
+
+    def _fold_slot(
+        self,
+        existing: ResidentInboxSignal | None,
+        signal: ResidentInboxSignal,
+        archive_ref: str,
+        *,
+        shape: str,
+    ) -> ResidentInboxSignal:
+        observed_at = signal.observed_at or signal.created_at.isoformat()
+        if existing is None:
+            return signal.with_updates(
+                shape_key=shape,
+                observation_count=1,
+                first_archive_ref=archive_ref,
+                last_archive_ref=archive_ref,
+                first_observed_at=observed_at,
+                observed_at=observed_at,
+                aggregate=fold_aggregate(
+                    ShapeAggregate(),
+                    signal.payload,
+                    max_distinct_values=self._max_distinct_values,
+                    max_extreme_payloads=self._max_extreme_payloads,
+                ),
+            )
+        # The newest observation becomes the slot's face; the aggregate carries
+        # everything the earlier ones varied by, so nothing is lost by showing
+        # the resident the most recent payload.
+        return existing.with_updates(
+            summary=signal.summary,
+            payload=signal.payload,
+            trace_context=signal.trace_context or existing.trace_context,
+            raw_ref=signal.raw_ref or existing.raw_ref,
+            classification=signal.classification,
+            confidence=signal.confidence,
+            reason=signal.reason,
+            observed_at=observed_at,
+            shape_key=shape,
+            observation_count=existing.observation_count + 1,
+            last_archive_ref=archive_ref,
+            aggregate=fold_aggregate(
+                existing.aggregate,
+                signal.payload,
+                max_distinct_values=self._max_distinct_values,
+                max_extreme_payloads=self._max_extreme_payloads,
+            ),
+        )
+
+    # -- selection ------------------------------------------------------
 
     async def list_signals(
         self,
@@ -111,18 +245,175 @@ class LocalResidentInbox(ResidentInboxBackend):
     ) -> list[tuple[str, ResidentInboxSignal]]:
         if limit == 0:
             return []
-        directory = self._path(self._signal_prefix)
+        wants_pending = not status or status == ResidentInboxStatus.NEW.value
+        wants_processed = not status or status != ResidentInboxStatus.NEW.value
+        items: list[tuple[str, ResidentInboxSignal]] = []
+
+        if wants_pending:
+            # Oldest-first: a slot that has been waiting longest is served
+            # first, so nothing starves behind newer arrivals. The queue is
+            # bounded by distinct shapes, so reading every slot stays cheap.
+            slots = self._read_directory(self._pending_prefix, status="")
+            slots.sort(key=lambda row: (row[1].first_observed_at, row[0]))
+            items.extend(slots)
+
+        if wants_processed and len(items) < limit:
+            processed = self._read_directory(self._processed_prefix, status=status, newest=True)
+            items.extend(processed)
+
+        return items[:limit]
+
+    def _read_directory(
+        self,
+        prefix: str,
+        *,
+        status: str,
+        newest: bool = False,
+    ) -> list[tuple[str, ResidentInboxSignal]]:
+        directory = self._path(prefix)
         if not directory.is_dir():
             return []
-        items: list[tuple[str, ResidentInboxSignal]] = []
-        for path in sorted(directory.glob("*.md"), reverse=True):
+        rows: list[tuple[str, ResidentInboxSignal]] = []
+        for path in sorted(directory.glob("*.md"), reverse=newest):
             signal = parse_inbox_signal(path.read_text(encoding="utf-8"))
             if signal is None or (status and signal.status != status):
                 continue
-            items.append((str(path.relative_to(self._root)), signal))
-            if len(items) >= limit:
-                break
-        return items
+            rows.append((str(path.relative_to(self._root)), signal))
+        return rows
+
+    # -- judgment -------------------------------------------------------
+
+    async def acknowledge(
+        self,
+        refs: tuple[str, ...],
+        *,
+        status: str = ResidentInboxStatus.REMEMBERED.value,
+        reason: str = "resident turn recorded",
+        expected: Mapping[str, str] | None = None,
+    ) -> tuple[str, ...]:
+        async with self._lock:
+            acknowledged = await asyncio.to_thread(
+                self._acknowledge_sync, refs, status, reason, dict(expected or {})
+            )
+        await self._maybe_prune_signals()
+        return acknowledged
+
+    def _acknowledge_sync(
+        self,
+        refs: tuple[str, ...],
+        status: str,
+        reason: str,
+        expected: dict[str, str],
+    ) -> tuple[str, ...]:
+        acknowledged: list[str] = []
+        processed_at = datetime.now(UTC)
+        for ref in refs:
+            path = self._resolve_ref(ref)
+            if path is None or not path.is_file():
+                continue
+            signal = parse_inbox_signal(path.read_text(encoding="utf-8"))
+            if signal is None:
+                continue
+            if signal.status != ResidentInboxStatus.NEW.value:
+                # Already judged: acknowledging twice is a no-op, not an error.
+                acknowledged.append(ref)
+                continue
+            judged_through = expected.get(ref, signal.last_archive_ref)
+            remainder = self._pending_remainder(signal, judged_through)
+            judged = signal.with_updates(
+                status=status,
+                reason=reason or signal.reason,
+                processed_at=processed_at,
+                last_archive_ref=judged_through,
+                observation_count=max(1, signal.observation_count - _count(remainder)),
+            )
+            self._atomic_write(
+                self._path(f"{self._processed_prefix}/{_slot_filename(judged)}"),
+                render_inbox_signal(judged),
+            )
+            if remainder is None:
+                path.unlink(missing_ok=True)
+            else:
+                # Observations that arrived while the resident was judging stay
+                # pending. It never acknowledges what it did not see.
+                self._atomic_write(path, render_inbox_signal(remainder))
+            acknowledged.append(ref)
+        return tuple(acknowledged)
+
+    def _pending_remainder(
+        self,
+        slot: ResidentInboxSignal,
+        judged_through: str,
+    ) -> ResidentInboxSignal | None:
+        """Rebuild the un-judged tail of a slot from durable archive records."""
+        if not judged_through or judged_through == slot.last_archive_ref:
+            return None
+        if archive_ref_sort_key(judged_through) >= archive_ref_sort_key(slot.last_archive_ref):
+            return None
+        records = self._archive.read_range(
+            after=judged_through,
+            through=slot.last_archive_ref,
+            limit=max(1, slot.observation_count),
+        )
+        rebuilt: ResidentInboxSignal | None = None
+        for archive_ref, record in records:
+            payload = record.get("signal")
+            if not isinstance(payload, dict):
+                continue
+            observation = _signal_from_dict(payload)
+            # Recomputed, never trusted from the record: the archive interleaves
+            # every shape, and only this slot's own observations may fold back in.
+            if _shape_of(observation) != slot.shape_key:
+                continue
+            rebuilt = self._fold_slot(rebuilt, observation, archive_ref, shape=slot.shape_key)
+        return rebuilt
+
+    async def record_failed_attempt(
+        self,
+        refs: tuple[str, ...],
+        *,
+        reason: str,
+    ) -> tuple[str, ...]:
+        async with self._lock:
+            return await asyncio.to_thread(self._record_failed_attempt_sync, refs, reason)
+
+    def _record_failed_attempt_sync(
+        self,
+        refs: tuple[str, ...],
+        reason: str,
+    ) -> tuple[str, ...]:
+        blocked: list[str] = []
+        processed_at = datetime.now(UTC)
+        for ref in refs:
+            path = self._resolve_ref(ref)
+            if path is None or not path.is_file():
+                continue
+            signal = parse_inbox_signal(path.read_text(encoding="utf-8"))
+            if signal is None or signal.status != ResidentInboxStatus.NEW.value:
+                continue
+            attempts = signal.attempts + 1
+            if attempts < self._max_invalid_attempts:
+                self._atomic_write(
+                    path, render_inbox_signal(signal.with_updates(attempts=attempts))
+                )
+                continue
+            # No resident turn has been able to judge this slot. Stop retrying
+            # and make it visible to a human instead of looping forever.
+            stuck = signal.with_updates(
+                status=ResidentInboxStatus.BLOCKED.value,
+                attempts=attempts,
+                reason=reason,
+                processed_at=processed_at,
+            )
+            self._atomic_write(
+                self._path(f"{self._processed_prefix}/{_slot_filename(stuck)}"),
+                render_inbox_signal(stuck),
+            )
+            path.unlink(missing_ok=True)
+            blocked.append(ref)
+        return tuple(blocked)
+
+    # -- records --------------------------------------------------------
 
     async def write_triage(self, triage: ResidentInboxTriage) -> str:
         stamp = timestamp_slug(triage.created_at)
@@ -146,79 +437,53 @@ class LocalResidentInbox(ResidentInboxBackend):
             )
         return ref
 
-    async def acknowledge(
-        self,
-        refs: tuple[str, ...],
-        *,
-        status: str = ResidentInboxStatus.REMEMBERED.value,
-        reason: str = "resident turn recorded",
-    ) -> tuple[str, ...]:
-        async with self._lock:
-            return await asyncio.to_thread(self._acknowledge_sync, refs, status, reason)
+    # -- retention ------------------------------------------------------
 
-    def _acknowledge_sync(
-        self,
-        refs: tuple[str, ...],
-        status: str,
-        reason: str,
-    ) -> tuple[str, ...]:
-        acknowledged: list[str] = []
-        processed_at = datetime.now(UTC)
-        for ref in refs:
-            if not ref.startswith(f"{self._signal_prefix}/"):
-                continue
-            path = self._path(ref)
-            if not path.is_file():
-                continue
-            signal = parse_inbox_signal(path.read_text(encoding="utf-8"))
-            if signal is None:
-                continue
-            self._atomic_write(
-                path,
-                render_inbox_signal(
-                    signal.with_updates(
-                        status=status,
-                        reason=reason or signal.reason,
-                        processed_at=processed_at,
-                    )
-                ),
-            )
-            acknowledged.append(ref)
-        return tuple(acknowledged)
+    async def _maybe_prune_signals(self) -> None:
+        """Sweep when one is due. Never on the write path, never blocking."""
+        if self._retention_max_pages <= 0 and self._retention_max_age_days <= 0:
+            return
+        now = time.monotonic()
+        if (
+            self._last_retention_sweep is not None
+            and now - self._last_retention_sweep < self._retention_sweep_interval_seconds
+        ):
+            return
+        self._last_retention_sweep = now
+        try:
+            await self.prune_signals()
+        except Exception:
+            logger.warning("resident inbox: retention sweep failed", exc_info=True)
 
     async def prune_signals(self) -> int:
         async with self._lock:
-            return await asyncio.to_thread(self._prune_signals_sync)
+            return await asyncio.to_thread(self._prune_processed_sync)
 
-    def _prune_signals_sync(self) -> int:
-        directory = self._path(self._signal_prefix)
+    def _prune_processed_sync(self) -> int:
+        """Delete judged records beyond the retention policy; return the count.
+
+        Only ``processed/`` is considered.  Pending slots are delivery state and
+        the raw archive is the only surviving copy of the history, so neither is
+        ever eligible — this is enforced by which directory is walked, not by a
+        status check that a future edit could weaken.
+        """
+        directory = self._path(self._processed_prefix)
         if not directory.is_dir():
             return 0
-        protected: list[tuple[float, Path]] = []
-        processed: list[tuple[float, Path]] = []
+        records: list[tuple[float, Path]] = []
         for path in directory.glob("*.md"):
             try:
-                entry = (path.stat().st_mtime, path)
-                signal = parse_inbox_signal(path.read_text(encoding="utf-8"))
+                records.append((path.stat().st_mtime, path))
             except OSError:
                 continue
-            if signal is None or signal.status == ResidentInboxStatus.NEW.value:
-                protected.append(entry)
-            else:
-                processed.append(entry)
         doomed: set[Path] = set()
         if self._retention_max_age_days > 0:
             cutoff = time.time() - self._retention_max_age_days * 86400
-            doomed.update(path for mtime, path in processed if mtime < cutoff)
-        retained = [(mtime, path) for mtime, path in processed if path not in doomed]
-        if self._retention_max_pages > 0:
-            # The cap is best-effort while NEW or unreadable records exist. They
-            # are delivery state, not history, and must never disappear merely
-            # because a resident is slow or unavailable.
-            processed_budget = max(0, self._retention_max_pages - len(protected))
-            if len(retained) > processed_budget:
-                retained.sort(key=lambda item: item[0], reverse=True)
-                doomed.update(path for _mtime, path in retained[processed_budget:])
+            doomed.update(path for mtime, path in records if mtime < cutoff)
+        retained = [(mtime, path) for mtime, path in records if path not in doomed]
+        if self._retention_max_pages > 0 and len(retained) > self._retention_max_pages:
+            retained.sort(key=lambda item: item[0], reverse=True)
+            doomed.update(path for _mtime, path in retained[self._retention_max_pages :])
         pruned = 0
         for path in doomed:
             try:
@@ -227,6 +492,96 @@ class LocalResidentInbox(ResidentInboxBackend):
             except FileNotFoundError:
                 continue
         return pruned
+
+    # -- migration ------------------------------------------------------
+
+    async def migrate_flat_layout(self) -> dict[str, int]:
+        """Move pre-coalescing flat signal files into the archive and queue.
+
+        Resumable and non-destructive: each record is archived and re-filed
+        before its original file is removed, so an interrupted run simply
+        resumes.  Returns reconciliation counts for the operator to check.
+        """
+        async with self._lock:
+            return await asyncio.to_thread(self._migrate_flat_layout_sync)
+
+    def _migrate_flat_layout_sync(self) -> dict[str, int]:
+        directory = self._path(self._signal_prefix)
+        counts = {"read": 0, "archived": 0, "pending": 0, "processed": 0, "unreadable": 0}
+        if not directory.is_dir():
+            return counts
+        # Oldest first, so folded slots keep a truthful archive range.
+        for path in sorted(directory.glob("*.md")):
+            counts["read"] += 1
+            try:
+                signal = parse_inbox_signal(path.read_text(encoding="utf-8"))
+            except OSError:
+                counts["unreadable"] += 1
+                continue
+            if signal is None:
+                counts["unreadable"] += 1
+                continue
+            self._write_signal_sync(signal)
+            counts["archived"] += 1
+            if signal.status == ResidentInboxStatus.NEW.value:
+                counts["pending"] += 1
+            else:
+                counts["processed"] += 1
+            path.unlink(missing_ok=True)
+        return counts
+
+    # -- paths ----------------------------------------------------------
+
+    def _find_processed_slot(self, shape: str) -> str | None:
+        directory = self._path(self._processed_prefix)
+        if not directory.is_dir():
+            return None
+        for path in sorted(directory.glob(f"*-{shape}.md")):
+            return str(path.relative_to(self._root))
+        return None
+
+    def _resolve_ref(self, ref: str) -> Path | None:
+        """Resolve a reference written by any layout this inbox has used.
+
+        A slot's reference changes when it is judged, and turn records keep the
+        pending reference they were built from.  Resolution therefore follows a
+        judged slot to ``processed/`` rather than reporting it missing.
+        """
+        direct = self._path(ref)
+        if direct.is_file():
+            return direct
+        name = ref.rsplit("/", 1)[-1]
+        for prefix in (self._pending_prefix, self._processed_prefix):
+            if ref.startswith(f"{prefix}/"):
+                continue
+            candidate = self._path(f"{prefix}/{name}")
+            if candidate.is_file():
+                return candidate
+        if ref.startswith(f"{self._pending_prefix}/"):
+            # Processed slot files carry a timestamp prefix, so a pending
+            # reference is followed by its shape rather than by its filename.
+            judged = self._find_processed_slot(name.removesuffix(".md"))
+            if judged is not None:
+                return self._path(judged)
+        return None
+
+    def _warn_on_unbounded_shapes(self) -> None:
+        if self._warned_pending_slots:
+            return
+        directory = self._path(self._pending_prefix)
+        if not directory.is_dir():
+            return
+        count = sum(1 for _ in directory.glob("*.md"))
+        if count < self._pending_slot_warn_threshold:
+            return
+        self._warned_pending_slots = True
+        logger.warning(
+            "resident inbox: %d pending shape slots exceeds the expected bound (%d). "
+            "A source is likely emitting variable field names, which defeats "
+            "coalescing and lets the queue grow with volume.",
+            count,
+            self._pending_slot_warn_threshold,
+        )
 
     def _path(self, ref: str) -> Path:
         path = (self._root / ref).resolve()
@@ -247,6 +602,37 @@ class LocalResidentInbox(ResidentInboxBackend):
             temporary.unlink(missing_ok=True)
 
 
+def _shape_of(signal: ResidentInboxSignal) -> str:
+    """The slot key one observation belongs to, derived only from its content."""
+    return shape_key(
+        source=signal.source,
+        kind=signal.kind,
+        payload=signal.payload,
+        distinct_id=_slot_identity(signal),
+    )
+
+
+def _slot_identity(signal: ResidentInboxSignal) -> str:
+    """Return the identity that forces a dedicated slot, or "" to coalesce.
+
+    Directed operator messages carry authority and must never be folded into a
+    shared slot or summarised away, so each one keeps its own identity.
+    """
+    if signal.kind == _OPERATOR_DIRECTED_MESSAGE_KIND:
+        return signal.id
+    return ""
+
+
+def _slot_filename(slot: ResidentInboxSignal) -> str:
+    stamp = _slug((slot.first_observed_at or slot.observed_at).replace("+00:00", "Z"))
+    stamp = stamp or slot.created_at.strftime("%Y%m%dT%H%M%SZ")
+    return f"{stamp}-{slot.shape_key or _slug(slot.id) or 'signal'}.md"
+
+
+def _count(remainder: ResidentInboxSignal | None) -> int:
+    return remainder.observation_count if remainder is not None else 0
+
+
 class MimirResidentInbox(ResidentInboxBackend):
     """Mimir-backed resident inbox under ``resident/inbox/...``."""
 
@@ -260,8 +646,10 @@ class MimirResidentInbox(ResidentInboxBackend):
         retention_max_pages: int = 500,
         retention_max_age_days: float = 7.0,
         retention_sweep_interval_seconds: float = 900.0,
+        max_invalid_attempts: int = 3,
     ) -> None:
         self._mimir = mimir
+        self._max_invalid_attempts = max(1, int(max_invalid_attempts))
         self._signal_prefix = signal_prefix.strip("/").strip() or _INBOX_SIGNAL_PREFIX
         self._triage_prefix = triage_prefix.strip("/").strip() or _INBOX_TRIAGE_PREFIX
         self._decision_prefix = decision_prefix.strip("/").strip() or _INBOX_DECISION_PREFIX
@@ -457,10 +845,17 @@ class MimirResidentInbox(ResidentInboxBackend):
         *,
         status: str = ResidentInboxStatus.REMEMBERED.value,
         reason: str = "resident turn recorded",
+        expected: Mapping[str, str] | None = None,
     ) -> tuple[str, ...]:
-        """Mark exact inbox pages consumed after their resident turn is durable."""
+        """Mark exact inbox pages consumed after their resident turn is durable.
+
+        This adapter does not coalesce, so one page is one observation and
+        ``expected`` can only ever agree; a mismatch means the page was replaced
+        underneath the caller and is left pending rather than acknowledged.
+        """
         acknowledged: list[str] = []
         processed_at = datetime.now(UTC)
+        expected = dict(expected or {})
         for path in refs:
             if not path.startswith(f"{self._signal_prefix}/"):
                 continue
@@ -470,6 +865,8 @@ class MimirResidentInbox(ResidentInboxBackend):
                 continue
             if signal is None:
                 continue
+            if path in expected and expected[path] != signal.last_archive_ref:
+                continue
             updated = signal.with_updates(
                 status=status,
                 reason=reason or signal.reason,
@@ -478,3 +875,41 @@ class MimirResidentInbox(ResidentInboxBackend):
             await self._mimir.upsert_page(path, render_inbox_signal(updated))
             acknowledged.append(path)
         return tuple(acknowledged)
+
+    async def record_failed_attempt(
+        self,
+        refs: tuple[str, ...],
+        *,
+        reason: str,
+    ) -> tuple[str, ...]:
+        """Count one invalid resident outcome; return pages that became blocked."""
+        blocked: list[str] = []
+        processed_at = datetime.now(UTC)
+        for path in refs:
+            if not path.startswith(f"{self._signal_prefix}/"):
+                continue
+            try:
+                signal = parse_inbox_signal(await self._mimir.read_page(path))
+            except FileNotFoundError:
+                continue
+            if signal is None or signal.status != ResidentInboxStatus.NEW.value:
+                continue
+            attempts = signal.attempts + 1
+            if attempts < self._max_invalid_attempts:
+                await self._mimir.upsert_page(
+                    path, render_inbox_signal(signal.with_updates(attempts=attempts))
+                )
+                continue
+            await self._mimir.upsert_page(
+                path,
+                render_inbox_signal(
+                    signal.with_updates(
+                        status=ResidentInboxStatus.BLOCKED.value,
+                        attempts=attempts,
+                        reason=reason,
+                        processed_at=processed_at,
+                    )
+                ),
+            )
+            blocked.append(path)
+        return tuple(blocked)

--- a/src/ravn/resident_inbox/models.py
+++ b/src/ravn/resident_inbox/models.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Protocol
 
+from .shape import ShapeAggregate
+
 _INBOX_SIGNAL_PREFIX = "resident/inbox/signals"
+#: Coalescing queue: at most one slot per structural shape awaiting judgment.
+_INBOX_PENDING_PREFIX = "resident/inbox/signals/pending"
+#: Judged slots, subject to normal retention.
+_INBOX_PROCESSED_PREFIX = "resident/inbox/signals/processed"
 _INBOX_TRIAGE_PREFIX = "resident/inbox/triage"
 _INBOX_DECISION_PREFIX = "resident/inbox/decisions"
 _INBOX_SIGNAL_JSON_START = "<resident-inbox-signal-json>"
@@ -66,6 +73,19 @@ class ResidentInboxSignal:
     observed_at: str = ""
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     processed_at: datetime | None = None
+    #: Structural slot identity. Observations sharing a shape share a slot.
+    shape_key: str = ""
+    #: How many raw observations this slot covers. 1 for an uncoalesced record.
+    observation_count: int = 1
+    #: Exact raw archive range this slot covers, inclusive.
+    first_archive_ref: str = ""
+    last_archive_ref: str = ""
+    #: Oldest observation in the slot; ``observed_at`` tracks the newest.
+    first_observed_at: str = ""
+    #: Variation across the slot's observations. Never merges across shapes.
+    aggregate: ShapeAggregate = field(default_factory=ShapeAggregate)
+    #: Resident turns that ended with an invalid outcome for this slot.
+    attempts: int = 0
 
     def with_updates(self, **updates: object) -> ResidentInboxSignal:
         return replace(self, **updates)  # type: ignore[arg-type]
@@ -122,7 +142,29 @@ class ResidentInboxBackend(Protocol):
         *,
         status: str = ResidentInboxStatus.REMEMBERED.value,
         reason: str = "resident turn recorded",
-    ) -> tuple[str, ...]: ...
+        expected: Mapping[str, str] | None = None,
+    ) -> tuple[str, ...]:
+        """Acknowledge exactly what the resident judged.
+
+        ``expected`` maps each ref to the archive reference the caller saw when
+        it listed the slot.  A slot that advanced while the turn ran is split:
+        the judged range is acknowledged and the newer observations stay
+        pending, so arrivals mid-turn are never silently swallowed.
+        """
+        ...
+
+    async def record_failed_attempt(
+        self,
+        refs: tuple[str, ...],
+        *,
+        reason: str,
+    ) -> tuple[str, ...]:
+        """Count one invalid resident outcome; return refs that became blocked.
+
+        A slot no resident turn can validly judge must stop being retried
+        forever and become visible to a human instead.
+        """
+        ...
 
 
 @dataclass(frozen=True)

--- a/src/ravn/resident_inbox/serialization.py
+++ b/src/ravn/resident_inbox/serialization.py
@@ -22,6 +22,7 @@ from .models import (
     ResidentInboxStatus,
     ResidentInboxTriage,
 )
+from .shape import ShapeAggregate
 
 
 def _signal_from_record(record: dict[str, Any], *, default_kind: str) -> ResidentInboxSignal:
@@ -164,6 +165,10 @@ def render_inbox_signal(signal: ResidentInboxSignal) -> str:
         f"- confidence: {signal.confidence:.2f}\n"
         f"- status: {signal.status}\n"
         f"- target_objective_id: {signal.target_objective_id}\n"
+        f"- shape_key: {signal.shape_key}\n"
+        f"- observation_count: {signal.observation_count}\n"
+        f"- archive_range: {signal.first_archive_ref}..{signal.last_archive_ref}\n"
+        f"- first_observed_at: {signal.first_observed_at}\n"
         f"- observed_at: {signal.observed_at}\n"
         f"- created_at: {signal.created_at.isoformat()}\n"
         f"- processed_at: {signal.processed_at.isoformat() if signal.processed_at else ''}\n\n"
@@ -224,6 +229,13 @@ def _signal_to_dict(signal: ResidentInboxSignal) -> dict[str, Any]:
         "observed_at": signal.observed_at,
         "created_at": signal.created_at.isoformat(),
         "processed_at": signal.processed_at.isoformat() if signal.processed_at else "",
+        "shape_key": signal.shape_key,
+        "observation_count": signal.observation_count,
+        "first_archive_ref": signal.first_archive_ref,
+        "last_archive_ref": signal.last_archive_ref,
+        "first_observed_at": signal.first_observed_at,
+        "aggregate": signal.aggregate.to_dict(),
+        "attempts": signal.attempts,
     }
 
 
@@ -247,6 +259,14 @@ def _signal_from_dict(data: dict[str, Any]) -> ResidentInboxSignal:
         observed_at=str(data.get("observed_at") or ""),
         created_at=_parse_datetime(data.get("created_at")),
         processed_at=_parse_optional_datetime(data.get("processed_at")),
+        shape_key=str(data.get("shape_key") or ""),
+        # Records written before coalescing existed cover exactly one observation.
+        observation_count=max(1, int(data.get("observation_count") or 1)),
+        first_archive_ref=str(data.get("first_archive_ref") or ""),
+        last_archive_ref=str(data.get("last_archive_ref") or ""),
+        first_observed_at=str(data.get("first_observed_at") or data.get("observed_at") or ""),
+        aggregate=ShapeAggregate.from_dict(data.get("aggregate")),
+        attempts=max(0, int(data.get("attempts") or 0)),
     )
 
 

--- a/src/ravn/resident_inbox/shape.py
+++ b/src/ravn/resident_inbox/shape.py
@@ -248,4 +248,3 @@ def _number(value: float) -> str:
     if value == int(value):
         return str(int(value))
     return f"{value:.4g}"
-

--- a/src/ravn/resident_inbox/shape.py
+++ b/src/ravn/resident_inbox/shape.py
@@ -1,0 +1,251 @@
+"""Structural shape derivation and aggregate folding for resident inbox slots.
+
+A *shape* is the structure of an observation: its source, its kind, and the set
+of field paths it carries with their value types.  Two observations share a
+pending queue slot only when their shapes are identical.
+
+Nothing here interprets meaning.  A shape says two observations are structurally
+comparable; it never says either of them is routine, safe, or ignorable.  The
+aggregates summarise variation *within* one identical shape and never merge
+across shapes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+#: Values folded into numeric ranges.  ``bool`` is deliberately excluded: it is
+#: an ``int`` subclass in Python, but a flag flipping is a categorical change,
+#: not a range.
+_NUMERIC_TYPES = (int, float)
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, str):
+        return "str"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    return type(value).__name__
+
+
+def field_paths(payload: Any, *, prefix: str = "") -> tuple[tuple[str, str], ...]:
+    """Return sorted ``(dotted path, type name)`` pairs for one payload.
+
+    Arrays contribute a single ``path[]`` entry typed by their first element, so
+    a list that merely grows does not change the shape while a list whose
+    element type changes does.
+    """
+    if isinstance(payload, dict):
+        paths: list[tuple[str, str]] = []
+        for key in sorted(payload):
+            child = f"{prefix}.{key}" if prefix else str(key)
+            paths.extend(field_paths(payload[key], prefix=child))
+        return tuple(paths)
+    if isinstance(payload, list):
+        element = payload[0] if payload else None
+        marker = f"{prefix}[]" if prefix else "[]"
+        if isinstance(element, dict | list):
+            return field_paths(element, prefix=marker)
+        return ((marker, _type_name(element) if payload else "empty"),)
+    return ((prefix, _type_name(payload)),)
+
+
+def shape_key(
+    *,
+    source: str,
+    kind: str,
+    payload: Any,
+    distinct_id: str = "",
+) -> str:
+    """Derive the stable slot key for one observation.
+
+    ``distinct_id`` forces a dedicated slot.  Callers pass it for observations
+    that must never fold into a shared slot regardless of structure — directed
+    operator messages, whose channel carries authority and must not be
+    summarised away.
+    """
+    digest = hashlib.sha256()
+    digest.update(source.encode())
+    digest.update(b"\x00")
+    digest.update(kind.encode())
+    digest.update(b"\x00")
+    digest.update(distinct_id.encode())
+    for path, type_name in field_paths(payload):
+        digest.update(b"\x00")
+        digest.update(path.encode())
+        digest.update(b"\x1f")
+        digest.update(type_name.encode())
+    return digest.hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class ShapeAggregate:
+    """Domain-neutral variation summary for observations sharing one shape."""
+
+    numeric: dict[str, tuple[float, float]] = field(default_factory=dict)
+    categorical: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    high_cardinality: tuple[str, ...] = ()
+    extreme_payloads: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "numeric": {path: [low, high] for path, (low, high) in sorted(self.numeric.items())},
+            "categorical": {
+                path: list(values) for path, values in sorted(self.categorical.items())
+            },
+            "high_cardinality": list(self.high_cardinality),
+            "extreme_payloads": self.extreme_payloads,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> ShapeAggregate:
+        if not isinstance(data, dict):
+            return cls()
+        numeric: dict[str, tuple[float, float]] = {}
+        for path, bounds in dict(data.get("numeric") or {}).items():
+            if isinstance(bounds, list | tuple) and len(bounds) == 2:
+                numeric[str(path)] = (float(bounds[0]), float(bounds[1]))
+        categorical = {
+            str(path): tuple(str(item) for item in values or ())
+            for path, values in dict(data.get("categorical") or {}).items()
+        }
+        extremes = {
+            str(key): dict(value)
+            for key, value in dict(data.get("extreme_payloads") or {}).items()
+            if isinstance(value, dict)
+        }
+        return cls(
+            numeric=numeric,
+            categorical=categorical,
+            high_cardinality=tuple(str(item) for item in data.get("high_cardinality") or ()),
+            extreme_payloads=extremes,
+        )
+
+
+def _flatten_values(payload: Any, *, prefix: str = "") -> dict[str, Any]:
+    if isinstance(payload, dict):
+        flat: dict[str, Any] = {}
+        for key, value in payload.items():
+            child = f"{prefix}.{key}" if prefix else str(key)
+            flat.update(_flatten_values(value, prefix=child))
+        return flat
+    if isinstance(payload, list):
+        marker = f"{prefix}[]" if prefix else "[]"
+        if payload and isinstance(payload[0], dict | list):
+            return _flatten_values(payload[0], prefix=marker)
+        return {marker: payload[0] if payload else None}
+    return {prefix: payload}
+
+
+def fold_aggregate(
+    aggregate: ShapeAggregate,
+    payload: Any,
+    *,
+    max_distinct_values: int,
+    max_extreme_payloads: int,
+) -> ShapeAggregate:
+    """Fold one observation's values into the running aggregate.
+
+    Numeric paths keep their observed range and the payload at each extreme, so
+    an excursion is never summarised away.  Categorical paths keep their
+    distinct values up to a cap; above it the path is recorded as
+    high-cardinality rather than growing without bound.
+    """
+    numeric = dict(aggregate.numeric)
+    categorical = {path: list(values) for path, values in aggregate.categorical.items()}
+    high_cardinality = set(aggregate.high_cardinality)
+    extremes = dict(aggregate.extreme_payloads)
+    flat_payload = payload if isinstance(payload, dict) else {"value": payload}
+
+    for path, value in _flatten_values(payload).items():
+        if isinstance(value, bool) or value is None:
+            value = str(value)
+        if isinstance(value, _NUMERIC_TYPES):
+            number = float(value)
+            previous = numeric.get(path)
+            if previous is None:
+                numeric[path] = (number, number)
+                _record_extreme(extremes, f"{path}:min", flat_payload, max_extreme_payloads)
+                _record_extreme(extremes, f"{path}:max", flat_payload, max_extreme_payloads)
+                continue
+            low, high = previous
+            if number < low:
+                numeric[path] = (number, high)
+                _record_extreme(extremes, f"{path}:min", flat_payload, max_extreme_payloads)
+            elif number > high:
+                numeric[path] = (low, number)
+                _record_extreme(extremes, f"{path}:max", flat_payload, max_extreme_payloads)
+            continue
+        if path in high_cardinality:
+            continue
+        text = str(value)
+        values = categorical.setdefault(path, [])
+        if text in values:
+            continue
+        if len(values) >= max_distinct_values:
+            high_cardinality.add(path)
+            categorical.pop(path, None)
+            continue
+        values.append(text)
+
+    return ShapeAggregate(
+        numeric=numeric,
+        categorical={path: tuple(values) for path, values in categorical.items()},
+        high_cardinality=tuple(sorted(high_cardinality)),
+        extreme_payloads=extremes,
+    )
+
+
+def _record_extreme(
+    extremes: dict[str, dict[str, Any]],
+    key: str,
+    payload: dict[str, Any],
+    cap: int,
+) -> None:
+    """Store the payload observed at a numeric extreme, bounded by ``cap``.
+
+    Existing extreme keys keep updating once the cap is reached; only new paths
+    are refused, so a slot's stored payloads cannot grow without bound.
+    """
+    if key not in extremes and len(extremes) >= cap:
+        return
+    extremes[key] = dict(payload)
+
+
+def aggregate_summary_lines(aggregate: ShapeAggregate) -> list[str]:
+    """Render the aggregate for a resident prompt; structural inventory first."""
+    lines: list[str] = []
+    if aggregate.numeric:
+        rendered = ", ".join(
+            f"{path} {_number(low)}–{_number(high)}"
+            for path, (low, high) in sorted(aggregate.numeric.items())
+        )
+        lines.append(f"  numeric ranges: {rendered}")
+    if aggregate.categorical:
+        rendered = ", ".join(
+            f"{path} {{{', '.join(values)}}}"
+            for path, values in sorted(aggregate.categorical.items())
+        )
+        lines.append(f"  categorical values: {rendered}")
+    if aggregate.high_cardinality:
+        lines.append(f"  high-cardinality paths: {', '.join(aggregate.high_cardinality)}")
+    return lines
+
+
+def _number(value: float) -> str:
+    if value == int(value):
+        return str(int(value))
+    return f"{value:.4g}"
+

--- a/src/ravn/resident_runtime.py
+++ b/src/ravn/resident_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import logging
 import re
 import time
 from collections.abc import Awaitable, Callable, Mapping
@@ -34,8 +35,11 @@ from ravn.resident_inbox import (
     ResidentInboxClassification,
     ResidentInboxSignal,
     ResidentInboxStatus,
+    aggregate_summary_lines,
 )
 from ravn.resident_text import compact_line
+
+logger = logging.getLogger(__name__)
 
 EnqueueResidentTask = Callable[[AgentTask], Awaitable[bool | None]]
 
@@ -613,6 +617,10 @@ class ResidentRuntime:
                     await self._state.consume_scheduled_wake(wake)
 
         if not outcome_valid:
+            # The turn and budget records are durable, so this attempt really
+            # happened. Count it: a slot no turn can validly judge must stop
+            # being retried forever and become visible to a human instead.
+            await self._record_invalid_outcome(task, case_id=case_id, turn_index=turn_index)
             self._inflight_cases.discard(case_id)
             self._inflight_refs.difference_update(task.resident_inbox_refs)
             return ResidentTurnDisposition(
@@ -635,6 +643,7 @@ class ResidentRuntime:
                     tuple(task.resident_inbox_refs),
                     status=ResidentInboxStatus.REMEMBERED.value,
                     reason=f"recorded by resident case {case_id} turn {turn_index}",
+                    expected=dict(task.resident_inbox_expected),
                 )
         if task.resident_answer_ref:
             answer = await self._state.read_operator_answer(case_id)
@@ -1009,6 +1018,48 @@ class ResidentRuntime:
         )
         return True
 
+    async def _record_invalid_outcome(
+        self,
+        task: AgentTask,
+        *,
+        case_id: str,
+        turn_index: int,
+    ) -> None:
+        """Count an invalid outcome against the observations it failed to judge."""
+        if self._inbox is None or not task.resident_inbox_refs:
+            return
+        telemetry = get_observability()
+        blocked = await self._inbox.record_failed_attempt(
+            tuple(task.resident_inbox_refs),
+            reason=(
+                f"blocked after repeated invalid resident outcomes; "
+                f"last case {case_id} turn {turn_index}"
+            ),
+        )
+        telemetry.count(
+            "ravn.resident.inbox_invalid_outcomes",
+            attributes={"ravn.resident.id": self._resident_id},
+        )
+        if not blocked:
+            return
+        # Escalate once: a metric alone leaves nobody looking at work that can
+        # never be judged.
+        telemetry.event(
+            "ravn.resident.inbox_blocked",
+            attributes={
+                "ravn.resident.id": self._resident_id,
+                "ravn.resident.case_id": case_id,
+                "ravn.resident.blocked_ref_count": len(blocked),
+            },
+            content={"refs": list(blocked)},
+        )
+        logger.error(
+            "resident inbox: %d observation slot(s) blocked after repeated invalid "
+            "outcomes and need operator review: %s",
+            len(blocked),
+            ", ".join(blocked),
+        )
+
     async def next_home_task(
         self,
         *,
@@ -1062,6 +1113,7 @@ class ResidentRuntime:
                 f"observed_at={signal.observed_at}; evidence_ref={evidence}; "
                 f"summary={compact_line(signal.summary, limit=280)}"
             )
+            context_lines.extend(_coalesced_evidence_lines(signal))
             raw_payload = signal.payload.get("payload", signal.payload)
             context_lines.extend(
                 (
@@ -1083,6 +1135,7 @@ class ResidentRuntime:
                     "  ```",
                 )
             )
+            context_lines.extend(_extreme_payload_lines(signal, payload_budget))
         task = AgentTask(
             task_id=_task_id("resident_home"),
             title=f"Resident home turn ({len(rows)} observations)",
@@ -1095,6 +1148,9 @@ class ResidentRuntime:
             resident_turn_index=int(origin.get("turn_index") or 0) + 1,
             resident_started_at=str(origin.get("case_started_at") or now.isoformat()),
             resident_inbox_refs=refs,
+            resident_inbox_expected={
+                ref: signal.last_archive_ref for ref, signal in rows if signal.last_archive_ref
+            },
             trace_context=next(
                 (dict(signal.trace_context) for _ref, signal in rows if signal.trace_context),
                 {},
@@ -1502,6 +1558,62 @@ def _string_refs(value: Any) -> tuple[str, ...]:
     if not isinstance(value, list | tuple):
         return ()
     return tuple(str(item).strip() for item in value if str(item).strip())
+
+
+def _coalesced_evidence_lines(signal: ResidentInboxSignal) -> list[str]:
+    """Say what a coalesced slot actually stands for.
+
+    A slot's payload is only its newest observation.  Presenting that alone
+    would hide both how many observations it represents and how far their
+    values ranged — the resident would judge one tick and unknowingly
+    acknowledge hundreds.  The structural inventory is never summarised away:
+    ranges, distinct values and the payloads at each numeric extreme all travel
+    with the slot, and the raw archive range names the durable evidence behind
+    them.
+    """
+    if signal.observation_count <= 1:
+        return []
+    lines = [
+        f"  Coalesced: {signal.observation_count} observations of this exact shape, "
+        f"{signal.first_observed_at} to {signal.observed_at}",
+        f"  Raw archive range: {signal.first_archive_ref}..{signal.last_archive_ref}",
+    ]
+    lines.extend(aggregate_summary_lines(signal.aggregate))
+    return lines
+
+
+def _extreme_payload_lines(signal: ResidentInboxSignal, budget: int) -> list[str]:
+    """Attach the full payload observed at each numeric extreme.
+
+    An excursion inside a large slot is exactly the observation a summary would
+    lose, so its whole payload travels rather than just its bound.
+    """
+    extremes = signal.aggregate.extreme_payloads
+    if signal.observation_count <= 1 or not extremes:
+        return []
+    lines = ["  Payloads at numeric extremes:"]
+    for key in sorted(extremes):
+        lines.extend(
+            (
+                f"  {key}:",
+                "  ```json",
+                _indent(
+                    _bounded(
+                        json.dumps(
+                            extremes[key],
+                            indent=2,
+                            sort_keys=True,
+                            ensure_ascii=False,
+                            default=str,
+                        ),
+                        budget,
+                    ),
+                    "  ",
+                ),
+                "  ```",
+            )
+        )
+    return lines
 
 
 def _bounded(value: Any, max_chars: int) -> str:

--- a/tests/test_ravn/test_resident_inbox.py
+++ b/tests/test_ravn/test_resident_inbox.py
@@ -29,7 +29,9 @@ async def test_local_inbox_is_durable_and_preserves_acknowledged_replays(tmp_pat
         content="Please inspect the current machine state",
         metadata={"message_id": "local-1", "telegram_date": "2026-07-21T12:00:00Z"},
     )
-    assert replay_ref == ref
+    # A judged slot lives under processed/, so the replay resolves to the record
+    # that already exists rather than resurrecting it as pending work.
+    assert replay_ref.startswith("resident/inbox/signals/processed/")
     assert await restarted.list_signals(status=ResidentInboxStatus.NEW.value) == []
     assert len(await restarted.list_signals(status=ResidentInboxStatus.REMEMBERED.value)) == 1
 

--- a/tests/test_ravn/test_resident_inbox_coalescing.py
+++ b/tests/test_ravn/test_resident_inbox_coalescing.py
@@ -1,0 +1,541 @@
+"""The archive is complete; the queue is bounded.
+
+These tests pin the properties the coalescing design depends on: ingestion cost
+does not grow with history, the queue is bounded by structure rather than
+volume, nothing the resident has not seen is acknowledged, and no path can
+delete raw evidence.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from ravn.resident_inbox import (
+    LocalResidentInbox,
+    ResidentInboxSignal,
+    ResidentInboxStatus,
+    ShapeAggregate,
+    field_paths,
+    shape_key,
+)
+from ravn.resident_inbox import aggregate_summary_lines as _summary_lines
+from ravn.resident_inbox.shape import fold_aggregate
+
+
+def _tick(
+    index: int,
+    *,
+    progress: float = 0.0,
+    temperature: float = 40.0,
+    **extra,
+) -> ResidentInboxSignal:
+    """One machine status observation: same shape, moving values."""
+    payload = {
+        "task": "print-7",
+        "state": "printing",
+        "progress": progress,
+        "temperature": temperature,
+        **extra,
+    }
+    return ResidentInboxSignal(
+        id=f"tick-{index}",
+        source="laevateinn",
+        kind="workshop.status",
+        summary=f"print-7 at {progress}%",
+        payload=payload,
+        observed_at=f"2026-08-03T10:{index:02d}:00Z",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shape derivation
+# ---------------------------------------------------------------------------
+
+
+def test_shape_key_ignores_values_but_not_structure() -> None:
+    same = shape_key(source="s", kind="k", payload={"a": 1, "b": "x"})
+    other_values = shape_key(source="s", kind="k", payload={"a": 999, "b": "y"})
+    added_field = shape_key(source="s", kind="k", payload={"a": 1, "b": "x", "error": "boom"})
+    retyped = shape_key(source="s", kind="k", payload={"a": "1", "b": "x"})
+
+    assert same == other_values
+    assert added_field != same
+    assert retyped != same
+
+
+def test_field_paths_are_sorted_and_typed() -> None:
+    paths = field_paths({"b": 1, "a": {"c": "x"}, "d": [1, 2]})
+    assert paths == (("a.c", "str"), ("b", "int"), ("d[]", "int"))
+
+
+def test_bool_is_categorical_not_numeric() -> None:
+    aggregate = fold_aggregate(
+        ShapeAggregate(), {"flag": True}, max_distinct_values=8, max_extreme_payloads=4
+    )
+    aggregate = fold_aggregate(
+        aggregate, {"flag": False}, max_distinct_values=8, max_extreme_payloads=4
+    )
+    assert "flag" not in aggregate.numeric
+    assert set(aggregate.categorical["flag"]) == {"True", "False"}
+
+
+def test_high_cardinality_paths_stop_growing() -> None:
+    aggregate = ShapeAggregate()
+    for index in range(10):
+        aggregate = fold_aggregate(
+            aggregate,
+            {"job": f"job-{index}"},
+            max_distinct_values=3,
+            max_extreme_payloads=4,
+        )
+    assert "job" in aggregate.high_cardinality
+    assert "job" not in aggregate.categorical
+
+
+# ---------------------------------------------------------------------------
+# Coalescing queue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_queue_is_bounded_by_shape_while_archive_keeps_everything(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+
+    for index in range(500):
+        await inbox.write_signal(_tick(index, progress=index / 5.0, temperature=40 + index % 20))
+
+    pending = await inbox.list_signals(limit=50)
+    assert len(pending) == 1, "one shape must occupy exactly one queue slot"
+    _ref, slot = pending[0]
+    assert slot.observation_count == 500
+    # Every observation survives, whatever the queue did.
+    assert inbox.archive.count() == 500
+
+
+@pytest.mark.asyncio
+async def test_ingestion_cost_does_not_grow_with_history(tmp_path, monkeypatch) -> None:
+    """The outage was an O(N) scan per write. Assert the bound, not the clock."""
+    from ravn.resident_inbox import backend as backend_module
+
+    inbox = LocalResidentInbox(tmp_path / "inbox", retention_sweep_interval_seconds=3600.0)
+    for index in range(300):
+        await inbox.write_signal(_tick(index, progress=index))
+
+    parses = 0
+    real_parse = backend_module.parse_inbox_signal
+
+    def counting_parse(content):
+        nonlocal parses
+        parses += 1
+        return real_parse(content)
+
+    monkeypatch.setattr(backend_module, "parse_inbox_signal", counting_parse)
+    await inbox.write_signal(_tick(301, progress=99))
+
+    assert parses <= 1, f"one write parsed {parses} records; cost must not follow history"
+
+
+@pytest.mark.asyncio
+async def test_a_changed_shape_never_folds(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+
+    await inbox.write_signal(_tick(1, progress=10))
+    await inbox.write_signal(_tick(2, progress=20))
+    # A payload that gains a field is a different shape and must surface.
+    await inbox.write_signal(_tick(3, progress=30, error="thermal runaway"))
+
+    pending = await inbox.list_signals(limit=50)
+    assert len(pending) == 2
+    shapes = {slot.shape_key for _ref, slot in pending}
+    assert len(shapes) == 2
+    errored = [slot for _ref, slot in pending if "error" in slot.payload]
+    assert errored and errored[0].observation_count == 1
+
+
+@pytest.mark.asyncio
+async def test_numeric_excursion_survives_in_the_aggregate(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+
+    for index in range(50):
+        await inbox.write_signal(_tick(index, progress=index, temperature=40.0))
+    await inbox.write_signal(_tick(51, progress=51, temperature=95.0))
+    for index in range(52, 80):
+        await inbox.write_signal(_tick(index, progress=index, temperature=40.0))
+
+    _ref, slot = (await inbox.list_signals(limit=1))[0]
+    low, high = slot.aggregate.numeric["temperature"]
+    assert (low, high) == (40.0, 95.0)
+    # The payload at the extreme is kept whole, not just its bound.
+    assert slot.aggregate.extreme_payloads["temperature:max"]["temperature"] == 95.0
+
+
+@pytest.mark.asyncio
+async def test_directed_operator_messages_never_coalesce(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+
+    for index in range(3):
+        await inbox.write_directed_message(
+            content=f"operator instruction {index}",
+            metadata={"message_id": str(index)},
+        )
+
+    pending = await inbox.list_signals(limit=10)
+    assert len(pending) == 3, "each operator message keeps its own slot"
+    assert all(slot.observation_count == 1 for _ref, slot in pending)
+
+
+@pytest.mark.asyncio
+async def test_pending_is_served_oldest_first(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+
+    await inbox.write_signal(_tick(1, progress=1))
+    await inbox.write_signal(
+        ResidentInboxSignal(
+            id="later",
+            source="other",
+            kind="workshop.other",
+            summary="later shape",
+            payload={"different": "shape"},
+            observed_at="2026-08-03T23:00:00Z",
+        )
+    )
+
+    refs = [slot.first_observed_at for _ref, slot in await inbox.list_signals(limit=10)]
+    assert refs == sorted(refs), "oldest waiting slot is served first"
+
+
+# ---------------------------------------------------------------------------
+# Acknowledgement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acknowledge_leaves_observations_that_arrived_mid_turn(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+    for index in range(3):
+        await inbox.write_signal(_tick(index, progress=index))
+
+    ref, seen = (await inbox.list_signals(limit=1))[0]
+    assert seen.observation_count == 3
+
+    # Two more arrive while the resident is judging what it saw.
+    await inbox.write_signal(_tick(4, progress=40, temperature=41.0))
+    await inbox.write_signal(_tick(5, progress=50, temperature=42.0))
+
+    assert await inbox.acknowledge((ref,), expected={ref: seen.last_archive_ref}) == (ref,)
+
+    still_pending = await inbox.list_signals(limit=10)
+    assert len(still_pending) == 1
+    _pending_ref, remainder = still_pending[0]
+    assert remainder.observation_count == 2, "only the unseen observations remain"
+    assert remainder.aggregate.numeric["temperature"] == (41.0, 42.0)
+
+    judged = await inbox.list_signals(status=ResidentInboxStatus.REMEMBERED.value, limit=10)
+    assert len(judged) == 1
+    assert judged[0][1].observation_count == 3
+
+
+@pytest.mark.asyncio
+async def test_acknowledge_without_new_arrivals_clears_the_slot(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+    for index in range(4):
+        await inbox.write_signal(_tick(index, progress=index))
+
+    ref, seen = (await inbox.list_signals(limit=1))[0]
+    await inbox.acknowledge((ref,), expected={ref: seen.last_archive_ref})
+
+    assert await inbox.list_signals(limit=10) == []
+    assert inbox.archive.count() == 4
+
+
+@pytest.mark.asyncio
+async def test_double_acknowledge_is_a_no_op(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+    await inbox.write_signal(_tick(1))
+    ref, _slot = (await inbox.list_signals(limit=1))[0]
+
+    assert await inbox.acknowledge((ref,)) == (ref,)
+    # The slot moved; acknowledging the old reference again must not raise or
+    # resurrect anything.
+    assert await inbox.acknowledge((ref,)) == (ref,)
+    assert await inbox.list_signals(limit=10) == []
+
+
+# ---------------------------------------------------------------------------
+# Retention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retention_never_touches_the_raw_archive(tmp_path) -> None:
+    inbox = LocalResidentInbox(
+        tmp_path / "inbox",
+        retention_max_pages=1,
+        retention_max_age_days=0.0001,
+        retention_sweep_interval_seconds=0.0,
+    )
+    for index in range(20):
+        await inbox.write_signal(_tick(index, progress=index))
+    ref, _slot = (await inbox.list_signals(limit=1))[0]
+    await inbox.acknowledge((ref,))
+
+    time.sleep(0.02)
+    await inbox.prune_signals()
+
+    assert inbox.archive.count() == 20, "raw evidence is the only surviving copy"
+    assert list(inbox.archive.directory.glob("*.ndjson"))
+
+
+@pytest.mark.asyncio
+async def test_retention_never_prunes_pending_slots(tmp_path) -> None:
+    inbox = LocalResidentInbox(
+        tmp_path / "inbox",
+        retention_max_pages=1,
+        retention_max_age_days=0.0001,
+        retention_sweep_interval_seconds=0.0,
+    )
+    for index in range(5):
+        await inbox.write_signal(
+            ResidentInboxSignal(
+                id=f"s-{index}",
+                source=f"source-{index}",
+                kind="k",
+                summary="pending work",
+                payload={"n": index},
+                observed_at=f"2026-08-03T10:0{index}:00Z",
+            )
+        )
+
+    time.sleep(0.02)
+    assert await inbox.prune_signals() == 0
+    assert len(await inbox.list_signals(limit=50)) == 5
+
+
+# ---------------------------------------------------------------------------
+# Invalid outcomes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repeated_invalid_outcomes_block_a_slot(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox", max_invalid_attempts=3)
+    await inbox.write_signal(_tick(1))
+    ref, _slot = (await inbox.list_signals(limit=1))[0]
+
+    assert await inbox.record_failed_attempt((ref,), reason="invalid outcome") == ()
+    assert await inbox.record_failed_attempt((ref,), reason="invalid outcome") == ()
+    assert len(await inbox.list_signals(limit=10)) == 1, "still retried below the bound"
+
+    blocked = await inbox.record_failed_attempt((ref,), reason="invalid outcome")
+
+    assert blocked == (ref,)
+    assert await inbox.list_signals(limit=10) == [], "no longer retried forever"
+    stuck = await inbox.list_signals(status=ResidentInboxStatus.BLOCKED.value, limit=10)
+    assert len(stuck) == 1
+    assert stuck[0][1].attempts == 3
+
+
+# ---------------------------------------------------------------------------
+# Migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_is_resumable_and_reconciles(tmp_path) -> None:
+    root = tmp_path / "inbox"
+    legacy = LocalResidentInbox(root)
+    # Write flat records the way the pre-coalescing layout did.
+    flat_dir = root / "resident/inbox/signals"
+    flat_dir.mkdir(parents=True, exist_ok=True)
+    from ravn.resident_inbox import render_inbox_signal
+
+    for index in range(30):
+        signal = _tick(index, progress=index)
+        (flat_dir / f"2026-08-03t10-{index:02d}-00z-tick-{index}.md").write_text(
+            render_inbox_signal(signal), encoding="utf-8"
+        )
+
+    counts = await legacy.migrate_flat_layout()
+
+    assert counts["read"] == 30
+    assert counts["archived"] == 30
+    assert legacy.archive.count() == 30
+    assert not list(flat_dir.glob("*.md")), "originals removed only after re-filing"
+    assert len(await legacy.list_signals(limit=50)) == 1
+
+    # Re-running is a no-op rather than a duplication.
+    assert (await legacy.migrate_flat_layout())["read"] == 0
+    assert legacy.archive.count() == 30
+
+
+@pytest.mark.asyncio
+async def test_migration_leaves_unreadable_files_in_place(tmp_path) -> None:
+    root = tmp_path / "inbox"
+    inbox = LocalResidentInbox(root)
+    flat_dir = root / "resident/inbox/signals"
+    flat_dir.mkdir(parents=True, exist_ok=True)
+    (flat_dir / "broken.md").write_text("# not a signal record", encoding="utf-8")
+
+    counts = await inbox.migrate_flat_layout()
+
+    assert counts["unreadable"] == 1
+    assert (flat_dir / "broken.md").exists(), "nothing unparsed is destroyed"
+
+
+# ---------------------------------------------------------------------------
+# Archive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_archive_references_address_exact_records(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+    for index in range(5):
+        await inbox.write_signal(_tick(index, progress=index * 10))
+
+    _ref, slot = (await inbox.list_signals(limit=1))[0]
+    first = inbox.archive.read(slot.first_archive_ref)
+    last = inbox.archive.read(slot.last_archive_ref)
+
+    assert first is not None and last is not None
+    assert first["signal"]["payload"]["progress"] == 0
+    assert last["signal"]["payload"]["progress"] == 40
+
+
+@pytest.mark.asyncio
+async def test_variable_field_names_warn_instead_of_failing_silently(tmp_path, caplog) -> None:
+    """Coalescing only bounds the queue when shapes are stable. Say so loudly."""
+    import logging
+
+    inbox = LocalResidentInbox(tmp_path / "inbox", pending_slot_warn_threshold=5)
+    with caplog.at_level(logging.WARNING, logger="ravn.resident_inbox.backend"):
+        for index in range(8):
+            await inbox.write_signal(
+                ResidentInboxSignal(
+                    id=f"v-{index}",
+                    source="chatty",
+                    kind="k",
+                    # A new field name every time defeats coalescing entirely.
+                    payload={f"field_{index}": index},
+                    summary="variable shape",
+                    observed_at=f"2026-08-03T10:0{index}:00Z",
+                )
+            )
+
+    warnings = [r for r in caplog.records if "pending shape slots" in r.message]
+    assert len(warnings) == 1, "warned exactly once, not on every write"
+
+
+@pytest.mark.asyncio
+async def test_archive_range_rebuild_skips_foreign_shapes(tmp_path) -> None:
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+    await inbox.write_signal(_tick(1, progress=1))
+    ref, seen = (await inbox.list_signals(limit=1))[0]
+
+    # An unrelated shape lands between the judged point and the slot's tail.
+    await inbox.write_signal(
+        ResidentInboxSignal(
+            id="unrelated",
+            source="elsewhere",
+            kind="other",
+            summary="different",
+            payload={"unrelated": True},
+            observed_at="2026-08-03T10:30:00Z",
+        )
+    )
+    await inbox.write_signal(_tick(2, progress=2))
+
+    await inbox.acknowledge((ref,), expected={ref: seen.last_archive_ref})
+
+    remainder = {
+        slot.shape_key: slot for _r, slot in await inbox.list_signals(limit=10)
+    }
+    assert remainder[seen.shape_key].observation_count == 1, "foreign records are not folded in"
+
+
+@pytest.mark.asyncio
+async def test_resident_sees_what_a_coalesced_slot_represents(tmp_path) -> None:
+    """Judging one tick must never silently acknowledge hundreds."""
+    from ravn.adapters.resident_state.mimir import LocalResidentState
+    from ravn.domain.models import OutputMode
+    from ravn.resident_runtime import ResidentRuntime
+
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+    for index in range(200):
+        await inbox.write_signal(_tick(index, progress=index / 2.0, temperature=40.0))
+    await inbox.write_signal(_tick(201, progress=99.0, temperature=95.0))
+
+    runtime = ResidentRuntime(state=LocalResidentState(tmp_path / "state"), inbox=inbox)
+    task = await runtime.next_home_task(limit=50, persona=None, output_mode=OutputMode.AMBIENT)
+
+    assert task is not None
+    context = task.initiative_context
+    assert "201 observations of this exact shape" in context
+    assert "temperature 40–95" in context
+    assert "Raw archive range:" in context
+    # The excursion travels as a whole payload, not just as a bound.
+    assert "Payloads at numeric extremes:" in context
+    assert "temperature:max" in context
+    # And acknowledgement is pinned to exactly what was shown.
+    assert task.resident_inbox_expected
+
+
+def test_aggregate_summary_lines_render_each_kind() -> None:
+    aggregate = ShapeAggregate(
+        numeric={"temp": (1.0, 2.5)},
+        categorical={"state": ("printing", "idle")},
+        high_cardinality=("job",),
+    )
+    rendered = "\n".join(_summary_lines(aggregate))
+    assert "temp 1–2.5" in rendered
+    assert "state {printing, idle}" in rendered
+    assert "high-cardinality paths: job" in rendered
+
+
+def test_archive_read_tolerates_bad_references(tmp_path) -> None:
+    from ravn.resident_inbox import RawSignalArchive
+
+    archive = RawSignalArchive(tmp_path)
+    assert archive.read("") is None
+    assert archive.read("not-a-ref") is None
+    assert archive.read("2026-08-03:99999") is None
+    assert archive.count() == 0
+    assert archive.read_range(after="", through="2026-08-03:0", limit=5) == []
+
+
+def test_archive_ref_sort_key_orders_and_tolerates_garbage() -> None:
+    from ravn.resident_inbox import archive_ref_sort_key
+
+    refs = ["2026-08-03:100", "2026-08-02:5", "2026-08-03:20", "garbage"]
+    # Malformed sorts first, so an unreadable reference reads as "judged
+    # nothing" and leaves observations pending rather than acknowledging them.
+    assert sorted(refs, key=archive_ref_sort_key) == [
+        "garbage",
+        "2026-08-02:5",
+        "2026-08-03:20",
+        "2026-08-03:100",
+    ]
+
+
+def test_archive_range_is_bounded_and_skips_malformed_lines(tmp_path) -> None:
+    from ravn.resident_inbox import RawSignalArchive
+
+    archive = RawSignalArchive(tmp_path)
+    refs = [archive.append({"n": index}) for index in range(6)]
+    # A corrupted line must not stop the range from reading the rest.
+    partition = next(iter(archive.directory.glob("*.ndjson")))
+    with partition.open("a", encoding="utf-8") as handle:
+        handle.write("{not json\n")
+
+    everything = archive.read_range(after="", through="9999-12-31:0", limit=100)
+    assert [record["n"] for _ref, record in everything] == [0, 1, 2, 3, 4, 5]
+
+    bounded = archive.read_range(after=refs[1], through=refs[4], limit=2)
+    assert [record["n"] for _ref, record in bounded] == [2, 3]
+
+    assert archive.read_range(after="", through=refs[0], limit=0) == []
+    # count() is a line count for reconciliation: a corrupt line is still a
+    # record that was written, and must not silently vanish from the total.
+    assert archive.count() == 7

--- a/tests/test_ravn/test_resident_inbox_coalescing.py
+++ b/tests/test_ravn/test_resident_inbox_coalescing.py
@@ -371,6 +371,45 @@ async def test_migration_is_resumable_and_reconciles(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_deploying_before_migrating_leaves_the_backlog_intact(tmp_path) -> None:
+    """The rollout depends on this: deploy first, migrate deliberately later.
+
+    A flat backlog written by the previous layout must be invisible to the queue
+    and untouchable by retention until an operator migrates it, so a deploy can
+    fix the write path without racing 84k files.
+    """
+    from ravn.resident_inbox import render_inbox_signal
+
+    root = tmp_path / "inbox"
+    flat_dir = root / "resident/inbox/signals"
+    flat_dir.mkdir(parents=True, exist_ok=True)
+    for index in range(25):
+        signal = _tick(index, progress=index)
+        (flat_dir / f"2026-08-03t10-{index:02d}-00z-tick-{index}.md").write_text(
+            render_inbox_signal(signal), encoding="utf-8"
+        )
+
+    inbox = LocalResidentInbox(
+        root,
+        retention_max_pages=1,
+        retention_max_age_days=0.0001,
+        retention_sweep_interval_seconds=0.0,
+    )
+    # New observations flow normally.
+    await inbox.write_signal(_tick(99, progress=99.0))
+    pending = await inbox.list_signals(limit=50)
+    assert len(pending) == 1
+    assert pending[0][1].observation_count == 1, "legacy files are not in the queue"
+
+    ref, _slot = pending[0]
+    await inbox.acknowledge((ref,))
+    time.sleep(0.02)
+    await inbox.prune_signals()
+
+    assert len(list(flat_dir.glob("*.md"))) == 25, "retention never reaches the old layout"
+
+
+@pytest.mark.asyncio
 async def test_migration_leaves_unreadable_files_in_place(tmp_path) -> None:
     root = tmp_path / "inbox"
     inbox = LocalResidentInbox(root)

--- a/tests/test_ravn/test_resident_inbox_coalescing.py
+++ b/tests/test_ravn/test_resident_inbox_coalescing.py
@@ -238,6 +238,44 @@ async def test_acknowledge_leaves_observations_that_arrived_mid_turn(tmp_path) -
 
 
 @pytest.mark.asyncio
+async def test_unrelated_traffic_cannot_truncate_the_unjudged_tail(tmp_path) -> None:
+    """A burst of other shapes must not cause a slot's tail to be lost.
+
+    The tail is rebuilt from the archive with a bound sized to the slot. If that
+    bound counted unrelated records, a noisy neighbour would fill it and the
+    slot's own unseen observations would be acknowledged without ever being
+    shown to the resident.
+    """
+    inbox = LocalResidentInbox(tmp_path / "inbox")
+    await inbox.write_signal(_tick(1, progress=1))
+    ref, seen = (await inbox.list_signals(limit=1))[0]
+    assert seen.observation_count == 1
+
+    # Far more unrelated observations than this slot's own count, all landing
+    # inside the range the rebuild has to scan.
+    for index in range(50):
+        await inbox.write_signal(
+            ResidentInboxSignal(
+                id=f"noise-{index}",
+                source="noisy-neighbour",
+                kind="other",
+                summary="unrelated",
+                payload={"noise": index},
+                observed_at=f"2026-08-03T11:{index % 60:02d}:00Z",
+            )
+        )
+    # Then two more of the original shape, which the resident has not seen.
+    await inbox.write_signal(_tick(2, progress=2))
+    await inbox.write_signal(_tick(3, progress=3))
+
+    await inbox.acknowledge((ref,), expected={ref: seen.last_archive_ref})
+
+    remaining = {slot.shape_key: slot for _r, slot in await inbox.list_signals(limit=50)}
+    assert seen.shape_key in remaining, "the slot's unseen tail must survive"
+    assert remaining[seen.shape_key].observation_count == 2
+
+
+@pytest.mark.asyncio
 async def test_acknowledge_without_new_arrivals_clears_the_slot(tmp_path) -> None:
     inbox = LocalResidentInbox(tmp_path / "inbox")
     for index in range(4):
@@ -488,9 +526,7 @@ async def test_archive_range_rebuild_skips_foreign_shapes(tmp_path) -> None:
 
     await inbox.acknowledge((ref,), expected={ref: seen.last_archive_ref})
 
-    remainder = {
-        slot.shape_key: slot for _r, slot in await inbox.list_signals(limit=10)
-    }
+    remainder = {slot.shape_key: slot for _r, slot in await inbox.list_signals(limit=10)}
     assert remainder[seen.shape_key].observation_count == 1, "foreign records are not folded in"
 
 


### PR DESCRIPTION
## Why

Ivaldi accumulated **84,066** signal files. The inbox was doing two jobs at once — durable archive *and* operational queue — so every write swept the whole directory, `NEW` records were never eligible for retention, and a telemetry stream that reports state on every tick had no way to occupy fewer than one queue slot per tick.

## What

**The archive is append-only and complete. The queue is coalescing and bounded.**

- `raw/YYYY-MM-DD.ndjson` — every observation, appended, never deleted, never read on the write path. Greppable and compressible; 84k files become roughly one per day.
- `pending/<shape>.md` — at most one slot per structural shape. A further observation of a shape the resident has not looked at yet folds into the existing slot, carrying a count, the exact archive range, numeric ranges, bounded categorical value sets, and the full payload at each numeric extreme.
- `processed/` — judged slots, and the only directory retention reads.

Coalescing only merges what the resident has not seen, so when it is keeping up nothing is coalesced at all. The collapse rate measures how far behind it is.

Nothing here interprets meaning. A shape says two observations are structurally comparable, never that either is routine. A payload that gains or retypes a field is a different shape and surfaces on its own; directed operator messages keep a dedicated slot so an authority-bearing channel is never summarised away.

### Acknowledgement is exact

Compare-and-set against the archive reference the resident actually saw. A slot that advanced mid-turn splits: the judged range moves to `processed/`, newer observations stay pending. No lease, no claim record — the slot *is* the boundary.

### Invalid outcomes are bounded

Counted in the completion path after the turn record is durable (they are completed turns, not failed enqueues). On exhaustion the slot is marked `BLOCKED`, keeps its evidence, and escalates once rather than looping forever behind a metric.

### Coalesced slots are visible to the resident

Count, time span, ranges and extreme payloads travel into the prompt, so judging one tick cannot silently acknowledge hundreds.

## Scope

`LocalResidentInbox` only, where the incident is confirmed. `MimirResidentInbox` already throttles retention off the write path and its page semantics do not support atomic rename, so it keeps its layout and gains only the attempt bound.

## Contract changes

- **A slot's reference moves when it is judged.** Resolution follows a judged slot, so references held in older turn records still resolve. One existing test asserted raw string equality on the returned ref and was updated.
- **A payload that retypes a field is a different shape.** `progress: 99` and `progress: 99.0` do not share a slot — intended fail-open behaviour, but an inconsistent producer creates more slots than expected. A one-time warning fires above a configured slot threshold.

## Migration

`ravn inbox-migrate <root>` — resumable, non-destructive, reconciled by count. **Tested against fixtures only, never against Ivaldi's real 84,066 files.** It must run with the resident stopped: the inbox lock is an in-process `asyncio.Lock`, so a separate migration process gets no mutual exclusion against a running daemon. The raw archive is the only surviving copy of this history (JetStream retains ~2h), so take a filesystem backup first.

## Verification

`ruff` clean; **17,930 passed**, coverage **86.03%** (gate 85%). Merged `dev` in (not rebased) and re-verified after.

Design doc: `docs/ravn-resident-attention.md`. Stage 3 (learned attention) is unimplemented and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)