### PR TITLE
fix(ting): authenticate shared integrations and isolate dev bootstrap

### DIFF
--- a/charts/ting/templates/configmap.yaml
+++ b/charts/ting/templates/configmap.yaml
@@ -200,5 +200,8 @@ data:
       {{- end }}
 
     shared_integrations:
+      database_name: {{ .Values.sharedIntegrations.databaseName | default "" | quote }}
+      auth:
+        {{- toYaml .Values.sharedIntegrations.auth | nindent 8 }}
       base_url: {{ .Values.sharedIntegrations.baseUrl | quote }}
       timeout_seconds: {{ .Values.sharedIntegrations.timeoutSeconds | default 30.0 }}

--- a/charts/ting/values.yaml
+++ b/charts/ting/values.yaml
@@ -362,6 +362,11 @@ credentialStore:
   secretKwargs: []
 
 sharedIntegrations:
+  # -- Shared database on the configured PostgreSQL host; mutually exclusive with baseUrl
+  databaseName: ""
+  auth:
+    adapter: niuu.adapters.outbound.http_auth.NoAuthHeaderAdapter
+    kwargs: {}
   # -- Internal base URL for niuu-shared integration APIs
   baseUrl: ""
   # -- HTTP timeout for shared integration requests

--- a/src/ting/config.py
+++ b/src/ting/config.py
@@ -109,6 +109,8 @@ class SharedIntegrationsConfig(BaseModel):
     """Configuration for consuming shared integration connections."""
 
     base_url: str = Field(default="")
+    database_name: str = Field(default="")
+    auth: HttpAuthAdapterConfig = Field(default_factory=HttpAuthAdapterConfig)
     timeout_seconds: float = Field(default=30.0)
 
 

--- a/src/ting/main.py
+++ b/src/ting/main.py
@@ -341,6 +341,37 @@ async def _seed_linear_integration(
     await integration_repo.save_connection(connection)
 
 
+@asynccontextmanager
+async def _integration_repository(settings: Settings, pool):
+    config = settings.shared_integrations
+    if config.database_name and config.base_url:
+        raise ValueError("Choose shared_integrations.database_name or base_url, not both")
+    if config.database_name:
+        database = settings.database.model_copy(update={"name": config.database_name})
+        async with database_pool(database) as shared_pool:
+            yield PostgresIntegrationRepository(shared_pool)
+        return
+    if config.base_url:
+        if not settings.auth.allow_anonymous_dev and config.auth.adapter.endswith(
+            ".NoAuthHeaderAdapter"
+        ):
+            raise ValueError("Authenticated shared integrations require an HTTP auth adapter")
+        repository = HTTPIntegrationRepository(
+            config.base_url,
+            timeout=config.timeout_seconds,
+            auth_adapter=config.auth.adapter
+            if not config.auth.adapter.endswith(".NoAuthHeaderAdapter")
+            else "",
+            auth_kwargs=resolve_secret_kwargs(config.auth.kwargs, config.auth.secret_kwargs_env),
+        )
+        try:
+            yield repository
+        finally:
+            await repository.close()
+        return
+    yield PostgresIntegrationRepository(pool)
+
+
 def create_app(
     settings: Settings | None = None,
     *,
@@ -412,22 +443,13 @@ def create_app(
     async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         """Manage application lifecycle."""
         settings = app.state.settings
-        async with database_pool(settings.database) as pool:
+        async with (
+            database_pool(settings.database) as pool,
+            _integration_repository(settings, pool) as integration_repo,
+        ):
             app.state.pool = pool
 
             # Wire shared credential/integration infrastructure
-            if settings.shared_integrations.base_url:
-                integration_repo = HTTPIntegrationRepository(
-                    settings.shared_integrations.base_url,
-                    timeout=settings.shared_integrations.timeout_seconds,
-                )
-                logger.info(
-                    "Integration repository: shared HTTP (%s)",
-                    settings.shared_integrations.base_url,
-                )
-            else:
-                integration_repo = PostgresIntegrationRepository(pool)
-                logger.info("Integration repository: local postgres")
             cs_cfg = settings.credential_store
             cs_cls = import_class(cs_cfg.adapter)
             cs_kwargs = resolve_secret_kwargs(cs_cfg.kwargs, cs_cfg.secret_kwargs_env)
@@ -474,7 +496,11 @@ def create_app(
             # mini/anonymous-dev mode the factory always returns the same
             # singleton; in multi-owner production the per-owner factory
             # lookup is the right path and this default is a fallback.
-            app.state.volundr = await app.state.volundr_factory.primary_for_owner("dev-user")
+            app.state.volundr = (
+                await app.state.volundr_factory.primary_for_owner("dev-user")
+                if settings.auth.allow_anonymous_dev
+                else None
+            )
             app.state.tracker_factory = TrackerAdapterFactory(
                 integration_repo, credential_store, pool=pool
             )
@@ -792,7 +818,7 @@ def create_app(
             # (slug "telegram") so the seeded credential in
             # integrations.seed_connections doesn't have to be duplicated.
             bot_token = settings.telegram.bot_token
-            if not bot_token:
+            if not bot_token and settings.auth.allow_anonymous_dev:
                 bot_token = await _resolve_dev_telegram_bot_token(
                     integration_repo, credential_store
                 )
@@ -802,9 +828,10 @@ def create_app(
             # Bridge the seeded chat_id into notification_subscriptions so the
             # webhook router's inbound auth check passes without any manual
             # SQL or deeplink dance.
-            await _ensure_telegram_subscription_from_integration(
-                pool, integration_repo, credential_store
-            )
+            if settings.auth.allow_anonymous_dev:
+                await _ensure_telegram_subscription_from_integration(
+                    pool, integration_repo, credential_store
+                )
 
             telegram_reply_client = TelegramReplyClient(
                 bot_token=bot_token,
@@ -1004,8 +1031,6 @@ def create_app(
             if telegram_polling is not None:
                 await telegram_polling.stop()
             await telegram_reply_client.close()
-            if isinstance(integration_repo, HTTPIntegrationRepository):
-                await integration_repo.close()
             if guild_registry_client is not None:
                 await guild_registry_client.close()
             if hasattr(llm_adapter, "close"):

--- a/tests/test_ting/test_main.py
+++ b/tests/test_ting/test_main.py
@@ -40,3 +40,78 @@ class TestBuildPersonaNamesDependency:
         dependency = build_persona_names_dependency(_StubPersonaSource([], should_raise=True))
 
         assert await dependency() == set()
+
+
+async def test_shared_integrations_database_closes_separate_pool(monkeypatch):
+    from contextlib import asynccontextmanager
+    from unittest.mock import MagicMock
+
+    from ting import main
+    from ting.config import Settings
+
+    configured = []
+    shared_pool = object()
+
+    @asynccontextmanager
+    async def pool(config):
+        configured.append(config.name)
+        yield shared_pool
+        configured.append("closed")
+
+    repo = MagicMock()
+    monkeypatch.setattr(main, "database_pool", pool)
+    monkeypatch.setattr(main, "PostgresIntegrationRepository", repo)
+    settings = Settings(shared_integrations={"database_name": "niuu_shared"})
+    async with main._integration_repository(settings, object()):
+        repo.assert_called_once_with(shared_pool)
+        assert configured == ["niuu_shared"]
+    assert configured == ["niuu_shared", "closed"]
+    assert settings.database.name == "ting"
+
+
+async def test_shared_integrations_rejects_unauthenticated_production_http():
+    from ting.config import Settings
+    from ting.main import _integration_repository
+
+    settings = Settings(
+        auth={"allow_anonymous_dev": False},
+        shared_integrations={"base_url": "https://identity.test"},
+    )
+    with pytest.raises(ValueError, match="HTTP auth adapter"):
+        async with _integration_repository(settings, object()):
+            pytest.fail("Unauthenticated production HTTP was accepted")
+
+
+async def test_shared_integrations_forwards_configured_auth_and_closes(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    from ting import main
+    from ting.config import Settings
+
+    repository = AsyncMock()
+    constructor = MagicMock(return_value=repository)
+    monkeypatch.setattr(main, "HTTPIntegrationRepository", constructor)
+    settings = Settings(
+        shared_integrations={
+            "base_url": "https://identity.test",
+            "auth": {"adapter": "niuu.adapters.outbound.http_auth.RequestBearerTokenAuthAdapter"},
+        },
+    )
+    async with main._integration_repository(settings, object()):
+        assert (
+            constructor.call_args.kwargs["auth_adapter"]
+            == settings.shared_integrations.auth.adapter
+        )
+    repository.close.assert_awaited_once()
+
+
+async def test_shared_integrations_rejects_ambiguous_store():
+    from ting.config import Settings
+    from ting.main import _integration_repository
+
+    settings = Settings(
+        shared_integrations={"base_url": "https://identity.test", "database_name": "shared"}
+    )
+    with pytest.raises(ValueError, match="not both"):
+        async with _integration_repository(settings, object()):
+            pytest.fail("Ambiguous integration store accepted")


### PR DESCRIPTION
Ting could not start after central identity enforcement: its shared-integration HTTP repository sent no bearer credential, and startup always queried the development user's Telegram integration. Configure either the shared PostgreSQL integration database or authenticated HTTP, reject unauthenticated production HTTP, and restrict development-only bootstrap and default adapters to anonymous mini mode.

Ymir will use its existing niuu_shared database so per-owner integration lookups and background processing retain their shared store. The separate connection pool closes with the application lifecycle. Helm exposes the database selection and HTTP auth configuration.

Validation: 1,782 Ting, shared-connection-auth, and Cedar chart tests passed; Ruff and diff checks passed. This fixes a blocker discovered during the authorized Cedar GitOps rollout.
