### PR TITLE
fix(auth): isolate workload verification from issuer outages

### DIFF
--- a/src/niuu/adapters/workload_identity/jwt.py
+++ b/src/niuu/adapters/workload_identity/jwt.py
@@ -6,6 +6,7 @@ SPIFFE JWT-SVIDs later by changing issuer/audience/JWKS configuration.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import ssl
 from typing import Any
@@ -17,7 +18,11 @@ from niuu.ports.workload_identity import WorkloadIdentityVerifier
 
 
 class JwtWorkloadIdentityVerifier(WorkloadIdentityVerifier):
-    """Verify JWT workload proofs using a remote or static JWKS."""
+    """Verify JWT workload proofs using a remote or static JWKS.
+
+    ``timeout_seconds`` bounds each JWKS socket operation (default: five seconds).
+    PyJWT retains ownership of key caching and rotation; remote I/O runs off-loop.
+    """
 
     def __init__(
         self,
@@ -27,6 +32,7 @@ class JwtWorkloadIdentityVerifier(WorkloadIdentityVerifier):
         jwks_uri: str = "",
         static_jwks: dict[str, Any] | str | None = None,
         ca_cert_path: str = "",
+        timeout_seconds: float = 5.0,
         algorithms: list[str] | None = None,
         insecure_skip_signature_verification: bool = False,
         **_extra: object,
@@ -48,9 +54,27 @@ class JwtWorkloadIdentityVerifier(WorkloadIdentityVerifier):
         ssl_context = None
         if ca_cert_path:
             ssl_context = ssl.create_default_context(cafile=ca_cert_path)
-        self._client = PyJWKClient(jwks_uri, ssl_context=ssl_context) if jwks_uri else None
+        if timeout_seconds <= 0:
+            raise ValueError("JWKS timeout_seconds must be positive")
+        self._client = (
+            PyJWKClient(jwks_uri, ssl_context=ssl_context, timeout=timeout_seconds)
+            if jwks_uri
+            else None
+        )
 
     async def verify(self, token: str) -> dict[str, Any]:
+        # Unverified claims only reject unrelated proofs; they never grant trust.
+        # Shared Kubernetes issuers still require trying each configured key set.
+        if self._issuer:
+            unverified = jwt.decode(token, options={"verify_signature": False})
+            if unverified.get("iss") != self._issuer:
+                raise jwt.InvalidIssuerError("Invalid issuer")
+        if (
+            not self._insecure_skip_signature_verification
+            and jwt.get_unverified_header(token).get("alg") not in self._algorithms
+        ):
+            raise jwt.InvalidAlgorithmError("The specified alg value is not allowed")
+
         options = {
             "verify_aud": bool(self._audiences),
             "verify_iss": bool(self._issuer),
@@ -66,7 +90,9 @@ class JwtWorkloadIdentityVerifier(WorkloadIdentityVerifier):
             claims = jwt.decode(token, **kwargs)
             return dict(claims)
 
-        key = self._resolve_key(token)
+        # PyJWKClient performs blocking urllib I/O on cache misses and rotation.
+        # Never run it on the server loop: an unavailable issuer must not stall health.
+        key = await asyncio.to_thread(self._resolve_key, token)
         claims = jwt.decode(token, key=key, **kwargs)
         return dict(claims)
 

--- a/src/niuu/domain/services/workload_identity.py
+++ b/src/niuu/domain/services/workload_identity.py
@@ -118,16 +118,23 @@ class WorkloadIdentityService(WorkloadTokenIssuer):
 
         build_scopes = bound_workload_scopes(scopes)
         last_error: Exception | None = None
+        verified: dict[str, dict[str, Any] | Exception] = {}
         for mapping in getattr(self._config, "mappings", []) or []:
             verifier_name = getattr(mapping, "verifier", "kubernetes")
             verifier = self._verifiers.get(verifier_name)
             if verifier is None:
                 last_error = WorkloadIdentityError(f"Verifier not configured: {verifier_name}")
                 continue
-            try:
-                claims = await verifier.verify(token)
-            except Exception as exc:
-                last_error = exc
+            # Preserve mapping priority, but verify a proof only once per verifier.
+            # Cache failures too so multiple mappings cannot multiply an outage.
+            if verifier_name not in verified:
+                try:
+                    verified[verifier_name] = await verifier.verify(token)
+                except Exception as exc:
+                    verified[verifier_name] = exc
+            claims = verified[verifier_name]
+            if isinstance(claims, Exception):
+                last_error = claims
                 continue
             if self._matches(mapping, claims):
                 return self._issue(

--- a/src/volundr/adapters/outbound/bifrost_catalog_http.py
+++ b/src/volundr/adapters/outbound/bifrost_catalog_http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import httpx
@@ -57,7 +58,7 @@ class HttpBifrostCatalogAdapter(BifrostCatalogPort):
         async with httpx.AsyncClient(timeout=self._timeout, transport=self._transport) as client:
             response = await client.get(
                 f"{self._base_url}/api/v1/bifrost/models",
-                headers=self._auth.headers(),
+                headers=await asyncio.to_thread(self._auth.headers),
             )
             response.raise_for_status()
         payload = response.json()

--- a/tests/test_adapters/test_bifrost_catalog_http.py
+++ b/tests/test_adapters/test_bifrost_catalog_http.py
@@ -41,3 +41,36 @@ async def test_list_models_calls_bifrost_models_endpoint_and_maps_payload() -> N
     assert models[0].id == "gpt-5"
     assert models[0].vendor == "openai"
     assert models[0].session_definition == "skuldCodex"
+
+
+@pytest.mark.asyncio
+async def test_auth_refresh_does_not_block_event_loop() -> None:
+    import asyncio
+    import threading
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class SlowAuth:
+        def headers(self):
+            entered.set()
+            if not release.wait(2):
+                raise TimeoutError("test release never arrived")
+            return {"Authorization": "Bearer refreshed"}
+
+    def handler(request):
+        assert request.headers["authorization"] == "Bearer refreshed"
+        return httpx.Response(200, json=[])
+
+    adapter = HttpBifrostCatalogAdapter(
+        base_url="http://bifrost.test", auth=SlowAuth(), transport=httpx.MockTransport(handler)
+    )
+    task = asyncio.create_task(adapter.list_models())
+    try:
+        async with asyncio.timeout(1):
+            while not entered.is_set():
+                await asyncio.sleep(0)
+            assert not task.done()
+    finally:
+        release.set()
+        await task

--- a/tests/test_workload_identity.py
+++ b/tests/test_workload_identity.py
@@ -678,3 +678,183 @@ def _render_chart(chart: str) -> str:
     if result.returncode != 0:
         pytest.fail(f"helm template failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}")
     return result.stdout
+
+
+@pytest.mark.asyncio
+async def test_exchange_skips_unrelated_unavailable_issuer(monkeypatch) -> None:
+    from niuu.adapters.workload_identity.jwt import JwtWorkloadIdentityVerifier
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    service = _service(key)
+    offline = JwtWorkloadIdentityVerifier(
+        issuer="https://offline.example", jwks_uri="https://offline.example/jwks"
+    )
+
+    def unexpected_fetch(token):
+        pytest.fail("An unrelated issuer must never be contacted")
+
+    monkeypatch.setattr(offline, "_resolve_key", unexpected_fetch)
+    service._verifiers["offline"] = offline
+    service._config.mappings.insert(0, SimpleNamespace(verifier="offline"))
+    result = await service.exchange(_workload_token(key))
+    assert result.principal.user_id == OWNER_ID
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fails", [False, True])
+async def test_exchange_verifies_once_per_request_and_preserves_mapping_order(fails) -> None:
+    from unittest.mock import AsyncMock
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    service = _service(key)
+    original = service._config.mappings[0]
+    service._config.mappings.insert(
+        0, SimpleNamespace(**{**vars(original), "subject": "another-workload"})
+    )
+    verifier = service._verifiers["kubernetes"]
+    verifier.verify = AsyncMock(
+        side_effect=ValueError("issuer unavailable") if fails else verifier.verify
+    )
+    for request in range(2):
+        if fails:
+            with pytest.raises(WorkloadIdentityError, match="issuer unavailable"):
+                await service.exchange(_workload_token(key))
+        else:
+            result = await service.exchange(_workload_token(key))
+            assert result.workload_name == original.name
+        assert verifier.verify.await_count == request + 1
+
+
+@pytest.mark.asyncio
+async def test_slow_jwks_does_not_block_other_issuers_or_event_loop(monkeypatch) -> None:
+    import asyncio
+    import threading
+
+    from niuu.adapters.workload_identity.jwt import JwtWorkloadIdentityVerifier
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    entered = threading.Event()
+    release = threading.Event()
+    slow = JwtWorkloadIdentityVerifier(issuer=WORKLOAD_ISSUER, jwks_uri="https://slow.example")
+
+    def fetch(token):
+        entered.set()
+        if not release.wait(2):
+            raise TimeoutError("test release never arrived")
+        return key.public_key()
+
+    monkeypatch.setattr(slow, "_resolve_key", fetch)
+    task = asyncio.create_task(slow.verify(_workload_token(key)))
+    try:
+        async with asyncio.timeout(1):
+            while not entered.is_set():
+                await asyncio.sleep(0)
+            assert not task.done()
+            result = await _service(key).exchange(_workload_token(key))
+            assert result.principal.user_id == OWNER_ID
+    finally:
+        release.set()
+        await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["signature", "issuer", "audience", "expired", "algorithm"])
+async def test_remote_jwks_still_requires_valid_signed_claims(monkeypatch, failure) -> None:
+    from niuu.adapters.workload_identity.jwt import JwtWorkloadIdentityVerifier
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verifier = JwtWorkloadIdentityVerifier(
+        issuer=WORKLOAD_ISSUER,
+        audiences=["volundr-api"],
+        jwks_uri="https://issuer.example/jwks",
+    )
+    monkeypatch.setattr(verifier, "_resolve_key", lambda token: key.public_key())
+    claims = jwt.decode(_workload_token(key), options={"verify_signature": False})
+    if failure == "issuer":
+        claims["iss"] = "untrusted"
+    if failure == "audience":
+        claims["aud"] = "untrusted"
+    if failure == "expired":
+        claims["exp"] = int(time.time()) - 60
+    signing_key = key
+    if failure == "signature":
+        signing_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = jwt.encode(claims, signing_key, algorithm="RS256")
+    if failure == "algorithm":
+        token = jwt.encode(claims, "diagnostic-test-secret-at-least-32-bytes", algorithm="HS256")
+    with pytest.raises(jwt.InvalidTokenError):
+        await verifier.verify(token)
+
+
+def test_jwks_timeout_is_configurable_and_positive() -> None:
+    from niuu.adapters.workload_identity.jwt import JwtWorkloadIdentityVerifier
+
+    verifier = JwtWorkloadIdentityVerifier(jwks_uri="https://issuer.example", timeout_seconds=2)
+    assert verifier._client.timeout == 2
+    with pytest.raises(ValueError, match="must be positive"):
+        JwtWorkloadIdentityVerifier(timeout_seconds=0)
+
+
+@pytest.mark.asyncio
+async def test_clusters_sharing_an_issuer_are_distinguished_by_signature() -> None:
+    from niuu.adapters.workload_identity.jwt import JwtWorkloadIdentityVerifier
+
+    trusted = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    other = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    service = _service(trusted)
+    service._verifiers["other-cluster"] = JwtWorkloadIdentityVerifier(
+        issuer=WORKLOAD_ISSUER,
+        audiences=["volundr-api"],
+        static_jwks={"keys": [_jwk_from_key(other, kid="k8s-proof")]},
+    )
+    original = service._config.mappings[0]
+    service._config.mappings.insert(
+        0, SimpleNamespace(**{**vars(original), "verifier": "other-cluster", "name": "wrong"})
+    )
+    result = await service.exchange(_workload_token(trusted))
+    assert result.workload_name == original.name
+
+
+@pytest.mark.asyncio
+async def test_remote_jwks_cache_and_key_rotation(monkeypatch) -> None:
+    import io
+    import json
+    import urllib.request
+
+    from niuu.adapters.workload_identity.jwt import JwtWorkloadIdentityVerifier
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    rotated = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    fetches = []
+    keys = [_jwk_from_key(key, kid="k8s-proof")]
+
+    def fetch(request, *, timeout, context):
+        fetches.append(request.full_url)
+        assert timeout == 5
+        return io.BytesIO(json.dumps({"keys": keys}).encode())
+
+    monkeypatch.setattr(urllib.request, "urlopen", fetch)
+    verifier = JwtWorkloadIdentityVerifier(
+        issuer=WORKLOAD_ISSUER, audiences="volundr-api", jwks_uri="https://issuer.example/jwks"
+    )
+    token = _workload_token(key)
+    assert (await verifier.verify(token))["sub"] == WORKLOAD_SUBJECT
+    await verifier.verify(token)
+    assert len(fetches) == 1
+
+    keys.append(_jwk_from_key(rotated, kid="rotated"))
+    claims = jwt.decode(token, options={"verify_signature": False})
+    rotated_token = jwt.encode(claims, rotated, algorithm="RS256", headers={"kid": "rotated"})
+    assert (await verifier.verify(rotated_token))["sub"] == WORKLOAD_SUBJECT
+    assert len(fetches) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("jwks", [None, {"keys": []}])
+async def test_verifier_rejects_missing_key_material(jwks) -> None:
+    from niuu.adapters.workload_identity.jwt import JwtWorkloadIdentityVerifier
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    verifier = JwtWorkloadIdentityVerifier(static_jwks=jwks)
+    with pytest.raises((ValueError, jwt.PyJWKSetError)):
+        await verifier.verify(_workload_token(key))


### PR DESCRIPTION
An unavailable cluster JWKS endpoint could stall Völundr’s event loop and trigger liveness restarts. Token exchange attempted remote key lookup before checking issuer and repeated verification for every mapping, so Observatory on Ymir could depend on Jarnvidr being reachable.

Reject mismatched issuers and disallowed algorithms before key lookup, move PyJWT JWKS I/O off the event loop, and expose a positive socket timeout through adapter kwargs (five seconds by default). Reuse successful and failed verification results only within each exchange while preserving mapping order. Move Völundr’s synchronous Bifrost auth-header refresh off the event loop too.

Unverified issuer claims only reject candidates; signature, issuer, audience, and expiry validation still establish trust. PyJWT continues to own JWKS caching and key rotation. Clusters sharing an issuer remain distinguished by their signing keys.

Validation:
- 92 related authentication and adapter tests pass; changed-module coverage is 86.24% (85% gate preserved).
- All five outage regressions fail on the original implementation and pass with this change.
- Ruff lint/format and git diff checks pass.

No cluster resources or deployment manifests changed. Deployment requires a built image and a separate GitOps update.
