### PR TITLE
fix(ravn): make unmet embedding config fatal and let memory outlive the pod

### DIFF
--- a/charts/skuld/templates/deployment.yaml
+++ b/charts/skuld/templates/deployment.yaml
@@ -445,6 +445,13 @@ spec:
               mountPath: /workspace
               subPath: {{ include "skuld.sessionId" . }}/workspace
             {{- end }}
+            {{- if .Values.homeVolume.enabled }}
+            # /workspace is an emptyDir for residents, so anything ravn writes
+            # there dies with the pod. The home claim is the only durable place
+            # it can keep episodic memory across restarts.
+            - name: home
+              mountPath: {{ .Values.homeVolume.mountPath }}
+            {{- end }}
             - name: ravn-config
               mountPath: /etc/ravn/config.yaml
               subPath: config.yaml

--- a/charts/skuld/templates/ravn-configmap.yaml
+++ b/charts/skuld/templates/ravn-configmap.yaml
@@ -150,4 +150,8 @@ data:
     observability:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.resident.memory }}
+    memory:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/skuld/values.yaml
+++ b/charts/skuld/values.yaml
@@ -492,6 +492,11 @@ resident:
   # or metrics until this block is supplied. Rendered verbatim into the ravn
   # config's `observability:` section.
   observability: {}
+  # -- Episodic memory settings. The default path lives under $HOME, which for a
+  # chart-deployed resident is the sessions volume — an emptyDir unless
+  # persistence.existingClaim is set, so episodes are erased on every restart.
+  # Point `path` at a persistent mount (e.g. the homeVolume claim) to keep them.
+  memory: {}
   environmentId: "local"
   # -- Display identity of the resident (e.g. "Muninn"); defaults to persona
   name: ""

--- a/docs/operator/grafana/valkyrie-runtime.json
+++ b/docs/operator/grafana/valkyrie-runtime.json
@@ -357,6 +357,81 @@
       "options": {"content": "**Reading this row.** `Admission rate` is the diagnostic: a healthy funnel keeps candidates and admitted within an order of magnitude. Candidates high with admitted at zero means retrieval is working and the `min_relevance` gate is discarding it \u2014 check the score distribution against the gate and the p95 candidate age, since the combined score multiplies relevance by an unbounded recency decay.\n\n`Embedding coverage` below 1 means part of the corpus can only be reached lexically; `index coverage` below 1 means part of it cannot be reached at all. Both are silent failures no per-call metric shows.", "mode": "markdown"},
       "title": "How to read the memory row",
       "type": "text"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 122},
+      "id": 81,
+      "panels": [],
+      "title": "Learned tools: build vs reuse",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "noValue": "no data yet", "thresholds": {"mode": "absolute", "steps": [{"color": "text", "value": null}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 123},
+      "id": 82,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [{"expr": "count(count by (ravn_learned_tool_name) (max_over_time(ravn_learned_tool_installed{job=~\"$job\"}[6h])))", "refId": "A"}],
+      "title": "Distinct learned tools",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "noValue": "no data yet", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1.05}, {"color": "red", "value": 1.25}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 123},
+      "id": 83,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [{"expr": "count(max_over_time(ravn_learned_tool_installed{job=~\"$job\"}[6h])) / clamp_min(count(count by (ravn_learned_tool_name) (max_over_time(ravn_learned_tool_installed{job=~\"$job\"}[6h]))), 1e-9)", "refId": "A"}],
+      "title": "Reinstall ratio (installs / distinct names)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "noValue": "no data yet", "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "orange", "value": 2}, {"color": "green", "value": 5}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 123},
+      "id": 84,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [{"expr": "sum(rate(ravn_agent_tool_calls{job=~\"$job\",gen_ai_tool_name=\"learned_tool_run\"}[6h])) / clamp_min(sum(rate(ravn_agent_tool_calls{job=~\"$job\",gen_ai_tool_name=\"build_tool\"}[6h])), 1e-9)", "refId": "A"}],
+      "title": "Reuse ratio (learned_tool_run / build_tool)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "noValue": "no data yet", "thresholds": {"mode": "absolute", "steps": [{"color": "text", "value": null}]}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 123},
+      "id": 85,
+      "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+      "targets": [{"expr": "sum(increase(ravn_agent_tool_calls{job=~\"$job\",gen_ai_tool_name=\"capability_list\"}[6h]))", "refId": "A"}],
+      "title": "Capability discovery calls",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"drawStyle": "line", "fillOpacity": 12, "lineWidth": 2, "showPoints": "never", "stacking": {"group": "A", "mode": "none"}}, "unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 127},
+      "id": 86,
+      "options": {"legend": {"displayMode": "table", "placement": "right", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"expr": "sum by (gen_ai_tool_name) (rate(ravn_agent_tool_calls{job=~\"$job\",gen_ai_tool_name=~\"build_tool|learned_tool_run|capability_list\"}[$__rate_interval]))", "legendFormat": "{{gen_ai_tool_name}}", "refId": "A"}],
+      "title": "Build vs reuse vs discovery",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${metrics}"},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 127},
+      "id": 87,
+      "options": {"showHeader": true},
+      "targets": [{"expr": "count by (ravn_learned_tool_name) (max_over_time(ravn_learned_tool_installed{job=~\"$job\"}[6h]))", "format": "table", "instant": true, "refId": "A"}],
+      "title": "Installed learned tools by name (scan for near-duplicates)",
+      "type": "table"
+    },
+    {
+      "gridPos": {"h": 5, "w": 24, "x": 0, "y": 135},
+      "id": 88,
+      "options": {"content": "**Is the resident rebuilding what it already has?**\n\n`Reinstall ratio` above 1 means the same tool *name* was installed more than once \u2014 a literal rebuild. It does not catch the more common case: a rebuild under a slightly different name (`k8s_` vs `kubernetes_` prefixes, swapped word order, `_v2`/`_v3` suffixes). Scan the name table for those; a normalized capability label would be needed to measure them directly.\n\n`Reuse ratio` is runs per build \u2014 higher is better. A low ratio alongside healthy `capability_list` calls means discovery is running but not finding the existing tool, which points back at retrieval, not at the tool builder.\n\nAll panels look over a 6h window: `ravn_learned_tool_installed` is emitted at install time and then goes stale, so an instant query returns nothing.", "mode": "markdown"},
+      "title": "How to read the tool row",
+      "type": "text"
     }
   ],
   "refresh": "10s",

--- a/docs/operator/grafana/valkyrie-runtime.json
+++ b/docs/operator/grafana/valkyrie-runtime.json
@@ -39,7 +39,7 @@
       "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
       "id": 4,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
-      "targets": [{"expr": "(sum(rate(ravn_agent_tasks{job=~\"$job\",ravn_task_outcome=~\"error|exception\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_agent_tasks{job=~\"$job\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "targets": [{"expr": "(sum(rate(ravn_agent_tasks{job=~\"$job\",ravn_task_outcome=~\"error|exception\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(ravn_agent_tasks{job=~\"$job\"}[$__rate_interval])), 1e-9)", "refId": "A"}],
       "title": "Task failure ratio",
       "type": "stat"
     },
@@ -263,27 +263,27 @@
     },
     {
       "datasource": {"type": "prometheus", "uid": "${metrics}"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit"}, "overrides": []},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit", "noValue": "no data yet"}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 0, "y": 91},
       "id": 71,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
-      "targets": [{"expr": "(sum(rate(ravn_memory_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_memory_operation=\"prefetch\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_memory_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_memory_operation=\"prefetch\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "targets": [{"expr": "(sum(rate(ravn_memory_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_memory_operation=\"prefetch\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(ravn_memory_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_memory_operation=\"prefetch\"}[$__rate_interval])), 1e-9)", "refId": "A"}],
       "title": "Prefetch hit rate",
       "type": "stat"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${metrics}"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit"}, "overrides": []},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit", "noValue": "no data yet"}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 6, "y": 91},
       "id": 72,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
-      "targets": [{"expr": "(sum(rate(ravn_memory_admitted{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_memory_candidates{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "targets": [{"expr": "(sum(rate(ravn_memory_admitted{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(ravn_memory_candidates{job=~\"$job\",ravn_environment_id=~\"$environment\"}[$__rate_interval])), 1e-9)", "refId": "A"}],
       "title": "Admission rate (admitted / candidates)",
       "type": "stat"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${metrics}"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit"}, "overrides": []},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit", "noValue": "no data yet"}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 12, "y": 91},
       "id": 73,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
@@ -293,11 +293,11 @@
     },
     {
       "datasource": {"type": "prometheus", "uid": "${metrics}"},
-      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit"}, "overrides": []},
+      "fieldConfig": {"defaults": {"color": {"mode": "thresholds"}, "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 0.05}]}, "unit": "percentunit", "noValue": "no data yet"}, "overrides": []},
       "gridPos": {"h": 4, "w": 6, "x": 18, "y": 91},
       "id": 74,
       "options": {"colorMode": "background", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
-      "targets": [{"expr": "(sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_mimir_operation=~\"search|query\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min((sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_mimir_operation=~\"search|query\"}[$__rate_interval])) or vector(0)), 1e-9)", "refId": "A"}],
+      "targets": [{"expr": "(sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_mimir_operation=~\"search|query\",ravn_memory_result=\"hit\"}[$__rate_interval])) or vector(0)) / clamp_min(sum(rate(ravn_mimir_operations{job=~\"$job\",ravn_environment_id=~\"$environment\",ravn_mimir_operation=~\"search|query\"}[$__rate_interval])), 1e-9)", "refId": "A"}],
       "title": "Mimir search hit rate",
       "type": "stat"
     },

--- a/src/ravn/cli/runtime_builders.py
+++ b/src/ravn/cli/runtime_builders.py
@@ -601,6 +601,10 @@ def _build_memory(settings: Settings, llm: Any = None) -> Any:
 
     embedding_port = None
     if settings.embedding.enabled:
+        # Asking for embeddings and silently getting lexical-only search is the
+        # failure this must not have: retrieval keeps working, quality collapses,
+        # and nothing says so. Configuration that cannot be honoured is a
+        # startup error, not a warning.
         try:
             cls = _import_class(settings.embedding.adapter)
             kwargs = _inject_secrets(
@@ -609,7 +613,12 @@ def _build_memory(settings: Settings, llm: Any = None) -> Any:
             )
             embedding_port = cls(**kwargs)
         except Exception as exc:
-            logger.warning("Failed to load embedding adapter: %s — falling back to FTS-only", exc)
+            raise RuntimeError(
+                f"embedding.enabled is true but the adapter "
+                f"{settings.embedding.adapter!r} could not be constructed: {exc}. "
+                f"Set embedding.enabled=false to run with lexical-only search, or "
+                f"fix the adapter configuration — memory will not silently degrade."
+            ) from exc
 
     adapter = None
 

--- a/tests/ravn/unit/test_composition_root.py
+++ b/tests/ravn/unit/test_composition_root.py
@@ -155,6 +155,37 @@ class TestBuildMemory:
         mem = _build_memory(settings)
         assert mem is None
 
+    def test_unloadable_embedding_adapter_raises_instead_of_degrading(
+        self, settings: Settings, tmp_path
+    ) -> None:
+        """Asking for embeddings and silently getting lexical-only must not happen.
+
+        The old behaviour logged a warning and continued, so a resident whose
+        config demanded semantic search ran keyword-only with retrieval quality
+        quietly collapsed and nothing to detect it by.
+        """
+        from ravn.cli.commands import _build_memory
+
+        settings.memory.backend = "sqlite"
+        settings.memory.path = str(tmp_path / "memory.db")
+        settings.embedding.enabled = True
+        settings.embedding.adapter = "ravn.adapters.embedding.nope.MissingAdapter"
+
+        with pytest.raises(RuntimeError, match="embedding.enabled is true"):
+            _build_memory(settings)
+
+    def test_disabled_embeddings_still_build_lexical_memory(
+        self, settings: Settings, tmp_path
+    ) -> None:
+        """Opting out explicitly is fine — only unmet configuration is an error."""
+        from ravn.cli.commands import _build_memory
+
+        settings.memory.backend = "sqlite"
+        settings.memory.path = str(tmp_path / "memory.db")
+        settings.embedding.enabled = False
+
+        assert _build_memory(settings) is not None
+
     def test_custom_backend_failure_raises_instead_of_disabling_memory(
         self, settings: Settings
     ) -> None:
@@ -168,17 +199,25 @@ class TestBuildMemory:
         with pytest.raises(ValueError, match="not importable"):
             _build_memory(settings)
 
-    def test_embedding_failure_falls_back_to_fts_only(self, settings: Settings) -> None:
+    def test_embedding_failure_is_fatal_not_a_silent_downgrade(
+        self, settings: Settings, tmp_path
+    ) -> None:
+        """Replaces an earlier test that asserted the opposite.
+
+        This previously returned a working memory adapter with embeddings
+        quietly dropped, which is how a resident ended up running keyword-only
+        retrieval while its config asked for semantic search. Continuing in a
+        degraded mode the operator did not ask for is the bug, not the feature.
+        """
         from ravn.cli.commands import _build_memory
 
         settings.memory.backend = "sqlite"
-        settings.memory.path = "/tmp/test_ravn_memory_fts.db"
+        settings.memory.path = str(tmp_path / "memory_fts.db")
         settings.embedding.enabled = True
         settings.embedding.adapter = "nonexistent.module.Embedding"
 
-        mem = _build_memory(settings)
-        # Memory still created, just without embedding
-        assert mem is not None
+        with pytest.raises(RuntimeError, match="will not silently degrade"):
+            _build_memory(settings)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_charts/test_skuld_chart.py
+++ b/tests/test_charts/test_skuld_chart.py
@@ -803,6 +803,37 @@ class TestResidentObservability:
         assert config["environment"]["id"] == "muninn"
 
 
+class TestResidentMemoryPersistence:
+    """The memory path must be settable, or episodes die with the pod.
+
+    The chart's default workspace is an emptyDir for residents, and ravn's
+    memory defaults to $HOME/.ravn/memory.db inside it — so a resident's entire
+    episodic history was erased on every restart, with prefetch reporting an
+    honest but useless zero hit rate against an empty corpus.
+    """
+
+    def test_memory_is_absent_by_default(self, tmp_path: Path) -> None:
+        rendered = _render_skuld_chart(
+            tmp_path, {"resident": {"enabled": True, "persona": "product-steward"}}
+        )
+        assert "memory" not in _ravn_config_from_rendered(rendered)
+
+    def test_memory_path_can_be_pointed_at_a_persistent_mount(self, tmp_path: Path) -> None:
+        rendered = _render_skuld_chart(
+            tmp_path,
+            {
+                "resident": {
+                    "enabled": True,
+                    "persona": "product-steward",
+                    "memory": {"backend": "sqlite", "path": "/volundr/home/.ravn/memory.db"},
+                }
+            },
+        )
+        config = _ravn_config_from_rendered(rendered)
+        assert config["memory"]["path"] == "/volundr/home/.ravn/memory.db"
+        assert config["memory"]["backend"] == "sqlite"
+
+
 def _ravn_config_from_rendered(rendered_yaml: str) -> dict:
     for document in yaml.safe_load_all(rendered_yaml):
         if not isinstance(document, dict) or document.get("kind") != "ConfigMap":

--- a/tests/test_charts/test_skuld_chart.py
+++ b/tests/test_charts/test_skuld_chart.py
@@ -834,6 +834,48 @@ class TestResidentMemoryPersistence:
         assert config["memory"]["backend"] == "sqlite"
 
 
+class TestRavnHomeVolume:
+    """Ravn must see the persistent home claim, not only the emptyDir workspace.
+
+    Making the memory path configurable achieves nothing if the only volume
+    the ravn container can write to is erased with the pod.
+    """
+
+    def test_ravn_mounts_the_home_volume_when_enabled(self, tmp_path: Path) -> None:
+        rendered = _render_skuld_chart(
+            tmp_path,
+            {
+                "resident": {"enabled": True, "persona": "product-steward"},
+                "homeVolume": {
+                    "enabled": True,
+                    "existingClaim": "some-home-claim",
+                    "mountPath": "/volundr/home",
+                },
+            },
+        )
+        deployment = _deployment_from_rendered(rendered)
+        ravn = next(
+            c for c in deployment["spec"]["template"]["spec"]["containers"] if c["name"] == "ravn"
+        )
+        paths = {m["mountPath"] for m in ravn["volumeMounts"]}
+        assert "/volundr/home" in paths
+        assert "/workspace" in paths
+
+    def test_ravn_has_no_home_mount_when_disabled(self, tmp_path: Path) -> None:
+        rendered = _render_skuld_chart(
+            tmp_path,
+            {
+                "resident": {"enabled": True, "persona": "product-steward"},
+                "homeVolume": {"enabled": False},
+            },
+        )
+        deployment = _deployment_from_rendered(rendered)
+        ravn = next(
+            c for c in deployment["spec"]["template"]["spec"]["containers"] if c["name"] == "ravn"
+        )
+        assert all("home" not in m["mountPath"] for m in ravn["volumeMounts"])
+
+
 def _ravn_config_from_rendered(rendered_yaml: str) -> dict:
     for document in yaml.safe_load_all(rendered_yaml):
         if not isinstance(document, dict) or document.get("kind") != "ConfigMap":


### PR DESCRIPTION
Reading the memory row's own numbers turned up the actual root cause, and two silent degradations that hid it.

## 1. Muninn's episodic memory is erased on every restart

`ravn_memory_candidates = 0` on every resident. That is not FTS failing — **there is nothing stored**:

```
/workspace/.ravn/memory.db: episodes=0 indexed=0 embedded=0
/workspace -> volume=sessions type=['emptyDir']
```

The Skuld chart rendered no `memory:` section, so a chart-deployed resident falls back to ravn's default `$HOME/.ravn/memory.db` — and `$HOME` is the sessions volume, an **emptyDir**. Muninn has been up for weeks with an empty store.

This makes the honest 0% prefetch hit rate useless, and it is the likeliest explanation for the tool sprawl in the other row: the resident cannot remember building `inspect_pod_unhealthy`, so it builds it again under a new name. There are 7 variants of that one capability.

`resident.memory` now renders into the ravn config, so the path can point at a persistent mount (the `homeVolume` PVC at `/volundr/home` already exists).

## 2. Unmet embedding config was a warning, not an error

```python
except Exception as exc:
    logger.warning("Failed to load embedding adapter: %s — falling back to FTS-only", exc)
```

The deployed image has **no** `sentence_transformers`, `fastembed`, or `numpy`. So setting `embedding.enabled: true` would have logged one line and run keyword-only — config satisfied on paper, silently unmet in fact.

Now fatal. Explicitly opting out (`enabled: false`) is still fine; only *asking for something and not getting it* raises. The existing test asserting the fallback is replaced — that expectation was the bug.

## Also

Carries the learned-tool build-vs-reuse row, already live on the infrastructure side, so the repo stays the source of truth rather than drifting again.

## Verification

`7,483 passed`, ruff clean. Chart tests render both the with- and without-`memory` cases through real `helm template`.

## Not fixed here

No embedding backend exists on the platform: Bifrost has no `/v1/embeddings`, the vLLM deployments are generative-only (`{"detail":"Not Found"}`), and the image lacks local embedding libs. `OpenAIEmbeddingAdapter` needs only `httpx` and takes a `base_url`, so a deployed embeddings model would be the cheapest route — that is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)