### PR TITLE
fix(ting): use workload identity for delivery memory

### DIFF
--- a/src/ting/system_workflows.yaml
+++ b/src/ting/system_workflows.yaml
@@ -788,7 +788,7 @@
         bindingMode: registry
         registryEntryId: mimir-yggdrasil
         url: https://mimir.yggdrasil.niuu.world/api/v1
-        authRef: integration:volundr
+        authRef: workload:mimir
         role: shared
         categories: [delivery, tracker, review]
         position:

--- a/tests/test_ting/test_system_workflows.py
+++ b/tests/test_ting/test_system_workflows.py
@@ -224,7 +224,7 @@ def test_load_system_workflows_only_keeps_supported_catalog() -> None:
     assert delivery_resources["Delivery Memory"]["url"] == (
         "https://mimir.yggdrasil.niuu.world/api/v1"
     )
-    assert delivery_resources["Delivery Memory"]["authRef"] == "integration:volundr"
+    assert delivery_resources["Delivery Memory"]["authRef"] == "workload:mimir"
 
     code_review_flow = next(
         workflow for workflow in workflows if workflow.name == "Code & Review Flow"


### PR DESCRIPTION
Tracker Delivery Flow could not start because its memory resource required integration:volundr, which is not configured for the caller. Use the existing workload:mimir authentication reference so the session accesses shared Mímir through projected workload identity. The operator explicitly approved this authentication change.

Only the delivery workflow is changed; no credential values are introduced. Updated catalog assertions and both system workflow tests pass.
