### PR TITLE
fix(mesh): restore named peers and usable room chat

### DIFF
--- a/src/niuu/mesh/identity.py
+++ b/src/niuu/mesh/identity.py
@@ -32,4 +32,6 @@ class MeshIdentity:
     rep_address: str | None = None
     pub_address: str | None = None
     spiffe_id: str | None = None
+    display_name: str = ""
+    participant_type: str = "ravn"
     sleipnir_routing_key: str | None = None

--- a/src/ravn/adapters/discovery/event_bus.py
+++ b/src/ravn/adapters/discovery/event_bus.py
@@ -114,6 +114,8 @@ class EventBusDiscoveryAdapter:
                 "peer_id",
                 "realm_id",
                 "persona",
+                "display_name",
+                "participant_type",
                 "capabilities",
                 "permission_mode",
                 "version",
@@ -158,6 +160,8 @@ class EventBusDiscoveryAdapter:
         peer = self._peers.get(peer_id)
         if peer is not None:
             peer.persona = str(identity.get("persona") or "")
+            peer.display_name = str(identity.get("display_name") or "")
+            peer.participant_type = str(identity.get("participant_type") or "ravn")
             peer.capabilities = list(identity.get("capabilities") or [])
             peer.permission_mode = str(identity.get("permission_mode") or "")
             peer.version = str(identity.get("version") or "")
@@ -174,6 +178,8 @@ class EventBusDiscoveryAdapter:
             peer_id=peer_id,
             realm_id=self._identity.realm_id,
             persona=str(identity.get("persona") or ""),
+            display_name=str(identity.get("display_name") or ""),
+            participant_type=str(identity.get("participant_type") or "ravn"),
             capabilities=list(identity.get("capabilities") or []),
             permission_mode=str(identity.get("permission_mode") or ""),
             version=str(identity.get("version") or ""),

--- a/src/ravn/cli/mesh_runtime.py
+++ b/src/ravn/cli/mesh_runtime.py
@@ -123,6 +123,7 @@ def _build_discovery(
         peer_id=peer_id,
         realm_id=realm_id,
         persona=persona_name,
+        display_name=settings.skuld.display_name or settings.environment.resident_name,
         capabilities=capabilities,
         permission_mode=settings.permission.mode,
         version=version,

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -441,6 +441,8 @@ class RavnIdentity:
     rep_address: str | None = None  # nng REP address for mesh.send()
     pub_address: str | None = None  # nng PUB address for mesh.send()
     spiffe_id: str | None = None  # infra mode only
+    display_name: str = ""
+    participant_type: str = "ravn"
     sleipnir_routing_key: str | None = None  # for SleipnirMeshAdapter routing
 
 

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -797,6 +797,8 @@ class Broker(
             peer_id=mesh_cfg.peer_id or self.session_id or "skuld",
             realm_id=mesh_cfg.realm_id,
             persona=mesh_cfg.persona,
+            display_name="Skuld",
+            participant_type="skuld",
             capabilities=list(mesh_cfg.capabilities),
             permission_mode="full_access",
             version="0.1.0",
@@ -814,7 +816,8 @@ class Broker(
                 await self._room_bridge.register_mesh_peer(
                     peer_id=peer.peer_id,
                     persona=peer.persona,
-                    display_name=peer.persona,
+                    display_name=getattr(peer, "display_name", "") or peer.persona,
+                    participant_type=getattr(peer, "participant_type", "ravn"),
                     subscribes_to=list(getattr(peer, "consumes_event_types", [])),
                     emits=list(getattr(peer, "emits_event_types", [])),
                     tools=list(getattr(peer, "capabilities", [])),

--- a/tests/test_ravn/test_event_bus_discovery.py
+++ b/tests/test_ravn/test_event_bus_discovery.py
@@ -10,6 +10,8 @@ def _identity(peer_id: str, realm_id: str = "flock-a") -> MeshIdentity:
         peer_id=peer_id,
         realm_id=realm_id,
         persona=peer_id,
+        display_name=f"Name {peer_id}",
+        participant_type="skuld" if peer_id == "second" else "ravn",
         capabilities=["chat"],
         permission_mode="permissive",
         version="test",
@@ -31,6 +33,9 @@ async def test_event_bus_discovery_converges_immediately_and_handles_leave() -> 
 
     assert set(first.peers()) == {"second"}
     assert set(second.peers()) == {"first"}
+    assert first.peers()["second"].display_name == "Name second"
+    assert first.peers()["second"].participant_type == "skuld"
+    assert second.peers()["first"].display_name == "Name first"
     assert second.peers()["first"].capabilities == ["chat"]
     assert second.peers()["first"].consumes_event_types == ["code.changed"]
     assert second.peers()["first"].emits_event_types == ["review.completed"]

--- a/web-next/packages/plugin-ravn/src/ui/SessionsView.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/SessionsView.test.tsx
@@ -742,7 +742,7 @@ describe('SessionsView — live chat', () => {
     fireEvent.change(screen.getByTestId('chat-textarea'), {
       target: { value: 'Coordinate this work' },
     });
-    expect(screen.getByTestId('send-btn')).toBeDisabled();
+    expect(screen.getByTestId('send-btn')).toBeEnabled();
 
     fireEvent.change(screen.getByTestId('chat-textarea'), {
       target: { value: '@', selectionStart: 1 },

--- a/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
+++ b/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
@@ -257,7 +257,7 @@ describe('ChatInput', () => {
 
     const textarea = screen.getByTestId('chat-textarea');
     fireEvent.change(textarea, { target: { value: 'Review this' } });
-    expect(screen.getByTestId('send-btn')).toBeDisabled();
+    expect(screen.getByTestId('send-btn')).toBeEnabled();
 
     fireEvent.change(textarea, { target: { value: '@', selectionStart: 1 } });
     fireEvent.click(screen.getByRole('option', { name: /review\.requested.*Hermes reviewer/ }));
@@ -292,5 +292,47 @@ describe('ChatInput', () => {
     rerender(<ChatInput {...defaultProps} disabled={true} />);
     fireEvent.click(screen.getByTestId('attach-btn'));
     expect(click).not.toHaveBeenCalled();
+  });
+});
+
+describe('mesh ordinary chat', () => {
+  it('sends plain messages and directs display-name mentions without event subscriptions', () => {
+    const onSend = vi.fn();
+    const onSendDirected = vi.fn();
+    const bragi = {
+      peerId: 'bragi',
+      persona: 'resident-codex',
+      displayName: 'Bragi',
+      participantType: 'ravn',
+    };
+    const heimdall = {
+      peerId: 'heimdall',
+      persona: 'resident-codex',
+      displayName: 'Heimdall',
+      participantType: 'ravn',
+    };
+    render(
+      <ChatInput
+        onSend={onSend}
+        onSendDirected={onSendDirected}
+        eventRouting
+        participants={
+          new Map([
+            [bragi.peerId, bragi],
+            [heimdall.peerId, heimdall],
+          ])
+        }
+      />,
+    );
+    const textarea = screen.getByTestId('chat-textarea');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    fireEvent.click(screen.getByTestId('send-btn'));
+    expect(onSend).toHaveBeenCalled();
+    fireEvent.change(textarea, { target: { value: '@Bragi hello' } });
+    fireEvent.click(screen.getByTestId('send-btn'));
+    expect(onSendDirected).toHaveBeenCalledWith([bragi], '@Bragi hello', []);
+    fireEvent.change(textarea, { target: { value: '@', selectionStart: 1 } });
+    expect(screen.getByRole('option', { name: /Bragi/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Heimdall/ })).toBeInTheDocument();
   });
 });

--- a/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
+++ b/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
@@ -334,5 +334,9 @@ describe('mesh ordinary chat', () => {
     fireEvent.change(textarea, { target: { value: '@', selectionStart: 1 } });
     expect(screen.getByRole('option', { name: /Bragi/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Heimdall/ })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('option', { name: /Bragi/ }));
+    fireEvent.change(textarea, { target: { value: '@resident-codex hello' } });
+    fireEvent.click(screen.getByTestId('send-btn'));
+    expect(onSendDirected.mock.calls[1]?.[0]).toEqual([bragi]);
   });
 });

--- a/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.tsx
+++ b/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.tsx
@@ -53,15 +53,19 @@ function resolveInlineAgentMentions(
   input: string,
   participants: ReadonlyMap<string, RoomParticipant>,
 ): RoomParticipant[] {
-  const byPersona = new Map(
-    Array.from(participants.values())
-      .filter((participant) => participant.participantType === 'ravn')
-      .flatMap((participant) =>
-        [participant.persona, participant.displayName, participant.peerId]
-          .filter((label): label is string => Boolean(label))
-          .map((label) => [label.toLowerCase(), participant] as const),
-      ),
-  );
+  const byPersona = new Map<string, RoomParticipant | null>();
+  for (const participant of participants.values()) {
+    if (participant.participantType !== 'ravn') continue;
+    for (const label of [participant.persona, participant.displayName, participant.peerId]) {
+      if (!label) continue;
+      const key = label.toLowerCase();
+      const existing = byPersona.get(key);
+      byPersona.set(
+        key,
+        existing !== undefined && existing?.peerId !== participant.peerId ? null : participant,
+      );
+    }
+  }
   const seen = new Set<string>();
   const matches = input.matchAll(/(^|\s)@([^\s@]+)/g);
   const resolved: RoomParticipant[] = [];

--- a/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.tsx
+++ b/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.tsx
@@ -56,7 +56,11 @@ function resolveInlineAgentMentions(
   const byPersona = new Map(
     Array.from(participants.values())
       .filter((participant) => participant.participantType === 'ravn')
-      .map((participant) => [participant.persona.toLowerCase(), participant] as const),
+      .flatMap((participant) =>
+        [participant.persona, participant.displayName, participant.peerId]
+          .filter((label): label is string => Boolean(label))
+          .map((label) => [label.toLowerCase(), participant] as const),
+      ),
   );
   const seen = new Set<string>();
   const matches = input.matchAll(/(^|\s)@([^\s@]+)/g);
@@ -141,7 +145,7 @@ export function ChatInput({
     (mention): mention is Extract<SelectedMention, { kind: 'agent' }> & { eventType: string } =>
       mention.kind === 'agent' && Boolean(mention.eventType),
   );
-  const canSend = hasContent && (!eventRouting || Boolean(selectedEventMention));
+  const canSend = hasContent;
 
   const resetTextareaHeight = useCallback(() => {
     const textarea = textareaRef.current;
@@ -163,8 +167,8 @@ export function ChatInput({
     const trimmed = input.trim();
     if (!trimmed || disabled) return;
 
-    if (eventRouting) {
-      if (!selectedEventMention || !onPublishEvent) return;
+    if (eventRouting && selectedEventMention) {
+      if (!onPublishEvent) return;
       const eventPrefix = `@${selectedEventMention.eventType}`;
       const fullMessage = trimmed.startsWith(eventPrefix) ? trimmed : `${eventPrefix} ${trimmed}`;
       onPublishEvent(
@@ -395,7 +399,7 @@ export function ChatInput({
             disabled
               ? 'Start session to chat...'
               : eventRouting
-                ? 'Select a participant event with @...'
+                ? 'Message the room, or select a participant with @...'
                 : 'Message...'
           }
           disabled={disabled}

--- a/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.test.tsx
+++ b/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.test.tsx
@@ -32,21 +32,21 @@ describe('MeshSidebar', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders ravn peers plus the skuld observer when a flock exists', () => {
+  it('renders agents without duplicating their session gateways', () => {
     render(
       <MeshSidebar participants={participants} selectedPeerId={null} onSelectPeer={vi.fn()} />,
     );
     expect(screen.getByTestId('peer-card-peer-1')).toBeInTheDocument();
     expect(screen.getByTestId('peer-card-peer-2')).toBeInTheDocument();
-    expect(screen.getByTestId('peer-card-peer-3')).toBeInTheDocument();
-    expect(screen.getByText('Skuld (observer)')).toBeInTheDocument();
+    expect(screen.queryByTestId('peer-card-peer-3')).not.toBeInTheDocument();
+    expect(screen.queryByText('Skuld (observer)')).not.toBeInTheDocument();
   });
 
   it('shows peer count', () => {
     render(
       <MeshSidebar participants={participants} selectedPeerId={null} onSelectPeer={vi.fn()} />,
     );
-    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 
   it('calls onSelectPeer when peer clicked', () => {

--- a/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.tsx
+++ b/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.tsx
@@ -23,10 +23,6 @@ interface GatewaySectionProps {
   region?: string;
 }
 
-function isMeshVisibleParticipant(participant: RoomParticipant): boolean {
-  return participant.participantType === 'ravn' || participant.participantType === 'skuld';
-}
-
 function formatParticipantLabel(participant: RoomParticipant): string {
   const role = participant.participantType === 'skuld' ? 'observer' : participant.persona;
   const baseName = participant.displayName ?? participant.persona ?? participant.peerId;
@@ -189,10 +185,9 @@ export function MeshSidebar({
   collapsed = false,
   onToggleCollapsed,
 }: MeshSidebarProps) {
-  const ravnPeers = Array.from(participants.values()).filter((p) => p.participantType === 'ravn');
-  const peers = Array.from(participants.values()).filter(isMeshVisibleParticipant);
+  const peers = Array.from(participants.values()).filter((p) => p.participantType === 'ravn');
 
-  if (ravnPeers.length === 0 || peers.length === 0) return null;
+  if (peers.length === 0) return null;
 
   if (collapsed) {
     return (

--- a/web-next/packages/ui/src/chat/hooks/useMentionMenu.test.ts
+++ b/web-next/packages/ui/src/chat/hooks/useMentionMenu.test.ts
@@ -265,20 +265,21 @@ describe('useMentionMenu — selectItem', () => {
     act(() => result.current.handleChange('@', 1));
 
     expect(result.current.items).toEqual([
+      { kind: 'agent', participant: hermes },
       { kind: 'agent', participant: hermes, eventType: 'code.changed' },
       { kind: 'agent', participant: hermes, eventType: 'review.requested' },
     ]);
 
     let selectedLabel = '';
     act(() => {
-      selectedLabel = result.current.selectItem(result.current.items[0]!);
+      selectedLabel = result.current.selectItem(result.current.items[1]!);
     });
     expect(selectedLabel).toBe('code.changed');
     expect(result.current.mentions).toEqual([
       { kind: 'agent', participant: hermes, eventType: 'code.changed' },
     ]);
 
-    act(() => result.current.selectItem(result.current.items[1]!));
+    act(() => result.current.selectItem(result.current.items[2]!));
     expect(result.current.mentions).toEqual([
       { kind: 'agent', participant: hermes, eventType: 'review.requested' },
     ]);

--- a/web-next/packages/ui/src/chat/hooks/useMentionMenu.ts
+++ b/web-next/packages/ui/src/chat/hooks/useMentionMenu.ts
@@ -145,11 +145,14 @@ export function useMentionMenu(
         .filter((participant) => participant.participantType === 'ravn')
         .flatMap((participant): MentionMenuItem[] => {
           if (!eventRouting) return [{ kind: 'agent', participant }];
-          return (participant.subscribesTo ?? []).map((eventType) => ({
-            kind: 'agent',
-            participant,
-            eventType,
-          }));
+          return [
+            { kind: 'agent', participant },
+            ...(participant.subscribesTo ?? []).map((eventType): MentionMenuItem => ({
+              kind: 'agent',
+              participant,
+              eventType,
+            })),
+          ];
         })
         .filter((item) => {
           if (item.kind !== 'agent' || !queryLower) return true;


### PR DESCRIPTION
Mesh rooms could not send ordinary messages when residents advertised no event subscriptions. Discovery also dropped resident display names and gateway types, making three residents appear as six agents with repeated persona labels.

Preserve display names and participant types through event-bus discovery, list only agents in the mesh sidebar, and support ordinary/direct messages alongside typed events. Resolve named mentions without delivering to another resident sharing the same persona.

Validation: 302 backend tests and 102 focused UI tests passed; production web build, workspace typecheck, full web coverage gate, and formatting checks passed. Live rollout will verify names, peer count, and a directed reply on Yggdrasil.
