### PR TITLE
fix(auth): prevent membership from elevating delegated credentials

### DIFF
--- a/src/identity/adapters/identity.py
+++ b/src/identity/adapters/identity.py
@@ -165,7 +165,19 @@ class EnvoyHeaderIdentityAdapter(EnvoyHeaderAuthenticationAdapter, IdentityPort)
             membership = next((m for m in memberships if m.tenant_id == principal.tenant_id), None)
             if membership is None:
                 raise InvalidTokenError("Local tenant membership is required")
-            principal = replace(principal, roles=[membership.role.value])
+            # Membership changes can reduce a credential's authority, never
+            # expand the roles granted to a delegated workload or older JWT.
+            role = membership.role.value
+            credential_roles = set(principal.roles)
+            if role in credential_roles or TenantRole.ADMIN.value in credential_roles:
+                roles = [role]
+            elif membership.role == TenantRole.ADMIN:
+                roles = sorted(credential_roles & {r.value for r in TenantRole})
+            else:
+                roles = []
+            if not roles:
+                raise InvalidTokenError("Credential roles do not grant the current membership role")
+            principal = replace(principal, roles=roles)
         return principal
 
     async def validate_token(self, raw_token: str) -> Principal:

--- a/tests/test_adapters/test_membership_authority.py
+++ b/tests/test_adapters/test_membership_authority.py
@@ -40,3 +40,26 @@ async def test_local_authority_does_not_auto_enroll_unknown_users():
 def test_unknown_authority_is_configuration_error():
     with pytest.raises(ValueError, match="membership_authority"):
         EnvoyHeaderIdentityAdapter(user_repository=AsyncMock(), membership_authority="fallback")
+
+
+@pytest.mark.parametrize("credential_role", ["volundr:developer", "volundr:viewer"])
+async def test_membership_never_elevates_delegated_credential(credential_role):
+    repo = AsyncMock()
+    repo.get.return_value = User(id="alice", email="a@test", status=UserStatus.ACTIVE)
+    repo.get_memberships.return_value = [TenantMembership("alice", "acme", TenantRole.ADMIN)]
+    adapter = EnvoyHeaderIdentityAdapter(user_repository=repo, membership_authority="local")
+    principal = await adapter.validate_headers(
+        {"x-auth-user-id": "alice", "x-auth-tenant": "acme", "x-auth-roles": credential_role}
+    )
+    assert principal.roles == [credential_role]
+
+
+async def test_disjoint_membership_and_credential_roles_fail_closed():
+    repo = AsyncMock()
+    repo.get.return_value = User(id="alice", email="a@test", status=UserStatus.ACTIVE)
+    repo.get_memberships.return_value = [TenantMembership("alice", "acme", TenantRole.DEVELOPER)]
+    adapter = EnvoyHeaderIdentityAdapter(user_repository=repo, membership_authority="local")
+    with pytest.raises(InvalidTokenError, match="Credential roles"):
+        await adapter.validate_headers(
+            {"x-auth-user-id": "alice", "x-auth-tenant": "acme", "x-auth-roles": "volundr:viewer"}
+        )


### PR DESCRIPTION
Canonical membership validation replaced every credential's roles with the current membership role. A developer workload acting for an admin owner consequently acquired admin authority. Cap authorization at the intersection of the credential and current membership grants; membership downgrades still take effect immediately, and incompatible grants fail closed.

Validation: 50 membership, identity, remote-authority, service-app and composition tests passed, including delegated developer/viewer credentials owned by an administrator. Ruff and diff checks passed. Discovered during live Cedar rollout validation.
