### PR TITLE
fix(ravn): return mesh-directed replies to their originating room

### DIFF
--- a/src/ravn/cli/trigger_wiring.py
+++ b/src/ravn/cli/trigger_wiring.py
@@ -361,7 +361,9 @@ def _wire_cascade(
                 return {"status": "rejected", "error": "empty content"}
             if not isinstance(metadata, dict):
                 metadata = {}
-            accepted = await drive_loop.handle_directed_message(content, metadata)
+            accepted = await drive_loop.handle_directed_message(
+                content, metadata, output_mode=OutputMode.AMBIENT
+            )
             return {"status": "accepted" if accepted else "rejected"}
 
         if msg_type == "task_result":

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -2147,6 +2147,8 @@ class DriveLoop:
         self,
         content: str,
         metadata: dict[str, Any] | None = None,
+        *,
+        output_mode: OutputMode = OutputMode.SURFACE,
     ) -> bool:
         """Enqueue a directed message from the browser as an agent task."""
         for handler in list(self._directed_message_interceptors):
@@ -2157,7 +2159,7 @@ class DriveLoop:
             except Exception:
                 logger.exception("drive_loop: directed message interceptor failed")
 
-        if await self._try_steer_active_agent(content):
+        if output_mode == OutputMode.SURFACE and await self._try_steer_active_agent(content):
             return True
 
         import time
@@ -2179,7 +2181,7 @@ class DriveLoop:
             title="Directed message from user",
             initiative_context=self._directed_message_context(content, metadata),
             triggered_by="skuld:directed_message",
-            output_mode=OutputMode.SURFACE,
+            output_mode=output_mode,
             persona=persona,
             priority=0,  # user input precedes autonomous continuation work
             human_initiated=True,

--- a/tests/test_ravn/test_cascade.py
+++ b/tests/test_ravn/test_cascade.py
@@ -315,7 +315,9 @@ async def test_mesh_rpc_directed_message_queues_without_waiting_for_result():
     )
 
     assert reply == {"status": "accepted"}
-    dl.handle_directed_message.assert_awaited_once_with("Use the local artifact.", metadata)
+    dl.handle_directed_message.assert_awaited_once_with(
+        "Use the local artifact.", metadata, output_mode=OutputMode.AMBIENT
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_ravn/test_drive_loop_outcome_contract.py
+++ b/tests/test_ravn/test_drive_loop_outcome_contract.py
@@ -1631,6 +1631,24 @@ summary: post-mortem source captured
         assert "transport check only" in enqueued.initiative_context
 
     @pytest.mark.asyncio
+    async def test_mesh_directed_message_keeps_its_reply_channel_and_session(self) -> None:
+        from ravn.domain.models import OutputMode
+
+        dl = _make_drive_loop()
+        dl.enqueue = AsyncMock(return_value=True)
+        dl._try_steer_active_agent = AsyncMock(return_value=True)
+        await dl.handle_directed_message(
+            "Reply to the originating room",
+            {"session_id": "remote-room", "root_correlation_id": "remote-room"},
+            output_mode=OutputMode.AMBIENT,
+        )
+        dl._try_steer_active_agent.assert_not_awaited()
+        task = dl.enqueue.await_args.args[0]
+        assert task.output_mode == OutputMode.AMBIENT
+        assert task.session_id == "remote-room"
+        assert task.root_correlation_id == "remote-room"
+
+    @pytest.mark.asyncio
     async def test_handle_directed_message_attaches_durable_inbox_ref(self) -> None:
         dl = _make_drive_loop()
         dl.enqueue = AsyncMock(return_value=True)


### PR DESCRIPTION
A direct message sent to a remote Ravn was accepted and answered, but its reply went only to that resident's local Skuld connection. The originating mesh room remained silent.

Queue mesh-directed input with mesh activity output while preserving the originating session, correlation, and trace metadata. Do not steer it into an existing task whose output belongs to another room. Local browser messages keep their existing live channel.

Validation: 133 cascade, outcome, and channel-construction tests passed; Ruff passed. The failure was reproduced with a browser message from Kvasir's room to Bragi on Yggdrasil.
