### PR TITLE
style(web): fix Prettier drift

### DIFF
--- a/web-next/packages/plugin-ravn/src/ui/ravn-views.css
+++ b/web-next/packages/plugin-ravn/src/ui/ravn-views.css
@@ -2033,4 +2033,3 @@
 .rv-pr-action-btn--primary:hover {
   filter: brightness(1.1);
 }
-

--- a/web-next/vitest.config.ts
+++ b/web-next/vitest.config.ts
@@ -45,12 +45,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: isCi ? ['text', 'lcov'] : ['text', 'html', 'lcov'],
       include: ['packages/*/src/**/*.{ts,tsx}'],
-      exclude: [
-        '**/*.test.{ts,tsx}',
-        '**/index.{ts,tsx}',
-        '**/ports.ts',
-        '**/*.d.ts',
-      ],
+      exclude: ['**/*.test.{ts,tsx}', '**/index.{ts,tsx}', '**/ports.ts', '**/*.d.ts'],
       thresholds: {
         statements: 85,
         branches: 85,


### PR DESCRIPTION
Fixes the `web-next / web-next: Lint` failure currently blocking #939.

The CI Prettier diff only reported two files:
- `web-next/packages/plugin-ravn/src/ui/ravn-views.css`
- `web-next/vitest.config.ts`

Verification:
- `pnpm install --frozen-lockfile` from `web-next`
- `pnpm format:check` from `web-next`

Result: all matched files use Prettier code style.

Signed-off-by: 冼健聪 <mark.xian@evenrealities.com>