### PR TITLE
test(ting): provide integration lookup in planning adapter

### DIFF
--- a/tests/test_ting/test_sagas_api.py
+++ b/tests/test_ting/test_sagas_api.py
@@ -1087,6 +1087,7 @@ class TestSpawnPlanSession:
         adapter = MagicMock()
         adapter.name = "local"
         adapter.target_id = "local"
+        adapter.list_integration_ids = AsyncMock(return_value=[])
         adapter.spawn_session = AsyncMock(
             return_value=VolundrSession(
                 id="plan-1",


### PR DESCRIPTION
The planning-route test uses a MagicMock Forge adapter. Since shared workflow launches now resolve integrations asynchronously, that adapter needs an async list_integration_ids implementation. Without it the request returned 502 and skipped the planning flow.

Validation: all 1,726 Ting tests pass with 85.59% branch-inclusive coverage, keeping the 85% gate unchanged. Test-only change.
