### PR TITLE
fix(ravn): unify resident controls and bound printer evidence

### DIFF
--- a/src/ravn/api/valkyrie_projection.py
+++ b/src/ravn/api/valkyrie_projection.py
@@ -77,7 +77,8 @@ class ValkyrieDashboardProjection:
 
     def dashboard(self) -> Dashboard:
         self._refresh_live_report()
-        return _merge_observed_runtime(deepcopy(self._dashboard))
+        self._dashboard = _merge_observed_runtime(self._dashboard)
+        return deepcopy(self._dashboard)
 
     def record_event(
         self,
@@ -637,6 +638,7 @@ class ValkyrieDashboardProjection:
         }
 
     def update_autonomy(self, request: AutonomyUpdateRequest) -> Dashboard:
+        self.dashboard()  # Resolve the same discovered roster used by GET /dashboard.
         valid_modes = {"guarded", "autonomous", "yolo"}
         if request.mode not in valid_modes:
             raise HTTPException(status_code=422, detail="Unsupported autonomy mode")

--- a/src/ravn/api/valkyrie_projection_common.py
+++ b/src/ravn/api/valkyrie_projection_common.py
@@ -63,12 +63,7 @@ def _environment_id(record: dict[str, Any]) -> str:
     if explicit:
         return explicit
     raw_id = _slug(str(_field(record, "id", "name", default="environment")))
-    kind = str(_field(record, "kind", default="generic"))
-    if raw_id.startswith("env-"):
-        return raw_id
-    if kind == "kubernetes":
-        return f"env-k8s-{raw_id}"
-    return f"env-{raw_id}"
+    return canonical_environment_id(raw_id)
 
 
 def _canonical_environment_id(value: Any) -> str:

--- a/src/ravn/resident_runtime.py
+++ b/src/ravn/resident_runtime.py
@@ -1932,8 +1932,14 @@ def _extreme_payload_lines(
     if signal.observation_count <= 1 or not extremes:
         return []
     lines = ["  Observations at numeric extremes:"]
+    keys_by_ref: dict[str, list[str]] = {}
     for key in sorted(extremes):
-        ref = extremes[key]
+        keys_by_ref.setdefault(extremes[key], []).append(key)
+    # Several sensor extrema can refer to the same event. Include it once,
+    # and share this slot's payload budget across the distinct events.
+    payload_budget = max(1, budget // len(keys_by_ref))
+    for ref, keys in keys_by_ref.items():
+        key = ", ".join(keys)
         record = archive.read(ref) if archive is not None else None
         payload = (record or {}).get("signal", {}).get("payload") if record else None
         if payload is None:
@@ -1952,7 +1958,7 @@ def _extreme_payload_lines(
                             ensure_ascii=False,
                             default=str,
                         ),
-                        budget,
+                        payload_budget,
                     ),
                     "  ",
                 ),

--- a/tests/test_ravn/test_ravn_api.py
+++ b/tests/test_ravn/test_ravn_api.py
@@ -1687,7 +1687,7 @@ def test_valkyrie_dashboard_accepts_typed_catalog_config(monkeypatch):
 
     dashboard = ValkyrieDashboardProjection(config).dashboard()
 
-    assert [environment["id"] for environment in dashboard["environments"]] == ["env-midgard"]
+    assert [environment["id"] for environment in dashboard["environments"]] == ["env-k8s-midgard"]
 
 
 def test_valkyrie_dashboard_rejects_malformed_typed_catalog():
@@ -3015,3 +3015,67 @@ def test_undirected_huddle_message_without_room_bridge_still_records(monkeypatch
     assert projection.dashboard()["huddles"][0]["messages"][0]["body"] == (
         "Room note for whoever reads the transcript."
     )
+
+
+@pytest.mark.parametrize("resident_id, environment_id", [("regin", "niuu"), ("ivaldi", "workshop")])
+def test_observed_residents_use_the_same_autonomy_roster(monkeypatch, resident_id, environment_id):
+    monkeypatch.setenv("RAVN_VALKYRIE_DASHBOARD_ENVIRONMENTS_JSON", _valkyrie_catalog())
+    projection = ValkyrieDashboardProjection()
+    projection.record_event(
+        SleipnirEvent(
+            event_type="valkyrie.presence.announced",
+            source=resident_id,
+            summary="resident present",
+            urgency=0,
+            domain="infrastructure",
+            timestamp=datetime.now(UTC),
+            payload={"environment_id": environment_id, "valkyrie_id": resident_id},
+        )
+    )
+    app = FastAPI()
+    app.include_router(create_valkyrie_router(projection))
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v1/ravn/valkyrie/autonomy",
+            json={
+                "valkyrieId": resident_id,
+                "mode": "autonomous",
+                "reason": "operator change",
+            },
+        )
+        assert response.status_code == 200
+        for dashboard in (response.json(), projection.dashboard(), projection.dashboard()):
+            residents = [r for r in dashboard["valkyries"] if r["id"] == resident_id]
+            assert len(residents) == 1
+            assert residents[0]["autonomyMode"] == "autonomous"
+
+
+def test_workshop_inventory_and_telemetry_share_environment_id(monkeypatch):
+    monkeypatch.setenv(
+        "RAVN_VALKYRIE_DASHBOARD_ENVIRONMENTS_JSON",
+        json.dumps(
+            {
+                "environments": [
+                    {"id": "workshop", "kind": "workshop", "valkyrie": {"valkyrieId": "ivaldi"}}
+                ],
+            }
+        ),
+    )
+    projection = ValkyrieDashboardProjection()
+    projection.record_event(
+        SleipnirEvent(
+            event_type="valkyrie.runtime.started",
+            source="ivaldi",
+            summary="resident present",
+            urgency=0,
+            domain="infrastructure",
+            timestamp=datetime.now(UTC),
+            payload={"environment_id": "workshop", "valkyrie_id": "ivaldi", "source_count": 1},
+        )
+    )
+    dashboard = projection.dashboard()
+    env_id = dashboard["environments"][0]["id"]
+    assert dashboard["environments"][0]["kind"] == "workshop"
+    assert dashboard["environments"][0]["identitySource"] == "observed"
+    assert dashboard["valkyries"][0]["environmentId"] == env_id
+    assert dashboard["telemetry"]["runtime"][0]["environmentId"] == env_id

--- a/tests/test_ravn/test_resident_inbox_coalescing.py
+++ b/tests/test_ravn/test_resident_inbox_coalescing.py
@@ -651,3 +651,23 @@ def test_archive_range_is_bounded_and_skips_malformed_lines(tmp_path) -> None:
     # count() is a line count for reconciliation: a corrupt line is still a
     # record that was written, and must not silently vanish from the total.
     assert archive.count() == 7
+
+
+def test_extreme_payloads_are_deduplicated_and_share_budget():
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    from ravn.resident_runtime import _extreme_payload_lines
+
+    refs = {f"sensor{n}:max": f"archive-{n % 4}" for n in range(72)}
+    signal = SimpleNamespace(observation_count=100, aggregate=SimpleNamespace(extreme_refs=refs))
+    archive = Mock()
+    archive.read.side_effect = lambda ref: {"signal": {"payload": {"detail": "Z" * 5000}}}
+    rendered = "\n".join(_extreme_payload_lines(signal, 4000, archive))
+    assert archive.read.call_count == 4
+    assert rendered.count("```json") == 4
+    assert rendered.count("Z") < 4000
+    for key, ref in refs.items():
+        assert key in rendered
+        assert ref in rendered
+    assert "truncated" in rendered

--- a/web-next/packages/plugin-valkyrie/src/ui/ValkyrieConsolePage.test.tsx
+++ b/web-next/packages/plugin-valkyrie/src/ui/ValkyrieConsolePage.test.tsx
@@ -884,3 +884,16 @@ describe('hero actions', () => {
     await waitFor(() => expect(select).toHaveValue('guarded'));
   });
 });
+
+it('shows an autonomy update failure instead of silently resetting the selector', async () => {
+  const user = userEvent.setup();
+  const service = createMockValkyrieService();
+  service.updateAutonomy = async () => {
+    throw new Error('Valkyrie not found');
+  };
+  render(<ValkyrieConsolePage />, { wrapper: wrapWithValkyrie({ valkyrie: service }) });
+  await screen.findByTestId('valkyrie-console-page');
+  await user.click(screen.getByTestId('valkyrie-change-autonomy'));
+  await user.selectOptions(screen.getByLabelText('Autonomy mode for Sigrun'), ['guarded']);
+  expect(await screen.findByRole('alert')).toHaveTextContent('Valkyrie not found');
+});

--- a/web-next/packages/plugin-valkyrie/src/ui/ValkyrieConsolePage.tsx
+++ b/web-next/packages/plugin-valkyrie/src/ui/ValkyrieConsolePage.tsx
@@ -454,6 +454,13 @@ function Hero({
           <p className={`niuu:text-xs ${MUTED}`}>
             Configured mode — the realm build grant still wins for tool builds.
           </p>
+          {updateAutonomy.isError ? (
+            <p role="alert" className="niuu:text-xs niuu:text-critical">
+              {updateAutonomy.error instanceof Error
+                ? updateAutonomy.error.message
+                : 'Unable to change autonomy'}
+            </p>
+          ) : null}
         </div>
       ) : null}
       {composing && huddle?.joined ? (


### PR DESCRIPTION
Regin appears in telemetry but autonomy updates searched only the configured roster, producing a hidden 404. Keep discovered residents in the shared dashboard roster and surface update errors. Use the existing canonical environment ID function for configured residents so Ivaldi’s workshop telemetry and history match its dashboard entry.

Ivaldi’s printer observations also repeated an archived event for each sensor extreme, overflowing the prompt budget before any judgment could run. Render each distinct archived event once and divide the existing payload allowance across those events, preserving all extrema labels and archive references.

Validation: 178 backend tests and 42 console tests passed; Ruff and ESLint passed. A read-only comparison on Ivaldi’s eight queued observations reduced the extrema section from 423,270 to 25,802 characters. No live runtime or Kubernetes resources were changed by this PR.
