### PR TITLE
feat(ravn): label memory metrics by environment and render resident otel

### DIFF
--- a/charts/skuld/templates/ravn-configmap.yaml
+++ b/charts/skuld/templates/ravn-configmap.yaml
@@ -146,4 +146,8 @@ data:
     environment:
       id: {{ .Values.resident.environmentId | quote }}
       resident_name: {{ $residentName | quote }}
+    {{- with .Values.resident.observability }}
+    observability:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/skuld/values.yaml
+++ b/charts/skuld/values.yaml
@@ -487,6 +487,11 @@ resident:
   # -- Exact collaboration-event redeliveries retained by the room adapter.
   roomDeliveryDedupeMaxEntries: 4096
   # -- Stable environment identity shared by the resident Ravn and its room.
+  # OpenTelemetry export for the resident's Ravn process. Omitted by default:
+  # ravn's ObservabilityConfig.enabled is false, so a resident emits no traces
+  # or metrics until this block is supplied. Rendered verbatim into the ravn
+  # config's `observability:` section.
+  observability: {}
   environmentId: "local"
   # -- Display identity of the resident (e.g. "Muninn"); defaults to persona
   name: ""

--- a/docs/operator/grafana/valkyrie-runtime.json
+++ b/docs/operator/grafana/valkyrie-runtime.json
@@ -267,7 +267,7 @@
       "gridPos": {"h": 4, "w": 6, "x": 0, "y": 91},
       "id": 71,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
-      "targets": [{"expr": "(sum(rate(ravn_memory_operations{job=~\"$job\",ravn_memory_operation=\"prefetch\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_memory_operations{job=~\"$job\",ravn_memory_operation=\"prefetch\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "targets": [{"expr": "(sum(rate(ravn_memory_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_memory_operation=\"prefetch\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_memory_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_memory_operation=\"prefetch\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
       "title": "Prefetch hit rate",
       "type": "stat"
     },
@@ -277,7 +277,7 @@
       "gridPos": {"h": 4, "w": 6, "x": 6, "y": 91},
       "id": 72,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
-      "targets": [{"expr": "(sum(rate(ravn_memory_admitted{job=~\"$job\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_memory_candidates{job=~\"$job\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "targets": [{"expr": "(sum(rate(ravn_memory_admitted{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_memory_candidates{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
       "title": "Admission rate (admitted / candidates)",
       "type": "stat"
     },
@@ -287,7 +287,7 @@
       "gridPos": {"h": 4, "w": 6, "x": 12, "y": 91},
       "id": 73,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
-      "targets": [{"expr": "min(ravn_memory_corpus_embedding_coverage{job=~\"$job\"})", "refId": "A"}],
+      "targets": [{"expr": "min(ravn_memory_corpus_embedding_coverage{job=~\"$job\",ravn_environment_id=~\"$environment\"})", "refId": "A"}],
       "title": "Embedding coverage",
       "type": "stat"
     },
@@ -297,7 +297,7 @@
       "gridPos": {"h": 4, "w": 6, "x": 18, "y": 91},
       "id": 74,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
-      "targets": [{"expr": "(sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_mimir_operation=~\"search|query\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_mimir_operation=~\"search|query\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "targets": [{"expr": "(sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_mimir_operation=~\"search|query\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_mimir_operation=~\"search|query\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
       "title": "Mimir search hit rate",
       "type": "stat"
     },
@@ -307,7 +307,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 95},
       "id": 75,
       "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"expr": "sum by (ravn_memory_backend) (rate(ravn_memory_candidates{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "{{ravn_memory_backend}} candidates", "refId": "A"}, {"expr": "sum by (ravn_memory_backend) (rate(ravn_memory_admitted{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "{{ravn_memory_backend}} admitted", "refId": "B"}],
+      "targets": [{"expr": "sum by (ravn_memory_backend) (rate(ravn_memory_candidates{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval]))", "legendFormat": "{{ravn_memory_backend}} candidates", "refId": "A"}, {"expr": "sum by (ravn_memory_backend) (rate(ravn_memory_admitted{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval]))", "legendFormat": "{{ravn_memory_backend}} admitted", "refId": "B"}],
       "title": "Retrieval funnel: candidates vs admitted",
       "type": "timeseries"
     },
@@ -317,7 +317,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 95},
       "id": 76,
       "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"expr": "histogram_quantile(0.50, sum by (le) (rate(ravn_memory_relevance_score_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p50 score", "refId": "A"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_relevance_score_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p95 score", "refId": "B"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_candidate_age_days_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p95 candidate age (days)", "refId": "C"}],
+      "targets": [{"expr": "histogram_quantile(0.50, sum by (le) (rate(ravn_memory_relevance_score_bucket{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])))", "legendFormat": "p50 score", "refId": "A"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_relevance_score_bucket{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])))", "legendFormat": "p95 score", "refId": "B"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_candidate_age_days_bucket{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])))", "legendFormat": "p95 candidate age (days)", "refId": "C"}],
       "title": "Relevance score distribution vs min_relevance gate",
       "type": "timeseries"
     },
@@ -327,7 +327,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 0, "y": 103},
       "id": 77,
       "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"expr": "sum by (ravn_memory_operation, ravn_memory_result) (rate(ravn_memory_operations{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "memory {{ravn_memory_operation}} {{ravn_memory_result}}", "refId": "A"}, {"expr": "sum by (ravn_resident_state_record_type, ravn_memory_result) (rate(ravn_resident_state_operations{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "resident {{ravn_resident_state_record_type}} {{ravn_memory_result}}", "refId": "B"}, {"expr": "sum by (ravn_memory_result) (rate(ravn_mimir_operations{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "mimir {{ravn_memory_result}}", "refId": "C"}],
+      "targets": [{"expr": "sum by (ravn_memory_operation, ravn_memory_result) (rate(ravn_memory_operations{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval]))", "legendFormat": "memory {{ravn_memory_operation}} {{ravn_memory_result}}", "refId": "A"}, {"expr": "sum by (ravn_resident_state_record_type, ravn_memory_result) (rate(ravn_resident_state_operations{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval]))", "legendFormat": "resident {{ravn_resident_state_record_type}} {{ravn_memory_result}}", "refId": "B"}, {"expr": "sum by (ravn_memory_result) (rate(ravn_mimir_operations{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval]))", "legendFormat": "mimir {{ravn_memory_result}}", "refId": "C"}],
       "title": "Memory / resident-state / Mimir operations by outcome",
       "type": "timeseries"
     },
@@ -337,7 +337,7 @@
       "gridPos": {"h": 8, "w": 12, "x": 12, "y": 103},
       "id": 78,
       "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"expr": "histogram_quantile(0.50, sum by (le) (rate(ravn_memory_prefetch_injected_chars_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p50 injected chars", "refId": "A"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_prefetch_injected_chars_bucket{job=~\"$job\"}[$__rate_interval])))", "legendFormat": "p95 injected chars", "refId": "B"}, {"expr": "sum by (ravn_resident_state_adapter, ravn_resident_state_reason) (rate(ravn_resident_state_fallback{job=~\"$job\"}[$__rate_interval]))", "legendFormat": "fallback -> {{ravn_resident_state_adapter}}", "refId": "C"}],
+      "targets": [{"expr": "histogram_quantile(0.50, sum by (le) (rate(ravn_memory_prefetch_injected_chars_bucket{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])))", "legendFormat": "p50 injected chars", "refId": "A"}, {"expr": "histogram_quantile(0.95, sum by (le) (rate(ravn_memory_prefetch_injected_chars_bucket{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])))", "legendFormat": "p95 injected chars", "refId": "B"}, {"expr": "sum by (ravn_resident_state_adapter, ravn_resident_state_reason) (rate(ravn_resident_state_fallback{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval]))", "legendFormat": "fallback -> {{ravn_resident_state_adapter}}", "refId": "C"}],
       "title": "Injected context and resident-state fallbacks",
       "type": "timeseries"
     },
@@ -347,7 +347,7 @@
       "gridPos": {"h": 7, "w": 24, "x": 0, "y": 111},
       "id": 79,
       "options": {"showHeader": true},
-      "targets": [{"expr": "ravn_memory_corpus_episodes{job=~\"$job\"}", "format": "table", "instant": true, "refId": "A"}, {"expr": "ravn_memory_corpus_embedding_coverage{job=~\"$job\"}", "format": "table", "instant": true, "refId": "B"}, {"expr": "ravn_memory_corpus_index_coverage{job=~\"$job\"}", "format": "table", "instant": true, "refId": "C"}],
+      "targets": [{"expr": "ravn_memory_corpus_episodes{job=~\"$job\",ravn_environment_id=~\"$environment\"}", "format": "table", "instant": true, "refId": "A"}, {"expr": "ravn_memory_corpus_embedding_coverage{job=~\"$job\",ravn_environment_id=~\"$environment\"}", "format": "table", "instant": true, "refId": "B"}, {"expr": "ravn_memory_corpus_index_coverage{job=~\"$job\",ravn_environment_id=~\"$environment\"}", "format": "table", "instant": true, "refId": "C"}],
       "title": "Corpus health: episodes, embedding coverage, index coverage",
       "type": "table"
     },

--- a/src/ravn/adapters/memory/postgres.py
+++ b/src/ravn/adapters/memory/postgres.py
@@ -146,6 +146,7 @@ class PostgresMemoryAdapter(MemoryPort):
         rrf_k: int = 60,
         semantic_candidate_limit: int = 200,
         search_port: SearchPort | None = None,
+        environment_id: str = "",
     ) -> None:
         resolved_dsn = os.environ.get(dsn_env, dsn) if dsn_env else dsn
         if not resolved_dsn:
@@ -161,6 +162,7 @@ class PostgresMemoryAdapter(MemoryPort):
         self._prefetch_min_relevance = prefetch_min_relevance
         self._recency_half_life_days = recency_half_life_days
         self._recency_floor = recency_floor
+        self._environment_id = environment_id
         self._session_search_truncate_chars = session_search_truncate_chars
         self._pool: asyncpg.Pool | None = None
         self._shared_context: SharedContext | None = None
@@ -219,6 +221,7 @@ class PostgresMemoryAdapter(MemoryPort):
                 backend=_BACKEND,
                 result=RESULT_ERROR,
                 seconds=monotonic() - started,
+                environment_id=self._environment_id,
             )
             raise
         record_memory_operation(
@@ -226,6 +229,7 @@ class PostgresMemoryAdapter(MemoryPort):
             backend=_BACKEND,
             result=RESULT_HIT,
             seconds=monotonic() - started,
+            environment_id=self._environment_id,
         )
 
     async def _record_episode(self, episode: Episode) -> None:
@@ -302,12 +306,14 @@ class PostgresMemoryAdapter(MemoryPort):
                 admitted=0,
                 scores=[],
                 top_candidate_age_days=None,
+                environment_id=self._environment_id,
             )
             record_memory_operation(
                 operation="query",
                 backend=_BACKEND,
                 result=RESULT_EMPTY,
                 seconds=monotonic() - started,
+                environment_id=self._environment_id,
             )
             return []
 
@@ -337,12 +343,14 @@ class PostgresMemoryAdapter(MemoryPort):
             limit=limit,
             backend=_BACKEND,
             recency_floor=self._recency_floor,
+            environment_id=self._environment_id,
         )
         record_memory_operation(
             operation="query",
             backend=_BACKEND,
             result=result_for(len(matches)),
             seconds=monotonic() - started,
+            environment_id=self._environment_id,
         )
         return matches
 
@@ -359,12 +367,15 @@ class PostgresMemoryAdapter(MemoryPort):
         if matches:
             budget_chars = self._prefetch_budget * _CHARS_PER_TOKEN
             block = build_prefetch_context(matches, budget_chars)
-        record_injected_chars(backend=_BACKEND, chars=len(block))
+        record_injected_chars(
+            backend=_BACKEND, chars=len(block), environment_id=self._environment_id
+        )
         record_memory_operation(
             operation="prefetch",
             backend=_BACKEND,
             result=result_for(len(block)),
             seconds=monotonic() - started,
+            environment_id=self._environment_id,
         )
         return block
 

--- a/src/ravn/adapters/memory/scoring.py
+++ b/src/ravn/adapters/memory/scoring.py
@@ -97,6 +97,7 @@ def score_and_admit(
     limit: int,
     backend: str,
     recency_floor: float = 0.0,
+    environment_id: str = "",
 ) -> list[EpisodeMatch]:
     """Score search-port candidates and keep those clearing *min_relevance*.
 
@@ -132,6 +133,7 @@ def score_and_admit(
         admitted=len(matches),
         scores=scores,
         top_candidate_age_days=_age_days(best[1].timestamp) if best else None,
+        environment_id=environment_id,
     )
 
     matches.sort(key=lambda m: m.relevance, reverse=True)

--- a/src/ravn/adapters/memory/sqlite.py
+++ b/src/ravn/adapters/memory/sqlite.py
@@ -171,6 +171,7 @@ class SqliteMemoryAdapter(MemoryPort):
         rrf_k: int = 60,
         semantic_candidate_limit: int = 50,
         corpus_stats_interval_seconds: float = 300.0,
+        environment_id: str = "",
     ) -> None:
         self._path = Path(path).expanduser()
         self._max_retries = max_retries
@@ -182,6 +183,7 @@ class SqliteMemoryAdapter(MemoryPort):
         self._prefetch_min_relevance = prefetch_min_relevance
         self._recency_half_life_days = recency_half_life_days
         self._recency_floor = recency_floor
+        self._environment_id = environment_id
         self._session_search_truncate_chars = session_search_truncate_chars
         self._embedding_port = embedding_port
         self._corpus_stats_interval_seconds = corpus_stats_interval_seconds
@@ -236,6 +238,7 @@ class SqliteMemoryAdapter(MemoryPort):
                 backend=_BACKEND,
                 result=RESULT_ERROR,
                 seconds=monotonic() - started,
+                environment_id=self._environment_id,
             )
             raise
         record_memory_operation(
@@ -243,6 +246,7 @@ class SqliteMemoryAdapter(MemoryPort):
             backend=_BACKEND,
             result=RESULT_HIT,
             seconds=monotonic() - started,
+            environment_id=self._environment_id,
         )
         await self._maybe_emit_corpus_gauges()
 
@@ -265,6 +269,7 @@ class SqliteMemoryAdapter(MemoryPort):
                     admitted=0,
                     scores=[],
                     top_candidate_age_days=None,
+                    environment_id=self._environment_id,
                 )
                 record_memory_operation(
                     operation="query",
@@ -287,6 +292,7 @@ class SqliteMemoryAdapter(MemoryPort):
                 limit=limit,
                 backend=_BACKEND,
                 recency_floor=self._recency_floor,
+                environment_id=self._environment_id,
             )
         except Exception:
             record_memory_operation(
@@ -294,6 +300,7 @@ class SqliteMemoryAdapter(MemoryPort):
                 backend=_BACKEND,
                 result=RESULT_ERROR,
                 seconds=monotonic() - started,
+                environment_id=self._environment_id,
             )
             raise
         record_memory_operation(
@@ -301,6 +308,7 @@ class SqliteMemoryAdapter(MemoryPort):
             backend=_BACKEND,
             result=result_for(len(matches)),
             seconds=monotonic() - started,
+            environment_id=self._environment_id,
         )
         return matches
 
@@ -317,12 +325,15 @@ class SqliteMemoryAdapter(MemoryPort):
         if matches:
             budget_chars = self._prefetch_budget * _CHARS_PER_TOKEN
             block = build_prefetch_context(matches, budget_chars)
-        record_injected_chars(backend=_BACKEND, chars=len(block))
+        record_injected_chars(
+            backend=_BACKEND, chars=len(block), environment_id=self._environment_id
+        )
         record_memory_operation(
             operation="prefetch",
             backend=_BACKEND,
             result=result_for(len(block)),
             seconds=monotonic() - started,
+            environment_id=self._environment_id,
         )
         return block
 
@@ -354,6 +365,7 @@ class SqliteMemoryAdapter(MemoryPort):
             episodes=episodes,
             embedding_coverage=embedded / episodes,
             index_coverage=min(1.0, indexed / episodes),
+            environment_id=self._environment_id,
         )
 
     async def count_episodes(self) -> int:

--- a/src/ravn/adapters/mimir/http.py
+++ b/src/ravn/adapters/mimir/http.py
@@ -68,8 +68,10 @@ class HttpMimirAdapter(MimirPort):
         base_url: str,
         auth: MimirAuth | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
+        environment_id: str = "",
     ) -> None:
         self._base_url = base_url.rstrip("/")
+        self._environment_id = environment_id
         self._auth = auth
         self._timeout = timeout
         self._client: httpx.AsyncClient | None = None
@@ -158,6 +160,7 @@ class HttpMimirAdapter(MimirPort):
                 operation=operation,
                 result=RESULT_ERROR,
                 seconds=monotonic() - started,
+                environment_id=self._environment_id,
             )
             raise
         result = RESULT_ERROR if response.is_error else RESULT_HIT
@@ -165,6 +168,7 @@ class HttpMimirAdapter(MimirPort):
             operation=operation,
             result=result,
             seconds=monotonic() - started,
+            environment_id=self._environment_id,
         )
         return response
 
@@ -208,6 +212,7 @@ class HttpMimirAdapter(MimirPort):
             operation="query",
             result=result_for(len(pages)),
             results_returned=len(pages),
+            environment_id=self._environment_id,
         )
         return MimirQueryResult(question=question, answer="", sources=pages)
 
@@ -220,6 +225,7 @@ class HttpMimirAdapter(MimirPort):
             operation="search",
             result=result_for(len(pages)),
             results_returned=len(pages),
+            environment_id=self._environment_id,
         )
         return pages
 

--- a/src/ravn/adapters/resident_state/__init__.py
+++ b/src/ravn/adapters/resident_state/__init__.py
@@ -10,7 +10,10 @@ def _adapter_name(candidate: ResidentStatePort) -> str:
     return type(candidate).__name__
 
 
-async def select_resident_state(*candidates: ResidentStatePort) -> ResidentStatePort:
+async def select_resident_state(
+    *candidates: ResidentStatePort,
+    environment_id: str = "",
+) -> ResidentStatePort:
     """Return the first candidate whose backend is available, in preference order.
 
     Lets composition prefer GBrain and fall back to a local/Mimir store when
@@ -32,6 +35,7 @@ async def select_resident_state(*candidates: ResidentStatePort) -> ResidentState
                 preferred=preferred,
                 selected=_adapter_name(candidate),
                 reason="preferred_unavailable",
+                environment_id=environment_id,
             )
         return candidate
     raise RuntimeError("no resident-state adapter is available")

--- a/src/ravn/adapters/resident_state/mimir.py
+++ b/src/ravn/adapters/resident_state/mimir.py
@@ -334,8 +334,10 @@ class LocalResidentState(LocalResidentMemory, ResidentStatePort):
         root: Path,
         *,
         continuation_prefix: str = "resident/continuation",
+        environment_id: str = "",
     ) -> None:
         LocalResidentMemory.__init__(self, root, prefix=continuation_prefix)
+        self._environment_id = environment_id
 
     async def available(self) -> bool:
         return True
@@ -354,6 +356,7 @@ class LocalResidentState(LocalResidentMemory, ResidentStatePort):
             operation="recall",
             record_type="continuation",
             adapter=type(self).__name__,
+            environment_id=self._environment_id,
             result=result_for(len(entries)),
         )
         return entries
@@ -364,6 +367,7 @@ class LocalResidentState(LocalResidentMemory, ResidentStatePort):
             operation="read",
             record_type="working_state",
             adapter=type(self).__name__,
+            environment_id=self._environment_id,
             result=result_for(1 if entry is not None else 0),
         )
         return entry
@@ -374,6 +378,7 @@ class LocalResidentState(LocalResidentMemory, ResidentStatePort):
             operation="write",
             record_type="turn",
             adapter=type(self).__name__,
+            environment_id=self._environment_id,
             result=RESULT_HIT,
         )
         return ref

--- a/src/ravn/cli/resident_runtime_wiring.py
+++ b/src/ravn/cli/resident_runtime_wiring.py
@@ -173,6 +173,8 @@ async def _build_resident_state(
                 if mimir is None:
                     raise RuntimeError("adapter requires Mimir but no Mimir backend is configured")
                 resolved["mimir"] = mimir
+            if "environment_id" in params and "environment_id" not in resolved:
+                resolved["environment_id"] = settings.environment.id
             return cls(**resolved)
         except Exception as exc:
             logger.warning("resident state adapter %s unavailable: %s", adapter_path, exc)
@@ -192,7 +194,7 @@ async def _build_resident_state(
     ]
     if not candidates:
         raise RuntimeError("no resident-state adapters could be constructed")
-    return await select_resident_state(*candidates)
+    return await select_resident_state(*candidates, environment_id=settings.environment.id)
 
 
 def _build_resident_runtime(

--- a/src/ravn/cli/runtime_builders.py
+++ b/src/ravn/cli/runtime_builders.py
@@ -632,6 +632,7 @@ def _build_memory(settings: Settings, llm: Any = None) -> Any:
             rrf_k=settings.embedding.rrf_k,
             semantic_candidate_limit=settings.embedding.semantic_candidate_limit,
             corpus_stats_interval_seconds=settings.memory.corpus_stats_interval_seconds,
+            environment_id=settings.environment.id,
         )
 
     elif backend == "postgres":
@@ -644,7 +645,7 @@ def _build_memory(settings: Settings, llm: Any = None) -> Any:
                 "Postgres memory backend configured but no DSN provided — memory disabled",
             )
             return None
-        adapter = PostgresMemoryAdapter(dsn=dsn)
+        adapter = PostgresMemoryAdapter(dsn=dsn, environment_id=settings.environment.id)
 
     else:
         # Custom backend via fully-qualified class path
@@ -842,7 +843,9 @@ def _build_mimir(settings: Settings) -> Any:
                 auth = None
                 if inst.auth is not None:
                     auth = _build_mimir_auth(settings, inst.auth)
-                port = HttpMimirAdapter(base_url=inst.url, auth=auth)
+                port = HttpMimirAdapter(
+                    base_url=inst.url, auth=auth, environment_id=settings.environment.id
+                )
             else:
                 logger.warning(
                     "Mímir instance %r has neither path nor url — skipping",

--- a/src/ravn/memory_telemetry.py
+++ b/src/ravn/memory_telemetry.py
@@ -61,6 +61,7 @@ ATTR_RECORD_TYPE = "ravn.resident_state.record_type"
 ATTR_REASON = "ravn.resident_state.reason"
 ATTR_MIMIR_OPERATION = "ravn.mimir.operation"
 ATTR_COMPONENT = "ravn.runtime.component"
+ATTR_ENVIRONMENT = "ravn.environment.id"
 
 # --- result values --------------------------------------------------------
 
@@ -74,6 +75,20 @@ def result_for(count: int) -> str:
     return RESULT_HIT if count > 0 else RESULT_EMPTY
 
 
+def _identity(component: str, environment_id: str) -> dict[str, str]:
+    """Attributes identifying which resident produced a sample.
+
+    The dashboard's environment picker filters on ``ravn.environment.id``, the
+    same key ``drive_loop`` stamps on its gauges. Without it these metrics
+    cannot be separated when a Mimir tenant holds more than one resident.
+    Omitted entirely when unset, so a series never carries an empty label.
+    """
+    attributes = {ATTR_COMPONENT: component}
+    if environment_id:
+        attributes[ATTR_ENVIRONMENT] = environment_id
+    return attributes
+
+
 def record_memory_operation(
     *,
     operation: str,
@@ -81,6 +96,7 @@ def record_memory_operation(
     result: str,
     seconds: float | None = None,
     component: str = "resident",
+    environment_id: str = "",
 ) -> None:
     """Emit the outcome (and optionally the latency) of one memory operation."""
     telemetry = get_observability()
@@ -88,7 +104,7 @@ def record_memory_operation(
         ATTR_OPERATION: operation,
         ATTR_BACKEND: backend,
         ATTR_RESULT: result,
-        ATTR_COMPONENT: component,
+        **_identity(component, environment_id),
     }
     telemetry.count(
         OPERATIONS,
@@ -112,6 +128,7 @@ def record_funnel(
     scores: list[float],
     top_candidate_age_days: float | None,
     component: str = "resident",
+    environment_id: str = "",
 ) -> None:
     """Emit the retrieval funnel for one query.
 
@@ -119,7 +136,7 @@ def record_funnel(
     the histogram shows a sub-threshold cluster instead of silence.
     """
     telemetry = get_observability()
-    attributes = {ATTR_BACKEND: backend, ATTR_COMPONENT: component}
+    attributes = {ATTR_BACKEND: backend, **_identity(component, environment_id)}
     telemetry.count(
         CANDIDATES,
         candidates,
@@ -149,12 +166,18 @@ def record_funnel(
         )
 
 
-def record_injected_chars(*, backend: str, chars: int, component: str = "resident") -> None:
+def record_injected_chars(
+    *,
+    backend: str,
+    chars: int,
+    component: str = "resident",
+    environment_id: str = "",
+) -> None:
     """Emit how much context prefetch actually injected into the prompt."""
     get_observability().record(
         INJECTED_CHARS,
         chars,
-        attributes={ATTR_BACKEND: backend, ATTR_COMPONENT: component},
+        attributes={ATTR_BACKEND: backend, **_identity(component, environment_id)},
         description="Characters of past context injected by prefetch.",
     )
 
@@ -166,6 +189,7 @@ def record_corpus(
     embedding_coverage: float,
     index_coverage: float,
     component: str = "resident",
+    environment_id: str = "",
 ) -> None:
     """Emit corpus-health gauges.
 
@@ -173,7 +197,7 @@ def record_corpus(
     embeddings never generated, or episodes missing from the search index.
     """
     telemetry = get_observability()
-    attributes = {ATTR_BACKEND: backend, ATTR_COMPONENT: component}
+    attributes = {ATTR_BACKEND: backend, **_identity(component, environment_id)}
     telemetry.gauge(
         CORPUS_EPISODES,
         episodes,
@@ -201,6 +225,7 @@ def record_resident_state_operation(
     adapter: str,
     result: str,
     component: str = "resident",
+    environment_id: str = "",
 ) -> None:
     """Emit one resident-state read or write."""
     get_observability().count(
@@ -210,7 +235,7 @@ def record_resident_state_operation(
             ATTR_RECORD_TYPE: record_type,
             ATTR_ADAPTER: adapter,
             ATTR_RESULT: result,
-            ATTR_COMPONENT: component,
+            **_identity(component, environment_id),
         },
         description="Resident-state operations by record type and outcome.",
     )
@@ -222,6 +247,7 @@ def record_resident_state_fallback(
     selected: str,
     reason: str,
     component: str = "resident",
+    environment_id: str = "",
 ) -> None:
     """Emit an adapter fallback.
 
@@ -234,7 +260,7 @@ def record_resident_state_fallback(
             "ravn.resident_state.preferred": preferred,
             ATTR_ADAPTER: selected,
             ATTR_REASON: reason,
-            ATTR_COMPONENT: component,
+            **_identity(component, environment_id),
         },
         description="Resident-state adapter fallbacks away from the preferred store.",
     )
@@ -247,13 +273,14 @@ def record_mimir_operation(
     seconds: float | None = None,
     results_returned: int | None = None,
     component: str = "resident",
+    environment_id: str = "",
 ) -> None:
     """Emit one Mímir call made by the agent."""
     telemetry = get_observability()
     attributes = {
         ATTR_MIMIR_OPERATION: operation,
         ATTR_RESULT: result,
-        ATTR_COMPONENT: component,
+        **_identity(component, environment_id),
     }
     telemetry.count(
         MIMIR_OPERATIONS,
@@ -281,6 +308,7 @@ __all__ = [
     "ATTR_ADAPTER",
     "ATTR_BACKEND",
     "ATTR_COMPONENT",
+    "ATTR_ENVIRONMENT",
     "ATTR_MIMIR_OPERATION",
     "ATTR_OPERATION",
     "ATTR_REASON",

--- a/tests/test_charts/test_skuld_chart.py
+++ b/tests/test_charts/test_skuld_chart.py
@@ -763,6 +763,57 @@ class TestBehaviorSettingsRendering:
         }
 
 
+class TestResidentObservability:
+    """The resident's OTel export must be renderable from values.
+
+    ravn's ObservabilityConfig.enabled defaults to false, so a resident
+    rendered without this block emits no traces or metrics at all — the state
+    Muninn was found in while every other fleet was reporting.
+    """
+
+    def test_observability_is_absent_by_default(self, tmp_path: Path) -> None:
+        rendered = _render_skuld_chart(
+            tmp_path,
+            {"resident": {"enabled": True, "persona": "product-steward"}},
+        )
+        config = _ravn_config_from_rendered(rendered)
+        assert "observability" not in config
+
+    def test_observability_block_is_rendered_when_supplied(self, tmp_path: Path) -> None:
+        rendered = _render_skuld_chart(
+            tmp_path,
+            {
+                "resident": {
+                    "enabled": True,
+                    "persona": "product-steward",
+                    "environmentId": "muninn",
+                    "observability": {
+                        "enabled": True,
+                        "service_name": "ravn",
+                        "metric_endpoint": "https://mimir.example/valhalla/otlp/v1/metrics",
+                        "metric_export_interval_milliseconds": 5000,
+                    },
+                }
+            },
+        )
+        config = _ravn_config_from_rendered(rendered)
+        assert config["observability"]["enabled"] is True
+        assert config["observability"]["metric_endpoint"].endswith("/otlp/v1/metrics")
+        # The environment id is what the dashboard's environment picker filters on.
+        assert config["environment"]["id"] == "muninn"
+
+
+def _ravn_config_from_rendered(rendered_yaml: str) -> dict:
+    for document in yaml.safe_load_all(rendered_yaml):
+        if not isinstance(document, dict) or document.get("kind") != "ConfigMap":
+            continue
+        body = (document.get("data") or {}).get("config.yaml")
+        if body and "environment:" in body:
+            return yaml.safe_load(body)
+    pytest.fail("ravn config.yaml was not rendered")
+    raise AssertionError("ravn config.yaml was not rendered")
+
+
 def _render_skuld_chart(tmp_path: Path, values: dict) -> str:
     helm = shutil.which("helm")
     if not helm:

--- a/tests/test_ravn/test_memory_telemetry.py
+++ b/tests/test_ravn/test_memory_telemetry.py
@@ -423,3 +423,76 @@ class TestRecencyFloor:
         )
 
         assert failure < success
+
+
+class TestEnvironmentIdentity:
+    """Metrics must carry the label the dashboard's environment picker filters on.
+
+    A Mimir tenant can hold more than one resident. Without ``ravn.environment.id``
+    the memory row silently blends them, which is exactly the failure mode this
+    instrumentation exists to prevent.
+    """
+
+    def test_funnel_carries_the_environment_id(self, telemetry: RecordingTelemetry) -> None:
+        episodes = {"fresh": _episode("fresh", age_days=1)}
+        results = [SearchResult(id="fresh", content="c", score=1.0)]
+
+        score_and_admit(
+            results,
+            episodes,
+            half_life_days=14.0,
+            min_relevance=0.3,
+            limit=5,
+            backend="sqlite",
+            environment_id="muninn",
+        )
+
+        attrs = telemetry.attributes_for(memory_telemetry.CANDIDATES)
+        assert attrs and all(a[memory_telemetry.ATTR_ENVIRONMENT] == "muninn" for a in attrs)
+
+    async def test_adapter_stamps_every_memory_metric(
+        self, telemetry: RecordingTelemetry, tmp_path
+    ) -> None:
+        adapter = SqliteMemoryAdapter(
+            path=str(tmp_path / "memory.db"),
+            environment_id="noatun",
+            corpus_stats_interval_seconds=0.0001,
+        )
+        await adapter.initialize()
+        await adapter.record_episode(_episode("fresh", age_days=0.1))
+        await adapter.prefetch("size the auxiliary postgres pools")
+
+        for metric in (memory_telemetry.OPERATIONS, memory_telemetry.CANDIDATES):
+            attrs = telemetry.attributes_for(metric)
+            assert attrs, f"{metric} never emitted"
+            assert all(a.get(memory_telemetry.ATTR_ENVIRONMENT) == "noatun" for a in attrs)
+        gauges = [a for n, _, a in telemetry.gauges if n == memory_telemetry.CORPUS_EPISODES]
+        assert gauges and gauges[0][memory_telemetry.ATTR_ENVIRONMENT] == "noatun"
+
+    def test_the_label_is_omitted_when_unset(self, telemetry: RecordingTelemetry) -> None:
+        """An unset id must not produce an empty-string label on the series."""
+        memory_telemetry.record_memory_operation(
+            operation="query",
+            backend="sqlite",
+            result=memory_telemetry.RESULT_HIT,
+        )
+
+        attrs = telemetry.attributes_for(memory_telemetry.OPERATIONS)[0]
+        assert memory_telemetry.ATTR_ENVIRONMENT not in attrs
+
+    async def test_resident_state_fallback_carries_the_environment_id(
+        self, telemetry: RecordingTelemetry
+    ) -> None:
+        class _Adapter:
+            def __init__(self, available: bool) -> None:
+                self._available = available
+
+            async def available(self) -> bool:
+                return self._available
+
+        await select_resident_state(
+            _Adapter(available=False), _Adapter(available=True), environment_id="regin"
+        )
+
+        attrs = telemetry.attributes_for(memory_telemetry.RESIDENT_STATE_FALLBACK)
+        assert attrs and attrs[0][memory_telemetry.ATTR_ENVIRONMENT] == "regin"


### PR DESCRIPTION
Follow-up to #929, closing two gaps found once the memory row was live.

## 1. Metrics carried no environment label

The dashboard has an `Environment` picker that filters 6 existing panels on `ravn_environment_id` — a label `drive_loop` stamps explicitly per metric call, not a resource attribute. The memory metrics didn't carry it, so the picker silently did nothing to the new row.

Every fleet currently runs `replicas: 1`, one resident per Mimir tenant, so this looked fine. With two residents in one tenant the row would have blended them with no way to separate — precisely the class of silent problem this instrumentation exists to catch.

`environment_id` now threads from the composition root into the memory, resident-state, and Mímir adapters as a plain constructor kwarg (matching the `root`/`mimir` injection already in `resident_runtime_wiring`). It's **omitted from the attribute dict when unset**, so a series never carries an empty label. The 18 new-row targets gained the same `ravn_environment_id=~"$environment"` filter panels 1–3 use; `allValue` is `.*` so "All" stays a no-op.

## 2. The Skuld chart rendered no observability block

`ravn`'s `ObservabilityConfig.enabled` defaults to `false`, and `charts/skuld/templates/ravn-configmap.yaml` had no `observability:` section at all — so **any** resident deployed through that chart emits no traces and no metrics.

That's why Muninn was dark while noatun, eitri, glitnir, jarnvidr, ymir, valaskjalf, vanaheim and Regin all report: those are raw manifests with the block written by hand, Muninn goes through the chart.

`resident.observability` is now rendered verbatim when supplied and absent otherwise, so existing releases are byte-identical.

## Verification

`5,518 passed`, ruff clean. Chart tests render both the with- and without-observability cases through real `helm template` and assert on the parsed ravn config.

The dashboard diff is 9 lines — only queries naming the new metrics were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)