### PR TITLE
fix: recover Regin workflow tracking and runtime delivery

### DIFF
--- a/charts/mimir/templates/_helpers.tpl
+++ b/charts/mimir/templates/_helpers.tpl
@@ -95,9 +95,17 @@ Return the proper image name (global overrides local)
   {{- end -}}
 {{- end -}}
 {{- if $registryName }}
+{{- if .Values.image.digest }}
+{{- printf "%s/%s@%s" $registryName $repositoryName .Values.image.digest -}}
+{{- else }}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end }}
+{{- else }}
+{{- if .Values.image.digest }}
+{{- printf "%s@%s" $repositoryName .Values.image.digest -}}
 {{- else }}
 {{- printf "%s:%s" $repositoryName $tag -}}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/mimir/values.yaml
+++ b/charts/mimir/values.yaml
@@ -27,6 +27,8 @@ image:
   repository: niuu
   # -- Image tag. Defaults to Chart.appVersion.
   tag: ""
+  # -- Immutable image digest; takes precedence over local and global tags.
+  digest: ""
   # -- Image pull policy.
   pullPolicy: IfNotPresent
 

--- a/charts/skuld/templates/_helpers.tpl
+++ b/charts/skuld/templates/_helpers.tpl
@@ -142,6 +142,12 @@ Return the proper image name (global overrides local)
 {{- if and .Values.git.credentials.secretName (not .Values.git.credentials.tokenFile) -}}
 - name: GIT_USERNAME
   value: {{ .Values.git.credentials.username | default "x-access-token" | quote }}
+- name: GIT_CONFIG_COUNT
+  value: "1"
+- name: GIT_CONFIG_KEY_0
+  value: credential.https://github.com.helper
+- name: GIT_CONFIG_VALUE_0
+  value: '!f() { [ "$1" = get ] || return 0; printf "username=%s\npassword=%s\n" "$GIT_USERNAME" "$GIT_TOKEN"; }; f'
 {{- range list "GIT_TOKEN" "GITHUB_TOKEN" "GH_TOKEN" }}
 - name: {{ . }}
   valueFrom:

--- a/charts/skuld/templates/_helpers.tpl
+++ b/charts/skuld/templates/_helpers.tpl
@@ -137,6 +137,21 @@ Return the proper image name (global overrides local)
 {{- printf "%s:%s" $repository $tag -}}
 {{- end }}
 
+{{/* Git and GitHub CLI credentials for session runtimes. */}}
+{{- define "skuld.gitCredentialEnv" -}}
+{{- if and .Values.git.credentials.secretName (not .Values.git.credentials.tokenFile) -}}
+- name: GIT_USERNAME
+  value: {{ .Values.git.credentials.username | default "x-access-token" | quote }}
+{{- range list "GIT_TOKEN" "GITHUB_TOKEN" "GH_TOKEN" }}
+- name: {{ . }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $.Values.git.credentials.secretName }}
+      key: {{ $.Values.git.credentials.tokenKey | default "token" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{/*
 Return image pull secrets (global overrides top-level, converts strings to objects)
 */}}

--- a/charts/skuld/templates/deployment.yaml
+++ b/charts/skuld/templates/deployment.yaml
@@ -412,18 +412,7 @@ spec:
             - name: {{ .name }}
               value: {{ .value | quote }}
             {{- end }}
-            {{- if and .Values.git.credentials.secretName (not .Values.git.credentials.tokenFile) }}
-            - name: GITHUB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.git.credentials.secretName }}
-                  key: {{ .Values.git.credentials.tokenKey | default "token" }}
-            - name: GH_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.git.credentials.secretName }}
-                  key: {{ .Values.git.credentials.tokenKey | default "token" }}
-            {{- end }}
+            {{- include "skuld.gitCredentialEnv" . | nindent 12 }}
             {{- if .Values.session.systemPrompt }}
             - name: SKULD__SESSION__SYSTEM_PROMPT
               value: {{ .Values.session.systemPrompt | quote }}
@@ -541,6 +530,15 @@ spec:
         {{- end }}
         {{- range .Values.extraContainers }}
         {{- $container := deepCopy . }}
+        {{- if hasPrefix "ravn-" $container.name }}
+        {{- $env := $container.env | default list }}
+        {{- $names := dict }}
+        {{- range $env }}{{- $_ := set $names .name true }}{{- end }}
+        {{- range (include "skuld.gitCredentialEnv" $ | fromYamlArray) }}
+        {{- if not (hasKey $names .name) }}{{- $env = append $env . }}{{- end }}
+        {{- end }}
+        {{- $_ := set $container "env" $env }}
+        {{- end }}
         {{- if and $.Values.homeVolume.enabled $.Values.homeVolume.persistentTmp }}
         {{- $scratchMounts := include "skuld.scratchMounts" (dict "root" $ "container" $container.name) | fromYamlArray }}
         {{- $mounts := $container.volumeMounts | default list }}

--- a/charts/volundr/values.yaml
+++ b/charts/volundr/values.yaml
@@ -434,7 +434,7 @@ launchSpecs:
     description: "Default Codex session for OpenAI-backed coding work."
     sessionDefinition: skuldCodex
     workloadType: session
-    model: "gpt-5.4"
+    model: "gpt-5.6-terra"
     cliTool: codex
     resourceConfig:
       cpu: "1"

--- a/scripts/openshell-volundr-smoke.sh
+++ b/scripts/openshell-volundr-smoke.sh
@@ -199,7 +199,7 @@ wait_running() {
 }
 
 suffix="$(date +%H%M%S)"
-codex_payload="$(create_session skuldCodex "openshell-codex-${suffix}" "gpt-5.4")"
+codex_payload="$(create_session skuldCodex "openshell-codex-${suffix}" "gpt-5.6-terra")"
 claude_payload="$(create_session skuldClaude "openshell-claude-${suffix}" "claude-sonnet-4-6")"
 
 codex_id="$(printf '%s' "${codex_payload}" | json_field id)"

--- a/src/mimir/router.py
+++ b/src/mimir/router.py
@@ -1208,7 +1208,7 @@ class MimirRouter:
             return self._adapter
 
         from ravn.adapters.mimir.composite import CompositeMimirAdapter
-        from ravn.domain.mimir import MimirMount
+        from ravn.domain.mimir import MimirMount, WriteRouting
 
         return CompositeMimirAdapter(
             mounts=[
@@ -1221,7 +1221,8 @@ class MimirRouter:
                 )
                 for mount in mounts
             ],
-            write_routing=getattr(self._adapter, "_write_routing", None),
+            write_routing=getattr(self._adapter, "_write_routing", None)
+            or WriteRouting(default=[self._name]),
         )
 
     def _resolve_port(self, mount_name: str | None) -> tuple[MimirPort, str]:

--- a/src/niuu/mesh/identity.py
+++ b/src/niuu/mesh/identity.py
@@ -32,4 +32,6 @@ class MeshIdentity:
     rep_address: str | None = None
     pub_address: str | None = None
     spiffe_id: str | None = None
+    display_name: str = ""
+    participant_type: str = "ravn"
     sleipnir_routing_key: str | None = None

--- a/src/ravn/adapters/discovery/event_bus.py
+++ b/src/ravn/adapters/discovery/event_bus.py
@@ -114,6 +114,8 @@ class EventBusDiscoveryAdapter:
                 "peer_id",
                 "realm_id",
                 "persona",
+                "display_name",
+                "participant_type",
                 "capabilities",
                 "permission_mode",
                 "version",
@@ -158,6 +160,8 @@ class EventBusDiscoveryAdapter:
         peer = self._peers.get(peer_id)
         if peer is not None:
             peer.persona = str(identity.get("persona") or "")
+            peer.display_name = str(identity.get("display_name") or "")
+            peer.participant_type = str(identity.get("participant_type") or "ravn")
             peer.capabilities = list(identity.get("capabilities") or [])
             peer.permission_mode = str(identity.get("permission_mode") or "")
             peer.version = str(identity.get("version") or "")
@@ -174,6 +178,8 @@ class EventBusDiscoveryAdapter:
             peer_id=peer_id,
             realm_id=self._identity.realm_id,
             persona=str(identity.get("persona") or ""),
+            display_name=str(identity.get("display_name") or ""),
+            participant_type=str(identity.get("participant_type") or "ravn"),
             capabilities=list(identity.get("capabilities") or []),
             permission_mode=str(identity.get("permission_mode") or ""),
             version=str(identity.get("version") or ""),

--- a/src/ravn/adapters/tools/a2a_task.py
+++ b/src/ravn/adapters/tools/a2a_task.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import json
 import logging
 from collections.abc import Awaitable, Callable
@@ -40,6 +42,7 @@ class A2ATaskTool(ToolPort):
         activity_emitter: Callable[[dict[str, object]], Awaitable[None]] | None = None,
         activity_finder: A2AActivityFinder | None = None,
         default_connection_id: str = "",
+        default_metadata: dict[str, Any] | None = None,
         push_callback_url: str = "",
     ) -> None:
         self._directory = agent_directory
@@ -51,8 +54,10 @@ class A2ATaskTool(ToolPort):
         self._message_max_chars = max(1_000, message_max_chars)
         self._activity_emitter = activity_emitter
         self._activity_finder = activity_finder
+        self._default_metadata = dict(default_metadata or {})
         self._default_connection_id = default_connection_id.strip()
         self._push_callback_url = push_callback_url.strip()
+        self._start_lock = asyncio.Lock()
 
     @property
     def name(self) -> str:
@@ -101,7 +106,8 @@ class A2ATaskTool(ToolPort):
                 "metadata": {
                     "type": "object",
                     "description": (
-                        "Optional continuation metadata returned by the peer. For a "
+                        "Launch metadata: repo is the repository URL, branch is the starting "
+                        "branch, and connectionId selects the target. For a "
                         "pending question, preserve requestId. For a pending gate, send "
                         "gateId plus gateDecision=approve or request_changes; include "
                         "review notes in answer when requesting changes."
@@ -139,7 +145,11 @@ class A2ATaskTool(ToolPort):
         }
         with telemetry.span("ravn.a2a.task", attributes=attributes) as span:
             try:
-                result = await self._execute_observed(input)
+                if operation == "start":
+                    async with self._start_lock:
+                        result = await self._execute_observed(input)
+                else:
+                    result = await self._execute_observed(input)
             except Exception as exc:
                 telemetry.mark_error(span, type(exc).__name__, str(exc))
                 telemetry.event(
@@ -212,6 +222,38 @@ class A2ATaskTool(ToolPort):
         if self._trusted_origins and endpoint_origin not in self._trusted_origins:
             return _error(f"Agent {agent_id!r} uses untrusted origin {endpoint_origin}")
 
+        request_fingerprint = ""
+        if operation == "start":
+            supplied = input.get("metadata")
+            metadata = {
+                **self._default_metadata,
+                **(supplied if isinstance(supplied, dict) else {}),
+            }
+            input = {**input, "metadata": metadata}
+            request_fingerprint = hashlib.sha256(
+                json.dumps(
+                    [
+                        agent_id,
+                        input.get("skill_id"),
+                        input.get("prompt"),
+                        metadata,
+                        self._default_connection_id,
+                    ],
+                    sort_keys=True,
+                ).encode()
+            ).hexdigest()
+            if self._activity_finder is not None:
+                active = await self._activity_finder(
+                    query=request_fingerprint,
+                    active_only=True,
+                    limit=1,
+                )
+                if active:
+                    return _error(
+                        "This request already has an active A2A task. Use get or reply "
+                        "with its handle instead of starting it again: " + json.dumps(active[0])
+                    )
+
         try:
             result = await self._execute_operation(operation, input, agent, endpoint)
         except _A2ATaskError as exc:
@@ -267,6 +309,7 @@ class A2ATaskTool(ToolPort):
                     500,
                 ),
                 "source_tool": self.name,
+                "request_fingerprint": request_fingerprint,
                 **({"push_registered": push_registered} if push_registered is not None else {}),
             }
         )

--- a/src/ravn/adapters/tools/builtin_registry.py
+++ b/src/ravn/adapters/tools/builtin_registry.py
@@ -404,6 +404,7 @@ BUILTIN_TOOLS: dict[str, BuiltinToolDef] = {
             "activity_emitter": ctx.get("a2a_activity_emitter"),
             "activity_finder": ctx.get("a2a_activity_finder"),
             "default_connection_id": s.gateway.platform.a2a_default_connection_id,
+            "default_metadata": s.gateway.platform.a2a_default_metadata,
             "push_callback_url": s.gateway.platform.a2a_push_callback_url,
         },
     ),

--- a/src/ravn/cli/mesh_runtime.py
+++ b/src/ravn/cli/mesh_runtime.py
@@ -123,6 +123,7 @@ def _build_discovery(
         peer_id=peer_id,
         realm_id=realm_id,
         persona=persona_name,
+        display_name=settings.skuld.display_name or settings.environment.resident_name,
         capabilities=capabilities,
         permission_mode=settings.permission.mode,
         version=version,

--- a/src/ravn/cli/trigger_wiring.py
+++ b/src/ravn/cli/trigger_wiring.py
@@ -361,7 +361,9 @@ def _wire_cascade(
                 return {"status": "rejected", "error": "empty content"}
             if not isinstance(metadata, dict):
                 metadata = {}
-            accepted = await drive_loop.handle_directed_message(content, metadata)
+            accepted = await drive_loop.handle_directed_message(
+                content, metadata, output_mode=OutputMode.AMBIENT
+            )
             return {"status": "accepted" if accepted else "rejected"}
 
         if msg_type == "task_result":

--- a/src/ravn/config.py
+++ b/src/ravn/config.py
@@ -1184,6 +1184,10 @@ class PlatformToolsConfig(BaseModel):
         default="",
         description="Default Volundr target injected into newly started A2A workflows.",
     )
+    a2a_default_metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Default A2A launch metadata; explicit per-call metadata takes precedence.",
+    )
     a2a_push_callback_url: str = Field(
         default="",
         description=("Public HTTPS callback registered for A2A tasks that advertise push support."),

--- a/src/ravn/domain/models.py
+++ b/src/ravn/domain/models.py
@@ -441,6 +441,8 @@ class RavnIdentity:
     rep_address: str | None = None  # nng REP address for mesh.send()
     pub_address: str | None = None  # nng PUB address for mesh.send()
     spiffe_id: str | None = None  # infra mode only
+    display_name: str = ""
+    participant_type: str = "ravn"
     sleipnir_routing_key: str | None = None  # for SleipnirMeshAdapter routing
 
 

--- a/src/ravn/domain/resident_continuation.py
+++ b/src/ravn/domain/resident_continuation.py
@@ -179,6 +179,7 @@ class ResidentA2ATaskRecord:
     case_output_tokens: int = 0
     case_started_at: str = ""
     push_registered: bool | None = None
+    request_fingerprint: str = ""
     update_fingerprint: str = ""
     updated_at: datetime = field(default_factory=lambda: datetime.now(UTC))
 

--- a/src/ravn/drive_loop.py
+++ b/src/ravn/drive_loop.py
@@ -2147,6 +2147,8 @@ class DriveLoop:
         self,
         content: str,
         metadata: dict[str, Any] | None = None,
+        *,
+        output_mode: OutputMode = OutputMode.SURFACE,
     ) -> bool:
         """Enqueue a directed message from the browser as an agent task."""
         for handler in list(self._directed_message_interceptors):
@@ -2157,7 +2159,7 @@ class DriveLoop:
             except Exception:
                 logger.exception("drive_loop: directed message interceptor failed")
 
-        if await self._try_steer_active_agent(content):
+        if output_mode == OutputMode.SURFACE and await self._try_steer_active_agent(content):
             return True
 
         import time
@@ -2179,7 +2181,7 @@ class DriveLoop:
             title="Directed message from user",
             initiative_context=self._directed_message_context(content, metadata),
             triggered_by="skuld:directed_message",
-            output_mode=OutputMode.SURFACE,
+            output_mode=output_mode,
             persona=persona,
             priority=0,  # user input precedes autonomous continuation work
             human_initiated=True,

--- a/src/ravn/resident_continuation.py
+++ b/src/ravn/resident_continuation.py
@@ -798,6 +798,7 @@ def _render_a2a_task(record: ResidentA2ATaskRecord) -> str:
         "case_output_tokens": record.case_output_tokens,
         "case_started_at": record.case_started_at,
         "push_registered": record.push_registered,
+        "request_fingerprint": record.request_fingerprint,
         "update_fingerprint": record.update_fingerprint,
         "updated_at": record.updated_at.isoformat(),
     }
@@ -831,6 +832,7 @@ def _parse_a2a_task(content: str) -> ResidentA2ATaskRecord | None:
         push_registered = None
     return ResidentA2ATaskRecord(
         task_id=str(payload["task_id"]),
+        request_fingerprint=str(payload.get("request_fingerprint") or ""),
         agent_id=str(payload.get("agent_id") or ""),
         skill_id=str(payload.get("skill_id") or ""),
         state=str(payload.get("state") or "TASK_STATE_UNSPECIFIED"),

--- a/src/ravn/resident_runtime.py
+++ b/src/ravn/resident_runtime.py
@@ -318,7 +318,6 @@ class ResidentRuntime:
                 content=prior.content,
             )
         a2a_tasks = await self.find_a2a_tasks(
-            case_id=task.resident_case_id,
             active_only=True,
             limit=10,
         )
@@ -406,6 +405,7 @@ class ResidentRuntime:
             ),
             case_started_at=value("case_started_at"),
             push_registered=push_registered,
+            request_fingerprint=value("request_fingerprint"),
             update_fingerprint=value("update_fingerprint"),
         )
         return await write(record)
@@ -434,6 +434,7 @@ class ResidentRuntime:
             haystack = " ".join(
                 (
                     record.task_id,
+                    record.request_fingerprint,
                     record.agent_id,
                     record.skill_id,
                     record.prompt,
@@ -446,7 +447,7 @@ class ResidentRuntime:
         found = [record for record in records if matches(record)]
         found.sort(key=lambda record: record.updated_at, reverse=True)
         rendered = [_a2a_record_payload(record) for record in found[: max(1, limit)]]
-        if rendered or not needle:
+        if rendered or not needle or active_only:
             return rendered
 
         # Older turns predate the registry. Existing state search remains the
@@ -1849,6 +1850,7 @@ def _a2a_record_payload(record: ResidentA2ATaskRecord) -> dict[str, Any]:
         "case_output_tokens": record.case_output_tokens,
         "case_started_at": record.case_started_at,
         "push_registered": record.push_registered,
+        "request_fingerprint": record.request_fingerprint,
         "update_fingerprint": record.update_fingerprint,
         "updated_at": record.updated_at.isoformat(),
     }

--- a/src/skuld/broker.py
+++ b/src/skuld/broker.py
@@ -797,6 +797,8 @@ class Broker(
             peer_id=mesh_cfg.peer_id or self.session_id or "skuld",
             realm_id=mesh_cfg.realm_id,
             persona=mesh_cfg.persona,
+            display_name="Skuld",
+            participant_type="skuld",
             capabilities=list(mesh_cfg.capabilities),
             permission_mode="full_access",
             version="0.1.0",
@@ -814,7 +816,8 @@ class Broker(
                 await self._room_bridge.register_mesh_peer(
                     peer_id=peer.peer_id,
                     persona=peer.persona,
-                    display_name=peer.persona,
+                    display_name=getattr(peer, "display_name", "") or peer.persona,
+                    participant_type=getattr(peer, "participant_type", "ravn"),
                     subscribes_to=list(getattr(peer, "consumes_event_types", [])),
                     emits=list(getattr(peer, "emits_event_types", [])),
                     tools=list(getattr(peer, "capabilities", [])),

--- a/src/ting/domain/services/workflow_campaign_projector.py
+++ b/src/ting/domain/services/workflow_campaign_projector.py
@@ -82,7 +82,9 @@ class WorkflowCampaignProjector:
                 WorkflowCampaignStatus.FAILED,
                 failure_error=error,
             )
-        elif event.session_status in {"stopped", "completed", "complete", "succeeded"}:
+        elif event.session_status == "stopped":
+            await self._save_transition(campaign, WorkflowCampaignStatus.BLOCKED)
+        elif event.session_status in {"completed", "complete", "succeeded"}:
             await self._save_transition(campaign, WorkflowCampaignStatus.COMPLETED)
         elif campaign.status == WorkflowCampaignStatus.PENDING and event.state in {
             "active",
@@ -291,9 +293,9 @@ def _status_from_session(
         return WorkflowCampaignStatus.PENDING
     if normalized in {"running", "active", "busy"}:
         return WorkflowCampaignStatus.RUNNING
-    if normalized in {"blocked", "waiting", "paused"}:
+    if normalized in {"blocked", "waiting", "paused", "stopped"}:
         return WorkflowCampaignStatus.BLOCKED
-    if normalized in {"stopped", "completed", "complete", "succeeded", "success"}:
+    if normalized in {"completed", "complete", "succeeded", "success"}:
         return WorkflowCampaignStatus.COMPLETED
     if normalized in {"failed", "error", "cancelled", "canceled"}:
         return WorkflowCampaignStatus.FAILED

--- a/src/ting/system_workflows.yaml
+++ b/src/ting/system_workflows.yaml
@@ -802,7 +802,7 @@
         stageMembers:
           - personaId: coder
             budget: 40
-            model: gpt-5.4
+            model: gpt-5.6-terra
             consumesEventTypes: [delivery.requested, review.changes_requested]
         position:
           x: 352
@@ -815,7 +815,7 @@
         stageMembers:
           - personaId: reviewer
             budget: 24
-            model: gpt-5.4
+            model: gpt-5.6-terra
             consumesEventTypes: [code.changed]
         position:
           x: 704
@@ -828,7 +828,7 @@
         stageMembers:
           - personaId: closer
             budget: 20
-            model: gpt-5.4
+            model: gpt-5.6-terra
             consumesEventTypes: [review.passed]
         position:
           x: 1056
@@ -841,7 +841,7 @@
         stageMembers:
           - personaId: publisher
             budget: 16
-            model: gpt-5.4
+            model: gpt-5.6-terra
             consumesEventTypes: [delivery.merged]
         position:
           x: 1408

--- a/src/volundr/config.py
+++ b/src/volundr/config.py
@@ -454,7 +454,7 @@ def _default_launch_specs() -> list[LaunchSpecConfig]:
             description="Default Codex session for OpenAI-backed coding work.",
             session_definition="skuldCodex",
             workload_type="session",
-            model="gpt-5.4",
+            model="gpt-5.6-terra",
             resource_config={"cpu": "1", "memory": "2Gi"},
             cli_tool="codex",
         ),

--- a/tests/test_charts/test_skuld_chart.py
+++ b/tests/test_charts/test_skuld_chart.py
@@ -253,6 +253,7 @@ class TestDeploymentTemplate:
         rendered = _render_skuld_chart(
             tmp_path,
             {
+                "git": {"credentials": {"secretName": "github-token"}},
                 "envVars": [{"name": "SKULD__MESH__ENABLED", "value": "true"}],
                 "mesh": {
                     "enabled": True,
@@ -303,6 +304,14 @@ class TestDeploymentTemplate:
         containers = {container["name"]: container for container in pod_spec["containers"]}
         assert "skuld" in containers
         assert "ravn-coder" in containers
+        for name in ("skuld", "ravn-coder"):
+            env = {entry["name"]: entry for entry in containers[name]["env"]}
+            for variable in ("GIT_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"):
+                assert env[variable]["valueFrom"]["secretKeyRef"] == {
+                    "name": "github-token",
+                    "key": "token",
+                }
+        assert not any(entry["name"] == "GIT_TOKEN" for entry in containers["nginx"].get("env", []))
         assert {"name": "SKULD__MESH__ENABLED", "value": "true"} in containers["skuld"]["env"]
         assert {"name": "mesh-pub", "containerPort": 7480, "protocol": "TCP"} in containers[
             "skuld"

--- a/tests/test_mimir/unit/test_router.py
+++ b/tests/test_mimir/unit/test_router.py
@@ -1528,3 +1528,26 @@ def test_federated_lint_failure_returns_json(tmp_path: Path, monkeypatch, cause,
     response = TestClient(_make_composite_app(tmp_path)).get("/mimir/lint")
     assert response.status_code == status
     assert response.json() == {"detail": "Mount cannot run lint"}
+
+
+def test_registry_mounts_preserve_named_service_write_destination(tmp_path):
+    from mimir.registry import MimirRegistryEntry
+
+    store = MimirRegistryStore(tmp_path / "registry.json")
+    store.save_entry(MimirRegistryEntry(name="remote", url="https://mimir.example"))
+    adapter = MarkdownMimirAdapter(root=tmp_path / "shared")
+    router = MimirRouter(adapter, name="shared", role="shared", registry_store=store)
+    app = FastAPI()
+    app.include_router(router.router, prefix="/mimir")
+    with TestClient(app) as client:
+        response = client.put(
+            "/mimir/page",
+            json={
+                "path": "deliveries/test/10-implementation.md",
+                "content": "# Delivery\nVerified.",
+            },
+        )
+    assert response.status_code == 204
+    assert (
+        tmp_path / "shared/wiki/deliveries/test/10-implementation.md"
+    ).read_text() == "# Delivery\nVerified."

--- a/tests/test_ravn/test_a2a_task_tool.py
+++ b/tests/test_ravn/test_a2a_task_tool.py
@@ -607,3 +607,45 @@ async def test_agent_discovers_peer_handles_question_and_uses_returned_artifact(
         "No blocking findings; tests cover the change." in str(message)
         for message in llm.messages[-1]
     )
+
+
+@pytest.mark.asyncio
+async def test_start_reuses_durable_request_identity_after_tool_restart(tmp_path) -> None:
+    from ravn.adapters.resident_state.mimir import LocalResidentState
+    from ravn.resident_runtime import ResidentRuntime
+
+    runtime = ResidentRuntime(state=LocalResidentState(tmp_path), resident_id="regin")
+    client = _Client(
+        [
+            {"id": "task-1", "status": {"state": "TASK_STATE_SUBMITTED"}},
+            {"id": "task-2", "status": {"state": "TASK_STATE_SUBMITTED"}},
+        ]
+    )
+
+    def tool():
+        return A2ATaskTool(
+            agent_directory=_Directory(_agent()),
+            client=client,
+            activity_emitter=runtime.record_a2a_activity,
+            activity_finder=runtime.find_a2a_tasks,
+            default_metadata={"repo": "https://github.com/example/repo", "branch": "regin"},
+        )
+
+    request = {
+        "operation": "start",
+        "agent_id": "agent-aggregate-1",
+        "skill_id": "review",
+        "prompt": "Review the change",
+    }
+    assert not (await tool().execute(request)).is_error
+    assert client.posts[0][1]["params"]["message"]["metadata"]["branch"] == "regin"
+    duplicate = await tool().execute(request)
+    assert duplicate.is_error
+    assert "task-1" in duplicate.content
+    assert len(client.posts) == 1
+    # A status update must preserve the request identity; a terminal task allows retry.
+    await runtime.record_a2a_activity({"task_id": "task-1", "state": "TASK_STATE_WORKING"})
+    assert (await tool().execute(request)).is_error
+    await runtime.record_a2a_activity({"task_id": "task-1", "state": "TASK_STATE_FAILED"})
+    assert not (await tool().execute(request)).is_error
+    assert len(client.posts) == 2

--- a/tests/test_ravn/test_cascade.py
+++ b/tests/test_ravn/test_cascade.py
@@ -315,7 +315,9 @@ async def test_mesh_rpc_directed_message_queues_without_waiting_for_result():
     )
 
     assert reply == {"status": "accepted"}
-    dl.handle_directed_message.assert_awaited_once_with("Use the local artifact.", metadata)
+    dl.handle_directed_message.assert_awaited_once_with(
+        "Use the local artifact.", metadata, output_mode=OutputMode.AMBIENT
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_ravn/test_drive_loop_outcome_contract.py
+++ b/tests/test_ravn/test_drive_loop_outcome_contract.py
@@ -1631,6 +1631,24 @@ summary: post-mortem source captured
         assert "transport check only" in enqueued.initiative_context
 
     @pytest.mark.asyncio
+    async def test_mesh_directed_message_keeps_its_reply_channel_and_session(self) -> None:
+        from ravn.domain.models import OutputMode
+
+        dl = _make_drive_loop()
+        dl.enqueue = AsyncMock(return_value=True)
+        dl._try_steer_active_agent = AsyncMock(return_value=True)
+        await dl.handle_directed_message(
+            "Reply to the originating room",
+            {"session_id": "remote-room", "root_correlation_id": "remote-room"},
+            output_mode=OutputMode.AMBIENT,
+        )
+        dl._try_steer_active_agent.assert_not_awaited()
+        task = dl.enqueue.await_args.args[0]
+        assert task.output_mode == OutputMode.AMBIENT
+        assert task.session_id == "remote-room"
+        assert task.root_correlation_id == "remote-room"
+
+    @pytest.mark.asyncio
     async def test_handle_directed_message_attaches_durable_inbox_ref(self) -> None:
         dl = _make_drive_loop()
         dl.enqueue = AsyncMock(return_value=True)

--- a/tests/test_ravn/test_event_bus_discovery.py
+++ b/tests/test_ravn/test_event_bus_discovery.py
@@ -10,6 +10,8 @@ def _identity(peer_id: str, realm_id: str = "flock-a") -> MeshIdentity:
         peer_id=peer_id,
         realm_id=realm_id,
         persona=peer_id,
+        display_name=f"Name {peer_id}",
+        participant_type="skuld" if peer_id == "second" else "ravn",
         capabilities=["chat"],
         permission_mode="permissive",
         version="test",
@@ -31,6 +33,9 @@ async def test_event_bus_discovery_converges_immediately_and_handles_leave() -> 
 
     assert set(first.peers()) == {"second"}
     assert set(second.peers()) == {"first"}
+    assert first.peers()["second"].display_name == "Name second"
+    assert first.peers()["second"].participant_type == "skuld"
+    assert second.peers()["first"].display_name == "Name first"
     assert second.peers()["first"].capabilities == ["chat"]
     assert second.peers()["first"].consumes_event_types == ["code.changed"]
     assert second.peers()["first"].emits_event_types == ["review.completed"]

--- a/tests/test_ting/test_sagas_api.py
+++ b/tests/test_ting/test_sagas_api.py
@@ -1087,6 +1087,7 @@ class TestSpawnPlanSession:
         adapter = MagicMock()
         adapter.name = "local"
         adapter.target_id = "local"
+        adapter.list_integration_ids = AsyncMock(return_value=[])
         adapter.spawn_session = AsyncMock(
             return_value=VolundrSession(
                 id="plan-1",

--- a/tests/test_ting/test_system_workflows.py
+++ b/tests/test_ting/test_system_workflows.py
@@ -213,6 +213,12 @@ def test_load_system_workflows_only_keeps_supported_catalog() -> None:
     assert delivery_stage_personas["Review implementation"] == ["reviewer"]
     assert delivery_stage_personas["Merge and close ticket"] == ["closer"]
     assert delivery_stage_personas["Publish delivery record"] == ["publisher"]
+    assert [
+        member["model"]
+        for node in delivery_flow.graph["nodes"]
+        if node.get("kind") == "stage"
+        for member in node["stageMembers"]
+    ] == ["gpt-5.6-terra"] * 4
     delivery_edge_labels = {edge["label"] for edge in delivery_flow.graph["edges"]}
     assert "review.changes_requested -> review.changes_requested" in delivery_edge_labels
     assert "review.passed -> review.passed" in delivery_edge_labels

--- a/tests/test_ting/test_workflow_campaign_projector.py
+++ b/tests/test_ting/test_workflow_campaign_projector.py
@@ -271,7 +271,7 @@ async def test_blocker_fetch_failure_reads_as_not_blocked() -> None:
 
 
 @pytest.mark.asyncio
-async def test_stopped_session_completes_without_blocker_checks() -> None:
+async def test_stopped_session_blocks_without_claiming_completion() -> None:
     adapter = _Adapter(
         session_status="stopped",
         blocker_error=RuntimeError("must not be called"),
@@ -281,7 +281,8 @@ async def test_stopped_session_completes_without_blocker_checks() -> None:
     await projector._refresh_campaign(_campaign())
 
     saved = repo.save_campaign.await_args.args[0]
-    assert saved.status == WorkflowCampaignStatus.COMPLETED
+    assert saved.status == WorkflowCampaignStatus.BLOCKED
+    assert saved.completed_at is None
 
 
 @pytest.mark.asyncio
@@ -305,7 +306,7 @@ async def test_terminal_activity_error_fails_running_campaign() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sse_terminal_event_completes_and_queues_push_without_session_read() -> None:
+async def test_sse_stopped_event_blocks_and_queues_push_without_session_read() -> None:
     adapter = _Adapter()
     campaign = _campaign()
     repo = AsyncMock()
@@ -332,7 +333,8 @@ async def test_sse_terminal_event_completes_and_queues_push_without_session_read
 
     assert handled is True
     saved = repo.save_campaign.await_args.args[0]
-    assert saved.status == WorkflowCampaignStatus.COMPLETED
+    assert saved.status == WorkflowCampaignStatus.BLOCKED
+    assert saved.completed_at is None
     push_dispatcher.queue_campaign.assert_awaited_once_with(saved)
 
 

--- a/web-next/packages/plugin-ravn/src/ui/SessionsView.test.tsx
+++ b/web-next/packages/plugin-ravn/src/ui/SessionsView.test.tsx
@@ -742,7 +742,7 @@ describe('SessionsView — live chat', () => {
     fireEvent.change(screen.getByTestId('chat-textarea'), {
       target: { value: 'Coordinate this work' },
     });
-    expect(screen.getByTestId('send-btn')).toBeDisabled();
+    expect(screen.getByTestId('send-btn')).toBeEnabled();
 
     fireEvent.change(screen.getByTestId('chat-textarea'), {
       target: { value: '@', selectionStart: 1 },

--- a/web-next/packages/plugin-volundr/src/adapters/mock.ts
+++ b/web-next/packages/plugin-volundr/src/adapters/mock.ts
@@ -1058,7 +1058,7 @@ const SYSTEM_LAUNCH_SPECS: VolundrLaunchSpec[] = [
     isDefault: false,
     sessionDefinition: 'skuldCodex',
     workloadType: 'skuld-codex',
-    model: 'gpt-5.4',
+    model: 'gpt-5.6-terra',
     systemPrompt: null,
     resourceConfig: { cpu: '1', memory: '2Gi', gpu: '0' },
     mcpServers: [],

--- a/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
+++ b/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.test.tsx
@@ -257,7 +257,7 @@ describe('ChatInput', () => {
 
     const textarea = screen.getByTestId('chat-textarea');
     fireEvent.change(textarea, { target: { value: 'Review this' } });
-    expect(screen.getByTestId('send-btn')).toBeDisabled();
+    expect(screen.getByTestId('send-btn')).toBeEnabled();
 
     fireEvent.change(textarea, { target: { value: '@', selectionStart: 1 } });
     fireEvent.click(screen.getByRole('option', { name: /review\.requested.*Hermes reviewer/ }));
@@ -292,5 +292,51 @@ describe('ChatInput', () => {
     rerender(<ChatInput {...defaultProps} disabled={true} />);
     fireEvent.click(screen.getByTestId('attach-btn'));
     expect(click).not.toHaveBeenCalled();
+  });
+});
+
+describe('mesh ordinary chat', () => {
+  it('sends plain messages and directs display-name mentions without event subscriptions', () => {
+    const onSend = vi.fn();
+    const onSendDirected = vi.fn();
+    const bragi = {
+      peerId: 'bragi',
+      persona: 'resident-codex',
+      displayName: 'Bragi',
+      participantType: 'ravn',
+    };
+    const heimdall = {
+      peerId: 'heimdall',
+      persona: 'resident-codex',
+      displayName: 'Heimdall',
+      participantType: 'ravn',
+    };
+    render(
+      <ChatInput
+        onSend={onSend}
+        onSendDirected={onSendDirected}
+        eventRouting
+        participants={
+          new Map([
+            [bragi.peerId, bragi],
+            [heimdall.peerId, heimdall],
+          ])
+        }
+      />,
+    );
+    const textarea = screen.getByTestId('chat-textarea');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    fireEvent.click(screen.getByTestId('send-btn'));
+    expect(onSend).toHaveBeenCalled();
+    fireEvent.change(textarea, { target: { value: '@Bragi hello' } });
+    fireEvent.click(screen.getByTestId('send-btn'));
+    expect(onSendDirected).toHaveBeenCalledWith([bragi], '@Bragi hello', []);
+    fireEvent.change(textarea, { target: { value: '@', selectionStart: 1 } });
+    expect(screen.getByRole('option', { name: /Bragi/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Heimdall/ })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('option', { name: /Bragi/ }));
+    fireEvent.change(textarea, { target: { value: '@resident-codex hello' } });
+    fireEvent.click(screen.getByTestId('send-btn'));
+    expect(onSendDirected.mock.calls[1]?.[0]).toEqual([bragi]);
   });
 });

--- a/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.tsx
+++ b/web-next/packages/ui/src/chat/components/ChatInput/ChatInput.tsx
@@ -53,11 +53,19 @@ function resolveInlineAgentMentions(
   input: string,
   participants: ReadonlyMap<string, RoomParticipant>,
 ): RoomParticipant[] {
-  const byPersona = new Map(
-    Array.from(participants.values())
-      .filter((participant) => participant.participantType === 'ravn')
-      .map((participant) => [participant.persona.toLowerCase(), participant] as const),
-  );
+  const byPersona = new Map<string, RoomParticipant | null>();
+  for (const participant of participants.values()) {
+    if (participant.participantType !== 'ravn') continue;
+    for (const label of [participant.persona, participant.displayName, participant.peerId]) {
+      if (!label) continue;
+      const key = label.toLowerCase();
+      const existing = byPersona.get(key);
+      byPersona.set(
+        key,
+        existing !== undefined && existing?.peerId !== participant.peerId ? null : participant,
+      );
+    }
+  }
   const seen = new Set<string>();
   const matches = input.matchAll(/(^|\s)@([^\s@]+)/g);
   const resolved: RoomParticipant[] = [];
@@ -141,7 +149,7 @@ export function ChatInput({
     (mention): mention is Extract<SelectedMention, { kind: 'agent' }> & { eventType: string } =>
       mention.kind === 'agent' && Boolean(mention.eventType),
   );
-  const canSend = hasContent && (!eventRouting || Boolean(selectedEventMention));
+  const canSend = hasContent;
 
   const resetTextareaHeight = useCallback(() => {
     const textarea = textareaRef.current;
@@ -163,8 +171,8 @@ export function ChatInput({
     const trimmed = input.trim();
     if (!trimmed || disabled) return;
 
-    if (eventRouting) {
-      if (!selectedEventMention || !onPublishEvent) return;
+    if (eventRouting && selectedEventMention) {
+      if (!onPublishEvent) return;
       const eventPrefix = `@${selectedEventMention.eventType}`;
       const fullMessage = trimmed.startsWith(eventPrefix) ? trimmed : `${eventPrefix} ${trimmed}`;
       onPublishEvent(
@@ -395,7 +403,7 @@ export function ChatInput({
             disabled
               ? 'Start session to chat...'
               : eventRouting
-                ? 'Select a participant event with @...'
+                ? 'Message the room, or select a participant with @...'
                 : 'Message...'
           }
           disabled={disabled}

--- a/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.test.tsx
+++ b/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.test.tsx
@@ -32,21 +32,21 @@ describe('MeshSidebar', () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders ravn peers plus the skuld observer when a flock exists', () => {
+  it('renders agents without duplicating their session gateways', () => {
     render(
       <MeshSidebar participants={participants} selectedPeerId={null} onSelectPeer={vi.fn()} />,
     );
     expect(screen.getByTestId('peer-card-peer-1')).toBeInTheDocument();
     expect(screen.getByTestId('peer-card-peer-2')).toBeInTheDocument();
-    expect(screen.getByTestId('peer-card-peer-3')).toBeInTheDocument();
-    expect(screen.getByText('Skuld (observer)')).toBeInTheDocument();
+    expect(screen.queryByTestId('peer-card-peer-3')).not.toBeInTheDocument();
+    expect(screen.queryByText('Skuld (observer)')).not.toBeInTheDocument();
   });
 
   it('shows peer count', () => {
     render(
       <MeshSidebar participants={participants} selectedPeerId={null} onSelectPeer={vi.fn()} />,
     );
-    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 
   it('calls onSelectPeer when peer clicked', () => {

--- a/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.tsx
+++ b/web-next/packages/ui/src/chat/components/MeshSidebar/MeshSidebar.tsx
@@ -23,10 +23,6 @@ interface GatewaySectionProps {
   region?: string;
 }
 
-function isMeshVisibleParticipant(participant: RoomParticipant): boolean {
-  return participant.participantType === 'ravn' || participant.participantType === 'skuld';
-}
-
 function formatParticipantLabel(participant: RoomParticipant): string {
   const role = participant.participantType === 'skuld' ? 'observer' : participant.persona;
   const baseName = participant.displayName ?? participant.persona ?? participant.peerId;
@@ -189,10 +185,9 @@ export function MeshSidebar({
   collapsed = false,
   onToggleCollapsed,
 }: MeshSidebarProps) {
-  const ravnPeers = Array.from(participants.values()).filter((p) => p.participantType === 'ravn');
-  const peers = Array.from(participants.values()).filter(isMeshVisibleParticipant);
+  const peers = Array.from(participants.values()).filter((p) => p.participantType === 'ravn');
 
-  if (ravnPeers.length === 0 || peers.length === 0) return null;
+  if (peers.length === 0) return null;
 
   if (collapsed) {
     return (

--- a/web-next/packages/ui/src/chat/hooks/useMentionMenu.test.ts
+++ b/web-next/packages/ui/src/chat/hooks/useMentionMenu.test.ts
@@ -265,20 +265,21 @@ describe('useMentionMenu — selectItem', () => {
     act(() => result.current.handleChange('@', 1));
 
     expect(result.current.items).toEqual([
+      { kind: 'agent', participant: hermes },
       { kind: 'agent', participant: hermes, eventType: 'code.changed' },
       { kind: 'agent', participant: hermes, eventType: 'review.requested' },
     ]);
 
     let selectedLabel = '';
     act(() => {
-      selectedLabel = result.current.selectItem(result.current.items[0]!);
+      selectedLabel = result.current.selectItem(result.current.items[1]!);
     });
     expect(selectedLabel).toBe('code.changed');
     expect(result.current.mentions).toEqual([
       { kind: 'agent', participant: hermes, eventType: 'code.changed' },
     ]);
 
-    act(() => result.current.selectItem(result.current.items[1]!));
+    act(() => result.current.selectItem(result.current.items[2]!));
     expect(result.current.mentions).toEqual([
       { kind: 'agent', participant: hermes, eventType: 'review.requested' },
     ]);

--- a/web-next/packages/ui/src/chat/hooks/useMentionMenu.ts
+++ b/web-next/packages/ui/src/chat/hooks/useMentionMenu.ts
@@ -145,11 +145,14 @@ export function useMentionMenu(
         .filter((participant) => participant.participantType === 'ravn')
         .flatMap((participant): MentionMenuItem[] => {
           if (!eventRouting) return [{ kind: 'agent', participant }];
-          return (participant.subscribesTo ?? []).map((eventType) => ({
-            kind: 'agent',
-            participant,
-            eventType,
-          }));
+          return [
+            { kind: 'agent', participant },
+            ...(participant.subscribesTo ?? []).map((eventType): MentionMenuItem => ({
+              kind: 'agent',
+              participant,
+              eventType,
+            })),
+          ];
         })
         .filter((item) => {
           if (item.kind !== 'agent' || !queryLower) return true;


### PR DESCRIPTION
Ting-launched workflows could lose their initial commission context, repeat an outstanding A2A request, and start coder sidecars without Git credentials. Preserve request fingerprints in Regin’s durable task ledger, include active commissions across cases, apply configured repository defaults, and pass the existing credential into Ravn sidecars with a native Git helper.

Fix Mímir registry writes targeting a nonexistent default mount, and let its chart select an immutable image digest. Treat stopped Ting sessions as blocked instead of completed, preserving explicit completion events.

Validation: 212 targeted A2A, resident runtime, Mímir router, and chart tests passed; 94 projector and chart tests passed after the final changes. Live rollout verified the retained session uses the fixed Skuld image, sidecars receive credentials, Mímir writes return 204 and read back exactly, and stopping/restarting leaves the unfinished campaign blocked. GitHub push remains blocked by the configured token’s permissions (403); runtime credential wiring alone cannot grant repository writes.

Deployed through infrastructure GitOps with pinned runtime images and chart versions. Duplicate NIU-1134 campaign canceled, original workspace backed up and retained, and Regin’s ledger reconciled with its actual task status.
