### PR TITLE
fix(ravn): isolate resident outcome repair from task history

### DIFF
--- a/src/ravn/agent.py
+++ b/src/ravn/agent.py
@@ -376,6 +376,39 @@ class RavnAgent:
                 "Failed to emit ravn.session.ended with outcome; continuing.", exc_info=True
             )
 
+    async def repair_outcome(self, prompt: str) -> TurnResult:
+        """Repair output formatting without replaying history or executing tools."""
+        if self._iteration_budget is not None and self._iteration_budget.exhausted:
+            raise MaxIterationsError(self._max_iterations)
+        system = "Repair the supplied outcome contract. Preserve the evidence and decisions."
+        messages = [{"role": "user", "content": prompt}]
+        sections = {
+            name: TokenEstimator.conservative(tokens, self._token_estimate_safety_factor)
+            for name, tokens in {
+                "system": TokenEstimator.rough(system),
+                "repair": TokenEstimator.rough_structured(messages),
+            }.items()
+        }
+        self._record_prompt_budget(sections, compressed=False)
+        self._enforce_prompt_budget(sections)
+        response = await self._llm.generate(
+            messages,
+            tools=[],
+            system=system,
+            model=self._model,
+            max_tokens=self._max_tokens,
+        )
+        if self._iteration_budget is not None:
+            self._iteration_budget.consume()
+        if response.tool_calls:
+            raise ValueError("Outcome repair must return text, not tool calls")
+        return TurnResult(
+            response=response.content,
+            tool_calls=[],
+            tool_results=[],
+            usage=response.usage,
+        )
+
     async def run_turn(self, user_input: str) -> TurnResult:
         """Process one user turn and return the result.
 

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -742,7 +742,8 @@ def _build_resident_valkyrie_schema_repair_prompt(
         f"{json.dumps(validation_errors, indent=2)}\n\n"
         "Fields parsed from the invalid attempt, if any:\n"
         f"{json.dumps(_json_safe(outcome_fields), indent=2)}\n\n"
-        "Use the original autonomous task context already present in this conversation.\n\n"
+        "Use only the supplied response and parsed fields. Preserve decisions, evidence, "
+        "references and working-state entries; do not invent observations or actions.\n\n"
         "Previous response:\n"
         "<previous_response>\n"
         f"{original_response[:4000]}\n"
@@ -3085,7 +3086,7 @@ class DriveLoop:
         task: AgentTask,
         response_text: str,
     ) -> object | None:
-        """Ask the same agent for one strict contract repair when a resident output is invalid."""
+        """Repair an invalid resident contract without replaying the agent's history."""
         if task.triggered_by == _RESIDENT_VALKYRIE_SCHEMA_REPAIR_TRIGGER:
             return None
         persona_config = getattr(agent, "persona_config", None) or self._persona_config
@@ -3098,8 +3099,8 @@ class DriveLoop:
         )
         if not canonical_event_type or not validation_errors:
             return None
-        run_turn = getattr(agent, "run_turn", None)
-        if run_turn is None or not asyncio.iscoroutinefunction(run_turn):
+        repair_outcome = getattr(agent, "repair_outcome", None)
+        if repair_outcome is None or not asyncio.iscoroutinefunction(repair_outcome):
             return None
 
         logger.warning(
@@ -3115,7 +3116,7 @@ class DriveLoop:
             outcome_fields=outcome_fields,
         )
         try:
-            repair_result = await run_turn(repair_prompt)
+            repair_result = await repair_outcome(repair_prompt)
         except Exception:
             logger.warning(
                 "drive_loop: resident Valkyrie schema repair failed; "

--- a/tests/test_ravn/test_agent.py
+++ b/tests/test_ravn/test_agent.py
@@ -12,10 +12,12 @@ from niuu.domain.outcome import OutcomeField
 from ravn.adapters.personas.loader import PersonaConfig, PersonaProduces
 from ravn.adapters.tools.build_tool import attach_build_tool
 from ravn.agent import RavnAgent, _build_assistant_content
+from ravn.budget import IterationBudget
 from ravn.domain.events import RavnEventType
-from ravn.domain.exceptions import MaxIterationsError
+from ravn.domain.exceptions import MaxIterationsError, PromptBudgetExceededError
 from ravn.domain.models import (
     LLMResponse,
+    Message,
     StopReason,
     StreamEvent,
     StreamEventType,
@@ -66,6 +68,58 @@ def make_agent(
 
 async def _record(events: list[SleipnirEvent], event: SleipnirEvent) -> None:
     events.append(event)
+
+
+@pytest.mark.asyncio
+async def test_outcome_repair_is_tool_free_and_does_not_replay_history() -> None:
+    llm = AsyncMock(spec=LLMPort)
+    usage = TokenUsage(input_tokens=100, output_tokens=50)
+    llm.generate.return_value = LLMResponse(
+        content="working_state:\n  observations: []",
+        tool_calls=[],
+        stop_reason=StopReason.END_TURN,
+        usage=usage,
+    )
+    agent, _ = make_agent(llm, tools=[EchoTool()], max_prompt_tokens=1000)
+    history = Message(role="user", content="old observations " * 20000)
+    agent.session.messages.append(history)
+
+    result = await agent.repair_outcome("Repair working_state as a mapping")
+
+    assert result.response == llm.generate.return_value.content
+    assert result.usage == usage
+    assert agent.session.messages == [history]
+    assert llm.generate.call_args.args[0] == [
+        {"role": "user", "content": "Repair working_state as a mapping"}
+    ]
+    assert llm.generate.call_args.kwargs["tools"] == []
+    assert agent.prompt_budget_status["estimated_prompt_tokens"] < 1000
+
+    llm.generate.reset_mock()
+    with pytest.raises(PromptBudgetExceededError):
+        await agent.repair_outcome("oversized repair " * 20000)
+    llm.generate.assert_not_called()
+
+    llm.generate.return_value = LLMResponse(
+        content="",
+        tool_calls=[ToolCall(id="x", name="echo", input={})],
+        stop_reason=StopReason.TOOL_USE,
+        usage=usage,
+    )
+    with pytest.raises(ValueError, match="not tool calls"):
+        await agent.repair_outcome("Repair working_state")
+
+    budget = IterationBudget(total=1)
+    agent, _ = make_agent(llm, iteration_budget=budget)
+    llm.generate.return_value = LLMResponse(
+        content="repaired", tool_calls=[], stop_reason=StopReason.END_TURN, usage=usage
+    )
+    await agent.repair_outcome("Repair working_state")
+    assert budget.exhausted
+    llm.generate.reset_mock()
+    with pytest.raises(MaxIterationsError):
+        await agent.repair_outcome("Repair working_state")
+    llm.generate.assert_not_called()
 
 
 class _FakeSandboxShell:

--- a/tests/test_ravn/test_drive_loop_outcome_contract.py
+++ b/tests/test_ravn/test_drive_loop_outcome_contract.py
@@ -244,7 +244,7 @@ class TestDriveLoopOutcomeContract:
             def __init__(self) -> None:
                 self.prompts: list[str] = []
 
-            async def run_turn(self, prompt: str) -> TurnResult:
+            async def repair_outcome(self, prompt: str) -> TurnResult:
                 self.prompts.append(prompt)
                 return TurnResult(
                     response=_valid_valkyrie_judgment_text(),
@@ -400,7 +400,7 @@ class TestDriveLoopOutcomeContract:
         assert "working_state` must be a mapping" in prompt
         assert "empty list as `field: []`" in prompt
         assert "at most five entries per list" in prompt
-        assert "already present in this conversation" in prompt
+        assert "Use only the supplied response and parsed fields" in prompt
         assert "<initiative_context>" not in prompt
 
         working_state_prompt = _build_resident_valkyrie_schema_repair_prompt(


### PR DESCRIPTION
Ivaldi completed its observation turn, but returned working_state as a string. Schema repair replayed the full observation and tool history, exceeded the 48,000-token budget, and left the judgment unpersisted.

Run resident schema repair as an isolated, tool-free model request containing the response, parsed fields and contract errors. Preserve prompt and iteration limits, account for repair usage, and continue validating the returned contract before persistence.

Validation: 185 targeted agent, outcome-contract and drive-loop tests passed (one existing skip); Ruff and git diff --check passed. The regression covers oversized prior history, prohibited tool output, prompt limits and iteration limits.
