### PR TITLE
fix(ravn): omit the auth header when no embedding api key is set

### DIFF
--- a/src/ravn/adapters/embedding/openai.py
+++ b/src/ravn/adapters/embedding/openai.py
@@ -62,13 +62,24 @@ class OpenAIEmbeddingAdapter(EmbeddingPort):
             await self._client.aclose()
             self._client = None
 
+    def _headers(self) -> dict[str, str]:
+        """Build request headers, omitting auth entirely when no key is set.
+
+        A self-hosted OpenAI-compatible server (vLLM, TGI, Ollama) needs no
+        key. Sending ``Authorization: Bearer`` with an empty value is not
+        merely ignored — httpx rejects the bare ``"Bearer "`` outright with
+        ``LocalProtocolError``, so every embed call fails against exactly the
+        deployments most likely to be used without credentials.
+        """
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+        return headers
+
     async def _post_embeddings(self, texts: list[str]) -> list[list[float]]:
         response = await self._get_client().post(
             f"{self._base_url}/embeddings",
-            headers={
-                "Authorization": f"Bearer {self._api_key}",
-                "Content-Type": "application/json",
-            },
+            headers=self._headers(),
             json={"input": texts, "model": self._model},
         )
         response.raise_for_status()

--- a/tests/test_ravn/test_openai_embedding.py
+++ b/tests/test_ravn/test_openai_embedding.py
@@ -116,3 +116,52 @@ class TestOpenAIEmbeddingAdapter:
         adapter = OpenAIEmbeddingAdapter(api_key="test")
         result = await adapter.embed_batch([])
         assert result == []
+
+
+class TestNoAuthSelfHostedServer:
+    """Self-hosted OpenAI-compatible servers take no API key.
+
+    vLLM, TGI and Ollama serve /v1/embeddings unauthenticated. Sending
+    ``Authorization: Bearer`` with an empty value is not ignored — httpx
+    rejects the bare ``"Bearer "`` with LocalProtocolError, so every call
+    failed against exactly the deployments most likely to run without
+    credentials. The header must be omitted, not emptied.
+    """
+
+    @respx.mock
+    async def test_no_authorization_header_when_key_is_absent(self) -> None:
+        route = respx.post("http://vllm.test/v1/embeddings").mock(
+            return_value=Response(200, json=_make_response([[0.1, 0.2, 0.3]]))
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="", base_url="http://vllm.test/v1")
+
+        vector = await adapter.embed("unhealthy pod in kube-system")
+
+        assert vector == [0.1, 0.2, 0.3]
+        assert "authorization" not in {k.lower() for k in route.calls[0].request.headers}
+        await adapter.close()
+
+    @respx.mock
+    async def test_authorization_header_is_sent_when_a_key_is_configured(self) -> None:
+        route = respx.post("http://api.test/v1/embeddings").mock(
+            return_value=Response(200, json=_make_response([[0.4, 0.5]]))
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="sk-secret", base_url="http://api.test/v1")
+
+        await adapter.embed("hello")
+
+        assert route.calls[0].request.headers["authorization"] == "Bearer sk-secret"
+        await adapter.close()
+
+    @respx.mock
+    async def test_dimension_is_learned_from_the_server(self) -> None:
+        """Qwen3-Embedding returns 1024 dims, not the OpenAI default of 1536."""
+        respx.post("http://vllm.test/v1/embeddings").mock(
+            return_value=Response(200, json=_make_response([[0.0] * 1024]))
+        )
+        adapter = OpenAIEmbeddingAdapter(api_key="", base_url="http://vllm.test/v1")
+
+        assert adapter.dimension == _DEFAULT_DIMENSION
+        await adapter.embed("x")
+        assert adapter.dimension == 1024
+        await adapter.close()


### PR DESCRIPTION
## The bug

`OpenAIEmbeddingAdapter` unconditionally sends `Authorization: Bearer {api_key}`. Self-hosted OpenAI-compatible servers (vLLM, TGI, Ollama) take no key, so the header becomes a bare `"Bearer "` — which httpx rejects outright:

```
httpx.LocalProtocolError: Illegal header value b'Bearer '
```

So the adapter failed against precisely the deployments most likely to run unauthenticated.

## How it surfaced

Enabling embeddings on noatun against the new vLLM endpoint. The pod started fine — the adapter constructs without touching the network — then every `record_episode` raised on the first embed call. [agent.py:651](src/ravn/agent.py:651) catches that and continues, so **episodes were being dropped silently** until I reverted the config.

Worth noting the startup fail-loud check from #932 does not cover this class: construction succeeds, and only first use fails.

## Fix

Build headers conditionally — omit `Authorization` entirely when no key is configured, send it when one is.

## Tests

Three cases: no header without a key, correct header with one, and dimension learned from the server (Qwen3-Embedding returns 1024, not OpenAI's 1536 default).

`7,246 passed`, ruff clean.

## Still open

An embed failure still costs the episode, because the agent catches and continues. Storing the episode *without* its vector would be strictly better — no data loss, and the degradation stays visible through `ravn_memory_operations{result=error}` and the embedding-coverage gauge. Flagged separately rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)