### PR TITLE
fix(openshell): retain resident credentials across restarts

### DIFF
--- a/src/volundr/adapters/outbound/openshell_gateway.py
+++ b/src/volundr/adapters/outbound/openshell_gateway.py
@@ -1579,6 +1579,9 @@ class OpenShellGatewayPodManager(
         )
         if sandbox is None or not sandbox.ready:
             raise RuntimeError("OpenShell resident sandbox is not ready")
+        credential_context = await self._resolve_credential_context(
+            self._resident_subject(runtime), values
+        )
         processes = self._resident_processes(runtime, values)
         exit_code, output = await asyncio.to_thread(
             self._client.exec_script,
@@ -1588,7 +1591,7 @@ class OpenShellGatewayPodManager(
         )
         if exit_code != 0:
             raise RuntimeError(f"OpenShell resident process stop failed: {output.strip()}")
-        files = self._resident_config_files(runtime, values)
+        files = {**credential_context.files, **self._resident_config_files(runtime, values)}
         for process in processes:
             files.update(_shared_resident_process_files(runtime, process.files))
         await asyncio.to_thread(
@@ -1597,6 +1600,9 @@ class OpenShellGatewayPodManager(
             files=files,
         )
         env = self._resident_environment(runtime, values)
+        env.update(resident_flock_environment(runtime))
+        env.update(credential_context.environment)
+        env.update(credential_context.process_environment)
         if runtime.engine is ResidentEngine.OPENCLAW:
             if self._credential_store is None:
                 raise RuntimeError("OpenClaw residents require the configured credential store")
@@ -2924,6 +2930,11 @@ def _resident_api_urls(values: dict[str, Any]) -> tuple[str, ...]:
     kwargs = provider.get("kwargs") if isinstance(provider.get("kwargs"), dict) else {}
     if kwargs.get("base_url") or kwargs.get("baseUrl"):
         urls.append(str(kwargs.get("base_url") or kwargs.get("baseUrl")))
+    broker = values.get("broker") or {}
+    codex_auth = broker.get("codexAuth") or {}
+    token_path = (codex_auth.get("kwargs") or {}).get("token_path", "")
+    if urlparse(token_path).scheme:
+        urls.append(token_path)
     return tuple(urls)
 
 

--- a/tests/test_adapters/test_openshell_gateway.py
+++ b/tests/test_adapters/test_openshell_gateway.py
@@ -1376,6 +1376,25 @@ async def test_resident_materializes_raw_protocol_credential_from_openbao(
         for grant in client.provider_grants
     )
 
+    await manager.restart(runtime, profile)
+
+    assert client.execs[-1]["env"]["RAVN_NATS_PASSWORD"] == "nats-from-openbao"
+
+
+@pytest.mark.parametrize(
+    "token_path",
+    [
+        "/api/v1/internal/credentials/codex/tokens",
+        "https://target.example.test/api/v1/internal/credentials/codex/tokens",
+    ],
+)
+def test_resident_api_urls_include_absolute_codex_broker(monkeypatch, token_path):
+    adapter = _import_adapter(monkeypatch)
+    urls = adapter._resident_api_urls(
+        {"broker": {"codexAuth": {"kwargs": {"token_path": token_path}}}}
+    )
+    assert urls == ((token_path,) if token_path.startswith("https://") else ())
+
 
 @pytest.mark.asyncio
 async def test_resident_restart_reuses_sandbox_and_dynamic_provider_environment(


### PR DESCRIPTION
Restarting an OpenShell resident lost credentials that must be supplied directly to raw protocols, breaking NATS authentication despite a healthy process. Resolve the existing credential mappings before stopping the processes, and restore their files and environment along with flock identity when launching again.

Also include explicitly configured absolute Codex token broker URLs in new residents' platform provider routes, so a target-owned broker can differ from the aggregate platform host.

Validation: 65 OpenShell adapter tests pass; Ruff passes. Includes restart coverage with a materialized NATS credential and relative/absolute broker URL cases.
