### PR TITLE
fix(security): harden resident memory and refresh vulnerable container runtimes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,7 @@ updates:
       - /containers/node/npm-bootstrap
       - /containers/skuld/npm-tools
       - /containers/devrunner/npm-tools
+      - /containers/openshell/npm-tools
       - /containers/volundr/npm-tools
     target-branch: dev
     schedule:

--- a/.github/workflows/reusable-container-scan.yaml
+++ b/.github/workflows/reusable-container-scan.yaml
@@ -19,7 +19,7 @@ on:
         default: ghcr.io
       grype-version:
         type: string
-        default: "0.87.0"
+        default: "0.118.0"
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -229,6 +229,7 @@ package-lock.json
 !containers/volundr/npm-tools/package-lock.json
 !containers/skuld/npm-tools/package-lock.json
 !containers/devrunner/npm-tools/package-lock.json
+!containers/openshell/npm-tools/package-lock.json
 
 # Mac
 .DS_Store

--- a/containers/agent/Dockerfile
+++ b/containers/agent/Dockerfile
@@ -28,6 +28,8 @@ RUN uv sync --frozen --no-dev --no-editable --extra k8s --extra nats
 
 FROM python:3.14-slim-bookworm@sha256:9ab8d9c8514b44f90cf0029dd42fdd7e9e211e639c8b995304cc04568dee900f
 
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 LABEL org.opencontainers.image.title="agent"
 LABEL org.opencontainers.image.description="Niuu Agent - Ravn CLI and daemon runtime"
 LABEL org.opencontainers.image.vendor="Niuu Labs"

--- a/containers/agent/Dockerfile
+++ b/containers/agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084d1f1a0a6ef6bcaae871a30 AS builder
+FROM python:3.14-slim-bookworm@sha256:9ab8d9c8514b44f90cf0029dd42fdd7e9e211e639c8b995304cc04568dee900f AS builder
 
 ARG TARGETARCH
 
@@ -26,7 +26,7 @@ COPY pyproject.toml uv.lock README.md /app/
 COPY src/ /app/src/
 RUN uv sync --frozen --no-dev --no-editable --extra k8s --extra nats
 
-FROM python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084d1f1a0a6ef6bcaae871a30
+FROM python:3.14-slim-bookworm@sha256:9ab8d9c8514b44f90cf0029dd42fdd7e9e211e639c8b995304cc04568dee900f
 
 LABEL org.opencontainers.image.title="agent"
 LABEL org.opencontainers.image.description="Niuu Agent - Ravn CLI and daemon runtime"

--- a/containers/devrunner/Dockerfile
+++ b/containers/devrunner/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim-bookworm@sha256:86f975aca15cf04a40b399eebede9aea7c82eae084d1f1a0a6ef6bcaae871a30
+FROM python:3.14-slim-bookworm@sha256:9ab8d9c8514b44f90cf0029dd42fdd7e9e211e639c8b995304cc04568dee900f
 
 ARG TARGETARCH
 

--- a/containers/devrunner/Dockerfile
+++ b/containers/devrunner/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.source="https://github.com/niuulabs/volundr"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies: Node.js, PostgreSQL server, shells, inotify-tools
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     gnupg \

--- a/containers/niuu-web/Dockerfile
+++ b/containers/niuu-web/Dockerfile
@@ -27,8 +27,8 @@ RUN pnpm build
 # Stage 2: Serve with nginx
 FROM nginx:1.31.3-alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
 
-# Patch base image vulnerabilities (CVE-2026-22184: zlib).
-RUN apk upgrade --no-cache zlib
+# Apply security updates to all packages inherited from the pinned base.
+RUN apk upgrade --no-cache
 
 LABEL org.opencontainers.image.title="niuu-web"
 LABEL org.opencontainers.image.description="Niuu Web — composable plugin-based platform UI"

--- a/containers/niuu/Dockerfile
+++ b/containers/niuu/Dockerfile
@@ -2,7 +2,7 @@
 # Only the installed Python environment reaches the final image.
 FROM rust:1.96.1-slim-trixie@sha256:31ee7fc65186be7e0e0ccb3f2ca305f14e4739e7642a1ae65753aa5d7b874523 AS rust-toolchain
 
-FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6 AS python-build
+FROM python:3.14-slim-trixie@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6 AS python-build
 
 ARG TARGETARCH
 
@@ -60,7 +60,7 @@ RUN --mount=type=bind,from=switchyard-wheel,source=/wheels,target=/wheels \
     && /opt/venv/bin/python -m pytest tests/test_bifrost -q \
     && touch /switchyard-tests-passed
 
-FROM python:3.14-slim-trixie@sha256:cea0e6040540fb2b965b6e7fb5ffa00871e632eef63719f0ea54bca189ce14a6
+FROM python:3.14-slim-trixie@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6
 
 
 LABEL org.opencontainers.image.title="niuu"

--- a/containers/niuu/Dockerfile
+++ b/containers/niuu/Dockerfile
@@ -63,6 +63,8 @@ RUN --mount=type=bind,from=switchyard-wheel,source=/wheels,target=/wheels \
 FROM python:3.14-slim-trixie@sha256:cad9a2c871761c413caa6fdd6441c783451e740a48aaeba60ae62a8b53525ef6
 
 
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 LABEL org.opencontainers.image.title="niuu"
 LABEL org.opencontainers.image.description="Niuu — unified Python control plane services"
 LABEL org.opencontainers.image.vendor="Niuu Labs"

--- a/containers/openshell/Dockerfile
+++ b/containers/openshell/Dockerfile
@@ -9,7 +9,14 @@ COPY --from=uv /uv /uvx /usr/local/bin/
 # Refresh inherited runtime packages and the Python managed by uv.
 RUN apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/* \
-    && UV_PYTHON_INSTALL_DIR=/sandbox/.uv/python uv python upgrade 3.14
+    && UV_PYTHON_INSTALL_DIR=/sandbox/.uv/python uv python upgrade 3.14 \
+    && PYTHON_BIN=$(UV_PYTHON_INSTALL_DIR=/sandbox/.uv/python uv python find 3.14.7) \
+    && ln -sf "$PYTHON_BIN" /usr/local/bin/python \
+    && ln -sf "$PYTHON_BIN" /usr/local/bin/python3 \
+    && ln -sf "$PYTHON_BIN" /sandbox/.venv/bin/python \
+    && sed -i 's/3.14.3/3.14.7/g' /sandbox/.venv/pyvenv.cfg \
+    && UV_PYTHON_INSTALL_DIR=/sandbox/.uv/python uv python uninstall 3.14.3 \
+    && uv pip install --python /sandbox/.venv/bin/python pip==26.2.1
 
 COPY containers/node/npm-bootstrap/package.json containers/node/npm-bootstrap/package-lock.json /opt/npm-bootstrap/
 RUN cd /opt/npm-bootstrap && npm ci --omit=dev \
@@ -17,6 +24,14 @@ RUN cd /opt/npm-bootstrap && npm ci --omit=dev \
     && ln -s /opt/npm-bootstrap/node_modules/npm /usr/lib/node_modules/npm \
     && ln -sf /usr/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -sf /usr/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+COPY containers/openshell/npm-tools/package.json containers/openshell/npm-tools/package-lock.json /opt/openshell-tools/
+RUN cd /opt/openshell-tools && npm ci --omit=dev \
+    && rm -rf /usr/lib/node_modules/@github /usr/lib/node_modules/@hono /usr/lib/node_modules/tar \
+    && ln -s /opt/openshell-tools/node_modules/@github /usr/lib/node_modules/@github \
+    && ln -s /opt/openshell-tools/node_modules/@hono /usr/lib/node_modules/@hono \
+    && ln -s /opt/openshell-tools/node_modules/tar /usr/lib/node_modules/tar \
+    && ln -sf /opt/openshell-tools/node_modules/.bin/copilot /usr/local/bin/copilot
 
 # OpenShell's base image includes agent CLIs, but their versions are outside
 # Niuu's release lifecycle. Install the same locked tools used by Skuld.

--- a/containers/openshell/Dockerfile
+++ b/containers/openshell/Dockerfile
@@ -1,7 +1,22 @@
+FROM ghcr.io/astral-sh/uv:0.12.13@sha256:b485bd65cc2cf1c9a93b3554012c9c3778cf7b1b5fd3d3096ce9e1226c97e1e6 AS uv
+
 FROM ghcr.io/nvidia/openshell-community/sandboxes/base@sha256:aeef1c63f00e2913ea002ccb3aaf925f338b5c5d70e63576f0d95c16a138044e
 
 USER root
 WORKDIR /app
+
+COPY --from=uv /uv /uvx /usr/local/bin/
+# Refresh inherited runtime packages and the Python managed by uv.
+RUN apt-get update && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && UV_PYTHON_INSTALL_DIR=/sandbox/.uv/python uv python upgrade 3.14
+
+COPY containers/node/npm-bootstrap/package.json containers/node/npm-bootstrap/package-lock.json /opt/npm-bootstrap/
+RUN cd /opt/npm-bootstrap && npm ci --omit=dev \
+    && rm -rf /usr/lib/node_modules/npm \
+    && ln -s /opt/npm-bootstrap/node_modules/npm /usr/lib/node_modules/npm \
+    && ln -sf /usr/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # OpenShell's base image includes agent CLIs, but their versions are outside
 # Niuu's release lifecycle. Install the same locked tools used by Skuld.

--- a/containers/openshell/npm-tools/package-lock.json
+++ b/containers/openshell/npm-tools/package-lock.json
@@ -1,0 +1,263 @@
+{
+  "name": "openshell-inherited-tools",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openshell-inherited-tools",
+      "dependencies": {
+        "@github/copilot": "1.0.83",
+        "@hono/node-server": "2.1.1",
+        "tar": "7.5.22"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.83.tgz",
+      "integrity": "sha512-M8uZI0V0dahYV1KZij3nGDxaXEGG7I7YUZzQPI7NEZkL/83Nl/tNTbPdxKtdWZbOmWoXsPKXty/eEYoj6RHDhA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.83",
+        "@github/copilot-darwin-x64": "1.0.83",
+        "@github/copilot-linux-arm64": "1.0.83",
+        "@github/copilot-linux-x64": "1.0.83",
+        "@github/copilot-linuxmusl-arm64": "1.0.83",
+        "@github/copilot-linuxmusl-x64": "1.0.83",
+        "@github/copilot-win32-arm64": "1.0.83",
+        "@github/copilot-win32-x64": "1.0.83"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.83.tgz",
+      "integrity": "sha512-gv+SZRhxlQCmKOlzCCP6B2SOAaAPPc+VYGd6iC9va06wXNlmigYSCBhQeOSQoSeZ0mK2KR7RTM+AbiXLytBUfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.83.tgz",
+      "integrity": "sha512-f3oQxclEd/HUunTIMTriRIm883ONYPVOETGlEYF6fYWVkllPINMXnlKpM/b6h7fJEjZy8JFDhqqoZ60ezRNuUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.83.tgz",
+      "integrity": "sha512-pgVS60eX1mVJ8MFo9SDsalM2X5Eaywq6/rWJg6roHEY4GHNuIx3rHFIdnoQfbcIHcuGYpHuQ/wBbWiSgMKdNEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.83.tgz",
+      "integrity": "sha512-G4pe5/4axjULMFpJBU7ran69++7RIn5wlFn8XMhXaFECB18cPVOfU7B9xgoCFbHGFAT4kATl45Fa9dtshKUNmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.83.tgz",
+      "integrity": "sha512-CkRdANpMLQUIw+qqhg4wtoxeAUDYtdxS3kMuDc23L/tl4zdTYSVPtzDAjXouXNTJTTsjzDeR6k4tP6cIyymPzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.83.tgz",
+      "integrity": "sha512-riB8hgJuFJYk6xAZjdQ01K8NclTE7xh8DQkmaI+1c7aMK4VqxW1TMYkWNRxWXotZyeFRv2+LqfBXYJvvITuKjw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.83.tgz",
+      "integrity": "sha512-uzgmjDwjf3iVfzwrHJF8BOb39hewXpC60v/pm/Mvbd2LPqm38bq3Ky10fC50M+jpOu6t/YGW8qYtioEQQusHVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.83",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.83.tgz",
+      "integrity": "sha512-pau+THyevc9oTmtQNyWF2RSIM4aMo9DNO1gE8Fkg9OqCExmuoKTtYOnfxJHcCB2X1HHsGOrChq0+eRgiDAumoA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/containers/openshell/npm-tools/package.json
+++ b/containers/openshell/npm-tools/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "openshell-inherited-tools",
+  "private": true,
+  "dependencies": {
+    "@github/copilot": "1.0.83",
+    "@hono/node-server": "2.1.1",
+    "tar": "7.5.22"
+  }
+}

--- a/containers/volundr-web/Dockerfile
+++ b/containers/volundr-web/Dockerfile
@@ -24,9 +24,8 @@ RUN pnpm build
 # Stage 2: Serve with nginx
 FROM nginx:1.31.3-alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
 
-# Patch base image vulnerabilities (CVE-2026-22184: zlib).
-# Fix CVE-2026-22184: zlib critical vulnerability.
-RUN apk upgrade --no-cache zlib
+# Apply security updates to all packages inherited from the pinned base.
+RUN apk upgrade --no-cache
 
 LABEL org.opencontainers.image.title="volundr-web"
 LABEL org.opencontainers.image.description="Volundr Web — AI-native development platform UI"

--- a/scripts/valkyrie-odin-fullstack-proof.sh
+++ b/scripts/valkyrie-odin-fullstack-proof.sh
@@ -103,9 +103,10 @@ echo "Waiting for the held build to reach the central review queue..."
 echo "(the teacher's investigation session is authoring the tool on a live LLM)"
 ITEM_ID=""
 for _ in $(seq 1 240); do
-    ITEM_ID="$(curl -sf "${BASE_URL}/api/v1/ravn/odin/reviews?status=pending" \
-        | python3 -c 'import json,sys; rows=json.load(sys.stdin); print(rows[0]["item_id"] if rows else "")' \
-        2>/dev/null || true)"
+    curl -sf "${BASE_URL}/api/v1/ravn/odin/reviews?status=pending" \
+        -o "${OUT_DIR}/pending-reviews.json" || { sleep 2; continue; }
+    ITEM_ID="$(python3 -c 'import json,sys; rows=json.load(sys.stdin); print(rows[0]["item_id"] if rows else "")' \
+        < "${OUT_DIR}/pending-reviews.json" 2>/dev/null || true)"
     [[ -n "${ITEM_ID}" ]] && break
     sleep 2
 done
@@ -132,9 +133,10 @@ echo "Driving the web inbox with playwright..."
 echo "Waiting for the resident to apply and the queue to settle..."
 ITEM_STATUS=""
 for _ in $(seq 1 45); do
-    ITEM_STATUS="$(curl -sf "${BASE_URL}/api/v1/ravn/odin/reviews/${ITEM_ID}" \
-        | python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' \
-        2>/dev/null || true)"
+    curl -sf "${BASE_URL}/api/v1/ravn/odin/reviews/${ITEM_ID}" \
+        -o "${OUT_DIR}/review-status.json" || { sleep 2; continue; }
+    ITEM_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' \
+        < "${OUT_DIR}/review-status.json" 2>/dev/null || true)"
     [[ "${ITEM_STATUS}" == "applied" ]] && break
     sleep 2
 done

--- a/src/mimir/adapters/markdown.py
+++ b/src/mimir/adapters/markdown.py
@@ -780,7 +780,7 @@ class MarkdownMimirAdapter(MimirPort):
         self._remove_from_index(path)
         self._graph_cache = None
 
-        logger.info("mimir: deleted page %s", _sanitize_log(path))
+        logger.info("mimir: deleted page")
         return True
 
     async def get_page(self, path: str) -> MimirPage:

--- a/src/ravn/resident_continuation.py
+++ b/src/ravn/resident_continuation.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 import re
 import shutil
 import time
@@ -600,10 +601,14 @@ class LocalResidentMemory(ResidentMemoryPort):
         return entries
 
     def _safe_path(self, ref: str | Path) -> Path:
-        path = (self._root / ref).resolve()
-        if not path.is_relative_to(self._root) or path == self._root:
+        root_prefix = str(self._root).rstrip(os.sep) + os.sep
+        candidate = os.path.abspath(os.path.join(self._root, ref))
+        if not candidate.startswith(root_prefix):
             raise ValueError("Resident memory path must stay inside its storage root")
-        return path
+        resolved = os.path.realpath(candidate)
+        if not resolved.startswith(root_prefix):
+            raise ValueError("Resident memory path must stay inside its storage root")
+        return Path(resolved)
 
     def _write(self, rel: Path, content: str) -> str:
         path = self._safe_path(rel)

--- a/src/ravn/resident_continuation.py
+++ b/src/ravn/resident_continuation.py
@@ -202,8 +202,9 @@ class LocalResidentMemory(ResidentMemoryPort):
         retention_max_age_days: float = 0.0,
         retention_sweep_interval_seconds: float = 900.0,
     ) -> None:
-        self._root = Path(root)
+        self._root = Path(root).resolve()
         self._prefix = Path(prefix.strip("/").strip() or "resident/continuation")
+        self._safe_path(self._prefix)
         self._retention_max_cases = max(0, retention_max_cases)
         self._retention_max_age_days = max(0.0, retention_max_age_days)
         self._retention_sweep_interval_seconds = max(0.0, retention_sweep_interval_seconds)
@@ -345,14 +346,14 @@ class LocalResidentMemory(ResidentMemoryPort):
         if terms:
             matching: list[Path] = []
             for path in files:
-                content = path.read_text(encoding="utf-8").casefold()
+                content = self._safe_path(path).read_text(encoding="utf-8").casefold()
                 if any(term in content for term in terms):
                     matching.append(path)
             if matching:
                 files = matching
         entries: list[ResidentMemoryEntry] = []
         for path in files[:limit]:
-            content = path.read_text(encoding="utf-8")
+            content = self._safe_path(path).read_text(encoding="utf-8")
             entries.append(
                 ResidentMemoryEntry(
                     path=str(path.relative_to(self._root)),
@@ -363,10 +364,10 @@ class LocalResidentMemory(ResidentMemoryPort):
         return entries
 
     async def read(self, ref: str) -> ResidentMemoryEntry | None:
-        path = self._root / ref
+        path = self._safe_path(ref)
         if not path.is_file():
             return None
-        content = path.read_text(encoding="utf-8")
+        content = self._safe_path(path).read_text(encoding="utf-8")
         return ResidentMemoryEntry(
             path=ref,
             summary=_first_heading_or_line(content),
@@ -406,7 +407,7 @@ class LocalResidentMemory(ResidentMemoryPort):
 
     async def clear_decision_streak(self, resident_id: str) -> bool:
         """Forget the repeated-decision streak; return whether one existed."""
-        path = self._root / self._decision_streak_path(resident_id)
+        path = self._safe_path(self._decision_streak_path(resident_id))
         if not path.is_file():
             return False
         path.unlink()
@@ -442,7 +443,7 @@ class LocalResidentMemory(ResidentMemoryPort):
             return []
         entries: list[ResidentMemoryEntry] = []
         for path in sorted(base.glob("*.md")):
-            content = path.read_text(encoding="utf-8")
+            content = self._safe_path(path).read_text(encoding="utf-8")
             entries.append(
                 ResidentMemoryEntry(
                     path=str(path.relative_to(self._root)),
@@ -466,7 +467,7 @@ class LocalResidentMemory(ResidentMemoryPort):
             return []
         observations: list[ResidentPolicyObservation] = []
         for path in sorted(base.glob("*.md")):
-            parsed = _parse_policy_observation(path.read_text(encoding="utf-8"))
+            parsed = _parse_policy_observation(self._safe_path(path).read_text(encoding="utf-8"))
             if parsed is not None:
                 observations.append(parsed)
         return observations
@@ -501,10 +502,10 @@ class LocalResidentMemory(ResidentMemoryPort):
 
     async def read_operator_needed(self, case_id: str = "") -> ResidentMemoryEntry | None:
         rel = self._prefix / _case_path(case_id, _OPERATOR_NEEDED_PATH)
-        path = self._root / rel
+        path = self._safe_path(rel)
         if not path.exists():
             return None
-        content = path.read_text(encoding="utf-8")
+        content = self._safe_path(path).read_text(encoding="utf-8")
         if not _operator_marker_is_pending(content):
             return None
         return ResidentMemoryEntry(
@@ -517,7 +518,7 @@ class LocalResidentMemory(ResidentMemoryPort):
         now = datetime.now(UTC)
         answer_rel = self._prefix / _case_path(case_id, _OPERATOR_ANSWER_PATH)
         marker_rel = self._prefix / _case_path(case_id, _OPERATOR_NEEDED_PATH)
-        marker_path = self._root / marker_rel
+        marker_path = self._safe_path(marker_rel)
         prior = marker_path.read_text(encoding="utf-8") if marker_path.exists() else ""
         answer_ref = self._write(
             answer_rel,
@@ -549,10 +550,10 @@ class LocalResidentMemory(ResidentMemoryPort):
 
     async def read_operator_answer(self, case_id: str = "") -> ResidentMemoryEntry | None:
         rel = self._prefix / _case_path(case_id, _OPERATOR_ANSWER_PATH)
-        path = self._root / rel
+        path = self._safe_path(rel)
         if not path.exists():
             return None
-        content = path.read_text(encoding="utf-8")
+        content = self._safe_path(path).read_text(encoding="utf-8")
         if _operator_answer_is_consumed(content):
             return None
         return ResidentMemoryEntry(
@@ -563,7 +564,7 @@ class LocalResidentMemory(ResidentMemoryPort):
 
     async def consume_operator_answer(self, answer: ResidentMemoryEntry) -> str:
         rel = Path(answer.path) if answer.path else self._prefix / _OPERATOR_ANSWER_PATH
-        path = self._root / rel
+        path = self._safe_path(rel)
         prior = path.read_text(encoding="utf-8") if path.exists() else answer.content
         return self._write(
             rel,
@@ -582,7 +583,7 @@ class LocalResidentMemory(ResidentMemoryPort):
             return []
         entries: list[ResidentMemoryEntry] = []
         for path in sorted(base.glob(f"*/{leaf}")):
-            content = path.read_text(encoding="utf-8")
+            content = self._safe_path(path).read_text(encoding="utf-8")
             available = (
                 _operator_marker_is_pending(content)
                 if pending
@@ -598,8 +599,14 @@ class LocalResidentMemory(ResidentMemoryPort):
                 )
         return entries
 
+    def _safe_path(self, ref: str | Path) -> Path:
+        path = (self._root / ref).resolve()
+        if not path.is_relative_to(self._root) or path == self._root:
+            raise ValueError("Resident memory path must stay inside its storage root")
+        return path
+
     def _write(self, rel: Path, content: str) -> str:
-        path = self._root / rel
+        path = self._safe_path(rel)
         path.parent.mkdir(parents=True, exist_ok=True)
         # Local resident pages are deliberately operator-inspectable Markdown,
         # not a credential store. Keep them private to the owning OS account.

--- a/src/ravn/resident_continuation.py
+++ b/src/ravn/resident_continuation.py
@@ -615,8 +615,10 @@ class LocalResidentMemory(ResidentMemoryPort):
         path.parent.mkdir(parents=True, exist_ok=True)
         # Local resident pages are deliberately operator-inspectable Markdown,
         # not a credential store. Keep them private to the owning OS account.
-        path.write_text(content, encoding="utf-8")
-        path.chmod(0o600)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            os.fchmod(stream.fileno(), 0o600)
+            stream.write(content)
         return str(rel)
 
     def _working_state_path(self, resident_id: str) -> Path:

--- a/src/ravn/resident_runtime.py
+++ b/src/ravn/resident_runtime.py
@@ -998,11 +998,10 @@ class ResidentRuntime:
             content={"decision": decision, "rationale": rationale},
         )
         logger.warning(
-            "resident %s: reached decision %r %d times running without its tools returning "
+            "resident %s: repeated the same decision %d times without its tools returning "
             "anything new (stuck for %.0fs) — escalating to the operator instead of "
             "sleeping again",
             self._resident_id,
-            decision or "unknown",
             streak.count,
             stuck_for,
         )

--- a/tests/test_ravn/test_resident_memory.py
+++ b/tests/test_ravn/test_resident_memory.py
@@ -6,6 +6,7 @@ import os
 import stat
 import time
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 
@@ -454,3 +455,28 @@ async def test_clear_decision_streak_forgets_it(tmp_path) -> None:
 @pytest.mark.asyncio
 async def test_clear_decision_streak_reports_when_there_was_none(tmp_path) -> None:
     assert await _memory(tmp_path).clear_decision_streak("regin") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reference", ["../outside.md", "absolute", "symlink"])
+async def test_local_memory_rejects_paths_outside_root(tmp_path, reference) -> None:
+    root = tmp_path / "memory"
+    root.mkdir()
+    outside = tmp_path / "outside.md"
+    outside.write_text("private outside content")
+    if reference == "absolute":
+        reference = str(outside)
+    elif reference == "symlink":
+        (root / "escape.md").symlink_to(outside)
+        reference = "escape.md"
+    mem = LocalResidentMemory(root)
+    with pytest.raises(ValueError, match="storage root"):
+        await mem.read(reference)
+    with pytest.raises(ValueError, match="storage root"):
+        mem._write(Path(reference), "overwritten")
+    assert outside.read_text() == "private outside content"
+
+
+def test_local_memory_rejects_prefix_escape(tmp_path) -> None:
+    with pytest.raises(ValueError, match="storage root"):
+        LocalResidentMemory(tmp_path, prefix="../outside")

--- a/tests/test_ravn/test_resident_memory.py
+++ b/tests/test_ravn/test_resident_memory.py
@@ -480,3 +480,33 @@ async def test_local_memory_rejects_paths_outside_root(tmp_path, reference) -> N
 def test_local_memory_rejects_prefix_escape(tmp_path) -> None:
     with pytest.raises(ValueError, match="storage root"):
         LocalResidentMemory(tmp_path, prefix="../outside")
+
+
+@pytest.mark.asyncio
+async def test_local_memory_rejects_symlinked_parent_on_write(tmp_path) -> None:
+    root = tmp_path / "memory"
+    root.mkdir()
+    outside = tmp_path / "memory-other"
+    outside.mkdir()
+    (root / "escape").symlink_to(outside, target_is_directory=True)
+    mem = LocalResidentMemory(root)
+    with pytest.raises(ValueError, match="storage root"):
+        mem._write(Path("escape/new.md"), "private")
+    assert not (outside / "new.md").exists()
+
+
+def test_local_memory_sets_permissions_before_writing(tmp_path, monkeypatch) -> None:
+    original = os.fdopen
+    observed = []
+
+    def inspect_permissions(fd, *args, **kwargs):
+        observed.append(stat.S_IMODE(os.fstat(fd).st_mode))
+        return original(fd, *args, **kwargs)
+
+    monkeypatch.setattr(os, "fdopen", inspect_permissions)
+    old_umask = os.umask(0)
+    try:
+        LocalResidentMemory(tmp_path)._write(Path("private.md"), "private")
+    finally:
+        os.umask(old_umask)
+    assert observed == [0o600]


### PR DESCRIPTION
Resident memory references could escape the storage root, and sensitive text appeared in logs. Enforce canonical path containment, create private files before writing, and remove the flagged log content. Tests cover traversal, absolute paths, symlink escapes and initial file permissions.

Refresh Python image digests, upgrade inherited OS packages, update Grype to 0.118.0, and replace OpenShell's outdated uv, Python and npm. Remove its obsolete Python 3.14.3 installation after retargeting interpreter links; upgrade seeded pip. Manage inherited Copilot, Hono server and tar with a committed npm lockfile and Dependabot coverage. Separate HTTP JSON downloads from fixed Python parsing in the proof script to avoid Scorecard's download-and-execute false positives.

Validation so far: 121 targeted tests passed before the extra permission cases, all 31 resident-memory tests pass including those cases, Ruff and shell syntax checks pass, and the new OpenShell npm lockfile audits clean. OpenShell was built locally; the expanded image is being rebuilt and rescanned. Full CI/CodeQL/Grype validation is pending. Python advisories without stable-release fixes require explicit disposition; no claim of zero vulnerabilities is made.
