### PR TITLE
fix(config): replace retired Codex model defaults

### DIFF
--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -434,7 +434,7 @@ launchSpecs:
     description: "Default Codex session for OpenAI-backed coding work."
     sessionDefinition: skuldCodex
     workloadType: session
-    model: "gpt-5.4"
+    model: "gpt-5.6-terra"
     cliTool: codex
     resourceConfig:
       cpu: "1"

--- a/scripts/openshell-volundr-smoke.sh
+++ b/scripts/openshell-volundr-smoke.sh
@@ -199,7 +199,7 @@ wait_running() {
 }
 
 suffix="$(date +%H%M%S)"
-codex_payload="$(create_session skuldCodex "openshell-codex-${suffix}" "gpt-5.4")"
+codex_payload="$(create_session skuldCodex "openshell-codex-${suffix}" "gpt-5.6-terra")"
 claude_payload="$(create_session skuldClaude "openshell-claude-${suffix}" "claude-sonnet-4-6")"
 
 codex_id="$(printf '%s' "${codex_payload}" | json_field id)"

--- a/src/ting/system_workflows.yaml
+++ b/src/ting/system_workflows.yaml
@@ -802,7 +802,7 @@
         stageMembers:
           - personaId: coder
             budget: 40
-            model: gpt-5.4
+            model: gpt-5.6-terra
             consumesEventTypes: [delivery.requested, review.changes_requested]
         position:
           x: 352
@@ -815,7 +815,7 @@
         stageMembers:
           - personaId: reviewer
             budget: 24
-            model: gpt-5.4
+            model: gpt-5.6-terra
             consumesEventTypes: [code.changed]
         position:
           x: 704
@@ -828,7 +828,7 @@
         stageMembers:
           - personaId: closer
             budget: 20
-            model: gpt-5.4
+            model: gpt-5.6-terra
             consumesEventTypes: [review.passed]
         position:
           x: 1056
@@ -841,7 +841,7 @@
         stageMembers:
           - personaId: publisher
             budget: 16
-            model: gpt-5.4
+            model: gpt-5.6-terra
             consumesEventTypes: [delivery.merged]
         position:
           x: 1408

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -454,7 +454,7 @@ def _default_launch_specs() -> list[LaunchSpecConfig]:
             description="Default Codex session for OpenAI-backed coding work.",
             session_definition="skuldCodex",
             workload_type="session",
-            model="gpt-5.4",
+            model="gpt-5.6-terra",
             resource_config={"cpu": "1", "memory": "2Gi"},
             cli_tool="codex",
         ),

--- a/tests/test_ting/test_system_workflows.py
+++ b/tests/test_ting/test_system_workflows.py
@@ -213,6 +213,12 @@ def test_load_system_workflows_only_keeps_supported_catalog() -> None:
     assert delivery_stage_personas["Review implementation"] == ["reviewer"]
     assert delivery_stage_personas["Merge and close ticket"] == ["closer"]
     assert delivery_stage_personas["Publish delivery record"] == ["publisher"]
+    assert [
+        member["model"]
+        for node in delivery_flow.graph["nodes"]
+        if node.get("kind") == "stage"
+        for member in node["stageMembers"]
+    ] == ["gpt-5.6-terra"] * 4
     delivery_edge_labels = {edge["label"] for edge in delivery_flow.graph["edges"]}
     assert "review.changes_requested -> review.changes_requested" in delivery_edge_labels
     assert "review.passed -> review.passed" in delivery_edge_labels

--- a/web-next/packages/plugin-volundr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.ts
@@ -1058,7 +1058,7 @@ const SYSTEM_LAUNCH_SPECS: VolundrLaunchSpec[] = [
     isDefault: false,
     sessionDefinition: 'skuldCodex',
     workloadType: 'skuld-codex',
-    model: 'gpt-5.4',
+    model: 'gpt-5.6-terra',
     systemPrompt: null,
     resourceConfig: { cpu: '1', memory: '2Gi', gpu: '0' },
     mcpServers: [],


### PR DESCRIPTION
Replace gpt-5.4 with gpt-5.6-terra in the Codex launch defaults, Tracker Delivery Flow stages, smoke script, and sample launch spec. ChatGPT-authenticated Codex no longer accepts gpt-5.4. Validation: 77 targeted tests pass; shell syntax and diff checks pass.