### PR TITLE
fix(ting): attach enabled integrations to workflow launches

### DIFF
--- a/src/ting/api/workflows.py
+++ b/src/ting/api/workflows.py
@@ -410,6 +410,10 @@ async def launch_workflow_execution(
             detail="No Volundr connection is available for this user",
         )
 
+    integration_ids = await target_adapter.list_integration_ids(
+        auth_token=bearer_token,
+        principal=principal,
+    )
     session = await target_adapter.spawn_session(
         SpawnRequest(
             name=session_name,
@@ -455,6 +459,7 @@ async def launch_workflow_execution(
                 ),
             },
             credential_names=_mimir_auth_credential_names(workflow_mimir),
+            integration_ids=integration_ids,
             definition=resolved_definition,
         ),
         auth_token=bearer_token,

--- a/tests/test_ting/test_a2a_tasks.py
+++ b/tests/test_ting/test_a2a_tasks.py
@@ -211,7 +211,7 @@ class RecordingVolundrPort(VolundrPort):
         self.stopped.append(session_id)
 
     async def list_integration_ids(self, *, auth_token=None, principal=None):
-        return []
+        return ["integration-github", "integration-memory"]
 
     async def list_repos(self, *, auth_token=None, principal=None):
         return []
@@ -465,6 +465,7 @@ class TestSendMessage:
 
         assert len(port.spawned) == 1
         assert port.spawned[0].workload_type == "ravn_flock"
+        assert port.spawned[0].integration_ids == ["integration-github", "integration-memory"]
         assert port.spawned[0].workload_config["provenance"]["trace_context"] == {
             "traceparent": "00-0123456789abcdef0123456789abcdef-0123456789abcdef-01",
             "tracestate": "niuu=resident",

--- a/tests/test_ting/test_workflows_api.py
+++ b/tests/test_ting/test_workflows_api.py
@@ -116,7 +116,8 @@ class RecordingVolundrPort(VolundrPort):
         raise NotImplementedError
 
     async def list_integration_ids(self, *, auth_token=None, principal=None):
-        return []
+        self.integration_principal = principal
+        return ["integration-github", "integration-memory"]
 
     async def list_repos(self, *, auth_token=None, principal=None):
         return []
@@ -609,6 +610,8 @@ class TestWorkflowCatalogAPI:
         assert spawn.tracker_issue_id == "workflow:grief-companions"
         assert spawn.workload_config["workflow"]["name"] == "Research Campaign"
         assert spawn.credential_names == []
+        assert spawn.integration_ids == ["integration-github", "integration-memory"]
+        assert adapter.integration_principal is not None
         assert spawn.workload_config["provenance"] == {
             "signal_id": "sig-1",
             "valkyrie_id": "valkyrie-ymir",


### PR DESCRIPTION
Workflow launches created Forge sessions without the caller's enabled integrations, unlike normal dispatch. This omitted repository/provider credentials and could prevent workflows with integration-backed memory from starting.

Resolve enabled integration IDs through the selected Forge connection with the same caller identity, then attach them to the spawned session. Both REST and A2A launches use this shared path. Discovery failures propagate before spawning.

Validation: 66 workflow API and A2A tests passed, including assertions that both launch paths attach integrations; Ruff and git diff --check passed. This does not provision credentials or change workflow memory authentication references.
