### PR TITLE
feat(ravn): observe memory usage and floor the episodic recency decay

### DIFF
--- a/docs/operator/grafana/valkyrie-runtime.json
+++ b/docs/operator/grafana/valkyrie-runtime.json
@@ -252,6 +252,111 @@
       "options": {"content": "### How to read one trajectory\nOpen a task trace and follow: JetStream `receive` → signal normalization/publish → queue admission → `invoke_agent` → ordered `chat` and `execute_tool` spans → capability, HTTP/A2A, resident-state, and ODIN child spans → JetStream ACK or NAK. Trace events contain bounded redacted content only when `observability.capture_content=true`; production defaults to metadata-only. `environment_type` is provenance, never a handler selector. A tool launch is not success: require terminal A2A state, verified artifact, adoption, execution, and later reuse evidence.", "mode": "markdown"},
       "title": "Evidence contract",
       "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 90},
+      "id": 70,
+      "panels": [],
+      "title": "Agent memory (episodic, resident state, Mimir)",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 91},
+      "id": 71,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [{"expr": "(sum(rate(ravn_memory_operations{job=~\"$job\",ravn_memory_operation=\"prefetch\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_memory_operations{job=~\"$job\",ravn_memory_operation=\"prefetch\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "title": "Prefetch hit rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 91},
+      "id": 72,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [{"expr": "(sum(rate(ravn_memory_admitted{job=~\"$job\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_memory_candidates{job=~\"$job\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "title": "Admission rate (admitted / candidates)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 91},
+      "id": 73,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [{"expr": "min(ravn_memory_corpus_embedding_coverage{job=~\"$job\"})", "refId": "A"}],
+      "title": "Embedding coverage",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 91},
+      "id": 74,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [{"expr": "(sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_mimir_operation=~\"search|query\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_mimir_operation=~\"search|query\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "title": "Mimir search hit rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 0, "lineWidth": 2, "showPoints": "never", "stacking": {"group": "A", "mode": "none"}}, "unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 95},
+      "id": 75,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (ravn_memory_backend) (rate(ravn_memory_candidates{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "{{ravn_memory_backend}} candidates", "refId": "A"}, {"expr": "sum by (ravn_memory_backend) (rate(ravn_memory_admitted{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "{{ravn_memory_backend}} admitted", "refId": "B"}],
+      "title": "Retrieval funnel: candidates vs admitted",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 0, "lineWidth": 2, "showPoints": "never", "stacking": {"group": "A", "mode": "none"}}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 95},
+      "id": 76,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "histogram_quantile(0.50, sum by (le) (rate(ravn_memory_relevance_score_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p50 score", "refId": "A"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_relevance_score_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p95 score", "refId": "B"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_candidate_age_days_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p95 candidate age (days)", "refId": "C"}],
+      "title": "Relevance score distribution vs min_relevance gate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 12, "lineWidth": 2, "showPoints": "never", "stacking": {"group": "A", "mode": "normal"}}, "unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 103},
+      "id": 77,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (ravn_memory_operation, ravn_memory_result) (rate(ravn_memory_operations{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "memory {{ravn_memory_operation}} {{ravn_memory_result}}", "refId": "A"}, {"expr": "sum by (ravn_resident_state_record_type, ravn_memory_result) (rate(ravn_resident_state_operations{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "resident {{ravn_resident_state_record_type}} {{ravn_memory_result}}", "refId": "B"}, {"expr": "sum by (ravn_memory_result) (rate(ravn_mimir_operations{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "mimir {{ravn_memory_result}}", "refId": "C"}],
+      "title": "Memory / resident-state / Mimir operations by outcome",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 0, "lineWidth": 2, "showPoints": "never", "stacking": {"group": "A", "mode": "none"}}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 103},
+      "id": 78,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "histogram_quantile(0.50, sum by (le) (rate(ravn_memory_prefetch_injected_chars_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p50 injected chars", "refId": "A"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_prefetch_injected_chars_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p95 injected chars", "refId": "B"}, {"expr": "sum by (ravn_resident_state_adapter, ravn_resident_state_reason) (rate(ravn_resident_state_fallback{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "fallback -> {{ravn_resident_state_adapter}}", "refId": "C"}],
+      "title": "Injected context and resident-state fallbacks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 7, "w": 24, "x": 0, "y": 111},
+      "id": 79,
+      "options": {"showHeader": true},
+      "targets": [{"expr": "ravn_memory_corpus_episodes{job=~\"$job\"}", "format": "table", "instant": true, "refId": "A"}, {"expr": "ravn_memory_corpus_embedding_coverage{job=~\"$job\"}", "format": "table", "instant": true, "refId": "B"}, {"expr": "ravn_memory_corpus_index_coverage{job=~\"$job\"}", "format": "table", "instant": true, "refId": "C"}],
+      "title": "Corpus health: episodes, embedding coverage, index coverage",
+      "type": "table"
+    },
+    {
+      "gridPos": {"h": 4, "w": 24, "x": 0, "y": 118},
+      "id": 80,
+      "options": {"content": "**Reading this row.** `Admission rate` is the diagnostic: a healthy funnel keeps candidates and admitted within an order of magnitude. Candidates high with admitted at zero means retrieval is working and the `min_relevance` gate is discarding it \u2014 check the score distribution against the gate and the p95 candidate age, since the combined score multiplies relevance by an unbounded recency decay.\n\n`Embedding coverage` below 1 means part of the corpus can only be reached lexically; `index coverage` below 1 means part of it cannot be reached at all. Both are silent failures no per-call metric shows.", "mode": "markdown"},
+      "title": "How to read the memory row",
+      "type": "text"
     }
   ],
   "refresh": "10s",

--- a/src/ravn/adapters/memory/postgres.py
+++ b/src/ravn/adapters/memory/postgres.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import UTC, datetime
+from time import monotonic
 from typing import Any
 
 import asyncpg
@@ -23,29 +24,34 @@ from niuu.ports.search import SearchPort
 from ravn.adapters.memory.scoring import (
     _AVG_EPISODE_CHARS,
     _CHARS_PER_TOKEN,
-    _OUTCOME_WEIGHTS,
-    _recency_score,
     build_prefetch_context,
     build_session_summaries,
+    combined_score,
+    score_and_admit,
 )
 from ravn.domain.models import Episode, EpisodeMatch, Outcome, SessionSummary, SharedContext
+from ravn.memory_telemetry import (
+    RESULT_EMPTY,
+    RESULT_ERROR,
+    RESULT_HIT,
+    record_funnel,
+    record_injected_chars,
+    record_memory_operation,
+    result_for,
+)
 from ravn.ports.memory import MemoryPort
+
+# Identifies this backend on every metric it emits.
+_BACKEND = "postgres"
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
-
-def _combined_score(
-    relevance: float,
-    timestamp: datetime,
-    outcome: Outcome,
-    half_life_days: float,
-) -> float:
-    """Combine normalised relevance, recency decay, and outcome weight into [0, 1]."""
-    recency = _recency_score(timestamp, half_life_days)
-    weight = _OUTCOME_WEIGHTS.get(outcome, 0.5)
-    return relevance * recency * weight
+# The scoring rule now lives in ``scoring`` alongside the admission loop that
+# applies it, so both adapters share one definition. Re-exported under the
+# historical name for existing importers.
+_combined_score = combined_score
 
 
 def _row_to_episode(row: asyncpg.Record | dict[str, Any]) -> Episode:
@@ -135,6 +141,7 @@ class PostgresMemoryAdapter(MemoryPort):
         prefetch_limit: int = 5,
         prefetch_min_relevance: float = 0.3,
         recency_half_life_days: float = 14.0,
+        recency_floor: float = 0.5,
         session_search_truncate_chars: int = 100_000,
         rrf_k: int = 60,
         semantic_candidate_limit: int = 200,
@@ -153,6 +160,7 @@ class PostgresMemoryAdapter(MemoryPort):
         self._prefetch_limit = prefetch_limit
         self._prefetch_min_relevance = prefetch_min_relevance
         self._recency_half_life_days = recency_half_life_days
+        self._recency_floor = recency_floor
         self._session_search_truncate_chars = session_search_truncate_chars
         self._pool: asyncpg.Pool | None = None
         self._shared_context: SharedContext | None = None
@@ -202,6 +210,25 @@ class PostgresMemoryAdapter(MemoryPort):
     # ------------------------------------------------------------------
 
     async def record_episode(self, episode: Episode) -> None:
+        started = monotonic()
+        try:
+            await self._record_episode(episode)
+        except Exception:
+            record_memory_operation(
+                operation="record",
+                backend=_BACKEND,
+                result=RESULT_ERROR,
+                seconds=monotonic() - started,
+            )
+            raise
+        record_memory_operation(
+            operation="record",
+            backend=_BACKEND,
+            result=RESULT_HIT,
+            seconds=monotonic() - started,
+        )
+
+    async def _record_episode(self, episode: Episode) -> None:
         pool = self._require_pool()
         async with pool.acquire() as conn:
             await conn.execute(
@@ -264,10 +291,24 @@ class PostgresMemoryAdapter(MemoryPort):
         if not query.strip():
             return []
 
+        started = monotonic()
         # Get raw search results from the shared search adapter.
         search_results = await self._search.search(query, limit=limit * 3)
 
         if not search_results:
+            record_funnel(
+                backend=_BACKEND,
+                candidates=0,
+                admitted=0,
+                scores=[],
+                top_candidate_age_days=None,
+            )
+            record_memory_operation(
+                operation="query",
+                backend=_BACKEND,
+                result=RESULT_EMPTY,
+                seconds=monotonic() - started,
+            )
             return []
 
         # Load full episode objects from ravn_episodes by ID.
@@ -288,35 +329,44 @@ class PostgresMemoryAdapter(MemoryPort):
         episodes_by_id = {row["episode_id"]: _row_to_episode(row) for row in rows}
 
         # Apply episode-specific scoring: recency decay × outcome weight.
-        matches: list[EpisodeMatch] = []
-        for result in search_results:
-            ep = episodes_by_id.get(result.id)
-            if ep is None:
-                continue
-            score = _combined_score(
-                result.score,
-                ep.timestamp,
-                ep.outcome,
-                self._recency_half_life_days,
-            )
-            if score >= min_relevance:
-                matches.append(EpisodeMatch(episode=ep, relevance=score))
-
-        matches.sort(key=lambda m: m.relevance, reverse=True)
-        return matches[:limit]
+        matches = score_and_admit(
+            search_results,
+            episodes_by_id,
+            half_life_days=self._recency_half_life_days,
+            min_relevance=min_relevance,
+            limit=limit,
+            backend=_BACKEND,
+            recency_floor=self._recency_floor,
+        )
+        record_memory_operation(
+            operation="query",
+            backend=_BACKEND,
+            result=result_for(len(matches)),
+            seconds=monotonic() - started,
+        )
+        return matches
 
     async def prefetch(self, context: str) -> str:
         if self._prefetch_limit == 0:
             return ""
+        started = monotonic()
         matches = await self.query_episodes(
             context,
             limit=self._prefetch_limit,
             min_relevance=self._prefetch_min_relevance,
         )
-        if not matches:
-            return ""
-        budget_chars = self._prefetch_budget * _CHARS_PER_TOKEN
-        return build_prefetch_context(matches, budget_chars)
+        block = ""
+        if matches:
+            budget_chars = self._prefetch_budget * _CHARS_PER_TOKEN
+            block = build_prefetch_context(matches, budget_chars)
+        record_injected_chars(backend=_BACKEND, chars=len(block))
+        record_memory_operation(
+            operation="prefetch",
+            backend=_BACKEND,
+            result=result_for(len(block)),
+            seconds=monotonic() - started,
+        )
+        return block
 
     async def count_episodes(self) -> int:
         """Return the total number of stored episodes."""

--- a/src/ravn/adapters/memory/scoring.py
+++ b/src/ravn/adapters/memory/scoring.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
+from collections.abc import Sequence
 from datetime import UTC, datetime
 
 from niuu.adapters.search.rrf import cosine_similarity, reciprocal_rank_fusion
+from niuu.ports.search import SearchResult
 from ravn.domain.models import Episode, EpisodeMatch, Outcome, SessionSummary
+from ravn.memory_telemetry import record_funnel
 
 # Re-export so existing ``from ravn.adapters.memory.scoring import ...`` calls work.
 __all__ = [
@@ -24,6 +27,8 @@ __all__ = [
     "reciprocal_rank_fusion",
     "build_prefetch_context",
     "build_session_summaries",
+    "combined_score",
+    "score_and_admit",
     "_CHARS_PER_TOKEN",
     "_AVG_EPISODE_CHARS",
     "_OUTCOME_WEIGHTS",
@@ -44,12 +49,93 @@ _OUTCOME_WEIGHTS: dict[str, float] = {
 }
 
 
-def _recency_score(timestamp: datetime, half_life_days: float) -> float:
-    """Compute exponential decay recency in [0, 1] given episode age."""
+def _recency_score(
+    timestamp: datetime,
+    half_life_days: float,
+    floor: float = 0.0,
+) -> float:
+    """Compute exponential decay recency in ``[floor, 1]`` given episode age.
+
+    Without a floor this decays to zero, and because the caller *multiplies*
+    it into the combined score, age stops being a ranking signal and becomes a
+    filter: at a 14-day half-life nothing older than roughly 24 days can clear
+    a ``min_relevance`` of 0.3 at any relevance. The floor keeps recency
+    ordering results without annihilating them, matching the ``recency_floor``
+    that Mímir's ranking layer already applies.
+    """
     now = datetime.now(UTC)
     ts = timestamp if timestamp.tzinfo is not None else timestamp.replace(tzinfo=UTC)
     age_days = (now - ts).total_seconds() / 86400.0
-    return math.exp(-age_days * math.log(2) / half_life_days)
+    return max(floor, math.exp(-age_days * math.log(2) / half_life_days))
+
+
+def _age_days(timestamp: datetime) -> float:
+    """Age of *timestamp* in days, naive timestamps assumed UTC."""
+    ts = timestamp if timestamp.tzinfo is not None else timestamp.replace(tzinfo=UTC)
+    return max(0.0, (datetime.now(UTC) - ts).total_seconds() / 86400.0)
+
+
+def combined_score(
+    relevance: float,
+    timestamp: datetime,
+    outcome: Outcome,
+    half_life_days: float,
+    recency_floor: float = 0.0,
+) -> float:
+    """Combine normalised relevance, recency decay, and outcome weight into [0, 1]."""
+    recency = _recency_score(timestamp, half_life_days, recency_floor)
+    weight = _OUTCOME_WEIGHTS.get(outcome, 0.5)
+    return relevance * recency * weight
+
+
+def score_and_admit(
+    search_results: Sequence[SearchResult],
+    episodes_by_id: dict[str, Episode],
+    *,
+    half_life_days: float,
+    min_relevance: float,
+    limit: int,
+    backend: str,
+    recency_floor: float = 0.0,
+) -> list[EpisodeMatch]:
+    """Score search-port candidates and keep those clearing *min_relevance*.
+
+    Shared by the SQLite and Postgres adapters so the ranking rule — and the
+    funnel telemetry that makes it diagnosable — exist in exactly one place.
+    Every candidate's score is reported, admitted or not, so a corpus scoring
+    just under the gate is visible rather than merely absent.
+    """
+    matches: list[EpisodeMatch] = []
+    scores: list[float] = []
+    best: tuple[float, Episode] | None = None
+
+    for result in search_results:
+        episode = episodes_by_id.get(result.id)
+        if episode is None:
+            continue
+        score = combined_score(
+            result.score,
+            episode.timestamp,
+            episode.outcome,
+            half_life_days,
+            recency_floor,
+        )
+        scores.append(score)
+        if best is None or score > best[0]:
+            best = (score, episode)
+        if score >= min_relevance:
+            matches.append(EpisodeMatch(episode=episode, relevance=score))
+
+    record_funnel(
+        backend=backend,
+        candidates=len(scores),
+        admitted=len(matches),
+        scores=scores,
+        top_candidate_age_days=_age_days(best[1].timestamp) if best else None,
+    )
+
+    matches.sort(key=lambda m: m.relevance, reverse=True)
+    return matches[:limit]
 
 
 def _format_episode_block(episode: Episode) -> str:

--- a/src/ravn/adapters/memory/sqlite.py
+++ b/src/ravn/adapters/memory/sqlite.py
@@ -17,20 +17,22 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import random
 import sqlite3
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+from time import monotonic
 
 from niuu.adapters.search.sqlite import SqliteSearchAdapter
 from ravn.adapters.memory.scoring import (
     _AVG_EPISODE_CHARS,
     _CHARS_PER_TOKEN,
-    _OUTCOME_WEIGHTS,
-    _recency_score,
     build_prefetch_context,
     build_session_summaries,
+    combined_score,
+    score_and_admit,
 )
 from ravn.domain.models import (
     Episode,
@@ -39,12 +41,27 @@ from ravn.domain.models import (
     SessionSummary,
     SharedContext,
 )
+from ravn.memory_telemetry import (
+    RESULT_EMPTY,
+    RESULT_ERROR,
+    RESULT_HIT,
+    record_corpus,
+    record_funnel,
+    record_injected_chars,
+    record_memory_operation,
+    result_for,
+)
 from ravn.ports.embedding import EmbeddingPort
 from ravn.ports.memory import MemoryPort
 
 # ---------------------------------------------------------------------------
 # Schema
 # ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
+
+# Identifies this backend on every metric it emits.
+_BACKEND = "sqlite"
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS episodes (
@@ -112,16 +129,10 @@ def _row_to_episode(row: sqlite3.Row) -> Episode:
     )
 
 
-def _combined_score(
-    relevance: float,
-    timestamp: datetime,
-    outcome: Outcome,
-    half_life_days: float,
-) -> float:
-    """Combine normalised relevance, recency decay, and outcome weight into [0, 1]."""
-    recency = _recency_score(timestamp, half_life_days)
-    weight = _OUTCOME_WEIGHTS.get(outcome, 0.5)
-    return relevance * recency * weight
+# The scoring rule now lives in ``scoring`` alongside the admission loop that
+# applies it, so both adapters share one definition. Re-exported under the
+# historical name for existing importers.
+_combined_score = combined_score
 
 
 # ---------------------------------------------------------------------------
@@ -154,10 +165,12 @@ class SqliteMemoryAdapter(MemoryPort):
         prefetch_limit: int = 5,
         prefetch_min_relevance: float = 0.3,
         recency_half_life_days: float = 14.0,
+        recency_floor: float = 0.5,
         session_search_truncate_chars: int = 100_000,
         embedding_port: EmbeddingPort | None = None,
         rrf_k: int = 60,
         semantic_candidate_limit: int = 50,
+        corpus_stats_interval_seconds: float = 300.0,
     ) -> None:
         self._path = Path(path).expanduser()
         self._max_retries = max_retries
@@ -168,8 +181,11 @@ class SqliteMemoryAdapter(MemoryPort):
         self._prefetch_limit = prefetch_limit
         self._prefetch_min_relevance = prefetch_min_relevance
         self._recency_half_life_days = recency_half_life_days
+        self._recency_floor = recency_floor
         self._session_search_truncate_chars = session_search_truncate_chars
         self._embedding_port = embedding_port
+        self._corpus_stats_interval_seconds = corpus_stats_interval_seconds
+        self._last_corpus_sample_at: float | None = None
         self._write_count = 0
         self._shared_context: SharedContext | None = None
 
@@ -198,20 +214,37 @@ class SqliteMemoryAdapter(MemoryPort):
         await asyncio.to_thread(self._init_db)
 
     async def record_episode(self, episode: Episode) -> None:
-        await asyncio.to_thread(self._record_episode_sync, episode)
-        # Index the episode in the search adapter for future retrieval.
-        content = f"{episode.task_description} {episode.summary} {' '.join(episode.tags)}"
-        metadata = {
-            "session_id": episode.session_id,
-            "timestamp": episode.timestamp.isoformat(),
-            "outcome": episode.outcome.value,
-        }
-        await self._search.index(
-            episode.episode_id,
-            content,
-            metadata,
-            embedding=episode.embedding,
+        started = monotonic()
+        try:
+            await asyncio.to_thread(self._record_episode_sync, episode)
+            # Index the episode in the search adapter for future retrieval.
+            content = f"{episode.task_description} {episode.summary} {' '.join(episode.tags)}"
+            metadata = {
+                "session_id": episode.session_id,
+                "timestamp": episode.timestamp.isoformat(),
+                "outcome": episode.outcome.value,
+            }
+            await self._search.index(
+                episode.episode_id,
+                content,
+                metadata,
+                embedding=episode.embedding,
+            )
+        except Exception:
+            record_memory_operation(
+                operation="record",
+                backend=_BACKEND,
+                result=RESULT_ERROR,
+                seconds=monotonic() - started,
+            )
+            raise
+        record_memory_operation(
+            operation="record",
+            backend=_BACKEND,
+            result=RESULT_HIT,
+            seconds=monotonic() - started,
         )
+        await self._maybe_emit_corpus_gauges()
 
     async def query_episodes(
         self,
@@ -220,46 +253,108 @@ class SqliteMemoryAdapter(MemoryPort):
         limit: int = 5,
         min_relevance: float = 0.3,
     ) -> list[EpisodeMatch]:
-        # Get raw search results from the shared search adapter.
-        search_results = await self._search.search(query, limit=limit * 3)
+        started = monotonic()
+        try:
+            # Get raw search results from the shared search adapter.
+            search_results = await self._search.search(query, limit=limit * 3)
 
-        if not search_results:
-            return []
+            if not search_results:
+                record_funnel(
+                    backend=_BACKEND,
+                    candidates=0,
+                    admitted=0,
+                    scores=[],
+                    top_candidate_age_days=None,
+                )
+                record_memory_operation(
+                    operation="query",
+                    backend=_BACKEND,
+                    result=RESULT_EMPTY,
+                    seconds=monotonic() - started,
+                )
+                return []
 
-        # Load full episode objects from the episodes table by ID.
-        episode_ids = [r.id for r in search_results]
-        episodes_by_id = await asyncio.to_thread(self._load_episodes_by_ids_sync, episode_ids)
+            # Load full episode objects from the episodes table by ID.
+            episode_ids = [r.id for r in search_results]
+            episodes_by_id = await asyncio.to_thread(self._load_episodes_by_ids_sync, episode_ids)
 
-        # Apply episode-specific scoring: recency decay × outcome weight.
-        matches: list[EpisodeMatch] = []
-        for result in search_results:
-            ep = episodes_by_id.get(result.id)
-            if ep is None:
-                continue
-            score = _combined_score(
-                result.score,
-                ep.timestamp,
-                ep.outcome,
-                self._recency_half_life_days,
+            # Apply episode-specific scoring: recency decay × outcome weight.
+            matches = score_and_admit(
+                search_results,
+                episodes_by_id,
+                half_life_days=self._recency_half_life_days,
+                min_relevance=min_relevance,
+                limit=limit,
+                backend=_BACKEND,
+                recency_floor=self._recency_floor,
             )
-            if score >= min_relevance:
-                matches.append(EpisodeMatch(episode=ep, relevance=score))
-
-        matches.sort(key=lambda m: m.relevance, reverse=True)
-        return matches[:limit]
+        except Exception:
+            record_memory_operation(
+                operation="query",
+                backend=_BACKEND,
+                result=RESULT_ERROR,
+                seconds=monotonic() - started,
+            )
+            raise
+        record_memory_operation(
+            operation="query",
+            backend=_BACKEND,
+            result=result_for(len(matches)),
+            seconds=monotonic() - started,
+        )
+        return matches
 
     async def prefetch(self, context: str) -> str:
         if self._prefetch_limit == 0:
             return ""
+        started = monotonic()
         matches = await self.query_episodes(
             context,
             limit=self._prefetch_limit,
             min_relevance=self._prefetch_min_relevance,
         )
-        if not matches:
-            return ""
-        budget_chars = self._prefetch_budget * _CHARS_PER_TOKEN
-        return build_prefetch_context(matches, budget_chars)
+        block = ""
+        if matches:
+            budget_chars = self._prefetch_budget * _CHARS_PER_TOKEN
+            block = build_prefetch_context(matches, budget_chars)
+        record_injected_chars(backend=_BACKEND, chars=len(block))
+        record_memory_operation(
+            operation="prefetch",
+            backend=_BACKEND,
+            result=result_for(len(block)),
+            seconds=monotonic() - started,
+        )
+        return block
+
+    async def _maybe_emit_corpus_gauges(self) -> None:
+        """Sample corpus-health gauges at most once per configured interval.
+
+        Coverage ratios only change slowly, so sampling on write keeps them
+        current without a dedicated scheduler or a per-call table scan.
+        """
+        if self._corpus_stats_interval_seconds <= 0:
+            return
+        now = monotonic()
+        if (
+            self._last_corpus_sample_at is not None
+            and now - self._last_corpus_sample_at < self._corpus_stats_interval_seconds
+        ):
+            return
+        self._last_corpus_sample_at = now
+        try:
+            episodes, embedded, indexed = await asyncio.to_thread(self._corpus_stats_sync)
+        except sqlite3.Error:
+            logger.warning("Corpus gauge sampling failed.", exc_info=True)
+            return
+        if episodes == 0:
+            record_corpus(backend=_BACKEND, episodes=0, embedding_coverage=0.0, index_coverage=0.0)
+            return
+        record_corpus(
+            backend=_BACKEND,
+            episodes=episodes,
+            embedding_coverage=embedded / episodes,
+            index_coverage=min(1.0, indexed / episodes),
+        )
 
     async def count_episodes(self) -> int:
         """Return the total number of stored episodes."""
@@ -391,6 +486,33 @@ class SqliteMemoryAdapter(MemoryPort):
             return {row["episode_id"]: _row_to_episode(row) for row in rows}
 
         return self._with_retry(_do)
+
+    def _corpus_stats_sync(self) -> tuple[int, int, int]:
+        """Return ``(episodes, episodes_with_embedding, indexed_documents)``.
+
+        ``indexed_documents`` counts rows the search adapter owns; a shortfall
+        against ``episodes`` means part of the corpus is unreachable by any
+        query regardless of how it is scored.
+        """
+
+        def _do_stats() -> tuple[int, int, int]:
+            conn = self._connect()
+            try:
+                row = conn.execute("SELECT COUNT(*), COUNT(embedding) FROM episodes").fetchone()
+                episodes = int(row[0]) if row else 0
+                embedded = int(row[1]) if row else 0
+                try:
+                    index_row = conn.execute("SELECT COUNT(*) FROM search_index").fetchone()
+                    indexed = int(index_row[0]) if index_row else 0
+                except sqlite3.OperationalError:
+                    indexed = 0
+                return episodes, embedded, indexed
+            except sqlite3.OperationalError:
+                return 0, 0, 0
+            finally:
+                conn.close()
+
+        return self._with_retry(_do_stats)
 
     def _count_episodes_sync(self) -> int:
         def _do_count() -> int:

--- a/src/ravn/adapters/mimir/http.py
+++ b/src/ravn/adapters/mimir/http.py
@@ -22,6 +22,7 @@ import time
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
+from time import monotonic
 from typing import Any
 from urllib.parse import quote
 
@@ -41,6 +42,12 @@ from niuu.domain.mimir import (
 )
 from niuu.ports.mimir import MimirPort
 from ravn.domain.mimir import MimirAuth
+from ravn.memory_telemetry import (
+    RESULT_ERROR,
+    RESULT_HIT,
+    record_mimir_operation,
+    result_for,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -133,10 +140,33 @@ class HttpMimirAdapter(MimirPort):
         return token
 
     async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue one Mímir call, timed and counted.
+
+        Every Mímir operation the agent performs funnels through here, so this
+        is the single place that can report whether the shared knowledge base
+        is reachable at all.
+        """
+        started = monotonic()
+        operation = f"{method} {path}"
         client = await self._get_client()
         headers = dict(kwargs.pop("headers", {}) or {})
         headers.update(await self._build_headers())
-        return await client.request(method, path, headers=headers, **kwargs)
+        try:
+            response = await client.request(method, path, headers=headers, **kwargs)
+        except Exception:
+            record_mimir_operation(
+                operation=operation,
+                result=RESULT_ERROR,
+                seconds=monotonic() - started,
+            )
+            raise
+        result = RESULT_ERROR if response.is_error else RESULT_HIT
+        record_mimir_operation(
+            operation=operation,
+            result=result,
+            seconds=monotonic() - started,
+        )
+        return response
 
     async def aclose(self) -> None:
         """Close the underlying HTTP client."""
@@ -172,13 +202,26 @@ class HttpMimirAdapter(MimirPort):
         response.raise_for_status()
         results = response.json()
         pages = [_parse_search_result(r) for r in results]
+        # Retrieval that succeeds and returns nothing is the failure mode a
+        # transport-level status code cannot express.
+        record_mimir_operation(
+            operation="query",
+            result=result_for(len(pages)),
+            results_returned=len(pages),
+        )
         return MimirQueryResult(question=question, answer="", sources=pages)
 
     async def search(self, query: str) -> list[MimirPage]:
         """GET /mimir/search — full-text search."""
         response = await self._request("GET", "/mimir/search", params={"q": query})
         response.raise_for_status()
-        return [_parse_search_result(r) for r in response.json()]
+        pages = [_parse_search_result(r) for r in response.json()]
+        record_mimir_operation(
+            operation="search",
+            result=result_for(len(pages)),
+            results_returned=len(pages),
+        )
+        return pages
 
     async def upsert_page(
         self,

--- a/src/ravn/adapters/resident_state/__init__.py
+++ b/src/ravn/adapters/resident_state/__init__.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 from ravn.domain.resident_state import ResidentStatePort
+from ravn.memory_telemetry import record_resident_state_fallback
+
+
+def _adapter_name(candidate: ResidentStatePort) -> str:
+    return type(candidate).__name__
 
 
 async def select_resident_state(*candidates: ResidentStatePort) -> ResidentStatePort:
@@ -10,10 +15,25 @@ async def select_resident_state(*candidates: ResidentStatePort) -> ResidentState
 
     Lets composition prefer GBrain and fall back to a local/Mimir store when
     GBrain is absent, without the caller branching on adapter type.
+
+    Falling back is invisible from the outside — the resident keeps working
+    against a store with different reach — so any selection past the first
+    preference is counted.
     """
-    for candidate in candidates:
-        if await candidate.available():
-            return candidate
+    if not candidates:
+        raise RuntimeError("no resident-state adapter is available")
+
+    preferred = _adapter_name(candidates[0])
+    for index, candidate in enumerate(candidates):
+        if not await candidate.available():
+            continue
+        if index > 0:
+            record_resident_state_fallback(
+                preferred=preferred,
+                selected=_adapter_name(candidate),
+                reason="preferred_unavailable",
+            )
+        return candidate
     raise RuntimeError("no resident-state adapter is available")
 
 

--- a/src/ravn/adapters/resident_state/mimir.py
+++ b/src/ravn/adapters/resident_state/mimir.py
@@ -17,6 +17,11 @@ from ravn.domain.resident_continuation import (
     ResidentWorkingStateRecord,
 )
 from ravn.domain.resident_state import ResidentStatePort
+from ravn.memory_telemetry import (
+    RESULT_HIT,
+    record_resident_state_operation,
+    result_for,
+)
 from ravn.ports.mimir import MimirPort
 from ravn.resident_continuation import (
     _A2A_TASKS_PATH,
@@ -334,6 +339,44 @@ class LocalResidentState(LocalResidentMemory, ResidentStatePort):
 
     async def available(self) -> bool:
         return True
+
+    # ------------------------------------------------------------------
+    # Observed operations
+    #
+    # GBrain and Letheo extend this class and delegate through ``super()``,
+    # so instrumenting here covers all three adapters. ``type(self).__name__``
+    # keeps them distinguishable on the metric.
+    # ------------------------------------------------------------------
+
+    async def recall(self, mandate: str, *, limit: int = 5) -> list[ResidentMemoryEntry]:
+        entries = await super().recall(mandate, limit=limit)
+        record_resident_state_operation(
+            operation="recall",
+            record_type="continuation",
+            adapter=type(self).__name__,
+            result=result_for(len(entries)),
+        )
+        return entries
+
+    async def read_working_state(self, resident_id: str) -> ResidentMemoryEntry | None:
+        entry = await super().read_working_state(resident_id)
+        record_resident_state_operation(
+            operation="read",
+            record_type="working_state",
+            adapter=type(self).__name__,
+            result=result_for(1 if entry is not None else 0),
+        )
+        return entry
+
+    async def write_turn(self, record: ResidentTurnRecord) -> str:
+        ref = await super().write_turn(record)
+        record_resident_state_operation(
+            operation="write",
+            record_type="turn",
+            adapter=type(self).__name__,
+            result=RESULT_HIT,
+        )
+        return ref
 
     async def list_refs(self, prefix: str = "") -> list[str]:
         root = self._root.resolve()

--- a/src/ravn/cli/runtime_builders.py
+++ b/src/ravn/cli/runtime_builders.py
@@ -626,10 +626,12 @@ def _build_memory(settings: Settings, llm: Any = None) -> Any:
             prefetch_limit=settings.memory.prefetch_limit,
             prefetch_min_relevance=settings.memory.prefetch_min_relevance,
             recency_half_life_days=settings.memory.recency_half_life_days,
+            recency_floor=settings.memory.recency_floor,
             session_search_truncate_chars=settings.memory.session_search_truncate_chars,
             embedding_port=embedding_port,
             rrf_k=settings.embedding.rrf_k,
             semantic_candidate_limit=settings.embedding.semantic_candidate_limit,
+            corpus_stats_interval_seconds=settings.memory.corpus_stats_interval_seconds,
         )
 
     elif backend == "postgres":

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -480,6 +480,25 @@ class MemoryConfig(BaseModel):
         default=14.0,
         description="Half-life in days for the exponential recency decay applied to episodes.",
     )
+    recency_floor: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Minimum recency multiplier, so an old-but-relevant episode still ranks. "
+            "Recency multiplies into the combined score, so without a floor the decay "
+            "acts as an age filter rather than a ranking signal: at the default "
+            "half-life nothing older than ~24 days can clear prefetch_min_relevance. "
+            "0.0 restores the previous unbounded decay."
+        ),
+    )
+    corpus_stats_interval_seconds: float = Field(
+        default=300.0,
+        description=(
+            "Minimum seconds between corpus-health gauge samples (episode count, "
+            "embedding and search-index coverage). 0 disables sampling."
+        ),
+    )
     max_retries: int = Field(
         default=15,
         description="Maximum retry attempts on SQLite 'database is locked' errors.",

--- a/src/ravn/memory_telemetry.py
+++ b/src/ravn/memory_telemetry.py
@@ -1,0 +1,313 @@
+"""Shared telemetry for Ravn's three memory surfaces.
+
+Ravn reads from three stores with very different contracts, and each one can
+fail silently in its own way:
+
+* **episodic memory** (:class:`ravn.ports.memory.MemoryPort`) — ranked, lossy;
+  a miss costs answer quality;
+* **resident state** (:class:`ravn.domain.resident_state.ResidentStatePort`) —
+  typed, exact-read; a miss breaks continuation;
+* **Mímir** (:class:`ravn.ports.mimir.MimirPort`) — the shared knowledge base
+  reached over HTTP.
+
+All three previously emitted nothing, so an empty result was indistinguishable
+from a healthy one. Metric names live here so the Grafana dashboard, the
+adapters, and ``tests/test_ravn/test_valkyrie_grafana_dashboard.py`` cannot
+drift apart.
+
+Names follow the OTel dotted convention already used by
+``ravn.tool_observability``; the Prometheus exporter renders
+``ravn.memory.operations`` as ``ravn_memory_operations_total``.
+
+The candidate funnel deserves a note. ``CANDIDATES`` counts what the search
+port returned *before* domain scoring; ``ADMITTED`` counts what survived the
+``min_relevance`` gate. Their ratio is the diagnostic that distinguishes the
+three very different causes of an empty prefetch — nothing stored, nothing
+matched, or the gate discarding good candidates. ``RELEVANCE_SCORE`` records
+every scored candidate including rejected ones, so a corpus scoring just below
+the threshold is visible rather than merely absent.
+"""
+
+from __future__ import annotations
+
+from niuu.observability import get_observability
+
+# --- metric names ---------------------------------------------------------
+
+OPERATIONS = "ravn.memory.operations"
+CANDIDATES = "ravn.memory.candidates"
+ADMITTED = "ravn.memory.admitted"
+RELEVANCE_SCORE = "ravn.memory.relevance.score"
+CANDIDATE_AGE_DAYS = "ravn.memory.candidate.age.days"
+INJECTED_CHARS = "ravn.memory.prefetch.injected.chars"
+DURATION = "ravn.memory.duration"
+CORPUS_EPISODES = "ravn.memory.corpus.episodes"
+CORPUS_EMBEDDING_COVERAGE = "ravn.memory.corpus.embedding.coverage"
+CORPUS_INDEX_COVERAGE = "ravn.memory.corpus.index.coverage"
+
+RESIDENT_STATE_OPERATIONS = "ravn.resident_state.operations"
+RESIDENT_STATE_FALLBACK = "ravn.resident_state.fallback"
+
+MIMIR_OPERATIONS = "ravn.mimir.operations"
+MIMIR_RESULTS = "ravn.mimir.results"
+
+# --- attribute keys -------------------------------------------------------
+
+ATTR_BACKEND = "ravn.memory.backend"
+ATTR_OPERATION = "ravn.memory.operation"
+ATTR_RESULT = "ravn.memory.result"
+ATTR_ADAPTER = "ravn.resident_state.adapter"
+ATTR_RECORD_TYPE = "ravn.resident_state.record_type"
+ATTR_REASON = "ravn.resident_state.reason"
+ATTR_MIMIR_OPERATION = "ravn.mimir.operation"
+ATTR_COMPONENT = "ravn.runtime.component"
+
+# --- result values --------------------------------------------------------
+
+RESULT_HIT = "hit"
+RESULT_EMPTY = "empty"
+RESULT_ERROR = "error"
+
+
+def result_for(count: int) -> str:
+    """Map a returned-item count onto the shared ``hit``/``empty`` vocabulary."""
+    return RESULT_HIT if count > 0 else RESULT_EMPTY
+
+
+def record_memory_operation(
+    *,
+    operation: str,
+    backend: str,
+    result: str,
+    seconds: float | None = None,
+    component: str = "resident",
+) -> None:
+    """Emit the outcome (and optionally the latency) of one memory operation."""
+    telemetry = get_observability()
+    attributes = {
+        ATTR_OPERATION: operation,
+        ATTR_BACKEND: backend,
+        ATTR_RESULT: result,
+        ATTR_COMPONENT: component,
+    }
+    telemetry.count(
+        OPERATIONS,
+        attributes=attributes,
+        description="Episodic memory operations by outcome.",
+    )
+    if seconds is not None:
+        telemetry.duration(
+            DURATION,
+            seconds,
+            attributes=attributes,
+            description="Episodic memory operation latency.",
+        )
+
+
+def record_funnel(
+    *,
+    backend: str,
+    candidates: int,
+    admitted: int,
+    scores: list[float],
+    top_candidate_age_days: float | None,
+    component: str = "resident",
+) -> None:
+    """Emit the retrieval funnel for one query.
+
+    ``scores`` carries every candidate's combined score, admitted or not, so
+    the histogram shows a sub-threshold cluster instead of silence.
+    """
+    telemetry = get_observability()
+    attributes = {ATTR_BACKEND: backend, ATTR_COMPONENT: component}
+    telemetry.count(
+        CANDIDATES,
+        candidates,
+        attributes=attributes,
+        description="Candidates returned by the search port before domain scoring.",
+    )
+    telemetry.count(
+        ADMITTED,
+        admitted,
+        attributes=attributes,
+        description="Candidates that survived the min_relevance gate.",
+    )
+    for score in scores:
+        telemetry.record(
+            RELEVANCE_SCORE,
+            score,
+            attributes=attributes,
+            description="Combined relevance x recency x outcome score per candidate.",
+        )
+    if top_candidate_age_days is not None:
+        telemetry.record(
+            CANDIDATE_AGE_DAYS,
+            top_candidate_age_days,
+            unit="d",
+            attributes=attributes,
+            description="Age of the highest-scoring candidate.",
+        )
+
+
+def record_injected_chars(*, backend: str, chars: int, component: str = "resident") -> None:
+    """Emit how much context prefetch actually injected into the prompt."""
+    get_observability().record(
+        INJECTED_CHARS,
+        chars,
+        attributes={ATTR_BACKEND: backend, ATTR_COMPONENT: component},
+        description="Characters of past context injected by prefetch.",
+    )
+
+
+def record_corpus(
+    *,
+    backend: str,
+    episodes: int,
+    embedding_coverage: float,
+    index_coverage: float,
+    component: str = "resident",
+) -> None:
+    """Emit corpus-health gauges.
+
+    Coverage ratios catch the silent failures that no per-call metric can:
+    embeddings never generated, or episodes missing from the search index.
+    """
+    telemetry = get_observability()
+    attributes = {ATTR_BACKEND: backend, ATTR_COMPONENT: component}
+    telemetry.gauge(
+        CORPUS_EPISODES,
+        episodes,
+        attributes=attributes,
+        description="Episodes stored.",
+    )
+    telemetry.gauge(
+        CORPUS_EMBEDDING_COVERAGE,
+        embedding_coverage,
+        attributes=attributes,
+        description="Fraction of episodes carrying an embedding.",
+    )
+    telemetry.gauge(
+        CORPUS_INDEX_COVERAGE,
+        index_coverage,
+        attributes=attributes,
+        description="Fraction of episodes present in the search index.",
+    )
+
+
+def record_resident_state_operation(
+    *,
+    operation: str,
+    record_type: str,
+    adapter: str,
+    result: str,
+    component: str = "resident",
+) -> None:
+    """Emit one resident-state read or write."""
+    get_observability().count(
+        RESIDENT_STATE_OPERATIONS,
+        attributes={
+            ATTR_OPERATION: operation,
+            ATTR_RECORD_TYPE: record_type,
+            ATTR_ADAPTER: adapter,
+            ATTR_RESULT: result,
+            ATTR_COMPONENT: component,
+        },
+        description="Resident-state operations by record type and outcome.",
+    )
+
+
+def record_resident_state_fallback(
+    *,
+    preferred: str,
+    selected: str,
+    reason: str,
+    component: str = "resident",
+) -> None:
+    """Emit an adapter fallback.
+
+    A resident whose preferred brain is unreachable keeps working against the
+    local store, so this degradation is invisible without a counter.
+    """
+    get_observability().count(
+        RESIDENT_STATE_FALLBACK,
+        attributes={
+            "ravn.resident_state.preferred": preferred,
+            ATTR_ADAPTER: selected,
+            ATTR_REASON: reason,
+            ATTR_COMPONENT: component,
+        },
+        description="Resident-state adapter fallbacks away from the preferred store.",
+    )
+
+
+def record_mimir_operation(
+    *,
+    operation: str,
+    result: str,
+    seconds: float | None = None,
+    results_returned: int | None = None,
+    component: str = "resident",
+) -> None:
+    """Emit one Mímir call made by the agent."""
+    telemetry = get_observability()
+    attributes = {
+        ATTR_MIMIR_OPERATION: operation,
+        ATTR_RESULT: result,
+        ATTR_COMPONENT: component,
+    }
+    telemetry.count(
+        MIMIR_OPERATIONS,
+        attributes=attributes,
+        description="Mimir operations issued by the agent, by outcome.",
+    )
+    if results_returned is not None:
+        telemetry.record(
+            MIMIR_RESULTS,
+            results_returned,
+            attributes=attributes,
+            description="Results returned per Mimir retrieval call.",
+        )
+    if seconds is not None:
+        telemetry.duration(
+            DURATION,
+            seconds,
+            attributes={ATTR_OPERATION: f"mimir.{operation}", ATTR_RESULT: result},
+            description="Mimir call latency.",
+        )
+
+
+__all__ = [
+    "ADMITTED",
+    "ATTR_ADAPTER",
+    "ATTR_BACKEND",
+    "ATTR_COMPONENT",
+    "ATTR_MIMIR_OPERATION",
+    "ATTR_OPERATION",
+    "ATTR_REASON",
+    "ATTR_RECORD_TYPE",
+    "ATTR_RESULT",
+    "CANDIDATES",
+    "CANDIDATE_AGE_DAYS",
+    "CORPUS_EMBEDDING_COVERAGE",
+    "CORPUS_EPISODES",
+    "CORPUS_INDEX_COVERAGE",
+    "DURATION",
+    "INJECTED_CHARS",
+    "MIMIR_OPERATIONS",
+    "MIMIR_RESULTS",
+    "OPERATIONS",
+    "RELEVANCE_SCORE",
+    "RESIDENT_STATE_FALLBACK",
+    "RESIDENT_STATE_OPERATIONS",
+    "RESULT_EMPTY",
+    "RESULT_ERROR",
+    "RESULT_HIT",
+    "record_corpus",
+    "record_funnel",
+    "record_injected_chars",
+    "record_memory_operation",
+    "record_mimir_operation",
+    "record_resident_state_fallback",
+    "record_resident_state_operation",
+    "result_for",
+]

--- a/tests/test_ravn/test_memory_telemetry.py
+++ b/tests/test_ravn/test_memory_telemetry.py
@@ -1,0 +1,425 @@
+"""Telemetry for Ravn's three memory surfaces.
+
+These tests pin the behaviour that was missing when episodic prefetch was
+found returning nothing for every query on a 3,321-episode store: retrieval
+succeeded, domain scoring discarded every candidate, and no signal
+distinguished that from an empty corpus. The funnel counters are what make the
+two cases distinguishable, so they are asserted directly.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+import respx
+
+from niuu.ports.search import SearchResult
+from ravn import memory_telemetry
+from ravn.adapters.memory.scoring import combined_score, score_and_admit
+from ravn.adapters.memory.sqlite import SqliteMemoryAdapter
+from ravn.adapters.mimir.http import HttpMimirAdapter
+from ravn.adapters.resident_state import select_resident_state
+from ravn.domain.models import Episode, Outcome
+
+_MIMIR_URL = "http://mimir.test"
+
+
+class RecordingTelemetry:
+    """Captures counter and histogram emissions instead of exporting them."""
+
+    def __init__(self) -> None:
+        self.counts: list[tuple[str, int, dict]] = []
+        self.records: list[tuple[str, float, dict]] = []
+        self.gauges: list[tuple[str, float, dict]] = []
+
+    def count(self, name, value=1, *, attributes=None, description="") -> None:
+        self.counts.append((name, value, attributes or {}))
+
+    def record(self, name, value, *, unit="1", attributes=None, description="") -> None:
+        self.records.append((name, value, attributes or {}))
+
+    def duration(self, name, seconds, *, attributes=None, description="") -> None:
+        self.records.append((name, seconds, attributes or {}))
+
+    def gauge(self, name, value, *, attributes=None, description="") -> None:
+        self.gauges.append((name, value, attributes or {}))
+
+    def total(self, metric: str) -> int:
+        return sum(value for name, value, _ in self.counts if name == metric)
+
+    def values(self, metric: str) -> list[float]:
+        return [value for name, value, _ in self.records if name == metric]
+
+    def attributes_for(self, metric: str) -> list[dict]:
+        return [attrs for name, _, attrs in self.counts if name == metric]
+
+
+@pytest.fixture
+def telemetry(monkeypatch: pytest.MonkeyPatch) -> RecordingTelemetry:
+    recorder = RecordingTelemetry()
+    monkeypatch.setattr(memory_telemetry, "get_observability", lambda: recorder)
+    return recorder
+
+
+def _episode(episode_id: str, *, age_days: float, outcome: Outcome = Outcome.SUCCESS) -> Episode:
+    return Episode(
+        episode_id=episode_id,
+        session_id="session-1",
+        timestamp=datetime.now(UTC) - timedelta(days=age_days),
+        summary="pool size raised to 20",
+        task_description="size the auxiliary postgres pools",
+        tools_used=["edit"],
+        outcome=outcome,
+        tags=["ravn"],
+    )
+
+
+class TestRetrievalFunnel:
+    def test_candidates_and_admitted_diverge_when_the_gate_culls(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        """The exact production failure: strong search hits, nothing admitted.
+
+        Old episodes carry a recency multiplier small enough to push a perfect
+        relevance score under the gate. Without both counters this is
+        indistinguishable from an empty corpus.
+        """
+        episodes = {f"e{i}": _episode(f"e{i}", age_days=120) for i in range(5)}
+        results = [SearchResult(id=f"e{i}", content="c", score=1.0) for i in range(5)]
+
+        matches = score_and_admit(
+            results,
+            episodes,
+            half_life_days=14.0,
+            min_relevance=0.3,
+            limit=5,
+            backend="sqlite",
+        )
+
+        assert matches == []
+        assert telemetry.total(memory_telemetry.CANDIDATES) == 5
+        assert telemetry.total(memory_telemetry.ADMITTED) == 0
+
+    def test_every_candidate_score_is_reported_including_rejected_ones(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        """A corpus scoring just under the gate must be visible, not silent."""
+        episodes = {f"e{i}": _episode(f"e{i}", age_days=120) for i in range(3)}
+        results = [SearchResult(id=f"e{i}", content="c", score=1.0) for i in range(3)]
+
+        score_and_admit(
+            results,
+            episodes,
+            half_life_days=14.0,
+            min_relevance=0.3,
+            limit=5,
+            backend="sqlite",
+        )
+
+        scores = telemetry.values(memory_telemetry.RELEVANCE_SCORE)
+        assert len(scores) == 3
+        assert all(0.0 < score < 0.3 for score in scores)
+
+    def test_top_candidate_age_is_reported(self, telemetry: RecordingTelemetry) -> None:
+        """Candidate age localises a recency-decay cull without reading code."""
+        episodes = {"old": _episode("old", age_days=90), "new": _episode("new", age_days=1)}
+        results = [
+            SearchResult(id="old", content="c", score=1.0),
+            SearchResult(id="new", content="c", score=0.9),
+        ]
+
+        score_and_admit(
+            results,
+            episodes,
+            half_life_days=14.0,
+            min_relevance=0.0,
+            limit=5,
+            backend="sqlite",
+        )
+
+        ages = telemetry.values(memory_telemetry.CANDIDATE_AGE_DAYS)
+        assert len(ages) == 1
+        assert ages[0] == pytest.approx(1.0, abs=0.1)
+
+    def test_fresh_relevant_episodes_are_admitted(self, telemetry: RecordingTelemetry) -> None:
+        episodes = {"fresh": _episode("fresh", age_days=1)}
+        results = [SearchResult(id="fresh", content="c", score=1.0)]
+
+        matches = score_and_admit(
+            results,
+            episodes,
+            half_life_days=14.0,
+            min_relevance=0.3,
+            limit=5,
+            backend="sqlite",
+        )
+
+        assert len(matches) == 1
+        assert telemetry.total(memory_telemetry.CANDIDATES) == 1
+        assert telemetry.total(memory_telemetry.ADMITTED) == 1
+
+
+class TestSqliteAdapterOperations:
+    async def test_prefetch_reports_empty_and_injects_nothing(
+        self, telemetry: RecordingTelemetry, tmp_path
+    ) -> None:
+        adapter = SqliteMemoryAdapter(path=str(tmp_path / "memory.db"))
+        await adapter.initialize()
+
+        block = await adapter.prefetch("anything at all")
+
+        assert block == ""
+        results = {
+            attrs[memory_telemetry.ATTR_OPERATION]: attrs[memory_telemetry.ATTR_RESULT]
+            for attrs in telemetry.attributes_for(memory_telemetry.OPERATIONS)
+        }
+        assert results["prefetch"] == memory_telemetry.RESULT_EMPTY
+        assert telemetry.values(memory_telemetry.INJECTED_CHARS) == [0]
+
+    async def test_prefetch_reports_a_hit_and_the_injected_size(
+        self, telemetry: RecordingTelemetry, tmp_path
+    ) -> None:
+        adapter = SqliteMemoryAdapter(path=str(tmp_path / "memory.db"))
+        await adapter.initialize()
+        await adapter.record_episode(_episode("fresh", age_days=0.1))
+
+        block = await adapter.prefetch("size the auxiliary postgres pools")
+
+        assert block != ""
+        injected = telemetry.values(memory_telemetry.INJECTED_CHARS)
+        assert injected[-1] == len(block)
+        results = [
+            attrs[memory_telemetry.ATTR_RESULT]
+            for attrs in telemetry.attributes_for(memory_telemetry.OPERATIONS)
+            if attrs[memory_telemetry.ATTR_OPERATION] == "prefetch"
+        ]
+        assert results == [memory_telemetry.RESULT_HIT]
+
+    async def test_corpus_gauges_expose_missing_embeddings(
+        self, telemetry: RecordingTelemetry, tmp_path
+    ) -> None:
+        """Embedding coverage of 0 is the state the live store was found in."""
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            corpus_stats_interval_seconds=0.0001,
+        )
+        await adapter.initialize()
+        await adapter.record_episode(_episode("one", age_days=1))
+
+        coverage = {
+            name: value
+            for name, value, _ in telemetry.gauges
+            if name == memory_telemetry.CORPUS_EMBEDDING_COVERAGE
+        }
+        assert coverage[memory_telemetry.CORPUS_EMBEDDING_COVERAGE] == 0.0
+        episodes = [
+            value for name, value, _ in telemetry.gauges if name == memory_telemetry.CORPUS_EPISODES
+        ]
+        assert episodes[-1] == 1
+
+    async def test_corpus_sampling_respects_its_interval(
+        self, telemetry: RecordingTelemetry, tmp_path
+    ) -> None:
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            corpus_stats_interval_seconds=3600.0,
+        )
+        await adapter.initialize()
+        for index in range(3):
+            await adapter.record_episode(_episode(f"e{index}", age_days=1))
+
+        samples = [
+            name for name, _, _ in telemetry.gauges if name == memory_telemetry.CORPUS_EPISODES
+        ]
+        assert len(samples) == 1
+
+
+class TestResidentStateSelection:
+    class _Adapter:
+        def __init__(self, available: bool) -> None:
+            self._available = available
+
+        async def available(self) -> bool:
+            return self._available
+
+    async def test_preferred_adapter_records_no_fallback(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        preferred = self._Adapter(available=True)
+
+        selected = await select_resident_state(preferred, self._Adapter(available=True))
+
+        assert selected is preferred
+        assert telemetry.total(memory_telemetry.RESIDENT_STATE_FALLBACK) == 0
+
+    async def test_falling_back_is_counted(self, telemetry: RecordingTelemetry) -> None:
+        """A resident silently demoted to its local store must be visible."""
+        fallback = self._Adapter(available=True)
+
+        selected = await select_resident_state(self._Adapter(available=False), fallback)
+
+        assert selected is fallback
+        assert telemetry.total(memory_telemetry.RESIDENT_STATE_FALLBACK) == 1
+
+    async def test_no_available_adapter_still_fails_loudly(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        with pytest.raises(RuntimeError):
+            await select_resident_state(self._Adapter(available=False))
+
+
+class TestMimirOperations:
+    """Mímir is reached over HTTP, so it has a failure mode the others lack:
+    a call that succeeds at the transport level and returns nothing."""
+
+    @respx.mock
+    async def test_search_returning_nothing_is_reported_as_empty(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        respx.get(f"{_MIMIR_URL}/mimir/search").mock(return_value=httpx.Response(200, json=[]))
+        adapter = HttpMimirAdapter(base_url=_MIMIR_URL)
+
+        pages = await adapter.search("anything")
+
+        assert pages == []
+        results = [
+            attrs[memory_telemetry.ATTR_RESULT]
+            for attrs in telemetry.attributes_for(memory_telemetry.MIMIR_OPERATIONS)
+            if attrs.get(memory_telemetry.ATTR_MIMIR_OPERATION) == "search"
+        ]
+        assert results == [memory_telemetry.RESULT_EMPTY]
+        assert telemetry.values(memory_telemetry.MIMIR_RESULTS) == [0]
+        await adapter.aclose()
+
+    @respx.mock
+    async def test_search_returning_pages_is_reported_as_a_hit(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        respx.get(f"{_MIMIR_URL}/mimir/search").mock(
+            return_value=httpx.Response(
+                200,
+                json=[{"path": "wiki/entities/ravn.md", "title": "Ravn", "summary": "s"}],
+            )
+        )
+        adapter = HttpMimirAdapter(base_url=_MIMIR_URL)
+
+        pages = await adapter.search("ravn")
+
+        assert len(pages) == 1
+        assert telemetry.values(memory_telemetry.MIMIR_RESULTS) == [1]
+        await adapter.aclose()
+
+    @respx.mock
+    async def test_transport_failure_is_counted_as_an_error(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        """An unreachable knowledge base must not look like an empty one."""
+        respx.get(f"{_MIMIR_URL}/mimir/search").mock(side_effect=httpx.ConnectError("unreachable"))
+        adapter = HttpMimirAdapter(base_url=_MIMIR_URL)
+
+        with pytest.raises(httpx.ConnectError):
+            await adapter.search("ravn")
+
+        results = [
+            attrs[memory_telemetry.ATTR_RESULT]
+            for attrs in telemetry.attributes_for(memory_telemetry.MIMIR_OPERATIONS)
+        ]
+        assert memory_telemetry.RESULT_ERROR in results
+        await adapter.aclose()
+
+    @respx.mock
+    async def test_an_error_status_is_reported_as_an_error(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        respx.get(f"{_MIMIR_URL}/mimir/search").mock(return_value=httpx.Response(503))
+        adapter = HttpMimirAdapter(base_url=_MIMIR_URL)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.search("ravn")
+
+        results = [
+            attrs[memory_telemetry.ATTR_RESULT]
+            for attrs in telemetry.attributes_for(memory_telemetry.MIMIR_OPERATIONS)
+        ]
+        assert results == [memory_telemetry.RESULT_ERROR]
+        await adapter.aclose()
+
+
+class TestRecencyFloor:
+    """The floor turns recency back into a ranking signal.
+
+    Multiplied into the combined score without a lower bound, exponential
+    decay stops ordering results and starts filtering them: at a 14-day
+    half-life and a 0.3 gate, nothing older than ~24 days can be admitted at
+    any relevance. That is what left a 3,321-episode store returning nothing.
+    """
+
+    def test_old_relevant_episodes_are_admitted_with_a_floor(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        episodes = {"old": _episode("old", age_days=120)}
+        results = [SearchResult(id="old", content="c", score=1.0)]
+
+        matches = score_and_admit(
+            results,
+            episodes,
+            half_life_days=14.0,
+            min_relevance=0.3,
+            limit=5,
+            backend="sqlite",
+            recency_floor=0.5,
+        )
+
+        assert len(matches) == 1
+        assert telemetry.total(memory_telemetry.ADMITTED) == 1
+
+    def test_a_zero_floor_reproduces_the_old_age_ceiling(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        """Explicitly opting out restores the previous behaviour."""
+        episodes = {"old": _episode("old", age_days=120)}
+        results = [SearchResult(id="old", content="c", score=1.0)]
+
+        matches = score_and_admit(
+            results,
+            episodes,
+            half_life_days=14.0,
+            min_relevance=0.3,
+            limit=5,
+            backend="sqlite",
+            recency_floor=0.0,
+        )
+
+        assert matches == []
+
+    def test_recency_still_orders_results(self) -> None:
+        """A floor must not flatten ordering — fresh still outranks old."""
+        fresh = combined_score(1.0, _episode("f", age_days=1).timestamp, Outcome.SUCCESS, 14.0, 0.5)
+        old = combined_score(1.0, _episode("o", age_days=365).timestamp, Outcome.SUCCESS, 14.0, 0.5)
+
+        assert fresh > old
+        assert old == pytest.approx(0.5, abs=1e-6)
+
+    def test_relevance_still_gates_irrelevant_old_episodes(self) -> None:
+        """The floor lifts recency, not relevance: weak matches stay out.
+
+        This is the guard against the floor trading "injects nothing" for
+        "injects stale noise".
+        """
+        weak = combined_score(
+            0.2, _episode("o", age_days=365).timestamp, Outcome.SUCCESS, 14.0, 0.5
+        )
+
+        assert weak < 0.3
+
+    def test_failed_episodes_are_still_down_weighted(self) -> None:
+        success = combined_score(
+            1.0, _episode("s", age_days=365).timestamp, Outcome.SUCCESS, 14.0, 0.5
+        )
+        failure = combined_score(
+            1.0, _episode("f", age_days=365).timestamp, Outcome.FAILURE, 14.0, 0.5
+        )
+
+        assert failure < success

--- a/tests/test_ravn/test_valkyrie_grafana_dashboard.py
+++ b/tests/test_ravn/test_valkyrie_grafana_dashboard.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ravn import memory_telemetry
+
 
 def test_runtime_dashboard_covers_judgment_and_causal_dependencies() -> None:
     dashboard_path = (
@@ -41,3 +43,64 @@ def test_runtime_dashboard_covers_judgment_and_causal_dependencies() -> None:
     assert "ravn_trace_relationship" in queries
     assert 'ravn_runtime_component="resident"' in queries
     assert "span.ravn.task.id" in queries
+
+
+def _dashboard_queries() -> str:
+    dashboard_path = (
+        Path(__file__).parents[2] / "docs" / "operator" / "grafana" / "valkyrie-runtime.json"
+    )
+    dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+    return "\n".join(
+        str(target.get("expr") or target.get("query") or "")
+        for panel in dashboard["panels"]
+        for target in panel.get("targets", [])
+    )
+
+
+def test_runtime_dashboard_covers_every_agent_memory_metric() -> None:
+    """Each metric ``ravn.memory_telemetry`` emits must be plotted somewhere.
+
+    The three memory surfaces previously emitted nothing at all, so an empty
+    prefetch was indistinguishable from a healthy one. Pinning the emitted
+    names against the dashboard keeps a new metric from landing unplotted, and
+    keeps a renamed one from silently blanking a panel.
+    """
+    queries = _dashboard_queries()
+
+    for metric in (
+        memory_telemetry.OPERATIONS,
+        memory_telemetry.CANDIDATES,
+        memory_telemetry.ADMITTED,
+        memory_telemetry.RELEVANCE_SCORE,
+        memory_telemetry.CANDIDATE_AGE_DAYS,
+        memory_telemetry.INJECTED_CHARS,
+        memory_telemetry.CORPUS_EPISODES,
+        memory_telemetry.CORPUS_EMBEDDING_COVERAGE,
+        memory_telemetry.CORPUS_INDEX_COVERAGE,
+        memory_telemetry.RESIDENT_STATE_OPERATIONS,
+        memory_telemetry.RESIDENT_STATE_FALLBACK,
+        memory_telemetry.MIMIR_OPERATIONS,
+    ):
+        assert metric.replace(".", "_") in queries, f"{metric} is emitted but never plotted"
+
+
+def test_runtime_dashboard_plots_the_admission_funnel_together() -> None:
+    """Candidates and admitted must share a panel.
+
+    Their ratio is the diagnostic that separates "nothing stored" from "the
+    gate discarded good candidates"; on separate panels the comparison is lost.
+    """
+    dashboard_path = (
+        Path(__file__).parents[2] / "docs" / "operator" / "grafana" / "valkyrie-runtime.json"
+    )
+    dashboard = json.loads(dashboard_path.read_text(encoding="utf-8"))
+    funnel_panels = [
+        panel
+        for panel in dashboard["panels"]
+        if all(
+            any(name in str(target.get("expr", "")) for target in panel.get("targets", []))
+            for name in ("ravn_memory_candidates", "ravn_memory_admitted")
+        )
+        and panel.get("targets")
+    ]
+    assert funnel_panels, "no panel plots candidates and admitted together"


### PR DESCRIPTION
## Why

Ravn reads from three memory surfaces — episodic memory, resident state, and Mímir — and **none of them emitted a single metric**. An empty prefetch was indistinguishable from a healthy one.

Investigating the live store found it returning **zero context on every query** across 3,321 episodes, and nothing anywhere recorded that.

## What

**Observability.** New `ravn.memory_telemetry` holds every metric name in one place. All three surfaces now report outcome, latency, and errors; episodic memory adds corpus-health gauges (episode count, embedding coverage, search-index coverage); resident state counts fallbacks off the preferred adapter; Mímir separates "reachable but empty" from "unreachable".

The retrieval funnel is the diagnostic that matters — candidates counted *before* domain scoring, admitted counted *after* the gate, and every candidate score reported including rejected ones. That splits an empty result into three distinct causes instead of one silent symptom.

The scoring loop was duplicated across the SQLite and Postgres adapters; it moves to `scoring.score_and_admit` so the rule and its instrumentation exist once.

**Recency floor.** The combined score multiplied relevance by an *unbounded* exponential decay, so age acted as a filter rather than a ranking signal: at the 14-day half-life nothing older than ~24 days could clear `min_relevance=0.3` at any relevance. `memory.recency_floor` (default 0.5) bounds it, matching what Mímir's ranking layer already does.

## Evidence

Measured against a copy of the live 3,321-episode store:

| query | admitted before | admitted after |
|---|---|---|
| `code.changed` | 0 | 11 |
| `mimir_source` | 0 | 4 |
| `resident valkyrie feedback` | 0 | 15 |

Correct episode ranked first in each. `prefetch_limit` and the token budget still bound what reaches the prompt.

Corpus gauges on that store read `embedding_coverage: 0.000`, `index_coverage: 0.827` — both silent failures that no per-call metric would have surfaced.

## Not fixed here

Conversational queries still return **zero candidates before scoring is reached** — with embedding coverage at 0, FTS5 can't match long natural-language input. That needs embeddings enabled separately; the floor does not address it.

## Dashboard

New "Agent memory" row in `valkyrie-runtime.json` (11 panels). The dashboard test now asserts every emitted metric is plotted somewhere and that the funnel counters share a panel, so neither can drift.

## Rollback

`memory.recency_floor: 0.0` restores the previous scoring without a redeploy.

## Verification

`5,276 passed`, ruff clean, 97% coverage on the new module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)